### PR TITLE
Fix laravel transaction naming (issue #86) - Don't use getName() if it's a auto generated route name

### DIFF
--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -347,24 +347,37 @@ static void nr_laravel_name_transaction(zval* router, zval* request TSRMLS_DC) {
 
       route_name_zv = nr_php_call(route, "getName");
       if (nr_php_is_zval_valid_string(route_name_zv)) {
-        char* route_name
-            = nr_strndup(Z_STRVAL_P(route_name_zv), Z_STRLEN_P(route_name_zv));
+        const char generated_prefix[] = "generated::";
+        nr_string_len_t generated_prefix_len
+            = sizeof(generated_prefix) - 1;
 
-        nrl_debug(NRL_FRAMEWORK,
-                  "%s: using Route::getName() for transaction naming",
-                  __func__);
-        nr_txn_set_path("Laravel", NRPRG(txn), route_name, NR_PATH_TYPE_ACTION,
-                        NR_OK_TO_OVERWRITE);
+        if (nr_strncmp(generated_prefix, Z_STRVAL_P(route_name_zv), generated_prefix_len) != 0) {
+          char* route_name
+              = nr_strndup(Z_STRVAL_P(route_name_zv), Z_STRLEN_P(route_name_zv));
 
+          nrl_debug(NRL_FRAMEWORK,
+                    "%s: using Route::getName() for transaction naming",
+                    __func__);
+          nr_txn_set_path("Laravel", NRPRG(txn), route_name, NR_PATH_TYPE_ACTION,
+                          NR_OK_TO_OVERWRITE);
+
+          nr_php_zval_free(&route_name_zv);
+          nr_free(route_name);
+          goto leave;
+        } else {
+          nrl_verbosedebug(
+            NRL_FRAMEWORK,
+            "%s: Route::getName() returned a randomly generated route name, skipping. ",
+            __func__);
+            nr_php_zval_free(&route_name_zv);
+        }
+      } else {
+        nrl_verbosedebug(
+            NRL_FRAMEWORK,
+            "%s: Route::getName() returned an unexpected value/type, skipping. ",
+            __func__);
         nr_php_zval_free(&route_name_zv);
-        nr_free(route_name);
-        goto leave;
       }
-      nrl_verbosedebug(
-          NRL_FRAMEWORK,
-          "%s: Route::getName() returned an unexpected value/type, skipping. ",
-          __func__);
-      nr_php_zval_free(&route_name_zv);
     }
 
     /*


### PR DESCRIPTION
Route::getName() returns a random generated string (generated::*) if a route isn't named [(Named Routes)](https://laravel.com/docs/8.x/routing#named-routes) and routes are cached via `php artisan route:cache` since laravel 7.x.

This causes the problem mentioned in #86. To fix the problem, I added a check if the returned string begins with `generated::`, to skip it and use `Route::getAction()` instead.