### PR TITLE
Instrument Magento2 `prepareOperationInput`.

### DIFF
--- a/agent/fw_magento2.c
+++ b/agent/fw_magento2.c
@@ -322,8 +322,9 @@ NR_PHP_WRAPPER(nr_magento2_soap_handler_prepareoperationinput) {
 
   svc_class = nr_php_arg_get(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   method_metadata = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  /* We expect method_metadata to be an array.  At index 'method', if we see
-   * a method name, we'll pass is to the transaction naming.
+  /* 
+   * We expect method_metadata to be an array.  At index 'method', if we see
+   * a method name, we'll pass it to the transaction naming.
    * See:
    * https://www.magentoextensions.org/documentation/class_magento_1_1_webapi_1_1_model_1_1_service_metadata.html
    */


### PR DESCRIPTION
`prepareOperationInput` was Introduced in Magento 2.3.2 to convert arguments received from SOAP server to arguments to pass to a service. Fixes issue #55 .

It takes the following arguments:
 * string $serviceClass
 * array $methodMetadata
 * array $arguments
 
Prior to the fix, a SOAP API call would be displayed as:
`WebTransaction/Action/FrontController/Magento\Webapi\Controller\Interceptor`
After the fix, 
It shows up in the UI as `/Webapi/Soap/Magento\Integration\Api\AdminTokenServiceInterface/createAdminAccessToken`

Tested with the following `php` file:
```
<?php
$request = new SoapClient("http://magento2.docker/soap/?wsdl&services=integrationAdminTokenServiceV1", array("soap_version" => SOAP_1_2));
$token = $request->integrationAdminTokenServiceV1CreateAdminAccessToken(array("username"=>"PUTANADMINUSERNAME", "password"=>"PUTANADMINPASSWORD"));

$opts = array(
    'http'=>array(
        'header' => 'Authorization: Bearer '.json_decode($token->result)
    )
);

$wsdlUrl = 'http://magento2.docker/soap/default?wsdl&services=directoryCurrencyInformationAcquirerV1';

$context = stream_context_create($opts);
$soapClient = new SoapClient($wsdlUrl, ['version' => SOAP_1_2, 'context' => $context]);

$soapResponse = $soapClient->__getFunctions();
echo '<pre>';
var_dump($soapResponse);
echo '</pre>';
```

Verified behavior with logs:
Before:
```
txnname='WebTransaction/Action/FrontController/Magento\Webapi\Controller\' 
```

After: 
```
verbosedebug: sending txnname='WebTransaction/Action/Webapi/Soap/Magento\Integration\Api\AdminT'
```