### PR TITLE
fix(php8): default newrelic.ini file in fpm/conf.d

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1327,7 +1327,7 @@ does not exist. This particular instance of PHP will be skipped.
   # stopgap, let's detect that situation and set ${pi_inidir_dso} so that the
   # INI file gets installed to the right place.
   #
-  for cfg_pfx in /etc/php5 /etc/php7 /etc/php/[57].*; do
+  for cfg_pfx in /etc/php5 /etc/php7 /etc/php8 /etc/php/[578].*; do
     if [ "${pi_inidir_cli}" = "${cfg_pfx}/cli/conf.d" -a -z "${pi_inidir_dso}" ]; then
       #
       # Check Apache first, then FPM. If both are installed, we want FPM to win:


### PR DESCRIPTION
I'm currently testing Php8 support provided by the last version `9.17.1.301`.
While migrating my installation script, I noticed that the file `/etc/php/8.0/fpm/conf.d/newrelic.ini` doesn't exist anymore by default after installation process on Ubuntu (but `/etc/php/8.0/cli/conf.d/newrelic.ini` still exists!).

After searching in the installation script, I guess that possible config paths to explore have not been updated. Here a patch proposal, but I didn't test nor search extensively if there is something elsewhere, I just wanted to understand *why* it was different 😅 