### PR TITLE
Fix to zend_http_client which surfaced during multiverse test.

### DIFF
--- a/agent/lib_zend_http.c
+++ b/agent/lib_zend_http.c
@@ -436,7 +436,7 @@ NR_PHP_WRAPPER_END
 void nr_zend_http_enable(TSRMLS_D) {
   if ((NR_FW_ZEND != NRPRG(current_framework))
       && (NR_FW_LAMINAS3 != NRPRG(current_framework))) {
-    nr_php_wrap_user_function(NR_PSTR(http_client_request),
+    nr_php_wrap_user_function(NR_PSTR(HTTP_CLIENT_REQUEST_Z),
                               nr_zend_http_client_request TSRMLS_CC);
   }
 }
@@ -452,7 +452,7 @@ void nr_laminas_http_enable(TSRMLS_D) {
     http_client = HTTP_CLIENT_L;
     http_client_request = HTTP_CLIENT_REQUEST_L;
 
-    nr_php_wrap_user_function(NR_PSTR(http_client_request),
+    nr_php_wrap_user_function(NR_PSTR(HTTP_CLIENT_REQUEST_L),
                               nr_zend_http_client_request TSRMLS_CC);
   }
 }


### PR DESCRIPTION
Defect surfaced during test cases runs.
After determining it wasn't a problem with the test case, put in the fix and retested with the failing test case which now passes.
This is for the zend_http library (not the zend framework) which was failing a zend 1.x zend_http library test.