### PR TITLE
Added stalebot.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. We appreciate your contributions, and we understand 
+  things get busy.  This issue will be closed after 14 days if no 
+  further activity occurs. 
+  Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because it has not had
+  recent activity.
+  Thank you for your contributions.


### PR DESCRIPTION
Set to trigger a message on stale issues after 30 days, if there is no response 14 days after that, it is automatically closed with the `wontfix` label.  The exceptions to this are issues marked with `security` and `pinned` labels.  The `pinned` label indicates issues or bugs that we don’t want to go stale (i.e., ones that newrelic has added as part of milestones/roadmap).