### PR TITLE
GHA workflow with associated Dockerfiles and build scripts.

### DIFF
--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+#
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#
+# Build the daemon, agent and axiom tests in accordance  with our pull request
+# guidelines, which are documented in the README.md file. Additionally, run
+# the axiom tests.
+#
+# This script is meant to run in GHA  with the GitHub Pull Request
+# action which handles reporting the outcome to GitHub for us.
+#
+
+set -e
+set -u
+
+die() {
+  echo
+  echo >&2 "FATAL: $*"
+  echo
+  exit 1
+}
+
+#
+# Ensure /usr/local/bin should be in the PATH.
+#
+case ":$PATH:" in
+  *:/usr/local/bin:*) ;;
+  *) PATH=/usr/local/bin:$PATH
+esac
+
+case ":$PATH:" in
+  *:/usr/local/go/bin:*) ;;
+  *) PATH=/usr/local/go/bin:$PATH
+esac
+
+export PATH
+
+
+#
+# Get PHPS from the environment.
+#
+
+PHPS=${PHP_VER}
+
+printf \\n
+printf 'running daemon tests\n'
+make -r -s daemon daemon_integration  "ARCH=${ARCH}"
+
+
+#
+# Limit valgrind to just the Linux builders. On Alpine Linux, valgrind
+# appears to alter the results of floating point to string conversions
+# causing spurious test failures.
+#
+
+PHP_SAPIS=$(php-config --php-sapis)
+
+case $PHP_SAPIS in
+  *embed*)
+    PHP_SAPIS_EMBED=1
+    ;;
+  *)
+    PHP_SAPIS_EMBED=0
+    ;;
+esac
+
+#
+# This check can be removed when the valgrind PHP 8.0 mem issues 
+# on 32-bit OSs are resolved.  64-bit has different issue.
+#
+VALGRIND_ISSUE=0
+    echo "php = $PHPS"
+case $PHPS in
+  *8.0*)
+    VALGRIND_ISSUE=1
+    ;;
+  *)
+    VALGRIND_ISSUE=0
+    ;;
+esac
+    echo "valgrindissue : $VALGRIND_ISSUE"
+
+if [ "$(uname)" = Linux ] && [ ! -e /etc/alpine-release ] && [ $PHP_SAPIS_EMBED ] && [ $VALGRIND_ISSUE = 0 ]; then
+  do_valgrind=yes
+  printf \\n
+  printf 'grinding axiom tests\n'
+  make -r -s -j $(nproc) axiom-valgrind "ARCH=${ARCH}"
+else
+  do_valgrind=
+  printf \\n
+  printf 'running axiom tests\n'
+  make -r -s -j $(nproc) axiom-run-tests "ARCH=${ARCH}"
+fi
+
+#
+# Run the agent integration tests without requiring any changes to the
+# PHP installation, and (ideally) without the tests being negatively
+# affected by any existing INI settings. For example, a pre-existing
+# "extension = newrelic.so". For each version of PHP, override the INI
+# file, INI directory and the extension directory using environment
+# variables. 
+#
+
+INTEGRATION_DIR="${PWD}/integration.tmp"
+if [ ! -d "$INTEGRATION_DIR" ]; then
+  mkdir "$INTEGRATION_DIR"
+  mkdir "${INTEGRATION_DIR}/etc"
+fi
+
+rm -rf "${INTEGRATION_DIR:?}"/*
+
+export PHPRC="${INTEGRATION_DIR}/php.ini"
+export PHP_INI_SCAN_DIR="${INTEGRATION_DIR}/etc"
+
+cat <<EOF >"$PHPRC"
+date.timezone = "America/Los_Angeles"
+extension_dir = "${PWD}/agent/modules"
+extension = "newrelic.so"
+newrelic.loglevel = "verbosedebug"
+EOF
+
+#
+# Build a specific version of PHP and run unit and integration tests.
+#
+# If PHP with thread safety (ZTS) is enabled, build to ensure
+# it compiles cleanly, but don't run the integration tests because
+# (empirically) some PHP extensions are inconsistent with ZTS enabled leading
+# to spurious failures that are not agent bugs.
+#
+
+  if [ -n "${LD_LIBRARY_PATH-}" ]; then
+    export LD_LIBRARY_PATH
+  fi
+
+  printf \\n
+  printf "building agent (PHP=%s)\n" "$PHPS"
+  make agent-clean
+  make -r -s -j $(nproc) agent "ARCH=${ARCH}"
+
+
+  printf \\n
+  case "$PHPS" in 
+  *8.0*)
+    printf "Skipping integration tests on PHP=%s while tests are under construction\n" "$PHPS"
+    ;;
+  *zts*)
+    printf "Skipping integration tests on ZTS (PHP=%s ZTS=enabled)\n" "$PHPS"
+    ;;
+  *)
+    printf "Running agent integration tests (PHP=%s ZTS=disabled)\n" "$PHPS"
+    make integration PHPS="$PHPS" "ARCH=${ARCH}" INTEGRATION_ARGS="--retry=1"
+    ;;
+  esac
+  printf \\n
+
+  #
+  # Run the agent unit tests (just on Linux).
+  #
+  if [ "$(uname -s)" = 'Linux' ]; then
+    PHP_PREFIX=$(php-config --prefix)
+
+    case $PHP_SAPIS in
+      *embed*)
+        if [ -n "$do_valgrind" ]; then
+          printf 'grinding agent unit tests\n'
+          make -r -s -j $(nproc) agent-valgrind "ARCH=${ARCH}" LDFLAGS='-Wl,--no-warn-search-mismatch -Wl,-z,muldefs'
+        else
+          printf 'running agent unit tests\n'
+          make -r -s -j $(nproc) agent-run-tests "ARCH=${ARCH}"
+        fi
+	;;
+      *)
+        printf 'skipping agent unit tests - embed SAPI not present\n'
+        ;;
+    esac
+  else
+    printf 'skipping agent unit tests - not Linux\n'
+  fi
+
+  printf \\n   # put a blank line

--- a/.github/docker/linux/release_build.sh
+++ b/.github/docker/linux/release_build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+echo php $PHP_VER
+echo arch $ARCH
+make -j $(nproc) clean
+make -r -j $(nproc) release-${PHP_VER}-gha "OPTIMIZE=1" "ARCH=${ARCH}"

--- a/.github/docker/linux/x64/Dockerfile
+++ b/.github/docker/linux/x64/Dockerfile
@@ -1,0 +1,93 @@
+#
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#
+# ARGs passed from GHA workflow.
+#
+ARG PHP_VER
+
+FROM php:${PHP_VER}
+
+RUN docker-php-source extract
+
+#
+# Uncomment deb-src lines for all enabled repos. First part of single-quoted
+# string (up the the !) is the pattern of the lines that will be ignored.
+# Needed for apt-get build-dep call later in script
+#
+RUN sed -Ei '/.*partner/! s/^# (deb-src .*)/\1/g' /etc/apt/sources.list
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential
+
+#
+# PHP dependencies
+#
+RUN apt-get update \
+ && apt-get -y install gcc git netcat wget unzip \
+ libpcre3 libpcre3-dev golang psmisc automake libtool \
+ insserv procps vim ${PHP_USER_SPECIFIED_PACKAGES}
+
+RUN apt-get install -y default-libmysqlclient-dev libmcrypt-dev
+
+#
+# Other tools
+#
+RUN apt-get install -y curl gdb valgrind libcurl4-openssl-dev pkg-config postgresql libpq-dev libedit-dev libreadline-dev git
+
+#
+# Install other packages.
+#
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  dnsutils \
+  git \
+  golang \
+  gyp \
+  lcov \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  perl \
+  strace \
+  python-dev \
+  python-setuptools \
+  python-yaml \
+  python3-argon2 \
+  sqlite3 \
+  libsqlite3-dev \
+  libghc-argon2-dev \
+  openssl \
+  libxml2 \
+  libxml2-dev \
+  libonig-dev \
+  libssl-dev \
+  telnet \
+  unzip \
+  wget \
+  zip && apt-get clean
+
+#
+# These args need to be repeated so we can propagate the VARS within this build context.
+#
+ARG PHP_VER
+ARG ARCH
+ARG BUILD_TYPE
+ENV PHP_VER=${PHP_VER}
+ENV ARCH=$ARCH
+ENV BUILD_TYPE=$BUILD_TYPE
+
+COPY /.github/docker/linux/${BUILD_TYPE}_build.sh /build.sh
+
+ENTRYPOINT ["/build.sh"]

--- a/.github/docker/linux/x86/Dockerfile
+++ b/.github/docker/linux/x86/Dockerfile
@@ -1,0 +1,96 @@
+#
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#
+# Build args passed from GHA
+#
+ARG PHP_VER
+
+FROM i386/php:${PHP_VER}
+
+RUN docker-php-source extract
+
+#
+# Uncomment deb-src lines for all enabled repos. First part of single-quoted
+# string (up the the !) is the pattern of the lines that will be ignored.
+# Needed for apt-get build-dep call later in script
+#
+RUN sed -Ei '/.*partner/! s/^# (deb-src .*)/\1/g' /etc/apt/sources.list
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential 
+
+#
+# PHP dependencies
+#
+RUN apt-get update \
+ && apt-get -y install gcc git netcat wget unzip \
+ libpcre3 libpcre3-dev golang psmisc automake libtool \
+ insserv procps vim ${PHP_USER_SPECIFIED_PACKAGES}
+
+RUN apt-get install -y default-libmysqlclient-dev libmcrypt-dev
+
+#
+# Other tools
+#
+
+RUN apt-get install -y curl gdb libcurl4-openssl-dev pkg-config postgresql libpq-dev libedit-dev libreadline-dev git
+
+#
+# Install basic packages.
+#
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  golang \
+  valgrind \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  perl \
+  strace \
+  python-dev \
+  python-setuptools \
+  python-yaml \
+  python3-argon2 \
+  sqlite3 \
+  libsqlite3-dev \
+  libghc-argon2-dev \openssl \
+  libxml2 \
+  libxml2-dev \
+  libonig-dev \
+  libssl-dev \
+  zip && apt-get clean
+
+#
+# C++ dependencies
+#
+RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
+
+#
+# Install packages for 32-bit compilation
+#
+RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
+
+RUN apt-get update
+
+#
+# These args need to be repeated so we can propagate the VARS within this build context.
+#
+
+ARG PHP_VER
+ARG ARCH
+ARG BUILD_TYPE
+ENV PHP_VER=${PHP_VER}
+ENV ARCH=$ARCH
+ENV BUILD_TYPE=$BUILD_TYPE
+
+COPY /.github/docker/linux/${BUILD_TYPE}_build.sh /build.sh
+
+ENTRYPOINT ["/build.sh"]

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -1,23 +1,43 @@
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#
+# This is the workflow to do a PR build.
+#
+
 name: agent-build
+
+#
+# Controls when the action will run. 
+#
 on:
+  #
+  # Triggers the workflow on push or pull request events but only for the main branch
+  #
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
 
 jobs:
-  build:
-
+  agent_pr:
+    env:
+      PHP_VER: ${{ matrix.php_ver }}
+      ARCH: ${{ matrix.arch }}
+      BUILD_TYPE: pr
+      OS: ${{ matrix.os }}
+      image_name: ${{ matrix.os }}:${{ matrix.php_ver }}${{ matrix.arch }}
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        os: [ubuntu20, ubuntu18, ubuntu16]
+        os: [linux]
+        php_ver: ['8.0', '8.0-zts']
+        arch: ['x64', 'x86']
     steps:
-    - uses: actions/checkout@v2
-    - if: matrix.os == 'ubuntu20'
-      uses: ./.github/actions/ubuntu20-build-action
-    - if: matrix.os == 'ubuntu18'
-      uses: ./.github/actions/ubuntu18-build-action
-    - if: matrix.os == 'ubuntu16'
-      uses: ./.github/actions/ubuntu16-build-action
+      - name: Checkout Repo 
+        uses: actions/checkout@v2
+      - name: Build Custom Docker Image
+        run: docker build --build-arg ARCH=$ARCH --build-arg PHP_VER=$PHP_VER --build-arg BUILD_TYPE=$BUILD_TYPE -f ./.github/docker/${OS}/${ARCH}/Dockerfile -t $image_name .
+      - name: Build and Test
+        run: docker run --name runtest --workdir /github/workspace --rm -e GITHUB_WORKSPACE -e GITHUB_ENV -v "${GITHUB_WORKSPACE}":"/github/workspace" $image_name

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -16,9 +16,15 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   #
   push:
-    branches: [ main ]
+    branches: 
+      - main
+      - 'php8'
+      - 'dev'
   pull_request:
-    branches: [ main ]
+    branches: 
+      - main
+      - 'php8'
+      - 'dev'
 
 jobs:
   agent_pr:

--- a/make/release.mk
+++ b/make/release.mk
@@ -100,6 +100,24 @@ release-agent: Makefile | releases/$(RELEASE_OS)/agent/$(RELEASE_ARCH)/
 #
 define RELEASE_AGENT_TARGET
 
+#
+# Target for non-zts GHA releases.
+#
+release-$1-gha: PHPIZE := /usr/local/bin/phpize
+release-$1-gha: PHP_CONFIG := /usr/local/bin/php-config
+release-$1-gha: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
+	@cp agent/modules/newrelic.so "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2.so"
+	@test -e agent/newrelic.map && cp agent/newrelic.map "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2.map" || true
+
+#
+# Target for zts GHA releases.
+#
+release-$1-zts-gha: PHPIZE := /usr/local/bin/phpize
+release-$1-zts-gha: PHP_CONFIG := /usr/local/bin/php-config
+release-$1-zts-gha: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
+	@cp agent/modules/newrelic.so "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2-zts.so"
+	 @test -e agent/newrelic.map && cp agent/newrelic.map "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2-zts.map" || true
+
 release-$1-no-zts: PHPIZE := /opt/nr/lamp/bin/phpize-$1-no-zts
 release-$1-no-zts: PHP_CONFIG := /opt/nr/lamp/bin/php-config-$1-no-zts
 release-$1-no-zts: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
@@ -114,6 +132,7 @@ release-$1-zts: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
 
 endef
 
+$(eval $(call RELEASE_AGENT_TARGET,8.0,20200930))
 $(eval $(call RELEASE_AGENT_TARGET,7.4,20190902))
 $(eval $(call RELEASE_AGENT_TARGET,7.3,20180731))
 $(eval $(call RELEASE_AGENT_TARGET,7.2,20170718))


### PR DESCRIPTION
1) Workflows to build release and PR for PHP 8.0.
2) Dockerfiles
3) Build scripts.

Issues:
1) `Integration tests` are currently disabled for PHP 8.0 builds while we work on upgrading those tests.
2) `valgrind` for PHP8.0 on 32bit OS turned up a memory issue.  `valgrind` on 64bit had compilation issue.`valgrind` check is disabled for PHP 8 on both 32-bit/64-bit dues to issues. Maybe it can be looked at as part of #62.
3) Because GHA does [not currently support](https://github.community/t/feature-request-build-args-support-in-docker-container-actions/16846) passing `—build-args` to a Dockerfile in an action, and in order to reduce the proliferation of Dockerfiles (phpver X OS X arch X zts/nozts), currently we build/run a Dockerfile in separate steps.  This can be revisited if/when GHA supports passing build args from within an action.

Fixes #65.