### PR TITLE
PHP 8 curl Object Fixes

### DIFF
--- a/agent/php_curl.c
+++ b/agent/php_curl.c
@@ -28,6 +28,14 @@ static int nr_php_curl_do_cross_process(TSRMLS_D) {
           || NRPRG(txn)->options.distributed_tracing_enabled);
 }
 
+static int nr_php_is_zval_valid_curl_handle(const zval* ch) {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  return NULL != ch && nr_php_is_zval_valid_object(curlres);
+#else
+  return NULL != ch && nr_php_is_zval_valid_resource(curlres);
+#endif /* PHP 8.0+ */
+}
+
 static void nr_php_curl_save_response_header_from_zval(const zval* ch,
                                                        const zval* zstr
                                                            TSRMLS_DC) {
@@ -113,7 +121,7 @@ static void nr_php_curl_set_default_response_header_callback(
   zval* retval = NULL;
   zval* curlopt = NULL;
 
-  if ((NULL == curlres) || (IS_RESOURCE != Z_TYPE_P(curlres))) {
+  if ((NULL == curlres)) {
     return;
   }
 
@@ -137,7 +145,7 @@ static void nr_php_curl_set_default_request_headers(zval* curlres TSRMLS_DC) {
   zval* retval = NULL;
   zval* curlopt = NULL;
 
-  if ((NULL == curlres) || (IS_RESOURCE != Z_TYPE_P(curlres))) {
+  if (!nr_php_is_zval_valid_curl_handle(curlres)) {
     return;
   }
 
@@ -358,7 +366,7 @@ end:
 }
 
 static void nr_php_curl_setopt_curlopt_writeheader(zval* curlval TSRMLS_DC) {
-  if ((NULL == curlval) || (IS_RESOURCE != Z_TYPE_P(curlval))) {
+  if (!nr_php_is_zval_valid_curl_handle(ch)) {
     return;
   }
 
@@ -421,8 +429,8 @@ void nr_php_curl_setopt_pre(zval* curlres,
     return;
   }
 
-  if ((NULL == curlres) || (NULL == curlopt) || (NULL == curlval)
-      || (IS_RESOURCE != Z_TYPE_P(curlres)) || (IS_LONG != Z_TYPE_P(curlopt))) {
+  if ( !nr_php_is_zval_valid_curl_handle(curlres) || (NULL == curlopt) || (NULL == curlval)
+       || (IS_LONG != Z_TYPE_P(curlopt))) {
     return;
   }
 
@@ -445,8 +453,8 @@ void nr_php_curl_setopt_post(zval* curlres,
     return;
   }
 
-  if ((NULL == curlres) || (NULL == curlopt) || (NULL == curlval)
-      || (IS_RESOURCE != Z_TYPE_P(curlres)) || (IS_LONG != Z_TYPE_P(curlopt))) {
+  if ( !nr_php_is_zval_valid_curl_handle(curlres) || (NULL == curlopt) || (NULL == curlval)
+      || (IS_LONG != Z_TYPE_P(curlopt))) {
     return;
   }
 
@@ -526,7 +534,7 @@ void nr_php_curl_setopt_array(zval* curlres,
       .func = func,
   };
 
-  if (!nr_php_is_zval_valid_resource(curlres)
+  if (!nr_php_is_zval_valid_curl_handle(curlres)
       || !nr_php_is_zval_valid_array(options)) {
     return;
   }
@@ -541,7 +549,7 @@ static bool nr_php_curl_finished(zval* curlres TSRMLS_DC) {
   zval* result = NULL;
   bool finished = false;
 
-  if (!nr_php_is_zval_valid_resource(curlres)) {
+  if (!nr_php_is_zval_valid_curl_handle(curlres)) {
     return false;
   }
 

--- a/agent/php_curl.c
+++ b/agent/php_curl.c
@@ -121,7 +121,7 @@ static void nr_php_curl_set_default_response_header_callback(
   zval* retval = NULL;
   zval* curlopt = NULL;
 
-  if ((NULL == curlres)) {
+  if (!nr_php_is_zval_valid_curl_handle(curlres)) {
     return;
   }
 

--- a/agent/php_curl.c
+++ b/agent/php_curl.c
@@ -30,9 +30,9 @@ static int nr_php_curl_do_cross_process(TSRMLS_D) {
 
 static int nr_php_is_zval_valid_curl_handle(const zval* ch) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
-  return NULL != ch && nr_php_is_zval_valid_object(curlres);
+  return NULL != ch && nr_php_is_zval_valid_object(ch);
 #else
-  return NULL != ch && nr_php_is_zval_valid_resource(curlres);
+  return NULL != ch && nr_php_is_zval_valid_resource(ch);
 #endif /* PHP 8.0+ */
 }
 
@@ -366,7 +366,7 @@ end:
 }
 
 static void nr_php_curl_setopt_curlopt_writeheader(zval* curlval TSRMLS_DC) {
-  if (!nr_php_is_zval_valid_curl_handle(ch)) {
+  if ((NULL == curlval) || (IS_RESOURCE != Z_TYPE_P(curlval))) {
     return;
   }
 

--- a/agent/php_curl.c
+++ b/agent/php_curl.c
@@ -429,8 +429,8 @@ void nr_php_curl_setopt_pre(zval* curlres,
     return;
   }
 
-  if ( !nr_php_is_zval_valid_curl_handle(curlres) || (NULL == curlopt) || (NULL == curlval)
-       || (IS_LONG != Z_TYPE_P(curlopt))) {
+  if (!nr_php_is_zval_valid_curl_handle(curlres) || (NULL == curlopt)
+      || (NULL == curlval) || (IS_LONG != Z_TYPE_P(curlopt))) {
     return;
   }
 
@@ -453,8 +453,8 @@ void nr_php_curl_setopt_post(zval* curlres,
     return;
   }
 
-  if ( !nr_php_is_zval_valid_curl_handle(curlres) || (NULL == curlopt) || (NULL == curlval)
-      || (IS_LONG != Z_TYPE_P(curlopt))) {
+  if (!nr_php_is_zval_valid_curl_handle(curlres) || (NULL == curlopt)
+      || (NULL == curlval) || (IS_LONG != Z_TYPE_P(curlopt))) {
     return;
   }
 

--- a/agent/php_curl_md.c
+++ b/agent/php_curl_md.c
@@ -15,17 +15,17 @@ static void nr_php_curl_md_destroy(nr_php_curl_md_t* metadata) {
 }
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
-#define check_curl_handle(ch)                                              \
-  ({                                                                       \
-    bool __ok = true;                                                      \
-                                                                           \
-    if (nrunlikely(!nr_php_is_zval_valid_object(ch))) {                    \
-      nrl_verbosedebug(NRL_CAT, "%s: invalid curl handle; not an object",  \
-                       __func__);                                          \
-      __ok = false;                                                        \
-    }                                                                      \
-                                                                           \
-    __ok;                                                                  \
+#define check_curl_handle(ch)                                             \
+  ({                                                                      \
+    bool __ok = true;                                                     \
+                                                                          \
+    if (nrunlikely(!nr_php_is_zval_valid_object(ch))) {                   \
+      nrl_verbosedebug(NRL_CAT, "%s: invalid curl handle; not an object", \
+                       __func__);                                         \
+      __ok = false;                                                       \
+    }                                                                     \
+                                                                          \
+    __ok;                                                                 \
   })
 #else
 #define check_curl_handle(ch)                                              \

--- a/agent/php_curl_md.c
+++ b/agent/php_curl_md.c
@@ -14,6 +14,20 @@ static void nr_php_curl_md_destroy(nr_php_curl_md_t* metadata) {
   nr_free(metadata);
 }
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+#define check_curl_handle(ch)                                              \
+  ({                                                                       \
+    bool __ok = true;                                                      \
+                                                                           \
+    if (nrunlikely(!nr_php_is_zval_valid_object(ch))) {                    \
+      nrl_verbosedebug(NRL_CAT, "%s: invalid curl handle; not an object",  \
+                       __func__);                                          \
+      __ok = false;                                                        \
+    }                                                                      \
+                                                                           \
+    __ok;                                                                  \
+  })
+#else
 #define check_curl_handle(ch)                                              \
   ({                                                                       \
     bool __ok = true;                                                      \
@@ -26,6 +40,7 @@ static void nr_php_curl_md_destroy(nr_php_curl_md_t* metadata) {
                                                                            \
     __ok;                                                                  \
   })
+#endif
 
 #define ensure_curl_metadata_hashmap()                                       \
   if (!NRTXNGLOBAL(curl_metadata)) {                                         \

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -2189,9 +2189,14 @@ NR_INNER_WRAPPER(curl_exec) {
   zval* curlres = NULL;
   int zcaught = 0;
 
-  if (SUCCESS
-      != zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "r", &curlres)) {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  int parse_status = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
+                                  ZEND_NUM_ARGS() TSRMLS_CC, "o", &curlres);
+#else
+  int parse_status = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
+                                  ZEND_NUM_ARGS() TSRMLS_CC, "r", &curlres);
+#endif /* PHP 8.0+ */
+  if (SUCCESS != parse_status) {
     nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     return;
   }
@@ -2221,9 +2226,15 @@ NR_INNER_WRAPPER(curl_multi_add_handle) {
   zval* curlres = NULL;
   int rv = FAILURE;
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  rv = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
+                                ZEND_NUM_ARGS() TSRMLS_CC, "oo", &multires,
+                                &curlres);
+#else
   rv = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
                                 ZEND_NUM_ARGS() TSRMLS_CC, "rr", &multires,
                                 &curlres);
+#endif /* PHP 8.0+ */
 
   if (SUCCESS == rv) {
     if (nr_php_curl_multi_md_add(multires, curlres TSRMLS_CC)
@@ -2255,9 +2266,15 @@ NR_INNER_WRAPPER(curl_multi_remove_handle) {
   zval* curlres = NULL;
   int rv = FAILURE;
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  rv = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
+                                ZEND_NUM_ARGS() TSRMLS_CC, "oo", &multires,
+                                &curlres);
+#else
   rv = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
                                 ZEND_NUM_ARGS() TSRMLS_CC, "rr", &multires,
                                 &curlres);
+#endif /* PHP 8.0+ */
 
   if (SUCCESS == rv) {
     if (nr_php_curl_multi_md_remove(multires, curlres TSRMLS_CC)) {

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -2190,11 +2190,11 @@ NR_INNER_WRAPPER(curl_exec) {
   int zcaught = 0;
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
-  int parse_status = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "o", &curlres);
+  int parse_status = zend_parse_parameters_ex(
+      ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "o", &curlres);
 #else
-  int parse_status = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "r", &curlres);
+  int parse_status = zend_parse_parameters_ex(
+      ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "r", &curlres);
 #endif /* PHP 8.0+ */
   if (SUCCESS != parse_status) {
     nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -2191,11 +2191,11 @@ NR_INNER_WRAPPER(curl_exec) {
   int rv = FAILURE;
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
-  rv = zend_parse_parameters_ex(
-      ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "o", &curlres);
+  rv = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
+                                ZEND_NUM_ARGS() TSRMLS_CC, "o", &curlres);
 #else
-  rv = zend_parse_parameters_ex(
-      ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "r", &curlres);
+  rv = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
+                                ZEND_NUM_ARGS() TSRMLS_CC, "r", &curlres);
 #endif /* PHP 8.0+ */
   if (SUCCESS != rv) {
     nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -2188,15 +2188,16 @@ NR_INNER_WRAPPER(curl_init) {
 NR_INNER_WRAPPER(curl_exec) {
   zval* curlres = NULL;
   int zcaught = 0;
+  int rv = FAILURE;
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
-  int parse_status = zend_parse_parameters_ex(
+  rv = zend_parse_parameters_ex(
       ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "o", &curlres);
 #else
-  int parse_status = zend_parse_parameters_ex(
+  rv = zend_parse_parameters_ex(
       ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "r", &curlres);
 #endif /* PHP 8.0+ */
-  if (SUCCESS != parse_status) {
+  if (SUCCESS != rv) {
     nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     return;
   }


### PR DESCRIPTION
Refactors all curl resource checks to account for the fact that in PHP 8, it is an object.

The necessary changes are nicely[ summarized here](https://php.watch/versions/8.0/resource-CurlHandle).  As you can see, API compatibility was very well maintained by the upstream code in PHP, but also somewhat surprisingly, in C as well.

Unit tests (with valgrind) pass with no issues, and small manual curl test program is correctly instrumented.

Fixes #42
Fixes #51 