### PR TITLE
Update PHP 8.0 ZTS build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        php_ver: ['8.0', '8.0-zts']
+        php_ver: ['8.0-zts']
         arch: [x64, x86]
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Only the PHP 8.0-zts should remain here so we don't overwrite the PHP 8.0 builds pulled in from Jenkins.