### PR TITLE
Remove -ldl in agent autoconf axiom check on BSD

### DIFF
--- a/agent/config.m4
+++ b/agent/config.m4
@@ -117,8 +117,20 @@ if test "$PHP_NEWRELIC" = "yes"; then
   dnl Check for axiom.
   dnl The -ldl in the first argument is there to get the library check to pass.
   dnl Without it, we get an undefined reference to dladdr as the dl lib must
-  dnl come after the axiom lib when linking.
-  PHP_CHECK_LIBRARY(axiom -ldl, nro_new, [
+  dnl come after the axiom lib when linking. Note: this does not apply to
+  dnl FreeBSD builds, and if present, causes errors when building the agent.
+  dnl If other platforms are known to have the same issue, simply change the
+  dnl   *freebsd*)
+  dnl line to something like
+  dnl   *freebsd*|*darwin*)
+  dnl See the other `case $host in` block later in this file for known targets
+  case "$host" in
+    *freebsd*) AXIOM_CHECK="axiom"
+               ;;
+    *) AXIOM_CHECK="axiom -ldl"
+               ;;
+  esac
+  PHP_CHECK_LIBRARY($AXIOM_CHECK, nro_new, [
     PHP_ADD_INCLUDE($PHP_AXIOM)
     dnl Avoid using PHP_ADD_LIBRARY and friends. They add an RPATH for
     dnl the axiom directory, and there's no way to prevent it.

--- a/agent/config.m4
+++ b/agent/config.m4
@@ -86,6 +86,7 @@ if test "$PHP_NEWRELIC" = "yes"; then
                 nrpic="-pic"
                 LDFLAGS="$LDFLAGS -pthread -lm"
                 EXTRA_LDFLAGS="$EXTRA_LDFLAGS -static-libgcc -export-symbols export.syms"
+                AXIOM_CHECK_LIB="axiom"
                 ;;
 
   esac
@@ -119,18 +120,14 @@ if test "$PHP_NEWRELIC" = "yes"; then
   dnl Without it, we get an undefined reference to dladdr as the dl lib must
   dnl come after the axiom lib when linking. Note: this does not apply to
   dnl FreeBSD builds, and if present, causes errors when building the agent.
-  dnl If other platforms are known to have the same issue, simply change the
-  dnl   *freebsd*)
-  dnl line to something like
-  dnl   *freebsd*|*darwin*)
-  dnl See the other `case $host in` block later in this file for known targets
-  case "$host" in
-    *freebsd*) AXIOM_CHECK="axiom"
-               ;;
-    *) AXIOM_CHECK="axiom -ldl"
-               ;;
-  esac
-  PHP_CHECK_LIBRARY($AXIOM_CHECK, nro_new, [
+  dnl Earlier in this file, you will find a `case $host in` block for system
+  dnl dependent settings. If in the future, other systems require a modified
+  dnl axiom library check string, set them in that block, just as the
+  dnl `*freebsd*` pattern does.
+  if test -z "${AXIOM_CHECK_LIB}"; then
+    AXIOM_CHECK_LIB="axiom -ldl"
+  fi
+  PHP_CHECK_LIBRARY($AXIOM_CHECK_LIB, nro_new, [
     PHP_ADD_INCLUDE($PHP_AXIOM)
     dnl Avoid using PHP_ADD_LIBRARY and friends. They add an RPATH for
     dnl the axiom directory, and there's no way to prevent it.


### PR DESCRIPTION
The `-ldl` flag added in https://github.com/newrelic/newrelic-php-agent/pull/73/commits/37901aa669dcdf408154e07bb0abdabaeb6f0f6b was the culprit of the build errors on FreeBSD.  Interestingly, the flag itself is not needed for the `agent`'s `autoconf` `axiom` lib check to pass on FreeBSD.  To get around this in an easily modifiable way, I've added a case statement that when on FreeBSD, omits the the `-ldl` arg, but defaults to including it.  If we encounter any issues with this in other scenarios, adding them to the FreeBSD block is all we need to get around the error.

Tested manually by logging in to Jenkins FreeBSD worker, pulling in this change and internal repo, and running both `build.sh` and `build-pull-request.sh` successfully.