### PR TITLE
Add flag to prevent sending URIs

### DIFF
--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -454,6 +454,8 @@ nriniuint_t
 nrinitime_t
     agent_span_queue_timeout; /* newrelic.infinite_tracing.span_events.agent_queue.timeout
                                */
+nrinibool_t
+    collect_script_name; /* newrelic.collect_script_name */
 
 /*
  * pid and user_function_wrappers are used to store user function wrappers.

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2669,6 +2669,9 @@ STD_PHP_INI_ENTRY_EX(
     newrelic_globals,
     0)
 
+/**
+ * The flag that determines whether the agent collects script name or not.
+ */
 STD_PHP_INI_ENTRY_EX("newrelic.collect_script_name",
                      "1",
                      NR_PHP_REQUEST,

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2669,6 +2669,15 @@ STD_PHP_INI_ENTRY_EX(
     newrelic_globals,
     0)
 
+STD_PHP_INI_ENTRY_EX("newrelic.collect_script_name",
+                     "1",
+                     NR_PHP_REQUEST,
+                     nr_boolean_mh,
+                     collect_script_name,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     0)
+
 PHP_INI_END() /* } */
 
 void nr_php_register_ini_entries(int module_number TSRMLS_DC) {

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -50,7 +50,7 @@ static void nr_php_collect_x_request_start(TSRMLS_D) {
   nr_free(x_request_start);
 }
 
-static void nr_php_set_initial_path(nrtxn_t* txn TSRMLS_DC) {
+void nr_php_set_initial_path(nrtxn_t* txn TSRMLS_DC) {
   const zval* docroot = NULL;
   const zval* uri = NULL;
   const char* suri = NULL;

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -62,6 +62,11 @@ static void nr_php_set_initial_path(nrtxn_t* txn TSRMLS_DC) {
     return;
   }
 
+  if (! NRPRG(txn)->options.collect_script_name) {
+    nrl_debug(NRL_INIT, "Skip collecting script name.");
+    return;
+  }
+
 #ifdef PHP7
   server = &PG(http_globals)[TRACK_VARS_SERVER];
 #else
@@ -679,6 +684,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   opts.allow_raw_exception_messages = NRINI(allow_raw_exception_messages);
   opts.custom_parameters_enabled = NRINI(custom_parameters_enabled);
   opts.distributed_tracing_enabled = NRINI(distributed_tracing_enabled);
+  opts.collect_script_name = NRINI(collect_script_name);
   opts.distributed_tracing_exclude_newrelic_header
       = NRINI(distributed_tracing_exclude_newrelic_header);
   opts.span_events_enabled = NRINI(span_events_enabled);

--- a/agent/php_txn_private.h
+++ b/agent/php_txn_private.h
@@ -36,3 +36,5 @@ nrobj_t* nr_php_txn_get_supported_security_policy_settings();
  * Params  : 1. The current transaction.
  */
 extern void nr_php_txn_handle_fpm_error(nrtxn_t* txn TSRMLS_DC);
+
+extern void nr_php_set_initial_path(nrtxn_t* txn TSRMLS_DC);

--- a/agent/tests/test_txn.c
+++ b/agent/tests/test_txn.c
@@ -172,7 +172,7 @@ static void test_set_initial_path(TSRMLS_D) {
 
   NR_PHP_PROCESS_GLOBALS(cli) = 1;
 
-#ifdef PHP7
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
   server = &PG(http_globals)[TRACK_VARS_SERVER];
 #else
   server = PG(http_globals)[TRACK_VARS_SERVER];

--- a/agent/tests/test_txn.c
+++ b/agent/tests/test_txn.c
@@ -165,9 +165,9 @@ static void test_max_segments_config_values(TSRMLS_D) {
 
 static void test_set_initial_path(TSRMLS_D) {
   nrtxn_t* txn;
-  zval* server;  
+  zval* server;
   /*
-   * Test : max_segments_cli defaults correctly.
+   * Test : Collect script name.
    */
 
   NR_PHP_PROCESS_GLOBALS(cli) = 1;

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -110,6 +110,8 @@ typedef struct _nrtxnopt_t {
                                    spans will be batched, and non-8T behaviour
                                    will be used. */
   nrtime_t span_queue_batch_timeout; /* Span queue batch timeout in us. */
+
+  int collect_script_name; /* Whether to collect script names. */
 } nrtxnopt_t;
 
 typedef enum _nrtxnstatus_cross_process_t {


### PR DESCRIPTION
Added a flag to prevent URIs (script names) from being sent to New Relic.

The name of the flag setting is `newrelic.collect_script_name` .
The default value is true so as not to break the existing behavior.

https://github.com/newrelic/newrelic-php-agent/issues/190