### PR TITLE
stalebot: Add 'backlog' and 'triage' to exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,8 @@ daysUntilClose: 14
 exemptLabels:
   - pinned
   - security
+  - backlog
+  - triage
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
This PR configures stalebot to ignore issues that we have yet to triage or tickets that we have accepted into our backlog.