### PR TITLE
Add epic to stalebot's exemptLabels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,9 +4,10 @@ daysUntilStale: 30
 daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
+  - backlog
+  - epic
   - pinned
   - security
-  - backlog
   - triage
 # Label to use when marking an issue as stale
 staleLabel: wontfix


### PR DESCRIPTION
This adds the `epic` label to the exempt labels used by stalebot.