### PR TITLE
Update integration tests to run on PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 agent/configure.ac
 agent/newrelic.map
+axiom/tests
 bin/
 pkg/
 

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -2695,11 +2695,17 @@ NR_INNER_WRAPPER(curl_multi_exec) {
   int zcaught = 0;
   zval* curlres = NULL;
   zend_long still_running;
+  int rv = FAILURE;
 
-  if (SUCCESS
-      != zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "rl", &curlres,
-                                  &still_running)) {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  rv = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC,
+                           "ol", &curlres, &still_running);
+#else
+  rv = zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC,
+                           "rl", &curlres, &still_running);
+#endif /* PHP 8.0+ */
+
+  if (SUCCESS != rv) {
     goto leave;
   }
 
@@ -2719,8 +2725,13 @@ NR_INNER_WRAPPER(curl_multi_exec) {
    * to clean up any curl handles for which no request could be made and
    * which are still lingering.
    */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC,
+                           "ol", &curlres, &still_running);
+#else
   zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC,
                            "rl", &curlres, &still_running);
+#endif /* PHP 8.0+ */
 
   if (0 == still_running) {
     nr_php_curl_multi_exec_finalize(curlres TSRMLS_CC);

--- a/tests/integration/api/add_custom_parameter/test_bad_input.php
+++ b/tests/integration/api/add_custom_parameter/test_bad_input.php
@@ -48,8 +48,16 @@ function test_add_custom_parameter() {
   $result = @newrelic_add_custom_parameter("key1");
   tap_refute($result, "should reject one arg");
 
-  $result = @newrelic_add_custom_parameter("key2", "value", "bad");
-  tap_refute($result, "should reject more than two args");
+  /*
+   * In PHP 8.0 this now throws an ArgumentCountError instead of a warning.
+   * Lets catch the error and move on to allow for backwards compatibility.
+   */
+  try {
+    $result = @newrelic_add_custom_parameter("key2", "value", "bad");
+    tap_refute($result, "should reject more than two args");
+  } catch (\ArgumentCountError $e) {
+    echo 'ok - should reject more than two args',"\n";
+  }
 
   $result = @newrelic_add_custom_parameter("key3", INF);
   tap_refute($result, "should reject infinity");

--- a/tests/integration/api/add_custom_parameter/test_key_conversions.php
+++ b/tests/integration/api/add_custom_parameter/test_key_conversions.php
@@ -46,14 +46,14 @@ newrelic.cross_application_tracer.enabled = 0
 class MyClass {}
 
 function test_add_custom_parameters() {
-  newrelic_add_custom_parameter(array(),       "IS_ARRAY");
-  newrelic_add_custom_parameter(true,          "IS_BOOL");
-  newrelic_add_custom_parameter(42.0,          "IS_DOUBLE");
-  newrelic_add_custom_parameter(42,            "IS_LONG");
-  newrelic_add_custom_parameter(null,          "IS_NULL");
-  newrelic_add_custom_parameter(new MyClass(), "IS_OBJECT");
-  newrelic_add_custom_parameter(curl_init(),   "IS_RESOURCE");
-  newrelic_add_custom_parameter("foo",         "IS_STRING");
+  newrelic_add_custom_parameter(array(),                  "IS_ARRAY");
+  newrelic_add_custom_parameter(true,                     "IS_BOOL");
+  newrelic_add_custom_parameter(42.0,                     "IS_DOUBLE");
+  newrelic_add_custom_parameter(42,                       "IS_LONG");
+  newrelic_add_custom_parameter(null,                     "IS_NULL");
+  newrelic_add_custom_parameter(new MyClass(),            "IS_OBJECT");
+  newrelic_add_custom_parameter(fopen('php://temp', 'r'), "IS_RESOURCE");
+  newrelic_add_custom_parameter("foo",                    "IS_STRING");
 }
 
 test_add_custom_parameters();

--- a/tests/integration/api/add_custom_parameter/test_value_conversions.php
+++ b/tests/integration/api/add_custom_parameter/test_value_conversions.php
@@ -58,7 +58,7 @@ function test_add_custom_parameters() {
   newrelic_add_custom_parameter("IS_LONG", 42);
   newrelic_add_custom_parameter("IS_NULL", null);
   newrelic_add_custom_parameter("IS_OBJECT", new MyClass());
-  newrelic_add_custom_parameter("IS_RESOURCE", curl_init());
+  newrelic_add_custom_parameter("IS_RESOURCE", fopen('php://temp', 'r'));
   newrelic_add_custom_parameter("IS_STRING", "foo");
 }
 

--- a/tests/integration/api/custom_metric/test_bad_input.php8.php
+++ b/tests/integration/api/custom_metric/test_bad_input.php8.php
@@ -11,8 +11,8 @@ and no metric should be added.
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
@@ -49,14 +49,28 @@ tap_refute($result, 'should reject zero args');
 $result = @newrelic_custom_metric('Custom/Metric');
 tap_refute($result, 'should reject one arg');
 
-$result = @newrelic_custom_metric(array(), 1.0);
-tap_refute($result, 'should reject non-string name');
+/*
+ * In PHP 8, internal function parameters have types and value validations enforced and will now
+ * throw TypeError exceptions if the expected type or value is not allowed. Prior to PHP 8, this
+ * only resulted in a PHP warning.
+ */
+try {
+  @newrelic_custom_metric(array(), 1.0);
+} catch (TypeError $e) {
+  echo 'ok - should reject non-string name',"\n";
+}
 
-$result = @newrelic_custom_metric('Custom/Metric', 'bad');
-tap_refute($result, 'should reject non-numeric value (string)');
+try {
+  @newrelic_custom_metric('Custom/Metric', 'bad');
+} catch (TypeError $e) {
+  echo 'ok - should reject non-numeric value (string)',"\n";
+}
 
-$result = @newrelic_custom_metric('Custom/Metric', array());
-tap_refute($result, 'should reject non-numeric value (array)');
+try {
+  @newrelic_custom_metric('Custom/Metric', array());
+} catch (TypeError $e) {
+  echo 'ok - should reject non-numeric value (array)',"\n";
+}
 
 $result = @newrelic_custom_metric('Custom/Metric', INF);
 tap_refute($result, 'should reject infinity');

--- a/tests/integration/api/distributed_trace/newrelic/test_accept_after_create.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_accept_after_create.php
@@ -9,6 +9,7 @@ same transaction after a call to newrelic_create_distributed_trace_payload.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_accept_distributed_trace.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_accept_distributed_trace.php
@@ -8,6 +8,10 @@
 Tests that our new API functions are added correctly.
 */
 
+/*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+*/
+
 /*EXPECT
 ok - newrelic_accept_distributed_trace_payload exists
 ok - newrelic_accept_distributed_trace_payload_httpsafe exists

--- a/tests/integration/api/distributed_trace/newrelic/test_accept_distributed_trace_noarg.php8.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_accept_distributed_trace_noarg.php8.php
@@ -5,33 +5,34 @@
  */
 
 /*DESCRIPTION
-Tests that the API function warns when params are missing.
+Tests that the API function throws an exception when params are missing.
+Prior to PHP 8 this was a warning.
 */
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">=")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 display_errors=1
 log_errors=0
 */
 
 /*EXPECT
-Warning Detected
-Warning Detected
+Error Detected
+Error Detected
 */
 
 $functions = array('newrelic_accept_distributed_trace_payload','newrelic_accept_distributed_trace_payload_httpsafe');
 foreach($functions as $function) {
     ob_start();
-    $function();
-    $contents = ob_get_clean();
-    if(strpos($contents, 'Warning:') !== false)
-    {
-        echo 'Warning Detected',"\n";
+    try {
+      $function();
+    } catch (ArgumentCountError $e) {
+      echo 'Error Detected',"\n";
     }
 }

--- a/tests/integration/api/distributed_trace/newrelic/test_accept_intrinsics.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_accept_intrinsics.php
@@ -10,13 +10,14 @@ Test that a version 0.1 payload is accepted.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability_trusted"])
+if (!isset($_ENV["ACCOUNT_supportability_trusted"]))
 {
     die("skip: env vars required");
 }
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_accept_no_txn.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_accept_no_txn.php
@@ -10,6 +10,7 @@ the transaction has ended.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_accept_version_0.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_accept_version_0.php
@@ -4,11 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/*SKIPIF
+<?php
+if (!isset($_ENV["ACCOUNT_supportability_trusted"]))
+{
+  die("skip: env vars required");
+}
+*/
+
 /*DESCRIPTION
 Test that a version 0.0 payload is accepted.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_accept_version_1.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_accept_version_1.php
@@ -4,11 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/*SKIPIF
+<?php
+if (!isset($_ENV["ACCOUNT_supportability_trusted"]))
+{
+  die("skip: env vars required");
+}
+*/
+
 /*DESCRIPTION
 Test that a version 0.1 payload is accepted.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_accept_version_2.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_accept_version_2.php
@@ -4,11 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/*SKIPIF
+<?php
+if (!isset($_ENV["ACCOUNT_supportability_trusted"]))
+{
+  die("skip: env vars required");
+}
+*/
+
 /*DESCRIPTION
 Test that a version 0.2 payload is accepted.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_create_intrinsics.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_intrinsics.php
@@ -9,6 +9,7 @@ Test that a version 0.2 payload is created.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_create_payload_span_events_disabled.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_payload_span_events_disabled.php
@@ -10,6 +10,7 @@ payload if span_events_enabled=0
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 newrelic.span_events_enabled=0
 newrelic.transaction_events.enabled = 0

--- a/tests/integration/api/distributed_trace/newrelic/test_create_transaction_off_span_on_cat_off.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_transaction_off_span_on_cat_off.php
@@ -11,6 +11,7 @@ that a distributed trace payload is still created.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 newrelic.span_events_enabled=1
 newrelic.transaction_events.enabled=0

--- a/tests/integration/api/distributed_trace/newrelic/test_create_transaction_off_span_on_cat_on.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_transaction_off_span_on_cat_on.php
@@ -11,6 +11,7 @@ that a distributed trace payload is still created.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 newrelic.span_events_enabled=1
 newrelic.transaction_events.enabled=0

--- a/tests/integration/api/distributed_trace/newrelic/test_disabled_accept.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_disabled_accept.php
@@ -10,6 +10,7 @@ when distributed tracing is disabled.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=0
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_disabled_create.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_disabled_create.php
@@ -10,6 +10,7 @@ when distributed tracing is disabled.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=0
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_enabled.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_enabled.php
@@ -10,6 +10,7 @@ when distributed tracing is enabled.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/distributed_trace/newrelic/test_keep_span_with_payload.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_keep_span_with_payload.php
@@ -10,6 +10,7 @@ the segment is kept when sampling the segment tree.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.detail = 1
 newrelic.transaction_tracer.threshold = 0

--- a/tests/integration/api/distributed_trace/newrelic/test_recording_disabled.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_recording_disabled.php
@@ -9,6 +9,7 @@ when recording is stopped.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 */
 

--- a/tests/integration/api/enable_params/test_enable_6.php
+++ b/tests/integration/api/enable_params/test_enable_6.php
@@ -6,7 +6,16 @@
 
 /*DESCRIPTION
 Calling newrelic_enable_params() with an argument that is neither a boolean nor
-an integer enables the recording of request parameters.
+an integer enables the recording of request parameters. This test is skipped on
+PHP 8+ because invalid arguments now throw a TypeError instead of a warning. Since
+this causes test execution to stop, it invalidates the test on PHP 8+ versions.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
 */
 
 /*ENVIRONMENT

--- a/tests/integration/api/metadata/test_linking_metadata_dt.php
+++ b/tests/integration/api/metadata/test_linking_metadata_dt.php
@@ -10,6 +10,7 @@ when DT is enabled.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
 */

--- a/tests/integration/api/metadata/test_linking_metadata_invalid.php8.php
+++ b/tests/integration/api/metadata/test_linking_metadata_invalid.php8.php
@@ -8,10 +8,11 @@
 Test that no linking metadata is returned when invalid arguments are given.
 */
 
+
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
@@ -20,8 +21,7 @@ newrelic.distributed_tracing_enabled = false
  */
 
 /*EXPECT_REGEX
-.*Warning.*newrelic_get_linking_metadata\(\) expects exactly 0 parameters, 1 given.*
-ok - empty metadata
+^\s*(PHP )?Fatal error:.*Uncaught ArgumentCountError:.*newrelic_get_linking_metadata\(\) expects exactly 0 arguments, 1 given.*
 */
 
 /*EXPECT_METRICS
@@ -44,6 +44,4 @@ ok - empty metadata
 
 require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
 
-$metadata = newrelic_get_linking_metadata("arg");
-
-tap_equal(array(), $metadata, 'empty metadata');
+tap_equal(array(), newrelic_get_linking_metadata("arg"), 'empty metadata');

--- a/tests/integration/api/metadata/test_trace_metadata_dt.php
+++ b/tests/integration/api/metadata/test_trace_metadata_dt.php
@@ -10,6 +10,7 @@ when Distributed Tracing (DT) is enabled.
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
 */

--- a/tests/integration/api/metadata/test_trace_metadata_invalid.php8.php
+++ b/tests/integration/api/metadata/test_trace_metadata_invalid.php8.php
@@ -3,24 +3,24 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 /*DESCRIPTION
 Test that no trace metadata is returned when invalid arguments are given.
 */
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
 /*INI
 newrelic.distributed_tracing_enabled = true
- */
+*/
 
 /*EXPECT_REGEX
-.*Warning.*newrelic_get_trace_metadata\(\) expects exactly 0 parameters, 1 given.*
-ok - empty metadata
+^\s*(PHP )?Fatal error:.*Uncaught ArgumentCountError:.*newrelic_get_trace_metadata\(\) expects exactly 0 arguments, 1 given.*
 */
 
 /*EXPECT_METRICS

--- a/tests/integration/api/notice_error/test_uncaught_is_ultimate.php
+++ b/tests/integration/api/notice_error/test_uncaught_is_ultimate.php
@@ -60,7 +60,7 @@ newrelic.error_collector.prioritize_api_errors = true
 ]
 */
 
-function nop_error_handler($errno, $errstr, $errfile, $errline, array $errctx)
+function nop_error_handler($errno, $errstr, $errfile, $errline)
 {
     /*
      * Nothing to do. This is only here to prevent early termination

--- a/tests/integration/api/other/test_is_sampled_extra_param.php
+++ b/tests/integration/api/other/test_is_sampled_extra_param.php
@@ -6,7 +6,14 @@
 
 /*DESCRIPTION
 Test that newrelic_is_sampled() returns true when DT is enabled and it is the sole txn
- */
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
+*/
 
 /*INI
 newrelic.distributed_tracing_enabled = true

--- a/tests/integration/api/other/test_is_sampled_extra_param.php8.php
+++ b/tests/integration/api/other/test_is_sampled_extra_param.php8.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that newrelic_is_sampled() returns an error when invalid arguments are given
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? start time",
+  "?? stop time",
+  [
+		[{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+																											[1, "??", "??", "??", "??", "??"]],
+		[{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+																											[1, "??", "??", "??", "??", "??"]],
+		[{"name": "Errors/OtherTransaction/php__FILE__"},	[1, "??", "??", "??", "??", "??"]],
+	  [{"name": "Errors/all"}, 													[1, "??", "??", "??", "??", "??"]],
+		[{"name": "Errors/allOther"},											[1, "??", "??", "??", "??", "??"]],
+		[{"name": "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+																											[1, "??", "??", "??", "??", "??"]],
+		[{"name": "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+																											[1, "??", "??", "??", "??", "??"]],
+		[{"name":"OtherTransaction/all"},									[1, "??", "??", "??", "??", "??"]],
+		[{"name":"OtherTransaction/php__FILE__"},					[1, "??", "??", "??", "??", "??"]],
+		[{"name":"OtherTransactionTotalTime"},						[1, "??", "??", "??", "??", "??"]],
+		[{"name":"OtherTransactionTotalTime/php__FILE__"},[1, "??", "??", "??", "??", "??"]],
+		[{"name":"Supportability/api/is_sampled"},				[2, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*(PHP )?Fatal error:.*Uncaught ArgumentCountError:.*newrelic_is_sampled\(\) expects exactly 0 arguments, 1 given.*
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+tap_not_equal(newrelic_is_sampled(), newrelic_is_sampled("foo!"),
+							"newrelic_is_sampled() unaffected by inclusion of parameter in call");

--- a/tests/integration/api/rum/test_bad_input_1.php
+++ b/tests/integration/api/rum/test_bad_input_1.php
@@ -6,7 +6,16 @@
 
 /*DESCRIPTION
 The agent treats bad input to newrelic_get_browser_timing_header() the same as
-newrelic_get_browser_timing_header(true).
+newrelic_get_browser_timing_header(true). This is skipped on PHP version 8+ because
+this will now throw an TypeError instead of a warning. Since that is a fatal error,
+this test is invalid and not needed in php 8+.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
 */
 
 /*EXPECT

--- a/tests/integration/api/rum/test_bad_input_2.php
+++ b/tests/integration/api/rum/test_bad_input_2.php
@@ -6,7 +6,16 @@
 
 /*DESCRIPTION
 The agent treats bad input to newrelic_get_browser_timing_footer() the same as
-newrelic_get_browser_timing_footer(true).
+newrelic_get_browser_timing_footer(true). This is skipped on PHP 8+ because this
+will now throw an TypeError instead of a warning. Since that is a fatal error,
+this test is invalid and not needed in php 8+.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
 */
 
 /*EXPECT

--- a/tests/integration/api/rum/test_too_many_args_1.php
+++ b/tests/integration/api/rum/test_too_many_args_1.php
@@ -5,9 +5,17 @@
  */
 
 /*DESCRIPTION
-The agent treats passing too many parameters to
-newrelic_get_browser_timing_header() the same as
-newrelic_get_browser_timing_header(true).
+The agent treats passing too many parameters to newrelic_get_browser_timing_header()
+the same as newrelic_get_browser_timing_header(true). This is skipped on PHP 8+
+because this will now throw an ArgumentCountError instead of a warning. Since
+that is a fatal error, this test is invalid and not needed in php 8+.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
 */
 
 /*EXPECT

--- a/tests/integration/api/rum/test_too_many_args_2.php
+++ b/tests/integration/api/rum/test_too_many_args_2.php
@@ -5,9 +5,17 @@
  */
 
 /*DESCRIPTION
-The agent treats passing too many parameters to
-newrelic_get_browser_timing_footer() the same as
-newrelic_get_browser_timing_footer(true).
+The agent treats passing too many parameters to newrelic_get_browser_timing_footer()
+the same as newrelic_get_browser_timing_footer(true). This is skipped on PHP 8+
+because this will now throw an ArgumentCountError instead of a warning. Since
+that is a fatal error, this test is invalid and not needed in php 8+.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
 */
 
 /*EXPECT

--- a/tests/integration/api/set_appname/test_bad_params.php
+++ b/tests/integration/api/set_appname/test_bad_params.php
@@ -8,6 +8,13 @@
 Test that newrelic_set_appname returns false when given bad parameters.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
+*/
+
 /*EXPECT_REGEX
 .*Warning:.*newrelic_set_appname\(\) expects at least 1 parameter, 0 given.*
 ok - newrelic_set_appname no params

--- a/tests/integration/api/set_appname/test_bad_params.php8.php
+++ b/tests/integration/api/set_appname/test_bad_params.php8.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that newrelic_set_appname with bad parameters.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
+}
+*/
+
+/*EXPECT
+newrelic_set_appname no params
+newrelic_set_appname bad appname
+newrelic_set_appname bad license
+newrelic_set_appname bad transmit
+newrelic_set_appname too many params
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name":"OtherTransaction/all"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name":"see_me"},                                 [1, 1, 1, 1, 1, 1]],
+    [{"name":"Supportability/api/custom_metric"},       [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/api/set_appname/before"},  [5, 0, 0, 0, 0, 0]]
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+
+$appname = ini_get("newrelic.appname");
+$license = ini_get("newrelic.license");
+
+newrelic_custom_metric('see_me', 1e+3);
+
+try {
+  newrelic_set_appname();
+} catch (ArgumentCountError $e) {
+  echo 'newrelic_set_appname no params',"\n";
+}
+
+try {
+  $result = @newrelic_set_appname(array());
+} catch (TypeError $e) {
+  echo 'newrelic_set_appname bad appname',"\n";
+}
+
+try {
+  @newrelic_set_appname($appname, array());
+} catch (TypeError $e) {
+  echo 'newrelic_set_appname bad license',"\n";
+}
+
+try {
+  @newrelic_set_appname($appname, $license, array());
+} catch (TypeError $e) {
+  echo 'newrelic_set_appname bad transmit',"\n";
+}
+
+try {
+  @newrelic_set_appname($appname, $license, true, 1);
+} catch (ArgumentCountError $e) {
+  echo 'newrelic_set_appname too many params',"\n";
+}

--- a/tests/integration/distributed_tracing/newrelic/test_inbound_payload_rejects_if_no_tx_or_id.php
+++ b/tests/integration/distributed_tracing/newrelic/test_inbound_payload_rejects_if_no_tx_or_id.php
@@ -12,12 +12,13 @@ the payload is rejected for this reason.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability_trusted"]) {
+if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
     die("skip: env vars required");
 }
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 */

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_majorVersion.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_majorVersion.php
@@ -13,12 +13,13 @@ by sending in a payload with a major version that is larger:
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability_trusted"]) {
+if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
     die("skip: env vars required");
 }
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 */

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_multiple.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_multiple.php
@@ -12,12 +12,13 @@ by calling newrelic_accept_distributed_trace_payload twice.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["ACCOUNT_supportability_trusted"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["ACCOUNT_supportability_trusted"])) {
     die("skip: env vars required");
 }
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 */

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_untrustedAccount.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_untrustedAccount.php
@@ -10,6 +10,7 @@ by changing the trusted key to an incorrect key "tk":"12345"
  */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 */

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_untrustedAccount_httpsafe.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_untrustedAccount_httpsafe.php
@@ -11,6 +11,7 @@ by changing the trusted key to an incorrect key "tk":"12345"
  */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 */

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_parseexception.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_parseexception.php
@@ -10,6 +10,7 @@ by removing information from the payload, in this case "ty":"App".
  */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 */

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_success.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_success.php
@@ -11,12 +11,13 @@ when the payload is correct.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 */

--- a/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_wrong_arg_type.php
+++ b/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_wrong_arg_type.php
@@ -8,6 +8,13 @@
 Tests that non-array arguments are gracefully rejected
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",

--- a/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_wrong_arg_type.php8.php
+++ b/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_wrong_arg_type.php8.php
@@ -5,7 +5,14 @@
  */
 
 /*DESCRIPTION
-Tests that non-reference arguments are rejected without segfault.
+Tests that non-array arguments are cause an error
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
+}
 */
 
 /*EXPECT_METRICS
@@ -20,13 +27,18 @@ Tests that non-reference arguments are rejected without segfault.
     [{"name":"OtherTransaction/all"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]]
+    [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/api/insert_distributed_trace_headers"},
+                                                          [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Fatal error:.*passed by reference.*
+^\s*(PHP )?Fatal error:.*Uncaught TypeError:.*newrelic_insert_distributed_trace_headers\(\).*
 */
 
-newrelic_insert_distributed_trace_headers("howdy");
+require_once(realpath (dirname ( __FILE__ )) . '/../../../include/tap.php');
+
+$string_arg = "howdy";
+tap_assert(!newrelic_insert_distributed_trace_headers($string_arg), 'rejected non-array argument');

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_headers.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_headers.php
@@ -11,7 +11,7 @@ when the payload is correct.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability_trusted"]) {
+if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_headers_parsed_key.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_headers_parsed_key.php
@@ -11,7 +11,7 @@ when the payload is correct.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability_trusted"]) {
+if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_no_sampled.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_no_sampled.php
@@ -11,7 +11,7 @@ correctly.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability_trusted"]) {
+if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_non_newrelic.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_non_newrelic.php
@@ -10,7 +10,7 @@ Tests that a trace context header parses other vendors correctly.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability_trusted"]) {
+if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/errors/test_E_COMPILE_WARNING.php8.php
+++ b/tests/integration/errors/test_E_COMPILE_WARNING.php8.php
@@ -10,8 +10,8 @@ The agent should capture compile warnings.
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
@@ -21,7 +21,7 @@ log_errors=0
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Warning:\s*Unterminated comment starting line [0-9]+ in .*? on line [0-9]+\s*$
+^\s*(PHP )?Warning:\s*Private methods cannot be final as they are never overridden by other classes
 */
 
 /*EXPECT_TRACED_ERRORS
@@ -31,7 +31,7 @@ log_errors=0
     [
       "?? when",
       "OtherTransaction/php__FILE__",
-      "Unterminated comment starting line ??",
+      "Private methods cannot be final as they are never overridden by other classes",
       "E_COMPILE_WARNING",
       {
         "stack_trace": [],
@@ -56,7 +56,7 @@ log_errors=0
         "type": "TransactionError",
         "timestamp": "??",
         "error.class": "E_COMPILE_WARNING",
-        "error.message": "Unterminated comment starting line ??",
+        "error.message": "Private methods cannot be final as they are never overridden by other classes",
         "transactionName": "OtherTransaction\/php__FILE__",
         "duration": "??",
         "nr.transactionGuid": "??"
@@ -67,6 +67,8 @@ log_errors=0
   ]
 ]
 */
-
-/*
-unterminated comment
+class Foo {
+  final private static function compileWarning(){
+    echo 'Compile warning',"\n";
+  }
+}

--- a/tests/integration/errors/test_E_DEPRECATED_2.php7.php
+++ b/tests/integration/errors/test_E_DEPRECATED_2.php7.php
@@ -13,6 +13,9 @@ The agent should capture and report deprecation warnings.
 if (version_compare(PHP_VERSION, "7.0", "<")) {
   die("skip: PHP 5 not supported\n");
 }
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
 */
 
 /*INI

--- a/tests/integration/errors/test_E_DEPRECATED_2.php8.php
+++ b/tests/integration/errors/test_E_DEPRECATED_2.php8.php
@@ -5,23 +5,24 @@
  */
 
 /*DESCRIPTION
-The agent should capture compile warnings.
+The agent should capture and report deprecation warnings.
 */
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
 /*INI
+error_reporting = E_ALL | E_STRICT
 display_errors=1
 log_errors=0
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Warning:\s*Unterminated comment starting line [0-9]+ in .*? on line [0-9]+\s*$
+^\s*(PHP )?Deprecated: Required parameter \$b follows optional parameter \$a in .*? on line [0-9]+\s*$
 */
 
 /*EXPECT_TRACED_ERRORS
@@ -31,10 +32,10 @@ log_errors=0
     [
       "?? when",
       "OtherTransaction/php__FILE__",
-      "Unterminated comment starting line ??",
-      "E_COMPILE_WARNING",
+      "Required parameter $b follows optional parameter $a",
+      "Error",
       {
-        "stack_trace": [],
+        "stack_trace": "??",
         "agentAttributes": "??",
         "intrinsics": "??"
       }
@@ -55,8 +56,8 @@ log_errors=0
       {
         "type": "TransactionError",
         "timestamp": "??",
-        "error.class": "E_COMPILE_WARNING",
-        "error.message": "Unterminated comment starting line ??",
+        "error.class": "Error",
+        "error.message": "Required parameter $b follows optional parameter $a",
         "transactionName": "OtherTransaction\/php__FILE__",
         "duration": "??",
         "nr.transactionGuid": "??"
@@ -68,5 +69,6 @@ log_errors=0
 ]
 */
 
-/*
-unterminated comment
+function test($a = [], $b) {
+  echo "Deprecated";
+}

--- a/tests/integration/errors/test_E_PARSE.zend.php
+++ b/tests/integration/errors/test_E_PARSE.zend.php
@@ -8,6 +8,13 @@
 The agent should capture and report parse errors.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
+*/
+
 /*INI
 display_errors=1
 log_errors=0

--- a/tests/integration/errors/test_E_PARSE.zend.php8.php
+++ b/tests/integration/errors/test_E_PARSE.zend.php8.php
@@ -5,13 +5,13 @@
  */
 
 /*DESCRIPTION
-The agent should capture compile warnings.
+The agent should capture and report parse errors.
 */
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
@@ -21,7 +21,7 @@ log_errors=0
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Warning:\s*Unterminated comment starting line [0-9]+ in .*? on line [0-9]+\s*$
+^\s*(PHP )?Parse error:\s*syntax error, unexpected token \"\}\" in .*? on line [0-9]+\s*$
 */
 
 /*EXPECT_TRACED_ERRORS
@@ -31,8 +31,8 @@ log_errors=0
     [
       "?? when",
       "OtherTransaction/php__FILE__",
-      "Unterminated comment starting line ??",
-      "E_COMPILE_WARNING",
+      "syntax error, unexpected token \"}\"",
+      "Error",
       {
         "stack_trace": [],
         "agentAttributes": "??",
@@ -55,8 +55,8 @@ log_errors=0
       {
         "type": "TransactionError",
         "timestamp": "??",
-        "error.class": "E_COMPILE_WARNING",
-        "error.message": "Unterminated comment starting line ??",
+        "error.class": "Error",
+        "error.message": "syntax error, unexpected token \"}\"",
         "transactionName": "OtherTransaction\/php__FILE__",
         "duration": "??",
         "nr.transactionGuid": "??"
@@ -68,5 +68,6 @@ log_errors=0
 ]
 */
 
-/*
-unterminated comment
+if (2 == 2) {
+  lacks_semicolon()
+}

--- a/tests/integration/errors/test_E_WARNING.php7.php
+++ b/tests/integration/errors/test_E_WARNING.php7.php
@@ -13,6 +13,9 @@ The agent should capture and report runtime warnings along with a stack trace.
 if (version_compare(PHP_VERSION, "7.0", "<")) {
   die("skip: PHP 5 not supported\n");
 }
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
 */
 
 /*INI

--- a/tests/integration/errors/test_E_WARNING.php8.php
+++ b/tests/integration/errors/test_E_WARNING.php8.php
@@ -5,13 +5,13 @@
  */
 
 /*DESCRIPTION
-The agent should capture compile warnings.
+The agent should capture and report runtime warnings along with a stack trace.
 */
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
@@ -21,7 +21,7 @@ log_errors=0
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Warning:\s*Unterminated comment starting line [0-9]+ in .*? on line [0-9]+\s*$
+^\s*(PHP )?Warning:\s*include\(abc.php\): Failed to open stream.*
 */
 
 /*EXPECT_TRACED_ERRORS
@@ -31,10 +31,10 @@ log_errors=0
     [
       "?? when",
       "OtherTransaction/php__FILE__",
-      "Unterminated comment starting line ??",
-      "E_COMPILE_WARNING",
+      "include(): Failed opening 'abc.php' for inclusion (include_path='.:')",
+      "E_WARNING",
       {
-        "stack_trace": [],
+        "stack_trace": "??",
         "agentAttributes": "??",
         "intrinsics": "??"
       }
@@ -55,8 +55,8 @@ log_errors=0
       {
         "type": "TransactionError",
         "timestamp": "??",
-        "error.class": "E_COMPILE_WARNING",
-        "error.message": "Unterminated comment starting line ??",
+        "error.class": "E_WARNING",
+        "error.message": "include(): Failed opening 'abc.php' for inclusion (include_path='.:')",
         "transactionName": "OtherTransaction\/php__FILE__",
         "duration": "??",
         "nr.transactionGuid": "??"
@@ -68,5 +68,6 @@ log_errors=0
 ]
 */
 
-/*
-unterminated comment
+include("abc.php");
+
+echo("Let this serve as a warning");

--- a/tests/integration/errors/test_ignore_all_except_E_WARNING.php7.php
+++ b/tests/integration/errors/test_ignore_all_except_E_WARNING.php7.php
@@ -14,6 +14,9 @@ newrelic.error_collector.ignore_errors setting.
 if (version_compare(PHP_VERSION, "7.0", "<")) {
   die("skip: PHP 5 not supported\n");
 }
+if (version_compare(PHP_VERSION, "7.4", ">")) {
+  die("skip: PHP > 7.4.0 not supported\n");
+}
 */
 
 /*INI

--- a/tests/integration/errors/test_ignore_all_except_E_WARNING.php8.php
+++ b/tests/integration/errors/test_ignore_all_except_E_WARNING.php8.php
@@ -5,23 +5,26 @@
  */
 
 /*DESCRIPTION
-The agent should capture compile warnings.
+The agent should capture and report errors NOT configured via the
+newrelic.error_collector.ignore_errors setting.
 */
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "7.4", ">")) {
-  die("skip: PHP > 7.4.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
 /*INI
+error_reporting = E_ALL | E_STRICT
+newrelic.error_collector.ignore_errors = E_ALL & ~E_WARNING
 display_errors=1
 log_errors=0
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Warning:\s*Unterminated comment starting line [0-9]+ in .*? on line [0-9]+\s*$
+^\s*(PHP )?Warning:\s*include\(abc.php\): Failed to open stream.*
 */
 
 /*EXPECT_TRACED_ERRORS
@@ -31,10 +34,10 @@ log_errors=0
     [
       "?? when",
       "OtherTransaction/php__FILE__",
-      "Unterminated comment starting line ??",
-      "E_COMPILE_WARNING",
+      "include(): Failed opening 'abc.php' for inclusion (include_path='.:')",
+      "E_WARNING",
       {
-        "stack_trace": [],
+        "stack_trace": "??",
         "agentAttributes": "??",
         "intrinsics": "??"
       }
@@ -55,8 +58,8 @@ log_errors=0
       {
         "type": "TransactionError",
         "timestamp": "??",
-        "error.class": "E_COMPILE_WARNING",
-        "error.message": "Unterminated comment starting line ??",
+        "error.class": "E_WARNING",
+        "error.message": "include(): Failed opening 'abc.php' for inclusion (include_path='.:')",
         "transactionName": "OtherTransaction\/php__FILE__",
         "duration": "??",
         "nr.transactionGuid": "??"
@@ -68,5 +71,6 @@ log_errors=0
 ]
 */
 
-/*
-unterminated comment
+include("abc.php");
+
+echo("Let this serve as a warning");

--- a/tests/integration/external/curl_exec/test_cat_request_headers_empty_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_empty_array.php
@@ -15,7 +15,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_cat_request_headers_present.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_present.php
@@ -15,7 +15,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_cat_request_headers_present_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_present_array.php
@@ -15,7 +15,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_cat_request_headers_referenced_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_referenced_array.php
@@ -15,7 +15,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_cat_response_header_function.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_function.php
@@ -15,7 +15,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_cat_response_header_returned.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_returned.php
@@ -14,7 +14,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_cat_response_header_to_stdout.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_to_stdout.php
@@ -14,7 +14,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_cat_simple.php
+++ b/tests/integration/external/curl_exec/test_cat_simple.php
@@ -14,7 +14,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_missing_handle.php
+++ b/tests/integration/external/curl_exec/test_missing_handle.php
@@ -40,8 +40,8 @@ if (!extension_loaded("curl")) {
     [
       "?? timestamp",
       "OtherTransaction/php__FILE__",
-      "curl_exec() expects exactly 1 parameter, 0 given",
-      "E_WARNING",
+      "?? error message",
+      "??",
       {
         "stack_trace": "??",
         "agentAttributes": "??",

--- a/tests/integration/external/curl_exec/test_synthetics.php
+++ b/tests/integration/external/curl_exec/test_synthetics.php
@@ -11,7 +11,7 @@ the current request is from the Synthetics product.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_synthetics_disabled.php
+++ b/tests/integration/external/curl_exec/test_synthetics_disabled.php
@@ -11,7 +11,7 @@ the Synthetics feature is disabled.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_exec/test_synthetics_with_dt.php
+++ b/tests/integration/external/curl_exec/test_synthetics_with_dt.php
@@ -11,7 +11,7 @@ the current request is from the Synthetics product.
 
 /*SKIPIF
 <?php
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_multi_exec/test_cat_simple.php
+++ b/tests/integration/external/curl_multi_exec/test_cat_simple.php
@@ -14,7 +14,7 @@ if (!extension_loaded("curl")) {
   die("skip: curl extension required");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/curl_multi_exec/test_missing_arg.php
+++ b/tests/integration/external/curl_multi_exec/test_missing_arg.php
@@ -40,8 +40,8 @@ if (!extension_loaded("curl")) {
     [
       "?? timestamp",
       "OtherTransaction/php__FILE__",
-      "curl_multi_exec() expects exactly 2 parameters, 1 given",
-      "E_WARNING",
+      "?? error message",
+      "??",
       {
         "stack_trace": "??",
         "agentAttributes": "??",

--- a/tests/integration/external/file_get_contents/test_cat_and_synthetics_disabled.php
+++ b/tests/integration/external/file_get_contents/test_cat_and_synthetics_disabled.php
@@ -13,7 +13,7 @@
 
 /*SKIPIF
 <?php
-if (!$_ENV["SYNTHETIC_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETIC_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_cat_context_provided.php
+++ b/tests/integration/external/file_get_contents/test_cat_context_provided.php
@@ -11,7 +11,7 @@ call.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_cat_default_context.php
+++ b/tests/integration/external/file_get_contents/test_cat_default_context.php
@@ -11,7 +11,7 @@ through the default context.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_cat_no_context.php
+++ b/tests/integration/external/file_get_contents/test_cat_no_context.php
@@ -10,7 +10,7 @@ Test that CAT works with file_get_contents without a context.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_dt_disabled.php
+++ b/tests/integration/external/file_get_contents/test_dt_disabled.php
@@ -11,7 +11,7 @@ distributed tracing is disabled.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_http_response_header_cv.php
+++ b/tests/integration/external/file_get_contents/test_http_response_header_cv.php
@@ -11,7 +11,7 @@ variable.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_synthetics_context_provided.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_context_provided.php
@@ -22,7 +22,7 @@ the current request is a synthetics request.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_synthetics_default_context.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_default_context.php
@@ -22,7 +22,7 @@ the current request is a synthetics request.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_synthetics_disabled.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_disabled.php
@@ -26,7 +26,7 @@ newrelic.synthetics.enabled = false
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_synthetics_no_context.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_no_context.php
@@ -22,7 +22,7 @@ the current request is a synthetics request.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_synthetics_with_cat_disabled.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_with_cat_disabled.php
@@ -14,7 +14,7 @@ cross application tracing is enabled.
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/file_get_contents/test_synthetics_with_dt.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_with_dt.php
@@ -27,7 +27,7 @@ newrelic.distributed_tracing_enabled = true
 
 /*SKIPIF
 <?php
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/guzzle5/test_cat.php
+++ b/tests/integration/external/guzzle5/test_cat.php
@@ -20,7 +20,7 @@ if (!unpack_guzzle(5)) {
     die("skip: guzzle 5 installation required\n");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/guzzle5/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics.php
@@ -20,7 +20,7 @@ if (!unpack_guzzle(5)) {
     die("skip: guzzle 5 installation required\n");
 }
 
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/guzzle6/test_cat.php
+++ b/tests/integration/external/guzzle6/test_cat.php
@@ -20,7 +20,7 @@ if (!unpack_guzzle(6)) {
     die("skip: guzzle 6 installation required\n");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/guzzle6/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics.php
@@ -20,7 +20,7 @@ if (!unpack_guzzle(6)) {
     die("skip: guzzle 6 installation required\n");
 }
 
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/http/test_v1_cat.php
+++ b/tests/integration/external/http/test_v1_cat.php
@@ -20,7 +20,7 @@ if (version_compare(phpversion('http'), '2.0.0', '>=')) {
     die("skip: http 1.x required\n");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/http/test_v1_cat_and_synthetics_disabled.php
+++ b/tests/integration/external/http/test_v1_cat_and_synthetics_disabled.php
@@ -22,7 +22,7 @@ if (version_compare(phpversion('http'), '2.0.0', '>=')) {
     die("skip: http 1.x required\n");
 }
 
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/http/test_v1_synthetics.php
+++ b/tests/integration/external/http/test_v1_synthetics.php
@@ -20,7 +20,7 @@ if (version_compare(phpversion('http'), '2.0.0', '>=')) {
     die("skip: http 1.x required\n");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/http/test_v1_synthetics_disabled.php
+++ b/tests/integration/external/http/test_v1_synthetics_disabled.php
@@ -22,7 +22,7 @@ if (version_compare(phpversion('http'), '2.0.0', '>=')) {
     die("skip: http 1.x required\n");
 }
 
-if (!$_ENV["ACCOUNT_supportability"] || !$_ENV["APP_supportability"] || !$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"]) || !isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/external/http/test_v1_synthetics_with_cat_disabled.php
+++ b/tests/integration/external/http/test_v1_synthetics_with_cat_disabled.php
@@ -25,7 +25,7 @@ if (version_compare(phpversion('http'), '2.0.0', '>=')) {
     die("skip: http 1.x required\n");
 }
 
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/pdo/test_bad_input_1.php
+++ b/tests/integration/pdo/test_bad_input_1.php
@@ -19,10 +19,6 @@ display_errors=1
 log_errors=0
 */
 
-/*EXPECT_REGEX
-^\s*(PHP )?Warning:\s*PDO::exec\(\) expects exactly 1 parameter, 0 given in .*? on line [0-9]+\s*$
-*/
-
 /*EXPECT_METRICS
 [
   "?? agent run id",
@@ -54,8 +50,8 @@ log_errors=0
     [
       "?? when",
       "OtherTransaction/php__FILE__",
-      "PDO::exec() expects exactly 1 parameter, 0 given",
-      "E_WARNING",
+      "?? error message",
+      "??",
       {
         "stack_trace": [
           " in PDO::exec called at __FILE__ (??)",

--- a/tests/integration/span_events/test_span_events_exception_caught_nested_rethrown.php
+++ b/tests/integration/span_events/test_span_events_exception_caught_nested_rethrown.php
@@ -140,7 +140,7 @@ newrelic.cross_application_tracer.enabled = false
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Fatal error: Uncaught.*Exception.*Rethrown caught exception: Division by zero.*
+^\s*(PHP )?Fatal error:.*Uncaught.*Exception.*Rethrown caught exception: Division by zero.*
 */
 
 function c()

--- a/tests/integration/span_events/test_span_events_root_parent.php
+++ b/tests/integration/span_events/test_span_events_root_parent.php
@@ -11,12 +11,13 @@ value of the inbound payload as its parent id;
 
 /*SKIPIF
 <?php
-if (!$_ENV["ACCOUNT_supportability_trusted"]) {
+if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
     die("skip: env vars required");
 }
 */
 
 /*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled=1
 newrelic.transaction_tracer.threshold = 0
 newrelic.cross_application_tracer.enabled = false

--- a/tests/integration/sqlite/test_bad_input_1.php
+++ b/tests/integration/sqlite/test_bad_input_1.php
@@ -45,7 +45,7 @@ arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in sqlite_query called at __FILE__ (??)",

--- a/tests/integration/sqlite/test_bad_input_2.php
+++ b/tests/integration/sqlite/test_bad_input_2.php
@@ -45,7 +45,7 @@ arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in sqlite_exec called at __FILE__ (??)",

--- a/tests/integration/sqlite/test_bad_input_3.php
+++ b/tests/integration/sqlite/test_bad_input_3.php
@@ -45,7 +45,7 @@ with the wrong arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in sqlite_query called at __FILE__ (??)",

--- a/tests/integration/sqlite/test_bad_input_4.php
+++ b/tests/integration/sqlite/test_bad_input_4.php
@@ -45,7 +45,7 @@ with the wrong arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in sqlite_unbuffered_query called at __FILE__ (??)",

--- a/tests/integration/sqlite/test_bad_input_5.php
+++ b/tests/integration/sqlite/test_bad_input_5.php
@@ -45,7 +45,7 @@ with the wrong argument types.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in sqlite_unbuffered_query called at __FILE__ (??)",

--- a/tests/integration/sqlite3/test_bad_input_1.php
+++ b/tests/integration/sqlite3/test_bad_input_1.php
@@ -45,7 +45,7 @@ arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in SQLite3::query called at __FILE__ (??)",

--- a/tests/integration/sqlite3/test_bad_input_2.php
+++ b/tests/integration/sqlite3/test_bad_input_2.php
@@ -45,7 +45,7 @@ arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in SQLite3::query called at __FILE__ (??)",

--- a/tests/integration/sqlite3/test_bad_input_3.php
+++ b/tests/integration/sqlite3/test_bad_input_3.php
@@ -45,7 +45,7 @@ arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           "\/ in SQLite3::query[sS]ingle called at .*\/",

--- a/tests/integration/sqlite3/test_bad_input_4.php
+++ b/tests/integration/sqlite3/test_bad_input_4.php
@@ -45,7 +45,7 @@ arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           "\/ in SQLite3::query[sS]ingle called at .*\/",

--- a/tests/integration/sqlite3/test_bad_input_5.php
+++ b/tests/integration/sqlite3/test_bad_input_5.php
@@ -45,7 +45,7 @@ arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in SQLite3::exec called at __FILE__ (??)",

--- a/tests/integration/sqlitedatabase/test_bad_input_1.php
+++ b/tests/integration/sqlitedatabase/test_bad_input_1.php
@@ -45,7 +45,7 @@ receiving the wrong arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in SQLiteDatabase::query called at __FILE__ (??)",

--- a/tests/integration/sqlitedatabase/test_bad_input_2.php
+++ b/tests/integration/sqlitedatabase/test_bad_input_2.php
@@ -45,7 +45,7 @@ wrong arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in SQLiteDatabase::queryExec called at __FILE__ (??)",

--- a/tests/integration/sqlitedatabase/test_bad_input_3.php
+++ b/tests/integration/sqlitedatabase/test_bad_input_3.php
@@ -45,7 +45,7 @@ the wrong arguments.
       "?? when",
       "OtherTransaction/php__FILE__",
       "?? error message",
-      "E_WARNING",
+      "??",
       {
         "stack_trace": [
           " in SQLiteDatabase::unbufferedQuery called at __FILE__ (??)",

--- a/tests/integration/synthetics/test_happy_path.php
+++ b/tests/integration/synthetics/test_happy_path.php
@@ -24,7 +24,7 @@ trace threshold. This has to happen when both CAT and DT are disabled.
 
 /*SKIPIF
 <?php
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/synthetics/test_happy_path_with_cat.php
+++ b/tests/integration/synthetics/test_happy_path_with_cat.php
@@ -24,7 +24,7 @@ trace threshold. Synthetics attributes should be added when CAT is enabled.
 
 /*SKIPIF
 <?php
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/integration/synthetics/test_happy_path_with_dt.php
+++ b/tests/integration/synthetics/test_happy_path_with_dt.php
@@ -25,7 +25,7 @@ be added.
 
 /*SKIPIF
 <?php
-if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
+if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
     die("skip: env vars required");
 }
 */

--- a/tests/regression/test_disable_functions.php
+++ b/tests/regression/test_disable_functions.php
@@ -20,4 +20,14 @@ NULL
 */
 
 var_dump(function_exists('strlen'));
-var_dump(strlen('foo'));
+
+/*
+ * In PHP 8+, disabled functions behave as if they are not declared at all.
+ * Prior to PHP 8, attempting to use a disabled functions resulted in a warning.
+ * Now it throws a standard error so we have to catch it in PHP 8
+ */
+try {
+  var_dump(strlen('foo'));
+} catch (\Throwable $e) {
+  echo 'NULL',"\n";
+}


### PR DESCRIPTION
This fixes #107 and includes updates to fix failing integration tests on PHP 8. There are quite a few tests that were touched, but most of them were minor changes. To make it easier to review, the commits are broken up to include the fixes for each test category. Here's a brief summary of the changes:

**Curl**
- `Curl_multi_exec` instrumentation was updated to expect a `curl` object rather than a `curl` resource.
- Any tests that performed an `IS_RESOURCE` check using a `curl` handle are updated to use another resource.

**Bad input tests**
- Any tests that performed invalid argument or type checks now throw an `ArgumentCountError` or `TypeError` in PHP 8 instead of a warning. Since that causes test execution to stop, those tests have either been rewritten for PHP 8 or have a `try/catch` block to make it backward compatible.

**Default error reporting**
- The PHP INI directive `error_reporting` controls which types of errors, warnings, and notices should be reported. In PHP 8.0, the default is changed to E_ALL. This now causes any tests using our deprecated `newrelic_accept_distributed_trace_payload()` function will show deprecation warnings. To silence these, `error_reporting` is set to `E_ALL & ~E_DEPRECATED & ~E_STRICT`.

**$_ENV[ACCOUNT_supportability]**
- Any tests that use environment variables to hide sensitive account information now need an `isset()` check. If the environment variable is not set then the test is skipped.

### Note:
- This does not include all of the changes needed for the error and drupal 6/7 tests. There are still 7 error test failures and 4 drupal test failures. Those will be added in a follow-up PR. 