### PR TITLE
Fix parallel build problem: Move protobuf header generation

### DIFF
--- a/axiom/Makefile
+++ b/axiom/Makefile
@@ -77,7 +77,10 @@ VERSION_FLAGS := -DNR_VERSION=$(AGENT_VERSION) -DNR_COMMIT=$(GIT_COMMIT)
 # Object files that we have to build. If you're adding a new C file to axiom,
 # you need to add a corresponding line here.
 #
+# Note: v1.pb-c.o is built first in order to generate v1.pb-c.h which is needed
+# by at least nr_span_encoding.c.
 OBJS := \
+	v1.pb-c.o \
 	cmd_appinfo_transmit.o \
 	cmd_span_batch_transmit.o \
 	cmd_txndata_transmit.o \
@@ -156,8 +159,7 @@ OBJS := \
 	util_text.o \
 	util_threads.o \
 	util_url.o \
-	util_vector.o \
-	v1.pb-c.o
+	util_vector.o
 
 #
 # The rule to actually build the library.


### PR DESCRIPTION
When building the agent, you currently have to run the build in parallel with something like `-j 4`. This PR fixes that.

`v1.pb-c.h` is generated when we compile `v1.pb-c.h`. The problem is, it is last in the list. `nr_span_encoding.c` needs it to be present for it to be able to build. The reason the `-j` workaround works is that it launches enough threads to compile `v1.pb-c.c` before `nr_span_encoding.c`.

By forcing `v1.pb-c.c` to be compiled first, we ensure that, regardless of which files need it to be present, it will be guaranteed to be there.

There are alternative fixes we could explore such as manually calling `protoc-c` earlier in the build process, tweaking the compile step for all `c` files, or adding a new dependency for the files that need the header file to be there, but this solution feels simpler (and was the quickest to implement).