### PR TITLE
Add supported systems and dependencies to development guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -12,8 +12,8 @@ Currently, the PHP agent has only been developed and compiled on Linux systems. 
 
 #### Operating Systems
 - Fully supported for building from source
-    - Debian/Ubuntu
-    - CentOS/RHEL/Fedora
+    - Ubuntu 16.04+
+    - CentOS/RHEL 7+
 - Supported in binary form only (may require experimentation to build)
     - MacOS
     - FreeBSD


### PR DESCRIPTION
Sections are broken up by build tools, pure libraries, and development headers for applications (such as memcached).

Includes the kernel, glibc, and musl libc versions listed in our [compatibility requirements guide](https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements)