### PR TITLE
Update to the CI.  

### DIFF
--- a/.github/docker/linux/x64/Dockerfile
+++ b/.github/docker/linux/x64/Dockerfile
@@ -61,7 +61,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   sqlite3 \
   libsqlite3-dev \
   openssl \

--- a/.github/docker/linux/x86/Dockerfile
+++ b/.github/docker/linux/x86/Dockerfile
@@ -57,7 +57,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   python3-argon2 \
   sqlite3 \
   libsqlite3-dev \


### PR DESCRIPTION
CI wasn't running due to a dockerfile build issue.  Modified the dockerfile, but longterm solution should be to store build images.