### PR TITLE
Pass parameters by reference when calling bindParam

### DIFF
--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -40,6 +40,16 @@ zval* nr_php_call_user_func(zval* object_ptr,
 
     param_values = (zval*)nr_calloc(param_count, sizeof(zval));
     for (i = 0; i < param_count; i++) {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+      /*
+       * With PHP8, we need to create references in order to pass or allow
+       * passing arguments by reference when invoking call_user_function.
+       */
+      if (!Z_ISREF_P(params[i])) {
+        Z_TRY_ADDREF_P(params[i]);
+        ZVAL_NEW_REF(params[i], params[i]);
+      }
+#endif
       param_values[i] = *params[i];
     }
   }

--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -40,16 +40,6 @@ zval* nr_php_call_user_func(zval* object_ptr,
 
     param_values = (zval*)nr_calloc(param_count, sizeof(zval));
     for (i = 0; i < param_count; i++) {
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
-      /*
-       * With PHP8, we need to create references in order to pass or allow
-       * passing arguments by reference when invoking call_user_function.
-       */
-      if (!Z_ISREF_P(params[i])) {
-        Z_TRY_ADDREF_P(params[i]);
-        ZVAL_NEW_REF(params[i], params[i]);
-      }
-#endif
       param_values[i] = *params[i];
     }
   }

--- a/agent/php_pdo.c
+++ b/agent/php_pdo.c
@@ -130,11 +130,11 @@ int nr_php_pdo_rebind_apply_parameter(struct pdo_bound_param_data* param,
   zval* type = nr_php_zval_alloc();
   zval* retval = NULL;
 
-#ifdef PHP7
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
   value = &param->parameter;
 #else
   value = param->parameter;
-#endif /* PHP7 */
+#endif /* PHP 7.0+ */
 
   if (nr_php_zend_hash_key_is_string(hash_key)) {
     /*
@@ -152,6 +152,16 @@ int nr_php_pdo_rebind_apply_parameter(struct pdo_bound_param_data* param,
 
   ZVAL_LONG(type, param->param_type);
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  /*
+   * Create a reference to value to prevent PHP 8 from
+   * emitting a warning.
+   */
+  if (!Z_ISREF_P(value)) {
+    Z_TRY_ADDREF_P(value);
+    ZVAL_NEW_REF(value, value);
+  }
+#endif
   retval = nr_php_call(stmt, "bindParam", key, value, type);
 
   nr_php_zval_free(&key);

--- a/tests/integration/pdo/test_prepared_stmt_params.php
+++ b/tests/integration/pdo/test_prepared_stmt_params.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a slow sql trace when a prepared
+statment with a parameter is executed via PDOStatement::execute()
+exceeds the explain threshold.
+*/
+
+/*SKIPIF
+<?php require('skipif_mysql.inc');
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.transaction_tracer.explain_enabled = true
+newrelic.transaction_tracer.explain_threshold = 0
+newrelic.transaction_tracer.record_sql = "obfuscated"
+*/
+
+/*EXPECT
+ok - execute prepared statement with a param
+*/
+
+/*EXPECT_SLOW_SQLS
+[
+  [
+    [
+      "OtherTransaction/php__FILE__",
+      "<unknown>",
+      "?? SQL id",
+      "select * from tables where table_name = ? limit ?;",
+      "Datastore/statement/MySQL/tables/select",
+      1,
+      "?? total time",
+      "?? min time",
+      "?? max time",
+      {
+        "backtrace": [
+          " in PDOStatement::execute called at __FILE__ (??)",
+          " in test_prepared_statement called at __FILE__ (??)"
+        ],
+        "explain_plan": [
+          [
+            "id",
+            "select_type",
+            "table",
+            "type",
+            "possible_keys",
+            "key",
+            "key_len",
+            "ref",
+            "rows",
+            "Extra"
+          ],
+          [
+            [
+              "1",
+              "SIMPLE",
+              "tables",
+              "ALL",
+              null,
+              "TABLE_NAME",
+              null,
+              null,
+              "??",
+              "??"
+            ]
+          ]
+        ]
+      }
+    ]
+  ]
+]
+*/
+
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/tap.php');
+require_once(realpath (dirname ( __FILE__ )) . '/pdo.inc');
+
+function test_prepared_statement() {
+  global $PDO_MYSQL_DSN, $MYSQL_USER, $MYSQL_PASSWD;
+
+  $conn = new PDO($PDO_MYSQL_DSN, $MYSQL_USER, $MYSQL_PASSWD);
+  $stmt = $conn->prepare('select * from tables where table_name = ? limit 1;');
+  $stmt->bindValue(1, "missing");
+  tap_assert($stmt->execute(), 'execute prepared statement with a param');
+}
+
+test_prepared_statement();


### PR DESCRIPTION
This PR fixes issue #143.

In the PHP 8 [upgrading internals](https://github.com/php/php-src/blob/PHP-8.0.0/UPGRADING.INTERNALS) document, there is this note:
>   The zend_fcall_info no_separation flag has been removed, and separation is
      never allowed. If you wish to pass (or allow passing) arguments by
      reference, explicitly create those arguments as references using
      ZEND_MAKE_REF. This removal also affects call_user_function_ex(), which
      should be replaced by call_user_function().

Here are some details about what that means in practice and how it compares to previous PHP releases.

PHP 8.0 emits a warning [when a reference is needed and wasn't provided](https://github.com/php/php-src/blob/PHP-8.0.3/Zend/zend_execute_API.c#L770-L776). The runtime still [creates a reference](https://github.com/php/php-src/blob/PHP-8.0.3/Zend/zend_execute_API.c#L799-L801), it is just [noisy](https://github.com/php/php-src/blob/PHP-8.0.0/Zend/zend_execute.c#L1955-L1968) about having to do it.

Prior to PHP 8.0, a flag could be passed in which indicated whether the runtime should [create a reference in such scenarios](https://github.com/php/php-src/blob/PHP-7.4.18/Zend/zend_execute_API.c#L762-L766). If a reference was needed and one wasn't provided, [the behavior](https://github.com/php/php-src/blob/PHP-7.4.18/Zend/zend_execute_API.c#L767-L775) is essentially what PHP 8.0 does (warning, but creates a reference anyway).

In our pdo instrumentation, we call [nr_php_call](https://github.com/newrelic/newrelic-php-agent/blob/adbdca64f20e999443d9aee7ff5d9596b32f976d/agent/php_pdo.c#L155) to invoke `bindParam`. This uses PHP's `call_user_function`. At this particular call site, a reference is needed and since we don't provide one, a warning is emitted.

The first attempt blindly created a reference for all parameters, but this breaks things as it introduces references where they are not expected. To truly copy the previous behavior, we would need to call [ARG_SHOULD_BE_SENT_BY_REF](https://github.com/php/php-src/blob/PHP-8.0.3/Zend/zend_compile.h#L995-L996) which requires that we resolve the function before invoking `call_user_function` which will have to resolve the function again. This introduces extra overhead which would be best to avoid.

We may be able to invoke a `call_user_function` variant that requires the function handle instead of the function name, but this is a more invasive change.

The approach in the latest revision chooses to require each call site make the determination about whether a reference is needed before calling `nr_php_call`. If there are places where we use `nr_php_call` and friends to make calls to arbitrary functions, such call sites will need to be reworked to programmatically determine whether a reference is needed. In practice, we usually just call a known function. We just now need to be sure to add references, where they are needed, before making such calls.

The reported issue was found using Doctrine. The call path [creates a prepared statement](https://github.com/doctrine/dbal/blob/c800380457948e65bbd30ba92cc17cda108bf8c9/lib/Doctrine/DBAL/Connection.php#L1289-L1295) and calls [bindValue](https://github.com/doctrine/dbal/blob/c800380457948e65bbd30ba92cc17cda108bf8c9/lib/Doctrine/DBAL/Connection.php#L2048) for the parameters. I was unable to reproduce the warning message using `bindParam` despite that being what we instrument. I can only assume that `bindValue` somehow depends on `bindParam`.

The added integration test runs a prepared statement and calls `bindValue` on a single parameter which enough to trigger the warning when the fix is not present.