### PR TITLE
Distributed tracing: time inversion for duration calculation

### DIFF
--- a/axiom/nr_distributed_trace.c
+++ b/axiom/nr_distributed_trace.c
@@ -1097,7 +1097,7 @@ static const char* nr_distributed_trace_convert_w3c_headers_tracestate(
   nr_free(str);
 
   str = nr_regex_substrings_get_named(ss, "timestamp");
-  nro_set_hash_long(tracestate_obj, "timestamp", strtol(str, NULL, 10));
+  nro_set_hash_long(tracestate_obj, "timestamp", strtoull(str, NULL, 10));
   nr_free(str);
 
   nro_set_hash(obj, "tracestate", tracestate_obj);

--- a/axiom/nr_distributed_trace.c
+++ b/axiom/nr_distributed_trace.c
@@ -378,7 +378,16 @@ nrtime_t nr_distributed_trace_inbound_get_timestamp_delta(
     return 0;
   }
 
-  return nr_time_duration(txn_start, dt->inbound.timestamp);
+  return nr_time_duration(dt->inbound.timestamp, txn_start);
+}
+
+extern bool nr_distributed_trace_inbound_has_timestamp(
+    const nr_distributed_trace_t* dt) {
+  if (NULL == dt) {
+      return 0;
+  }
+
+  return dt->inbound.timestamp != 0;
 }
 
 const char* nr_distributed_trace_inbound_get_transport_type(

--- a/axiom/nr_distributed_trace.h
+++ b/axiom/nr_distributed_trace.h
@@ -195,6 +195,8 @@ extern const char* nr_distributed_trace_inbound_get_type(
 extern nrtime_t nr_distributed_trace_inbound_get_timestamp_delta(
     const nr_distributed_trace_t* dt,
     nrtime_t txn_start);
+extern bool nr_distributed_trace_inbound_has_timestamp(
+    const nr_distributed_trace_t* dt);
 extern const char* nr_distributed_trace_inbound_get_transport_type(
     const nr_distributed_trace_t* dt);
 extern const char* nr_distributed_trace_inbound_get_tracing_vendors(

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -433,8 +433,7 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
           event, NR_SPAN_PARENT_TRANSPORT_TYPE,
           nr_distributed_trace_inbound_get_transport_type(
               segment->txn->distributed_trace));
-      if (nr_distributed_trace_inbound_get_timestamp_delta(
-              segment->txn->distributed_trace, 0)) {
+      if (nr_distributed_trace_inbound_has_timestamp(segment->txn->distributed_trace)) {
         nr_span_event_set_parent_transport_duration(
             event, nr_distributed_trace_inbound_get_timestamp_delta(
                        segment->txn->distributed_trace,

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -2048,7 +2048,7 @@ void nr_txn_add_distributed_tracing_intrinsics(const nrtxn_t* txn,
     nro_set_hash_string(intrinsics, "parent.transportType",
                         nr_distributed_trace_inbound_get_transport_type(dt));
 
-    if (nr_distributed_trace_inbound_get_timestamp_delta(dt, 0)) {
+    if (nr_distributed_trace_inbound_has_timestamp(dt)) {
       nro_set_hash_double(intrinsics, "parent.transportDuration",
                           nr_distributed_trace_inbound_get_timestamp_delta(
                               dt, nr_txn_start_time(txn))


### PR DESCRIPTION
**Context:** I'm facing a strange issue in my NewRelic data, all `parent.transportDuration` values are `0` for transactions between 2 Php applications instrumented by NewRelic. I opened a ticket and they suggest that servers are not synchronized (but I know they are 😉 ). So I dig into the code…

## Explanations
The [`nr_time_duration`](https://github.com/newrelic/newrelic-php-agent/blob/6498785b65c7bf2247a2b268e493d26d5264d83d/axiom/util_time.h#L69-L72) function compute the time elapsed between a `start` timestamp and a `stop` timestamp. If `start > stop`, it returns `0`.

The [`nr_distributed_trace_inbound_get_timestamp_delta` function](https://github.com/newrelic/newrelic-php-agent/blob/6498785b65c7bf2247a2b268e493d26d5264d83d/axiom/nr_distributed_trace.c#L374-L382) intends to return the _transport duration_, i.e. the time elapsed during the timestamp stored in _distributed trace header_ and the start time of the current transaction, by calling `nr_time_duration`.

**Hypothesis:** parameters are passed in the wrong order, then all transport duration are reported to `0` 😨 

Example: When [`parent.transportDuration` is set](https://github.com/newrelic/newrelic-php-agent/blob/6498785b65c7bf2247a2b268e493d26d5264d83d/axiom/nr_txn.c#L2053-L2054).

⚠️ We can find the test [`if(nr_distributed_trace_inbound_get_timestamp_delta(dt, 0))`](https://github.com/newrelic/newrelic-php-agent/blob/6498785b65c7bf2247a2b268e493d26d5264d83d/axiom/nr_txn.c#L2051) (to check if distributed trace has a non-zero timestamp as far as I understand), it seems to _work_ because it relies on this wrong behavior. But this function cannot work in both case, in pseudo-code we cannot have `duration(dt, 0)  > 0` AND `duration(dt, now) > 0` if `0 < dt < now`.

ℹ️ Tests use the same function to compute the expected value, then a wrong value always equals the same wrong value.

## What I did
* I reversed parameters order in `nr_time_duration` call inside `nr_distributed_trace_inbound_get_timestamp_delta`
* I also reverted order in tests to compute expected value, and added an _assertion_ to ensure that the duration is not `0` (a _wrong_ value in this case). We could also _hard-code_ the expected value, to be sure to not rely on internal implementation of the tested function.
* I modified a `nr_distributed_trace_inbound_get_timestamp_delta(dt, 0)` calls to a new explicit function `nr_distributed_trace_inbound_has_timestamp` (I think it's the original intent). I created some tests, but I don't understand the `default value` case of `nr_distributed_trace_inbound_get_timestamp_delta` function… IMHO there is some trouble here, since it returns `0` because the transaction have a `0` start time 🤔 
* I fixed some tests relying on a wrong expected value, I had to correctly initialize the transaction start time to make sense.
* Previous fix revealed an other issue in `nr_distributed_trace_convert_w3c_headers_tracestate`, the timestamp string value was converted to an integer, causing a capacity overflow on `x86` arch, I changed to convert to `long long unsigned`

## And now…
I made this PR to run tests on CI, and to share my thoughts with you. What do you think? Am I totally wrong or is there something to investigate? Did I misunderstood something?

Thanks for your attention, I'm looking forward for your feedback 🙇‍♂️ 
