### PR TITLE
PHP-2672: Reconnect on FailedPrecondition

### DIFF
--- a/src/newrelic/infinite_tracing/grpc_sender.go
+++ b/src/newrelic/infinite_tracing/grpc_sender.go
@@ -133,7 +133,7 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 			default:
 				log.Errorf("unexpected error from grpc endpoint:  %v", err)
 				status := newSpanBatchStatusFromGrpcErr(err)
-				if status.code == statusShutdown {
+				if status.code == statusShutdown || status.code == statusReconnect {
 					s.responseError <- status
 					return
 				} else {

--- a/src/newrelic/infinite_tracing/trace_observer.go
+++ b/src/newrelic/infinite_tracing/trace_observer.go
@@ -127,10 +127,9 @@ func newTraceObserverWithWorker(cfg *Config) (*TraceObserver, func()) {
 	}
 	go to.handleSupportability()
 	worker := func() {
-		defer to.sender.shutdown()
-		to.responseError = to.sender.response()
-
 		for {
+			to.responseError = to.sender.response()
+
 			status := to.doStreaming()
 
 			if status.code == statusShutdown {
@@ -153,6 +152,7 @@ func newTraceObserverWithWorker(cfg *Config) (*TraceObserver, func()) {
 		}
 
 		to.completeShutdown()
+		to.sender.shutdown()
 	}
 
 	return to, worker


### PR DESCRIPTION
This enables the daemon to attempt a reconnect on 8T cell shifts.

How it works:
1. The `spanBatchSender` interface is extended by a `clone` method. This method returns a clone of the sender (duplicating the underlying configuration). The clone establishes its own TCP connection (which also includes resolving the host name).
2. There's an additional `statusReconnect` constant, signifying that a TCP reconnect is needed.
3. The `FailedPrecondition` gRPC return code is translated into a `statusReconnect` status.
4. In the main worker loop, if a `statusReconnect` status is received, the store sender is shut down, cloned, and replaced with its clone.