### PR TITLE
Prevent build up of duplicate Distributed Tracing headers

### DIFF
--- a/agent/php_file_get_contents.c
+++ b/agent/php_file_get_contents.c
@@ -138,6 +138,13 @@ static void nr_php_file_get_contents_add_headers_internal(zval* context,
     return;
   }
 
+  if (nr_stridx(Z_STRVAL_P(http_header), W3C_TRACESTATE) != -1 &&
+      nr_stridx(headers, W3C_TRACESTATE) != -1) {
+    /* Distributed Tracing headers already present and we are trying to
+       add them again, don't add duplicates. */
+    return;
+  }
+
   /* There is a non-empty header string which must be preserved. */
   {
     char* all_headers = NULL;

--- a/agent/php_file_get_contents.c
+++ b/agent/php_file_get_contents.c
@@ -138,8 +138,8 @@ static void nr_php_file_get_contents_add_headers_internal(zval* context,
     return;
   }
 
-  if (nr_stridx(Z_STRVAL_P(http_header), W3C_TRACESTATE) != -1 &&
-      nr_stridx(headers, W3C_TRACESTATE) != -1) {
+  if (nr_stridx(Z_STRVAL_P(http_header), W3C_TRACESTATE":") != -1 &&
+      nr_stridx(headers, W3C_TRACESTATE":") != -1) {
     /* Distributed Tracing headers already present and we are trying to
        add them again, don't add duplicates. */
     return;

--- a/tests/include/tracing_endpoint.php
+++ b/tests/include/tracing_endpoint.php
@@ -13,7 +13,13 @@ $request_headers = array_change_key_case(getallheaders());
 
 foreach (array(DT_TRACEPARENT, DT_TRACESTATE, DT_NEWRELIC) as $header) {
   if (array_key_exists(strtolower($header), $request_headers)) {
-    echo $header . "=found ";
+    /* A comma indicates there is more than one value for the header.
+       Flag this as having duplicate values. */
+    if (strpos($request_headers[$header], ",") !== false) {
+        echo $header . "=dup ";
+    } else {
+        echo $header . "=found ";
+    }
   }
 }
 

--- a/tests/integration/external/file_get_contents/test_dt_context_provided.php
+++ b/tests/integration/external/file_get_contents/test_dt_context_provided.php
@@ -22,6 +22,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
 traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
 traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
 traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
+traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
 traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found tracing endpoint reached
 traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found tracing endpoint reached
 traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found tracing endpoint reached
@@ -39,11 +40,11 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? start time",
   "?? stop time",
   [
-    [{"name":"External/all"},                             [12, "??", "??", "??", "??", "??"]],
-    [{"name":"External/allOther"},                        [12, "??", "??", "??", "??", "??"]],
-    [{"name":"External/127.0.0.1/all"},                   [12, "??", "??", "??", "??", "??"]],
+    [{"name":"External/all"},                             [13, "??", "??", "??", "??", "??"]],
+    [{"name":"External/allOther"},                        [13, "??", "??", "??", "??", "??"]],
+    [{"name":"External/127.0.0.1/all"},                   [13, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 
-      "scope":"OtherTransaction/php__FILE__"},            [12, "??", "??", "??", "??", "??"]],
+      "scope":"OtherTransaction/php__FILE__"},            [13, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                     [ 1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},             [ 1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [ 1, "??", "??", "??", "??", "??"]],
@@ -53,9 +54,9 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, 
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/TraceContext/Create/Success"},    
-							  [12, "??", "??", "??", "??", "??"]],
+							  [13, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/CreatePayload/Success"}, 
-                                                          [12, "??", "??", "??", "??", "??"]]
+                                                          [13, "??", "??", "??", "??", "??"]]
   ]
 ]
 */
@@ -72,6 +73,9 @@ echo file_get_contents($url, false, $context);
 /* Context Empty Array Options. */
 $opts = array();
 $context = stream_context_create($opts);
+echo file_get_contents($url, false, $context);
+
+/* Reuse Existing Context (headers should not be duplicated). */
 echo file_get_contents($url, false, $context);
 
 /* Context Without ['http'] */


### PR DESCRIPTION
This PR prevents a build up of Distributed Tracing headers from being added to a request when using `file_get_contents` and reusing the stream context parameter.

It does this by:
* Modifying the test trace endpoint to detect if there is more than one value for a distributed tracing header
* Adding a scenario that reuses the stream context when calling `file_get_contents`, this triggers the modified detection logic in the trace endpoint
* Updating `nr_php_file_get_contents_add_headers_internal` to detect if one of the DT headers are present in both the existing headers string and the headers that are about to be added. This change assumes that all of the DT headers are added as a group and that detecting one of them is sufficient.

The flow goes roughly like this:
* `nr_php_file_get_contents_create_outbound_headers` calls `nr_header_create_outbound_request_create`. The resulting headers are converted to a string.
* The headers string is passed by `nr_php_file_get_contents_add_headers` to `nr_php_file_get_contents_add_headers_internal` which concats the new headers to the existing headers.

In this flow, the existing headers are already a string. This changes attempts to reparse the existing headers to reduce overhead. The simplest approach seems to be just looking for the presence of a key phrase when determining if the DT headers are already present and are about to be added.

`W3C_TRACESTATE` was somewhat arbitrarily chosen. `NEWRELIC` can be optionally excluded via configuration so it wasn't an option. `W3C_TRACEPARENT` was the other option.

A colon is included in the searched for string to avoid matching any content in the value portion of any of the headers.