### PR TITLE
PHP 8: Added suppression for 32bit compiler

### DIFF
--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -73,23 +73,7 @@ case $PHP_SAPIS in
     ;;
 esac
 
-#
-# This check can be removed when the valgrind PHP 8.0 mem issues 
-# on 32-bit OSs are resolved.  64-bit has different issue.
-#
-VALGRIND_ISSUE=0
-    echo "php = $PHPS"
-case $PHPS in
-  *8.0*)
-    VALGRIND_ISSUE=1
-    ;;
-  *)
-    VALGRIND_ISSUE=0
-    ;;
-esac
-    echo "valgrindissue : $VALGRIND_ISSUE"
-
-if [ "$(uname)" = Linux ] && [ ! -e /etc/alpine-release ] && [ $PHP_SAPIS_EMBED ] && [ $VALGRIND_ISSUE = 0 ]; then
+if [ "$(uname)" = Linux ] && [ ! -e /etc/alpine-release ] && [ $PHP_SAPIS_EMBED ]; then
   do_valgrind=yes
   printf \\n
   printf 'grinding axiom tests\n'

--- a/agent/tests/valgrind-suppressions
+++ b/agent/tests/valgrind-suppressions
@@ -1,4 +1,26 @@
 {
+   agent-32bit-debian-invalid-read
+   Memcheck:Addr4
+   fun:check_free
+   fun:free_key_mem
+   fun:__dlerror_main_freeres
+   fun:__libc_freeres
+   fun:_vgnU_freeres
+   ...
+}
+
+{
+   agent-32bit-debian-invalid-free
+   Memcheck:Free
+   fun:free
+   fun:free_key_mem
+   fun:__dlerror_main_freeres
+   fun:__libc_freeres
+   fun:_vgnU_freeres
+   ...
+}
+
+{
   <glib leaks caused by glibc>
   Memcheck:Leak
   ...

--- a/axiom/tests/valgrind-suppressions
+++ b/axiom/tests/valgrind-suppressions
@@ -4,6 +4,28 @@
 # Suppressing things may hide true problems, so watch out.
 
 {
+   agent-32bit-debian-invalid-read
+   Memcheck:Addr4
+   fun:check_free
+   fun:free_key_mem
+   fun:__dlerror_main_freeres
+   fun:__libc_freeres
+   fun:_vgnU_freeres
+   ...
+}
+
+{
+   agent-32bit-debian-invalid-free
+   Memcheck:Free
+   fun:free
+   fun:free_key_mem
+   fun:__dlerror_main_freeres
+   fun:__libc_freeres
+   fun:_vgnU_freeres
+   ...
+}
+
+{
   <mach/macosx dynamic loader 1>
   Memcheck:Leak
   fun:malloc


### PR DESCRIPTION
* Added suppressions for valgrind message generated on the 32bit compiler.

Valgrind had been generating the following message:

```
tests/test_globals.valgrind.log
==40137== Memcheck, a memory error detector
==40137== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==40137== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==40137== Command: ./tests/test_globals
==40137== Parent PID: 40071
==40137== 
==40137== Invalid read of size 4
==40137==    at 0x4952692: check_free (dlerror.c:188)
==40137==    by 0x4952BD8: free_key_mem (dlerror.c:221)
==40137==    by 0x4952BD8: __dlerror_main_freeres (dlerror.c:239)
==40137==    by 0x61FA667: __libc_freeres (in /lib/i386-linux-gnu/libc-2.28.so)
==40137==    by 0x482D1DE: _vgnU_freeres (vg_preloaded.c:77)
==40137==  Address 0x8cfd698 is 15 bytes after a block of size 1 free'd
==40137==    at 0x4835867: free (vg_replace_malloc.c:530)
==40137==    by 0x19B97D: nr_realfree (util_memory.c:30)
==40137==    by 0x122AFC: test_main_parallel_driver (tlib_main.c:265)
==40137==    by 0x122609: main (tlib_main.c:142)
==40137==  Block was alloc'd at
==40137==    at 0x4836A16: calloc (vg_replace_malloc.c:752)
==40137==    by 0x19BB01: nr_calloc (util_memory.c:79)
==40137==    by 0x122936: test_main_parallel_driver (tlib_main.c:231)
==40137==    by 0x122609: main (tlib_main.c:142)
==40137== 
==40137== Invalid free() / delete / delete[] / realloc()
==40137==    at 0x4835867: free (vg_replace_malloc.c:530)
==40137==    by 0x4952BE0: free_key_mem (dlerror.c:223)
==40137==    by 0x4952BE0: __dlerror_main_freeres (dlerror.c:239)
==40137==    by 0x61FA667: __libc_freeres (in /lib/i386-linux-gnu/libc-2.28.so)
==40137==    by 0x482D1DE: _vgnU_freeres (vg_preloaded.c:77)
==40137==  Address 0x8cfd688 is 0 bytes inside a block of size 1 free'd
==40137==    at 0x4835867: free (vg_replace_malloc.c:530)
==40137==    by 0x19B97D: nr_realfree (util_memory.c:30)
==40137==    by 0x122AFC: test_main_parallel_driver (tlib_main.c:265)
==40137==    by 0x122609: main (tlib_main.c:142)
==40137==  Block was alloc'd at
==40137==    at 0x4836A16: calloc (vg_replace_malloc.c:752)
==40137==    by 0x19BB01: nr_calloc (util_memory.c:79)
==40137==    by 0x122936: test_main_parallel_driver (tlib_main.c:231)
==40137==    by 0x122609: main (tlib_main.c:142)
==40137== 
```

After investigating, this seemed specific to this compiler and not related an actual memory leak.
Suppressions are specific so they won't trigger on actual issues.