### PR TITLE
Fix LASP test cases affected by PHP 8.1 PDO changes

### DIFF
--- a/tests/lasp/suite-least-secure/test_slow_sql_on.php
+++ b/tests/lasp/suite-least-secure/test_slow_sql_on.php
@@ -12,6 +12,9 @@ indicates record_sql:{enabled:true} and agent is configured to send obfuscated.
 
 /*SKIPIF
 <?php require('../../integration/pdo/skipif_mysql.inc');
+if (version_compare(PHP_VERSION, "8.1", ">=")) {
+  die("skip: PHP >= 8.1.0 not supported\n");
+}
 */
 
 /*INI

--- a/tests/lasp/suite-least-secure/test_slow_sql_on.php81.php
+++ b/tests/lasp/suite-least-secure/test_slow_sql_on.php81.php
@@ -5,14 +5,15 @@
  */
 
 /*DESCRIPTION
-Tests the agent sends slow sql transactions when LASP configuration
+Tests the agent sends slow sql transactions when 
+Language Agent Security Policy (LASP) configuration
 indicates record_sql:{enabled:true} and agent is configured to send obfuscated.
 */
 
 /*SKIPIF
 <?php require('../../integration/pdo/skipif_mysql.inc');
-if (version_compare(PHP_VERSION, "8.1", ">=")) {
-  die("skip: PHP >= 8.1.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP < 8.1.0 not supported\n");
 }
 */
 
@@ -53,7 +54,7 @@ newrelic.transaction_tracer.record_sql = "obfuscated"
           ],
           [
             [
-              "1",
+              1,
               "SIMPLE",
               "tables",
               "ALL",

--- a/tests/lasp/suite-random-2/test_slow_sql_on.php81.php
+++ b/tests/lasp/suite-random-2/test_slow_sql_on.php81.php
@@ -11,8 +11,8 @@ indicates record_sql:{enabled:true} and agent is configured to send obfuscated.
 
 /*SKIPIF
 <?php require('../../integration/pdo/skipif_mysql.inc');
-if (version_compare(PHP_VERSION, "8.1", ">=")) {
-  die("skip: PHP >= 8.1.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP < 8.1.0 not supported\n");
 }
 */
 
@@ -53,7 +53,7 @@ newrelic.transaction_tracer.record_sql = "obfuscated"
           ],
           [
             [
-              "1",
+              1,
               "SIMPLE",
               "tables",
               "ALL",


### PR DESCRIPTION
PHP 8.1 changed the behavior of the PDO MySQL extension:
```
PDO MySQL:
    Integers and floats in result sets will now be returned using native PHP
    types instead of strings when using emulated prepared statements. This
    matches the behavior of native prepared statements. You can restore the
    previous behavior by enabling the PDO::ATTR_STRINGIFY_FETCHES option.
```

This has impacted some of the LASP "slow sql" test cases which expect a string return value but now on PHP 8.1 it is a numeric value instead.

The fix we adopted in the integration tests for this was to split the test into a "pre-8.1" test and an "8.1 and beyond" test which are guarded by the appropriate code in the SKIPIF.