### PR TITLE
Updates to support building PHP 8.1 and installer script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ src/newrelic/infinite_tracing/com_newrelic_trace_v1/v1.pb.go: protocol/infinite_
 
 .PHONY: integration
 integration: Makefile daemon lasp-test-all
-	for PHP in $${PHPS:-8.1 8.0 7.4 7.3 7.2 7.1 7.0 5.6 5.5 5.4 5.3}; do \
+	for PHP in $${PHPS:-8.1 8.0 7.4 7.3 7.2 7.1 7.0 5.6 5.5}; do \
           echo; echo "# PHP=$${PHP}"; \
 	  env NRLAMP_PHP=$${PHP} bin/integration_runner $(INTEGRATION_ARGS) || exit 1; \
 	  echo "# PHP=$${PHP}"; \
@@ -381,7 +381,7 @@ lasp-test: daemon
 	if [ ! $(SUITE_LASP) ]; then echo "USAGE: make lasp-test SUITE_LASP=suite-most-secure"; exit 1; fi
 	if [ "$(LICENSE_lasp_$(subst -,_,$(SUITE_LASP)))" = "" ] ; then echo "Missing license for $(SUITE_LASP)"; exit 1; fi
 	if [ ! -d "tests/lasp/$(SUITE_LASP)" ]; then echo "No such suite in tests/lasp folder"; exit 1; fi
-	for PHP in $${PHPS:-8.1 8.0 7.4 7.3 7.2 7.1 7.0 5.6 5.5 5.4 5.3}; do \
+	for PHP in $${PHPS:-8.1 8.0 7.4 7.3 7.2 7.1 7.0 5.6 5.5}; do \
           echo; echo "# PHP=$${PHP}"; \
           NRLAMP_PHP=$${PHP} bin/integration_runner $(INTEGRATION_ARGS) -loglevel debug \
         -license $(LICENSE_lasp_$(subst -,_,$(SUITE_LASP))) \

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -312,13 +312,17 @@ if [ -z "${ispkg}" ]; then
   check_file "${ilibdir}/scripts/newrelic-daemon.logrotate"
 fi
 check_file "${ilibdir}/scripts/newrelic.ini.template"
-for pmv in "20090626" "20100525" "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
+for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" \
+"20180731" "20190902" "20200930" "20210902"; do
   # If on a 32-bit system, don't look for a PHP 8.0 build.
-  if [ "${arch}" = "x64" -o "${pmv}" != "20200930" ]; then
-    check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
-    check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"
+  if [ "${arch}" = "x64" ]; then
+    if [ "${pmv}" -lt "20200930" ]; then
+      check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
+      check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"
+    fi
   fi
-  if [ -z "${ispkg}" ] && [ "${arch}" = "x64" ] && [ "${pmv}" != "20200930" ]; then
+
+  if [ -z "${ispkg}" ] && [ "${arch}" = "x64" ] && [ "${pmv}" -lt "20200930" ]; then
     # Only check for x86 agent files on supported platforms.
     case "$ostype" in
       alpine|darwin|freebsd) ;;
@@ -507,8 +511,6 @@ add_to_path /usr/local/php
 add_to_path /usr/local/php/bin
 add_to_path /usr/local/zend/bin
 
-add_to_path /usr/local/php-5.3/bin
-add_to_path /usr/local/php-5.4/bin
 add_to_path /usr/local/php-5.5/bin
 add_to_path /usr/local/php-5.6/bin
 add_to_path /usr/local/php-7.0/bin
@@ -517,12 +519,11 @@ add_to_path /usr/local/php-7.2/bin
 add_to_path /usr/local/php-7.3/bin
 add_to_path /usr/local/php-7.4/bin
 add_to_path /usr/local/php-8.0/bin
+add_to_path /usr/local/php-8.1/bin
 
 add_to_path /opt/local/bin
 add_to_path /usr/php/bin
 
-add_to_path /usr/php-5.3/bin
-add_to_path /usr/php-5.4/bin
 add_to_path /usr/php-5.5/bin
 add_to_path /usr/php-5.6/bin
 add_to_path /usr/php-7.0/bin
@@ -531,9 +532,8 @@ add_to_path /usr/php-7.2/bin
 add_to_path /usr/php-7.3/bin
 add_to_path /usr/php-7.4/bin
 add_to_path /usr/php-8.0/bin
+add_to_path /usr/php-8.1/bin
 
-add_to_path /usr/php/5.3/bin
-add_to_path /usr/php/5.4/bin
 add_to_path /usr/php/5.5/bin
 add_to_path /usr/php/5.6/bin
 add_to_path /usr/php/7.0/bin
@@ -542,12 +542,11 @@ add_to_path /usr/php/7.2/bin
 add_to_path /usr/php/7.3/bin
 add_to_path /usr/php/7.4/bin
 add_to_path /usr/php/8.0/bin
+add_to_path /usr/php/8.1/bin
 
 add_to_path /opt/php/bin
 add_to_path /opt/zend/bin
 
-add_to_path /opt/php-5.3/bin
-add_to_path /opt/php-5.4/bin
 add_to_path /opt/php-5.5/bin
 add_to_path /opt/php-5.6/bin
 add_to_path /opt/php-7.0/bin
@@ -556,6 +555,7 @@ add_to_path /opt/php-7.2/bin
 add_to_path /opt/php-7.3/bin
 add_to_path /opt/php-7.4/bin
 add_to_path /opt/php-8.0/bin
+add_to_path /opt/php-8.1/bin
 
 if [ -n "${NR_INSTALL_PATH}" ]; then
   oIFS="${IFS}"
@@ -905,6 +905,8 @@ set_daemon_location() {
 #   NR_INSTALL_ARCH and NR_INSTALL_PATH to force the architecture. If
 #   NR_INSTALL_ARCH is set, it will always set the value of pi_arch, no matter
 #   what we detect.
+# pi_php8
+#   True if PHP version is 8.0+
 #
 # For installation, 4 things are important:
 # the extension API version, the extension load directory, and whether or not
@@ -1041,6 +1043,10 @@ for this copy of PHP. We apologize for the inconvenience.
       pi_php8="yes"
       ;;
 
+    8.1.*)
+      pi_php8="yes"
+      ;;
+
     *)
       error "unsupported version '${pi_ver}' of PHP found at:
     ${pdir}
@@ -1105,7 +1111,8 @@ Ignoring this particular instance of PHP.
 
   if [ -n "${ispkg}" -a "${arch}" = "x64" ]; then
     if [ "${pi_arch}" = "x86" ]; then
-      for pmv in "20090626" "20100525" "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" "20190902" "20200930"; do
+      for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" "20180731" \
+      "20190902" "20200930" "20210902"; do
         check_file "${ilibdir}/agent/x86/newrelic-${pmv}.so"
         check_file "${ilibdir}/agent/x86/newrelic-${pmv}-zts.so"
       done
@@ -1207,8 +1214,6 @@ does not exist. This particular instance of PHP will be skipped.
 #
   pi_modver=
   case "${pi_ver}" in
-    5.3.*)  pi_modver="20090626" ;;
-    5.4.*)  pi_modver="20100525" ;;
     5.5.*)  pi_modver="20121212" ;;
     5.6.*)  pi_modver="20131226" ;;
     7.0.*)  pi_modver="20151012" ;;
@@ -1217,6 +1222,7 @@ does not exist. This particular instance of PHP will be skipped.
     7.3.*)  pi_modver="20180731" ;;
     7.4.*)  pi_modver="20190902" ;;
     8.0.*)  pi_modver="20200930" ;;
+    8.1.*)  pi_modver="20210902" ;;
   esac
   log "${pdir}: pi_modver=${pi_modver}"
 

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1012,12 +1012,6 @@ for this copy of PHP. We apologize for the inconvenience.
   fi
 
   case "${pi_ver}" in
-    5.3.*)
-      ;;
-
-    5.4.*)
-      ;;
-
     5.5.*)
       ;;
 

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -959,6 +959,7 @@ gather_info() {
   havecfg=
   havebin=
   pi_bin=
+  pi_php8=
 
   #
   # Get the path to the binary.

--- a/make/release.mk
+++ b/make/release.mk
@@ -85,8 +85,7 @@ endif
 	$(MAKE) agent-clean; $(MAKE) release-7.0-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.6-no-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.5-no-zts
-	$(MAKE) agent-clean; $(MAKE) release-5.4-no-zts
-	$(MAKE) agent-clean; $(MAKE) release-5.3-no-zts
+
 ifeq (x64,$(ARCH))
 	$(MAKE) agent-clean; $(MAKE) release-8.1-zts
 	$(MAKE) agent-clean; $(MAKE) release-8.0-zts
@@ -98,8 +97,7 @@ endif
 	$(MAKE) agent-clean; $(MAKE) release-7.0-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.6-zts
 	$(MAKE) agent-clean; $(MAKE) release-5.5-zts
-	$(MAKE) agent-clean; $(MAKE) release-5.4-zts
-	$(MAKE) agent-clean; $(MAKE) release-5.3-zts
+
 
 #
 # Add a new target to build the agent against build machines.
@@ -150,8 +148,7 @@ $(eval $(call RELEASE_AGENT_TARGET,7.1,20160303))
 $(eval $(call RELEASE_AGENT_TARGET,7.0,20151012))
 $(eval $(call RELEASE_AGENT_TARGET,5.6,20131226))
 $(eval $(call RELEASE_AGENT_TARGET,5.5,20121212))
-$(eval $(call RELEASE_AGENT_TARGET,5.4,20100525))
-$(eval $(call RELEASE_AGENT_TARGET,5.3,20090626))
+
 
 #
 # Release directories


### PR DESCRIPTION
Changes:
- agent/newrelic-install.sh:
  - Remove references to 5.3 and 5.4 and add 8.1 as required.
  - Rework some logic which assumed the only possible 8.x release was 8.0 to work now we have 8.0 and 8.1.

- make/release.mk
  - Add guards so 8.1 is only built on 64 bit systems.
  - Remove building for 5.3 and 5.4.

Makefile
 - Remove 5.3 and 5.4 from lists for version to run for integration and LASP tests.
