### PR TITLE
Update URL of New Relic for PHP Docs website used in error messages

### DIFF
--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -531,8 +531,8 @@ PHP_MINIT_FUNCTION(newrelic) {
                   "expects a daemon "
                   "to be started externally. "
                   "Please refer to: "
-                  "https://newrelic.com/docs/php/"
-                  "newrelic-daemon-startup-modes#daemon-external");
+                  "https://docs.newrelic.com/docs/apm/agents/php-agent/"
+                  "advanced-installation/starting-php-daemon-advanced/#daemon-external");
     }
   }
 

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -530,9 +530,9 @@ PHP_MINIT_FUNCTION(newrelic) {
                   "failed to connect to the newrelic-daemon.  The agent "
                   "expects a daemon "
                   "to be started externally. "
-                  "Please refer to: "
-                  NR_PHP_AGENT_EXT_DOCS_URL
-                  "advanced-installation/starting-php-daemon-advanced/#daemon-external");
+                  "Please refer to: " NR_PHP_AGENT_EXT_DOCS_URL
+                  "advanced-installation/starting-php-daemon-advanced/"
+                  "#daemon-external");
     }
   }
 

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -531,7 +531,7 @@ PHP_MINIT_FUNCTION(newrelic) {
                   "expects a daemon "
                   "to be started externally. "
                   "Please refer to: "
-                  "https://docs.newrelic.com/docs/apm/agents/php-agent/"
+                  NR_PHP_AGENT_EXT_DOCS_URL
                   "advanced-installation/starting-php-daemon-advanced/#daemon-external");
     }
   }

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -18,7 +18,6 @@
 #include "util_vector.h"
 
 #define PHP_NEWRELIC_EXT_NAME "newrelic"
-#define PHP_NEWRELIC_EXT_URL "https://newrelic.com/docs/php/new-relic-for-php"
 
 extern PHP_MINIT_FUNCTION(newrelic);
 extern PHP_MSHUTDOWN_FUNCTION(newrelic);

--- a/agent/scripts/init.darwin
+++ b/agent/scripts/init.darwin
@@ -131,7 +131,7 @@ INFO: newrelic.cfg not found - daemon must be launched by the agent.
       If you want to start the daemon via this script then please copy the
       file scripts/newrelic.cfg.template to /etc/newrelic/newrelic.cfg,
       edit it to taste, and then re-run this script. For more information
-      please refer to https://newrelic.com/docs/php/new-relic-for-php.
+      please refer to https://docs.newrelic.com/docs/apm/agents/php-agent/advanced-installation/starting-php-daemon-advanced/.
 EOF
     fi
     exit 0

--- a/agent/scripts/init.debian
+++ b/agent/scripts/init.debian
@@ -192,7 +192,7 @@ INFO: newrelic.cfg not found - daemon must be launched by the agent.
       If you want to start the daemon via this script then please copy the
       file /etc/newrelic/newrelic.cfg.template to /etc/newrelic/newrelic.cfg,
       edit it to taste, and then re-run this script. For more information
-      please refer to https://newrelic.com/docs/php/new-relic-for-php.
+      please refer to https://docs.newrelic.com/docs/apm/agents/php-agent/advanced-installation/starting-php-daemon-advanced/.
 EOF
     fi
     exit 0

--- a/agent/scripts/init.freebsd
+++ b/agent/scripts/init.freebsd
@@ -141,7 +141,7 @@ INFO: newrelic.cfg not found - daemon must be launched by the agent.
       If you want to start the daemon via this script then please copy the
       file scripts/newrelic.cfg.template to /etc/newrelic/newrelic.cfg,
       edit it to taste, and then re-run this script. For more information
-      please refer to https://newrelic.com/docs/php/new-relic-for-php.
+      please refer to https://docs.newrelic.com/docs/apm/agents/php-agent/advanced-installation/starting-php-daemon-advanced/.
 EOF
     fi
     exit 0

--- a/agent/scripts/init.generic
+++ b/agent/scripts/init.generic
@@ -128,7 +128,7 @@ INFO: newrelic.cfg not found - daemon must be launched by the agent.
       If you want to start the daemon via this script then please copy the
       file scripts/newrelic.cfg.template to /etc/newrelic/newrelic.cfg,
       edit it to taste, and then re-run this script. For more information
-      please refer to https://newrelic.com/docs/php/new-relic-for-php.
+      please refer to https://docs.newrelic.com/docs/apm/agents/php-agent/advanced-installation/starting-php-daemon-advanced/.
 EOF
     fi
     exit 0

--- a/agent/scripts/init.rhel
+++ b/agent/scripts/init.rhel
@@ -186,7 +186,7 @@ INFO: newrelic.cfg not found - daemon must be launched by the agent.
       If you want to start the daemon via this script then please copy the
       file /etc/newrelic/newrelic.cfg.template to /etc/newrelic/newrelic.cfg,
       edit it to taste, and then re-run this script. For more information
-      please refer to https://newrelic.com/docs/php/new-relic-for-php.
+      please refer to https://docs.newrelic.com/docs/apm/agents/php-agent/advanced-installation/starting-php-daemon-advanced/.
 EOF
     fi
     exit 0

--- a/agent/scripts/init.solaris
+++ b/agent/scripts/init.solaris
@@ -137,7 +137,7 @@ INFO: newrelic.cfg not found - daemon must be launched by the agent.
       If you want to start the daemon via this script then please copy the
       file scripts/newrelic.cfg.template to /etc/newrelic/newrelic.cfg,
       edit it to taste, and then re-run this script. For more information
-      please refer to https://newrelic.com/docs/php/new-relic-for-php.
+      please refer to https://docs.newrelic.com/docs/apm/agents/php-agent/advanced-installation/starting-php-daemon-advanced/.
 EOF
     fi
     exit 0

--- a/axiom/nr_agent.c
+++ b/axiom/nr_agent.c
@@ -479,7 +479,7 @@ static void nr_agent_warn_connect_failure(int connect_fd,
       "Failed to connect to the newrelic-daemon. Please make sure that there "
       "is a properly configured newrelic-daemon running. "
       "For additional assistance, please see: "
-      "https://docs.newrelic.com/docs/apm/agents/php-agent/"
+      NR_PHP_AGENT_EXT_DOCS_URL
       "advanced-installation/starting-php-daemon-advanced/",
       connect_fd, nr_agent_connect_method_msg, connect_rv,
       nr_errno(connect_err));

--- a/axiom/nr_agent.c
+++ b/axiom/nr_agent.c
@@ -479,7 +479,8 @@ static void nr_agent_warn_connect_failure(int connect_fd,
       "Failed to connect to the newrelic-daemon. Please make sure that there "
       "is a properly configured newrelic-daemon running. "
       "For additional assistance, please see: "
-      "https://newrelic.com/docs/php/newrelic-daemon-startup-modes",
+      "https://docs.newrelic.com/docs/apm/agents/php-agent/"
+      "advanced-installation/starting-php-daemon-advanced/",
       connect_fd, nr_agent_connect_method_msg, connect_rv,
       nr_errno(connect_err));
 }

--- a/axiom/nr_agent.c
+++ b/axiom/nr_agent.c
@@ -478,8 +478,7 @@ static void nr_agent_warn_connect_failure(int connect_fd,
       "daemon connect(fd=%d %.256s) returned %d errno=%.16s. "
       "Failed to connect to the newrelic-daemon. Please make sure that there "
       "is a properly configured newrelic-daemon running. "
-      "For additional assistance, please see: "
-      NR_PHP_AGENT_EXT_DOCS_URL
+      "For additional assistance, please see: " NR_PHP_AGENT_EXT_DOCS_URL
       "advanced-installation/starting-php-daemon-advanced/",
       connect_fd, nr_agent_connect_method_msg, connect_rv,
       nr_errno(connect_err));

--- a/axiom/nr_agent.h
+++ b/axiom/nr_agent.h
@@ -12,6 +12,8 @@
 #include "nr_axiom.h"
 #include "nr_app.h"
 
+#define NR_PHP_AGENT_EXT_DOCS_URL "https://docs.newrelic.com/docs/apm/agents/php-agent/"
+
 /*
  * The means by which the agent and the daemon connect.
  */


### PR DESCRIPTION
Use current location of New Relic for PHP Docs website in init scripts as well as in agent code error messages.