### PR TITLE
PHP 8.0 agent build and install changes

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -313,8 +313,11 @@ if [ -z "${ispkg}" ]; then
 fi
 check_file "${ilibdir}/scripts/newrelic.ini.template"
 for pmv in "20090626" "20100525" "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
-  check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
-  check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"
+  # If on a 32-bit system, don't look for a PHP 8.0 build.
+  if [ "${arch}" = "x64" ] -o [ "${pmv}" != "20200930" ]; then
+    check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
+    check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"
+  fi
   if [ -z "${ispkg}" ] && [ "${arch}" = "x64" ] && [ "${pmv}" != "20200930" ]; then
     # Only check for x86 agent files on supported platforms.
     case "$ostype" in

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -314,7 +314,7 @@ fi
 check_file "${ilibdir}/scripts/newrelic.ini.template"
 for pmv in "20090626" "20100525" "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
   # If on a 32-bit system, don't look for a PHP 8.0 build.
-  if [ "${arch}" = "x64" ] -o [ "${pmv}" != "20200930" ]; then
+  if [ "${arch}" = "x64" -o "${pmv}" != "20200930" ]; then
     check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
     check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"
   fi

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -312,10 +312,10 @@ if [ -z "${ispkg}" ]; then
   check_file "${ilibdir}/scripts/newrelic-daemon.logrotate"
 fi
 check_file "${ilibdir}/scripts/newrelic.ini.template"
-for pmv in "20090626" "20100525" "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
+for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"
-  if [ -z "${ispkg}" ] && [ "${arch}" = "x64" ]; then
+  if [ -z "${ispkg}" ] && [ "${arch}" = "x64" ] && [ "${pmv}" != "20200930"]; then
     # Only check for x86 agent files on supported platforms.
     case "$ostype" in
       alpine|darwin|freebsd) ;;
@@ -1090,7 +1090,7 @@ Ignoring this particular instance of PHP.
 
   if [ -n "${ispkg}" -a "${arch}" = "x64" ]; then
     if [ "${pi_arch}" = "x86" ]; then
-      for pmv in "20090626" "20100525" "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
+      for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
         check_file "${ilibdir}/agent/x86/newrelic-${pmv}.so"
         check_file "${ilibdir}/agent/x86/newrelic-${pmv}-zts.so"
       done

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1038,18 +1038,25 @@ for this copy of PHP. We apologize for the inconvenience.
       ;;
 
     8.0.*)
+      if [ "${arch}" = "x86" ]; then
+        UNSUPPORTED_VERSION="yes"
+      fi
       ;;
 
     *)
-      error "unsupported version '${pi_ver}' of PHP found at:
+      UNSUPPORTED_VERSION="yes"
+      ;;
+  esac
+
+  if [ "${UNSUPPORTED_VERSION}" = "yes" ]; then
+    error "unsupported version '${pi_ver}' of PHP found at:
     ${pdir}
 Ignoring this particular instance of PHP.
 "
-      log "${pdir}: unsupported version '${pi_ver}'"
-      unsupported_php=1
-      return 1
-      ;;
-  esac
+    log "${pdir}: unsupported version '${pi_ver}'"
+    unsupported_php=1
+    return 1
+  fi
 
   #
   # Get the extension and ini directories.

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -312,10 +312,10 @@ if [ -z "${ispkg}" ]; then
   check_file "${ilibdir}/scripts/newrelic-daemon.logrotate"
 fi
 check_file "${ilibdir}/scripts/newrelic.ini.template"
-for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
+for pmv in "20090626" "20100525" "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"
-  if [ -z "${ispkg}" ] && [ "${arch}" = "x64" ] && [ "${pmv}" != "20200930"]; then
+  if [ -z "${ispkg}" ] && [ "${arch}" = "x64" ] && [ "${pmv}" != "20200930" ]; then
     # Only check for x86 agent files on supported platforms.
     case "$ostype" in
       alpine|darwin|freebsd) ;;
@@ -1090,7 +1090,7 @@ Ignoring this particular instance of PHP.
 
   if [ -n "${ispkg}" -a "${arch}" = "x64" ]; then
     if [ "${pi_arch}" = "x86" ]; then
-      for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
+      for pmv in "20090626" "20100525" "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
         check_file "${ilibdir}/agent/x86/newrelic-${pmv}.so"
         check_file "${ilibdir}/agent/x86/newrelic-${pmv}-zts.so"
       done

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1038,25 +1038,19 @@ for this copy of PHP. We apologize for the inconvenience.
       ;;
 
     8.0.*)
-      if [ "${arch}" = "x86" ]; then
-        UNSUPPORTED_VERSION="yes"
-      fi
+      pi_php8="yes"
       ;;
 
     *)
-      UNSUPPORTED_VERSION="yes"
-      ;;
-  esac
-
-  if [ "${UNSUPPORTED_VERSION}" = "yes" ]; then
-    error "unsupported version '${pi_ver}' of PHP found at:
+      error "unsupported version '${pi_ver}' of PHP found at:
     ${pdir}
 Ignoring this particular instance of PHP.
 "
-    log "${pdir}: unsupported version '${pi_ver}'"
-    unsupported_php=1
-    return 1
-  fi
+      log "${pdir}: unsupported version '${pi_ver}'"
+      unsupported_php=1
+      return 1
+      ;;
+  esac
 
   #
   # Get the extension and ini directories.
@@ -1096,6 +1090,17 @@ Ignoring this particular instance of PHP.
   fi
   if [ -z "${pi_arch}" ]; then
     pi_arch="${arch}"
+  fi
+
+  # This handles both 32-bit on 64-bit systems and 32-bit only systems
+  if [ "${pi_arch}" = "x86" -a "${pi_php8}" = "yes" ]; then
+    error "unsupported 32-bit version '${pi_ver}' of PHP found at:
+    ${pdir}
+Ignoring this particular instance of PHP.
+"
+    log "${pdir}: unsupported 32-bit version '${pi_ver}'"
+    unsupported_php=1
+    return 1
   fi
 
   if [ -n "${ispkg}" -a "${arch}" = "x64" ]; then

--- a/make/release.mk
+++ b/make/release.mk
@@ -43,7 +43,7 @@ endif
 # Build for PHP 8.0 on everything other than 32-bit Linux
 BUILD_PHP_80 := yes
 ifeq (linux,$(RELEASE_OS))
-  ifeq (x32,$(ARCH))
+  ifeq (x86,$(ARCH))
     BUILD_PHP_80 := no
   endif
 endif

--- a/make/release.mk
+++ b/make/release.mk
@@ -41,10 +41,10 @@ ifeq (osx,$(RELEASE_OS))
 endif
 
 # Build for PHP 8.0 on everything other than 32-bit Linux
-BUILD_PHP_80 := "yes"
+BUILD_PHP_80 := yes
 ifeq (linux,$(RELEASE_OS))
   ifeq (x32,$(ARCH))
-    BUILD_PHP_80 := "no"
+    BUILD_PHP_80 := no
   endif
 endif
 

--- a/make/release.mk
+++ b/make/release.mk
@@ -40,14 +40,6 @@ ifeq (osx,$(RELEASE_OS))
   endif
 endif
 
-# Build for PHP 8.0 on everything other than 32-bit Linux
-BUILD_PHP_80 := yes
-ifeq (linux,$(RELEASE_OS))
-  ifeq (x86,$(ARCH))
-    BUILD_PHP_80 := no
-  endif
-endif
-
 release: Makefile release-daemon release-installer release-agent release-docs release-scripts | releases/$(RELEASE_OS)/
 	printf '%s\n' "$(AGENT_VERSION)" > releases/$(RELEASE_OS)/VERSION
 	printf '%s\n' "$(GIT_COMMIT)" > releases/$(RELEASE_OS)/COMMIT
@@ -81,7 +73,8 @@ release-scripts: Makefile | releases/$(RELEASE_OS)/scripts/
 # Build the agent sequentially for each version of PHP. This is necessary
 # because the PHP build process only supports in-tree builds.
 release-agent: Makefile | releases/$(RELEASE_OS)/agent/$(RELEASE_ARCH)/
-ifeq (yes,$(BUILD_PHP_80))
+# Build for PHP 8.0 only on 64-bit targets
+ifeq (x64,$(ARCH))
 	$(MAKE) agent-clean; $(MAKE) release-8.0-no-zts
 endif
 	$(MAKE) agent-clean; $(MAKE) release-7.4-no-zts
@@ -93,7 +86,7 @@ endif
 	$(MAKE) agent-clean; $(MAKE) release-5.5-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.4-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.3-no-zts
-ifeq (yes,$(BUILD_PHP_80))
+ifeq (x64,$(ARCH))
 	$(MAKE) agent-clean; $(MAKE) release-8.0-zts
 endif
 	$(MAKE) agent-clean; $(MAKE) release-7.4-zts

--- a/make/release.mk
+++ b/make/release.mk
@@ -91,6 +91,8 @@ endif
 	$(MAKE) agent-clean; $(MAKE) release-7.0-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.6-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.5-no-zts
+	$(MAKE) agent-clean; $(MAKE) release-5.4-no-zts
+	$(MAKE) agent-clean; $(MAKE) release-5.3-no-zts
 ifeq (yes,$(BUILD_PHP_80))
 	$(MAKE) agent-clean; $(MAKE) release-8.0-zts
 endif
@@ -101,6 +103,8 @@ endif
 	$(MAKE) agent-clean; $(MAKE) release-7.0-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.6-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.5-zts
+	$(MAKE) agent-clean; $(MAKE) release-5.4-zts
+	$(MAKE) agent-clean; $(MAKE) release-5.3-zts
 
 #
 # Add a new target to build the agent against build machines.
@@ -150,6 +154,8 @@ $(eval $(call RELEASE_AGENT_TARGET,7.1,20160303))
 $(eval $(call RELEASE_AGENT_TARGET,7.0,20151012))
 $(eval $(call RELEASE_AGENT_TARGET,5.6,20131226))
 $(eval $(call RELEASE_AGENT_TARGET,5.5,20121212))
+$(eval $(call RELEASE_AGENT_TARGET,5.4,20100525))
+$(eval $(call RELEASE_AGENT_TARGET,5.3,20090626))
 
 #
 # Release directories

--- a/make/release.mk
+++ b/make/release.mk
@@ -40,6 +40,14 @@ ifeq (osx,$(RELEASE_OS))
   endif
 endif
 
+# Build for PHP 8.0 on everything other than 32-bit Linux
+BUILD_PHP_80 := "yes"
+ifeq (linux,$(RELEASE_OS))
+  ifeq (x32,$(ARCH))
+    BUILD_PHP_80 := "no"
+  endif
+endif
+
 release: Makefile release-daemon release-installer release-agent release-docs release-scripts | releases/$(RELEASE_OS)/
 	printf '%s\n' "$(AGENT_VERSION)" > releases/$(RELEASE_OS)/VERSION
 	printf '%s\n' "$(GIT_COMMIT)" > releases/$(RELEASE_OS)/COMMIT
@@ -73,6 +81,9 @@ release-scripts: Makefile | releases/$(RELEASE_OS)/scripts/
 # Build the agent sequentially for each version of PHP. This is necessary
 # because the PHP build process only supports in-tree builds.
 release-agent: Makefile | releases/$(RELEASE_OS)/agent/$(RELEASE_ARCH)/
+ifeq (yes,$(BUILD_PHP_80))
+	$(MAKE) agent-clean; $(MAKE) release-8.0-no-zts
+endif
 	$(MAKE) agent-clean; $(MAKE) release-7.4-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-7.3-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-7.2-no-zts
@@ -82,6 +93,9 @@ release-agent: Makefile | releases/$(RELEASE_OS)/agent/$(RELEASE_ARCH)/
 	$(MAKE) agent-clean; $(MAKE) release-5.5-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.4-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.3-no-zts
+ifeq (yes,$(BUILD_PHP_80))
+	$(MAKE) agent-clean; $(MAKE) release-8.0-zts
+endif
 	$(MAKE) agent-clean; $(MAKE) release-7.4-zts
 	$(MAKE) agent-clean; $(MAKE) release-7.3-zts
 	$(MAKE) agent-clean; $(MAKE) release-7.2-zts

--- a/make/release.mk
+++ b/make/release.mk
@@ -91,8 +91,6 @@ endif
 	$(MAKE) agent-clean; $(MAKE) release-7.0-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.6-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.5-no-zts
-	$(MAKE) agent-clean; $(MAKE) release-5.4-no-zts
-	$(MAKE) agent-clean; $(MAKE) release-5.3-no-zts
 ifeq (yes,$(BUILD_PHP_80))
 	$(MAKE) agent-clean; $(MAKE) release-8.0-zts
 endif
@@ -103,8 +101,6 @@ endif
 	$(MAKE) agent-clean; $(MAKE) release-7.0-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.6-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.5-zts
-	$(MAKE) agent-clean; $(MAKE) release-5.4-zts
-	$(MAKE) agent-clean; $(MAKE) release-5.3-zts
 
 #
 # Add a new target to build the agent against build machines.
@@ -154,8 +150,6 @@ $(eval $(call RELEASE_AGENT_TARGET,7.1,20160303))
 $(eval $(call RELEASE_AGENT_TARGET,7.0,20151012))
 $(eval $(call RELEASE_AGENT_TARGET,5.6,20131226))
 $(eval $(call RELEASE_AGENT_TARGET,5.5,20121212))
-$(eval $(call RELEASE_AGENT_TARGET,5.4,20100525))
-$(eval $(call RELEASE_AGENT_TARGET,5.3,20090626))
 
 #
 # Release directories


### PR DESCRIPTION
This PR:
* updates the `release` target to build for PHP 8.0, but only on 64-bit targets.
* modifies the `newrelic-install.sh` script to not look for PHP 8.0 builds when installing on either 32-bit or 64-bit targets.