### PR TITLE
PHP: 64-bit valgrind now builds correctly.

### DIFF
--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -81,9 +81,7 @@ VALGRIND_ISSUE=0
     echo "php = $PHPS"
 case $PHPS in
   *8.0*)
-    if [ $ARCH = "x86" ]; then
-      VALGRIND_ISSUE=1
-    fi
+    VALGRIND_ISSUE=1
     ;;
   *)
     VALGRIND_ISSUE=0

--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -41,6 +41,12 @@ export PATH
 
 
 #
+# Set LD_LIBRARY_PATH
+#
+LD_LIBRARY_PATH=/usr/local/lib
+export LD_LIBRARY_PATH
+
+#
 # Get PHPS from the environment.
 #
 
@@ -49,7 +55,6 @@ PHPS=${PHP_VER}
 printf \\n
 printf 'running daemon tests\n'
 make -r -s daemon daemon_integration  "ARCH=${ARCH}"
-
 
 #
 # Limit valgrind to just the Linux builders. On Alpine Linux, valgrind
@@ -76,7 +81,9 @@ VALGRIND_ISSUE=0
     echo "php = $PHPS"
 case $PHPS in
   *8.0*)
-    VALGRIND_ISSUE=1
+    if [ $ARCH = "x86" ]; then
+      VALGRIND_ISSUE=1
+    fi
     ;;
   *)
     VALGRIND_ISSUE=0
@@ -152,7 +159,8 @@ EOF
     ;;
   *)
     printf "Running agent integration tests (PHP=%s ZTS=disabled)\n" "$PHPS"
-    make integration PHPS="$PHPS" "ARCH=${ARCH}" INTEGRATION_ARGS="--retry=1"
+    printf "Temporarily disable integration tests in GHA while determining what to do with private keys.\n"
+    #make integration PHPS="$PHPS" "ARCH=${ARCH}" INTEGRATION_ARGS="--retry=1"
     ;;
   esac
   printf \\n
@@ -167,10 +175,10 @@ EOF
       *embed*)
         if [ -n "$do_valgrind" ]; then
           printf 'grinding agent unit tests\n'
-          make -r -s -j $(nproc) agent-valgrind "ARCH=${ARCH}" LDFLAGS='-Wl,--no-warn-search-mismatch -Wl,-z,muldefs'
+          make -r -s -j $(nproc) agent-valgrind "ARCH=${ARCH}"
         else
           printf 'running agent unit tests\n'
-          make -r -s -j $(nproc) agent-run-tests "ARCH=${ARCH}"
+          make -r -s -j $(nproc) agent-check "ARCH=${ARCH}"
         fi
 	;;
       *)

--- a/.github/docker/linux/x64/Dockerfile
+++ b/.github/docker/linux/x64/Dockerfile
@@ -27,16 +27,15 @@ RUN apt-get install -y build-essential
 # PHP dependencies
 #
 RUN apt-get update \
- && apt-get -y install gcc git netcat wget unzip \
+ && apt-get -y install gcc git netcat \
  libpcre3 libpcre3-dev golang psmisc automake libtool \
- insserv procps vim ${PHP_USER_SPECIFIED_PACKAGES}
-
-RUN apt-get install -y default-libmysqlclient-dev libmcrypt-dev
+ insserv procps vim ${PHP_USER_SPECIFIED_PACKAGES} \
+ zlib1g-dev libmcrypt-dev
 
 #
 # Other tools
 #
-RUN apt-get install -y curl gdb valgrind libcurl4-openssl-dev pkg-config postgresql libpq-dev libedit-dev libreadline-dev git
+RUN apt-get install -y gdb valgrind libcurl4-openssl-dev pkg-config libpq-dev libedit-dev libreadline-dev git
 
 #
 # Install other packages.
@@ -50,7 +49,6 @@ RUN apt-get update && apt-get install -y \
   curl \
   dnsutils \
   git \
-  golang \
   gyp \
   lcov \
   libc6 \
@@ -64,19 +62,37 @@ RUN apt-get update && apt-get install -y \
   python-dev \
   python-setuptools \
   python-yaml \
-  python3-argon2 \
   sqlite3 \
   libsqlite3-dev \
-  libghc-argon2-dev \
   openssl \
   libxml2 \
   libxml2-dev \
   libonig-dev \
   libssl-dev \
-  telnet \
   unzip \
   wget \
   zip && apt-get clean
+
+#
+# If the debian version is jessie or stretch, we need to install go manually;
+# otherwise, we just install the golang package from the repository.
+# go 1.11.6 matches the version that buster uses.
+#
+RUN if [ -z "$(grep '^10\.' /etc/debian_version)" ]; then \
+      wget --quiet https://golang.org/dl/go1.11.6.linux-amd64.tar.gz -O- | tar -C /usr/local -zxvf -; \
+      export GOROOT=/usr/local/go; \
+      exportGOPATH="${HOME}/go"; \
+      exportPATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"; \
+    else \
+      apt-get install -y golang; \
+    fi
+
+#
+# If the debian version is jessie, don't install argon2
+#
+RUN if [ -z "$(grep '^8\.' /etc/debian_version)" ]; then \
+    apt-get install -y argon2 libghc-argon2-dev; \
+    fi
 
 #
 # These args need to be repeated so we can propagate the VARS within this build context.

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -38,8 +38,25 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        php_ver: ['8.0', '8.0-zts']
+        php_ver: ['7.0', '7.1', '7.2', '7.3', '7.4-zts', '8.0', '8.0-zts']
         arch: ['x64', 'x86']
+        exclude:
+        # Excludes PHP 5.x, 7.x on linux 32-bit
+        - os: linux
+          php_ver: '7.0'
+          arch: 'x86'
+        - os: linux
+          php_ver: '7.1'
+          arch: 'x86'
+        - os: linux
+          php_ver: '7.2'
+          arch: 'x86'
+        - os: linux
+          php_ver: '7.3'
+          arch: 'x86'
+        - os: linux
+          php_ver: '7.4-zts'
+          arch: 'x86'
     steps:
       - name: Checkout Repo 
         uses: actions/checkout@v2

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        php_ver: ['7.0', '7.1', '7.2', '7.3', '7.4-zts', '8.0', '8.0-zts']
+        php_ver: ['7.0', '7.1-zts', '7.2', '7.3', '7.4', '8.0', '8.0-zts']
         arch: ['x64', 'x86']
         exclude:
         # Excludes PHP 5.x, 7.x on linux 32-bit
@@ -46,7 +46,7 @@ jobs:
           php_ver: '7.0'
           arch: 'x86'
         - os: linux
-          php_ver: '7.1'
+          php_ver: '7.1-zts'
           arch: 'x86'
         - os: linux
           php_ver: '7.2'
@@ -55,7 +55,7 @@ jobs:
           php_ver: '7.3'
           arch: 'x86'
         - os: linux
-          php_ver: '7.4-zts'
+          php_ver: '7.4'
           arch: 'x86'
     steps:
       - name: Checkout Repo 


### PR DESCRIPTION
* Addressed the 64-bit valgrind issue.  The PHP 8.0 build now does unit tests with valgrind.
* Changed the workflow to show 7.x builds on x64.

Issues:
1) On GHA unit tests skip for 7.2 and below because SAPI embed was not compiled into that PHP image.

2) Integration tests:
We can disable lasp on the GHA runs, but it still asks for private keys (like license key).

3) 5.5 and 5.6 on x64
Axiom builds, but agent build can’t find axiom.

4) Now that valgrind runs on 64-bit, it's surfaced a possible memory issue that needs to be investigated.