### PR TITLE
Fix curl multi memory leak

### DIFF
--- a/agent/php_curl.c
+++ b/agent/php_curl.c
@@ -770,9 +770,9 @@ void nr_php_curl_multi_exec_post(zval* curlres TSRMLS_DC) {
 
   /*
    * Looping over all handled added to this curl_multi_exec handle. Each
-   * handle is checked; if the request represented by the handle is  done and
+   * handle is checked; if the request represented by the handle is done and
    * the necessary instrumentation was created, the handle is removed from the
-   * vector.
+   * vector and our dup'ed copy of the handle is freed.
    */
   if (handles) {
     for (pos = 0; pos < nr_vector_size(handles); pos++) {
@@ -785,6 +785,7 @@ void nr_php_curl_multi_exec_post(zval* curlres TSRMLS_DC) {
       nr_php_curl_exec_post(handle, true TSRMLS_CC);
 
       nr_vector_remove(handles, pos, &removed_handle);
+      nr_php_zval_free((zval**)&removed_handle);
       pos--;
     }
   }
@@ -817,6 +818,7 @@ void nr_php_curl_multi_exec_finalize(zval* curlres TSRMLS_DC) {
       nr_php_curl_exec_post(handle, false TSRMLS_CC);
 
       nr_vector_remove(handles, pos, &removed_handle);
+      nr_php_zval_free((zval**)&removed_handle);
       pos--;
     }
   }


### PR DESCRIPTION
This PR fixes a memory leak in our curl-mutli instrumentation.

### Background
The agent [creates metadata](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl_md.c#L344-L356) for each curl multi handle. The metadata includes, among other things, [a vector](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl_md.h#L22-L23) of curl handle `zval`s. When a new curl handle is added to a multi handle, it is [added to this vector](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl_md.c#L358-L368). When a handle is manually removed from the multi handle, it is [removed from the vector](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl_md.c#L391-L408).

Curl handles are also removed from the curl multi handle metadata [when the associated request is completed, right after the agent records the instrumentation for the handle](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl.c#L781-L787).

When `curl_multi_exec` indicates it is done processing all of the curl handles, [a finalization routine is called](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_internal_instrument.c#L2690-L2709) to clean up any curl handles that did not complete successfully.

### Source of the Leak
The leak occurs when completed curl handles [are removed](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl.c#L787) from the curl multi metadata curl handles vector and [during finalization](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl.c#L819) of a curl multi exec run. Note that only the entry in the vector is removed. Nothing is done to the handle itself.
```php
nr_vector_remove(handles, pos, &removed_handle);
```

Contrast that with what is done when a curl handle is [removed from a multi handle](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl_md.c#L391-L408).
```php
    if (!nr_vector_remove(&multi_metadata->curl_handles, index,
                          (void**)&element)) {
      nrl_error(NRL_CAT, "%s: error removing curl_multi handle metadata",
                __func__);
      return false;
    }
    nr_php_zval_free(&element);
```

The `zval` is freed in this latter case. The reason this is needed (and creates a leak if it is missing) is that the agent [dup's](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl_md.c#L359) the curl handle when it is added to the vector. This prevents the PHP runtime from prematurely garbage collecting the `zval`, but does require that the reference count be decremented when the agent is done with the reference.

There are two places where a curl handle is removed from the curl multi curl_handles vector, but is not freed. These result in a dangling reference that is cleaned up when the PHP process exits. (Aside: If the references had been kept in the `curl_handles` vector, the hashmap destructor would have cleaned them at the end of the transaction or during RSHUTDOWN.)

### The Fix
The chosen fix is to add just add the missing calls to free. This is more efficient than calling `nr_php_curl_multi_md_remove` at the two call sites as the latter duplicates the work to find the index of the curl handle to remove (among other things).

### Test Results
All tests are using an iteration count of 1,000.

Using a customer provided reproduction that uses Symfony's CurlHttpClient:
PHP 7 and PHP 8 - reduction of over 47MB of memory usage

Using a curl_multi based reproduction:
PHP 8 - reduction of over 42MB of memory usage
PHP 7 - reduction of 300k of memory usage, but overall memory usage was far lower to start

In the case of PHP 8, the fix always dramatically improves memory usage. In the case of PHP 7, the impact of the defect looks to vary based on how the `curl_multi` APIs are used.

### Other Considerations
The agent keeps metadata [for both curl handles and curl multi handles](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_newrelic.h#L489-L490). Entries in these hashmaps are never destroyed individually. They are destroyed as a group when [a transaction is ended](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_txn.c#L1034-L1035) and, in the case of curl multi metadata, [during the RSHUTDOWN phase](https://github.com/newrelic/newrelic-php-agent/blob/490d52afc560f9d8cbcda88571b6a564ea6c139e/agent/php_curl_md.c#L296-L319).

Why does this matter? It means that the amount of memory held onto by the agent will increase for each curl handle and curl multi handle created. This can be a problem for long running transactions. There are several ways to improve this situation.

In PHP code:
* Be sure to remove handles from multi handles and to close all curl handles. This allows handles to be reused by curl which will result in fewer hashmap entries being kept by the agent.
* Minimize the length of transactions. This will cause the agent to clean up the curl handle and curl multi handle metadata.

In the agent:
* Consider creating internal instrumentation for `curl_close` and `curl_multi_close`. This instrumentation would prune individual metadata entries whenever a handle is closed. This will require the code to be refactor to not be so eager to add new entries into the metadata hashmaps. Since this change is far more invasive than this fix and the impact can be limited via changes in the instrumented PHP code, I have chosen to hold off on pursuing this.