### PR TITLE
Rename LICENSE.txt to LICENSE

### DIFF
--- a/agent/README.txt
+++ b/agent/README.txt
@@ -4,6 +4,6 @@ For installation instructions, INI file settings,
 and API descriptions please see the online FAQ at:
     http://newrelic.com/docs/php/new-relic-for-php
 
-For license and copyright, see LICENSE.txt.
+For license and copyright, see LICENSE.
 
 For support, contact us at http://support.newrelic.com for assistance.

--- a/make/release.mk
+++ b/make/release.mk
@@ -52,7 +52,7 @@ release-installer: Makefile bin/newrelic-install bin/newrelic-iutil | releases/$
 	cp bin/newrelic-iutil   releases/$(RELEASE_OS)/scripts/newrelic-iutil.$(RELEASE_ARCH)
 
 release-docs: Makefile | releases/$(RELEASE_OS)/
-	cp agent/README.txt LICENSE.txt releases/$(RELEASE_OS)
+	cp agent/README.txt LICENSE releases/$(RELEASE_OS)
 
 release-scripts: Makefile | releases/$(RELEASE_OS)/scripts/
 	cp agent/scripts/init.alpine               releases/$(RELEASE_OS)/scripts


### PR DESCRIPTION
The file `LICENSE.txt` in the root directory of the `newrelic-php-agent` repository was renamed to `LICENSE`.

This change needs to be accounted for in several places.