### PR TITLE
Fix memory leak that occurs when exceptions occur in stacked segments

### DIFF
--- a/agent/php_error.c
+++ b/agent/php_error.c
@@ -643,6 +643,7 @@ nr_status_t nr_php_error_record_exception_segment(nrtxn_t* txn,
   nr_segment_record_exception(nr_txn_get_current_segment(NRPRG(txn), NULL),
                               error_message, klass);
 
+  nr_free(file);
   nr_free(error_message);
   nr_free(klass);
   nr_free(message);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1073,7 +1073,8 @@ static inline void nr_php_execute_segment_end(
 
   if (create_metric || (duration >= NR_PHP_PROCESS_GLOBALS(expensive_min))
       || nr_vector_size(stacked->metrics) || stacked->id
-      || stacked->attributes) {
+      || stacked->attributes
+      || stacked->error) {
     nr_segment_t* s = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
     nr_php_execute_segment_add_metric(s, metadata, create_metric);
     nr_segment_end(&s);


### PR DESCRIPTION
This PR fixes a couple of memory leaks introduced in v9.12 of the agent.
* A string that wasn't freed in `nr_php_error_record_exception_segment`.
* The memory pointed to by `segment->error` when an exception occurs in a stacked segment that is not converted to a heap segment.

The fix for the latter involves converting the stacked segment to a heap allocated segment prior to deallocation if `segment->error` is set. The pre-existing code does the same thing if `segment->attributes` is set.