### PR TITLE
PHP 8.1: Agent changes to support PHP 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 agent/configure.ac
 agent/newrelic.map
+agent/*.dep
 axiom/tests
 bin/
 pkg/

--- a/agent/php_api_datastore.c
+++ b/agent/php_api_datastore.c
@@ -14,6 +14,7 @@
 #include "php_api_datastore_private.h"
 #include "php_call.h"
 #include "php_hash.h"
+#include "php_includes.h"
 #include "util_logging.h"
 #include "util_sql.h"
 

--- a/agent/php_error.c
+++ b/agent/php_error.c
@@ -447,7 +447,13 @@ static int nr_php_should_record_error(int type, const char* format TSRMLS_DC) {
 
   return 1;
 }
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+void nr_php_error_cb(int type,
+                     zend_string* error_filename,
+                     uint error_lineno,
+                     zend_string* message) {
+#elif ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
 void nr_php_error_cb(int type,
                      const char* error_filename,
                      uint error_lineno,
@@ -458,7 +464,7 @@ void nr_php_error_cb(int type,
                      uint error_lineno,
                      const char* format,
                      va_list args) {
-#endif /* PHP >= 8.0 */
+#endif /* PHP >= 8.1 */
   TSRMLS_FETCH();
   char* stack_json = NULL;
   const char* errclass = NULL;

--- a/agent/php_error.c
+++ b/agent/php_error.c
@@ -453,7 +453,7 @@ void nr_php_error_cb(int type,
                      zend_string* error_filename,
                      uint error_lineno,
                      zend_string* message) {
-#elif ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+#elif ZEND_MODULE_API_NO == ZEND_8_0_X_API_NO
 void nr_php_error_cb(int type,
                      const char* error_filename,
                      uint error_lineno,

--- a/agent/php_explain_pdo_mysql.c
+++ b/agent/php_explain_pdo_mysql.c
@@ -121,8 +121,8 @@ nr_explain_plan_t* nr_php_explain_pdo_mysql_statement(zval* stmt,
   const char* pdo_query_string = ZSTR_VAL(pdo_stmt->query_string);
   int pdo_query_string_len = ZSTR_LEN(pdo_stmt->query_string);
 #else
-  const char* pdo_query_string = pdo_stmt->query_string int pdo_query_string_len
-      = pdo_stmt->query_stringlen
+  const char* pdo_query_string = pdo_stmt->query_string; 
+  int pdo_query_string_len = pdo_stmt->query_stringlen;
 #endif /* PHP8.1+ */
 
   if (!nr_php_explain_mysql_query_is_explainable(pdo_query_string,
@@ -294,8 +294,8 @@ static zval* issue_explain_query(zval* dbh,
   const char* pdo_query_string = ZSTR_VAL(pdo_stmt->query_string);
   int pdo_query_string_len = ZSTR_LEN(pdo_stmt->query_string);
 #else
-  const char* pdo_query_string = pdo_stmt->query_string
-    int pdo_query_string_len = pdo_stmt->query_stringlen
+  const char* pdo_query_string = pdo_stmt->query_string;
+  int pdo_query_string_len = pdo_stmt->query_stringlen;
 #endif /* PHP8.1+ */
 
   explain_query = (char*)nr_zalloc(pdo_query_string_len + sizeof("EXPLAIN "));

--- a/agent/php_explain_pdo_mysql.c
+++ b/agent/php_explain_pdo_mysql.c
@@ -113,13 +113,20 @@ nr_explain_plan_t* nr_php_explain_pdo_mysql_statement(zval* stmt,
     goto end;
   }
 
-#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
-  if (!nr_php_explain_mysql_query_is_explainable(
-          ZSTR_VAL(pdo_stmt->query_string), ZSTR_LEN(pdo_stmt->query_string))) {
+/*
+ * PHP 8.1 changed to using a zend_string for PDO.
+ * For further details, see PHP 8.1 UPGRADING.INTERNALS
+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO /* PHP 8.1+ */
+  const char* pdo_query_string = ZSTR_VAL(pdo_stmt->query_string);
+  int pdo_query_string_len = ZSTR_LEN(pdo_stmt->query_string);
 #else
-  if (!nr_php_explain_mysql_query_is_explainable(pdo_stmt->query_string,
-                                                 pdo_stmt->query_stringlen)) {
-#endif
+  const char* pdo_query_string = pdo_stmt->query_string int pdo_query_string_len
+      = pdo_stmt->query_stringlen
+#endif /* PHP8.1+ */
+
+  if (!nr_php_explain_mysql_query_is_explainable(pdo_query_string,
+                                                 pdo_query_string_len)) {
     goto end;
   }
 
@@ -278,24 +285,22 @@ static zval* issue_explain_query(zval* dbh,
    * Construct the EXPLAIN query that needs to be sent, which simply involves
    * prepending the keyword EXPLAIN.
    */
-  /*
-   * PHP 8.1 changed to using a zend_string
-   */
-  explain_query = (char*)nr_zalloc(
-#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
-      ZSTR_LEN(pdo_stmt->query_string)
+
+/*
+ * PHP 8.1 changed to using a zend_string for PDO.
+ * For further details, see PHP 8.1 UPGRADING.INTERNALS
+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO /* PHP 8.1+ */
+  const char* pdo_query_string = ZSTR_VAL(pdo_stmt->query_string);
+  int pdo_query_string_len = ZSTR_LEN(pdo_stmt->query_string);
 #else
-      pdo_stmt->query_stringlen
-#endif
-      + sizeof("EXPLAIN "));
+  const char* pdo_query_string = pdo_stmt->query_string
+    int pdo_query_string_len = pdo_stmt->query_stringlen
+#endif /* PHP8.1+ */
+
+  explain_query = (char*)nr_zalloc(pdo_query_string_len + sizeof("EXPLAIN "));
   nr_strcat(explain_query, "EXPLAIN ");
-  nr_strncat(explain_query,
-#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
-             ZSTR_VAL(pdo_stmt->query_string), ZSTR_LEN(pdo_stmt->query_string)
-#else
-             pdo_stmt->query_string, pdo_stmt->query_stringlen
-#endif
-                 );
+  nr_strncat(explain_query, pdo_query_string, pdo_query_string_len);
   explain_stmt = nr_php_pdo_prepare_query(dbh, explain_query TSRMLS_CC);
   if (NULL == explain_stmt) {
     goto end;

--- a/agent/php_hooks.h
+++ b/agent/php_hooks.h
@@ -46,7 +46,12 @@ void my_error_notify_cb(int type,
                 }
                 zend_register_error_notify_callback(my_error_notify_cb);
  */
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+extern void nr_php_error_cb(int type,
+                            zend_string* filename,
+                            uint error_lineno,
+                            zend_string* message);
+#elif ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
 extern void nr_php_error_cb(int type,
                             const char* filename,
                             uint error_lineno,
@@ -58,7 +63,7 @@ extern void nr_php_error_cb(int type,
                             const char* fmt,
                             va_list args)
     ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
-#endif /* PHP >= 8.0 */
+#endif /* PHP >= 8.1 */
 
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
 extern void nr_php_execute_internal(zend_execute_data* execute_data,

--- a/agent/php_hooks.h
+++ b/agent/php_hooks.h
@@ -51,7 +51,7 @@ extern void nr_php_error_cb(int type,
                             zend_string* filename,
                             uint error_lineno,
                             zend_string* message);
-#elif ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+#elif ZEND_MODULE_API_NO == ZEND_8_0_X_API_NO
 extern void nr_php_error_cb(int type,
                             const char* filename,
                             uint error_lineno,

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -50,6 +50,10 @@
 #define ZEND_7_3_X_API_NO 20180731
 #define ZEND_7_4_X_API_NO 20190902
 #define ZEND_8_0_X_API_NO 20200930
+/*
+ * TEMPORARY value for 8.1 based on RC2 - update when final 8.1 is released.
+ */
+#define ZEND_8_1_X_API_NO 20210902
 
 #if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
 #include "Zend/zend_virtual_cwd.h"
@@ -72,6 +76,41 @@
 #define TSRMLS_C
 #define TSRMLS_CC
 #define TSRMLS_FETCH()
+#endif
+
+/*
+ * The convert_to_explicit_type() macro was removed for 8.1.
+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+#define convert_to_explicit_type(pzv, type) \
+  do {                                      \
+    switch (type) {                         \
+      case IS_NULL:                         \
+        convert_to_null(pzv);               \
+        break;                              \
+      case IS_LONG:                         \
+        convert_to_long(pzv);               \
+        break;                              \
+      case IS_DOUBLE:                       \
+        convert_to_double(pzv);             \
+        break;                              \
+      case _IS_BOOL:                        \
+        convert_to_boolean(pzv);            \
+        break;                              \
+      case IS_ARRAY:                        \
+        convert_to_array(pzv);              \
+        break;                              \
+      case IS_OBJECT:                       \
+        convert_to_object(pzv);             \
+        break;                              \
+      case IS_STRING:                       \
+        convert_to_string(pzv);             \
+        break;                              \
+      default:                              \
+        assert(0);                          \
+        break;                              \
+    }                                       \
+  } while (0);
 #endif
 
 #endif /* PHP_INCLUDES_HDR */

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -39,6 +39,7 @@
 
 /*
  * Zend Engine API numbers.
+ * Find these numbers at: php-src/Zend/zend_modules.h
  */
 #define ZEND_5_3_X_API_NO 20090626
 #define ZEND_5_4_X_API_NO 20100525
@@ -50,9 +51,6 @@
 #define ZEND_7_3_X_API_NO 20180731
 #define ZEND_7_4_X_API_NO 20190902
 #define ZEND_8_0_X_API_NO 20200930
-/*
- * TEMPORARY value for 8.1 based on RC2 - update when final 8.1 is released.
- */
 #define ZEND_8_1_X_API_NO 20210902
 
 #if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -181,7 +181,12 @@ typedef void (*nrphpfn_t)(INTERNAL_FUNCTION_PARAMETERS);
 typedef void(ZEND_FASTCALL* nrphpfn_t)(INTERNAL_FUNCTION_PARAMETERS);
 #endif /* PHP < 7.3 */
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+typedef void (*nrphperrfn_t)(int type,
+                             zend_string* error_filename,
+                             uint error_lineno,
+                             zend_string* message);
+#elif ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
 typedef void (*nrphperrfn_t)(int type,
                              const char* error_filename,
                              uint error_lineno,

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -186,7 +186,7 @@ typedef void (*nrphperrfn_t)(int type,
                              zend_string* error_filename,
                              uint error_lineno,
                              zend_string* message);
-#elif ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+#elif ZEND_MODULE_API_NO == ZEND_8_0_X_API_NO
 typedef void (*nrphperrfn_t)(int type,
                              const char* error_filename,
                              uint error_lineno,

--- a/agent/tests/tlib_php.c
+++ b/agent/tests/tlib_php.c
@@ -448,7 +448,7 @@ static void tlib_php_error_silence_cb(int type NRUNUSED,
                                       zend_string* message NRUNUSED) {
   /* Squash the error by doing absolutely nothing. */
 }
-#elif ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+#elif ZEND_MODULE_API_NO == ZEND_8_0_X_API_NO
 static void tlib_php_error_silence_cb(int type NRUNUSED,
                                       const char* error_filename NRUNUSED,
                                       const uint32_t error_lineno NRUNUSED,
@@ -470,7 +470,7 @@ int tlib_php_require_extension(const char* extension TSRMLS_DC) {
   int loaded = 0;
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
   void (*prev_error_cb)(int, zend_string*, const uint32_t, zend_string*);
-#elif ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+#elif ZEND_MODULE_API_NO == ZEND_8_0_X_API_NO
   void (*prev_error_cb)(int, const char*, const uint32_t, zend_string*);
 #elif ZEND_MODULE_API_NO >= ZEND_7_3_X_API_NO
   void (*prev_error_cb)(int, const char*, const uint32_t, const char*, va_list);


### PR DESCRIPTION
Great job Michael, the prototype seems to be all in order to support PHP 8.1 (with the exception of the valgrind issue that Zach's PR is addressing).  This looks ready to merge. 

Addresses Issue https://github.com/newrelic/newrelic-php-agent/issues/290