### PR TITLE
Fix error handling related integration tests

### DIFF
--- a/tests/integration/errors/test_E_NOTICE.php
+++ b/tests/integration/errors/test_E_NOTICE.php
@@ -15,7 +15,7 @@ log_errors=0
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Notice:\s*Undefined variable: usernmae in .*? on line [0-9]+\s*$
+^\s*(PHP )?Notice:\s*session_start\(\):.*session.*in .*? on line [0-9]+\s*$
 */
 
 /*EXPECT_TRACED_ERRORS
@@ -27,13 +27,9 @@ null
 */
 
 function provoke_notice() {
-  $username = 'foo';
-
-  // Misspell username to cause a notice.
-  if ($usernmae) {
-    return 1;
-  }
-  return 0;
+  session_start();
+  /* Trigger a NOTICE by attempting to start another session. */
+  session_start();
 }
 
 provoke_notice();

--- a/tests/integration/errors/test_E_PARSE.zend.php8.php
+++ b/tests/integration/errors/test_E_PARSE.zend.php8.php
@@ -32,7 +32,7 @@ log_errors=0
       "?? when",
       "OtherTransaction/php__FILE__",
       "syntax error, unexpected token \"}\"",
-      "Error",
+      "E_PARSE",
       {
         "stack_trace": [],
         "agentAttributes": "??",
@@ -55,7 +55,7 @@ log_errors=0
       {
         "type": "TransactionError",
         "timestamp": "??",
-        "error.class": "Error",
+        "error.class": "E_PARSE",
         "error.message": "syntax error, unexpected token \"}\"",
         "transactionName": "OtherTransaction\/php__FILE__",
         "duration": "??",

--- a/tests/integration/errors/test_ignore_E_WARNING.php
+++ b/tests/integration/errors/test_ignore_E_WARNING.php
@@ -17,7 +17,7 @@ log_errors=0
 */
 
 /*EXPECT_REGEX
-^\s*(PHP )?Warning:\s*Division by zero in .*? on line [0-9]+\s*$
+^\s*(PHP )?Warning:\s*session_gc\(\):.*? on line [0-9]+\s*$
 */
 
 /*EXPECT_TRACED_ERRORS
@@ -29,7 +29,7 @@ null
 */
 
 function run_test() {
-  $x = 8 / 0;
+  session_gc();
 }
 
 run_test();


### PR DESCRIPTION
This is part of the fixes for #107. The changes unique to this PR fix our error handling related integration tests. This required both changes to the tests and the agent.

In `php_error.c`, we need to strip off `E_DONT_BAIL` from the error type. `E_DONT_BAIL` is a new error value [added in PHP 8](https://github.com/php/php-src/commit/db233501ff9d56765ef4a870b777a643c2136711) that is used to indicate to the runtime that a clean exit should be performed. To avoid having to sprinkle this modification of `type` in several places, this is done just once in `nr_php_error_cb` prior to any of the other related functions being called.

In PHP 8.0+, the format string for an exception is [expanded](https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_exceptions.c#L905-L914) before it gets to us. In `nr_php_should_report_error`, we check both the error type (fixed with the previous fix) and the format string of the exception to ensure our handler is only called on uncaught exceptions. The simplest fix for this change is to just not look for the `%s` in the format string (or message) as that will work across PHP versions.

The other changes are all in the tests:
* `test_E_NOTICE`: replace a reference to an undefined variable (which is now an E_WARNING instead of an E_NOTICE) with two calls to `session_start()` which emits a notice.
* `test_ignore_E_WARNING`: replace a divide by zero (which is now an E_ERROR instead of an E_WARNING) with a call to `session_gc` which emits a warning when it is called outside of an active session.
* `test_E_PARSE` (PHP 8 version): the change to replace `E_PARSE` with `Error` from the previous round of fixes is no longer needed as `get_error_type_string` once again returns `E_PARSE` now that we account for `E_DONT_BAIL`. Note: The PHP 8 version of the test is still needed as the parse error text is still a bit different between the versions. Some regex work would allow the tests to be merged.