### PR TITLE
Remove Drupal NegativeModuleLength Supportability metric

### DIFF
--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -334,7 +334,7 @@ static void nr_drupal_wrap_hook_within_module_invoke_all(
 
   rv = module_invoke_all_parse_module_and_hook(
       &module, &module_len, NRPRG(drupal_module_invoke_all_hook),
-      NRPRG(drupal_module_invoke_all_hook_len), func TSRMLS_CC);
+      NRPRG(drupal_module_invoke_all_hook_len), func);
 
   if (NR_SUCCESS != rv) {
     return;

--- a/agent/fw_drupal_common.c
+++ b/agent/fw_drupal_common.c
@@ -195,7 +195,7 @@ nr_status_t module_invoke_all_parse_module_and_hook(char** module_ptr,
                                                     size_t* module_len_ptr,
                                                     const char* hook,
                                                     size_t hook_len,
-                                                    const zend_function* func TSRMLS_DC) {
+                                                    const zend_function* func) {
   const char* module_hook = NULL;
   size_t module_hook_len = 0;
 
@@ -211,7 +211,7 @@ nr_status_t module_invoke_all_parse_module_and_hook(char** module_ptr,
   module_hook_len = (size_t)nr_php_function_name_length(func);
 
   return module_invoke_all_parse_module_and_hook_from_strings(
-      module_ptr, module_len_ptr, hook, hook_len, module_hook, module_hook_len TSRMLS_CC);
+      module_ptr, module_len_ptr, hook, hook_len, module_hook, module_hook_len);
 }
 
 void nr_drupal_headers_add(zval* arg, bool is_drupal_7 TSRMLS_DC) {

--- a/agent/fw_drupal_common.c
+++ b/agent/fw_drupal_common.c
@@ -128,7 +128,7 @@ nr_status_t module_invoke_all_parse_module_and_hook_from_strings(
     const char* hook,
     size_t hook_len,
     const char* module_hook,
-    size_t module_hook_len TSRMLS_DC) {
+    size_t module_hook_len) {
   size_t module_len = 0;
   char* module = NULL;
 

--- a/agent/fw_drupal_common.c
+++ b/agent/fw_drupal_common.c
@@ -180,16 +180,6 @@ nr_status_t module_invoke_all_parse_module_and_hook_from_strings(
                      __func__, (int)module_len, NRSAFELEN(hook_len), NRSAFESTR(hook),
                      NRSAFELEN(module_hook_len), NRSAFESTR(module_hook));
 
-    char* metric_name = NULL;
-    if (NR_FW_DRUPAL == NRPRG(current_framework)) {
-      metric_name = "Supportability/framework/Drupal/NegativeModuleLength";
-    } else if (NR_FW_DRUPAL8 == NRPRG(current_framework)) {
-      metric_name = "Supportability/framework/Drupal8/NegativeModuleLength";
-    }
-
-    if (metric_name != NULL) {
-      nrm_force_add(NRTXN(unscoped_metrics), metric_name, 0);
-    }
     return NR_FAILURE;
   }
 

--- a/agent/fw_drupal_common.h
+++ b/agent/fw_drupal_common.h
@@ -132,8 +132,7 @@ nr_status_t module_invoke_all_parse_module_and_hook_from_strings(
     const char* hook,
     size_t hook_len,
     const char* module_hook,
-    size_t module_hook_len
-    TSRMLS_DC);
+    size_t module_hook_len);
 
 /*
  * Purpose: This function adds NR request headers for Drupal. arg is the second

--- a/agent/fw_drupal_common.h
+++ b/agent/fw_drupal_common.h
@@ -110,8 +110,7 @@ nr_status_t module_invoke_all_parse_module_and_hook(char** module_ptr,
                                                     size_t* module_len_ptr,
                                                     const char* hook,
                                                     size_t hook_len,
-                                                    const zend_function* func
-						    TSRMLS_DC);
+                                                    const zend_function* func);
 /*
  * Purpose : Given a function that is a hook function in a module, determine
  *           which component is the module and which is the hook, given that we

--- a/agent/tests/test_fw_drupal.c
+++ b/agent/tests/test_fw_drupal.c
@@ -17,21 +17,20 @@ tlib_parallel_info_t parallel_info
 static void test_single_extract_module_name_from_hook_and_hook_function(
     const char* hook_function_name,
     char* hook_name,
-    char* expected_module_name
-    TSRMLS_DC) {
+    char* expected_module_name) {
   char* module = 0;
   size_t module_len = 0;
 
   module_invoke_all_parse_module_and_hook_from_strings(
       &module, &module_len, hook_name, strlen(hook_name), hook_function_name,
-      strlen(hook_function_name) TSRMLS_CC);
+      strlen(hook_function_name));
 
   tlib_pass_if_str_equal("Extracted Correct Module Name", module,
                          expected_module_name);
   nr_free(module);
 }
 
-static void test_module_name(TSRMLS_D) {
+static void test_module_name() {
   int i = 0;
   int number_of_fixtures = 0;
 
@@ -57,7 +56,7 @@ static void test_module_name(TSRMLS_D) {
 
   for (i = 0; i < number_of_fixtures; i++) {
     test_single_extract_module_name_from_hook_and_hook_function(
-        fixtures[i][0], fixtures[i][1], fixtures[i][2] TSRMLS_CC);
+        fixtures[i][0], fixtures[i][1], fixtures[i][2]);
   }
 }
 
@@ -375,7 +374,7 @@ void test_main(void* p NRUNUSED) {
   void*** tsrm_ls = NULL;
 #endif /* ZTS && !PHP7 */
   tlib_php_engine_create("" PTSRMLS_CC);
-  test_module_name(TSRMLS_C);
+  test_module_name();
   test_drupal_headers_add(TSRMLS_C);
   test_drupal_http_request_drupal_7(TSRMLS_C);
   test_drupal_http_request_drupal_6(TSRMLS_C);


### PR DESCRIPTION
This PR removes the code that attempts to create a `NegativeModuleLength` Supportability metric. The intention behind this metric was to record how often a certain edge case was encountered. Unfortunately, it appears to cause a segfault on at least some systems. The simplest approach here is to just remove the metric as it is currently causing more harm than good.