### PR TITLE
Disable 32bit builds for PHP 8.x in GitHub workflow

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -42,6 +42,7 @@ jobs:
         arch: ['x64', 'x86']
         exclude:
         # Excludes PHP 5.x, 7.x on linux 32-bit
+	# Excludes PHP 8.x as only 64bit is supported for these versions
         - os: linux
           php_ver: '7.0'
           arch: 'x86'
@@ -56,6 +57,12 @@ jobs:
           arch: 'x86'
         - os: linux
           php_ver: '7.4'
+          arch: 'x86'
+        - os: linux
+          php_ver: '8.0'
+          arch: 'x86'
+        - os: linux
+          php_ver: '8.1'
           arch: 'x86'
     steps:
       - name: Checkout Repo 

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -62,7 +62,13 @@ jobs:
           php_ver: '8.0'
           arch: 'x86'
         - os: linux
+          php_ver: '8.0-zts'
+          arch: 'x86'
+        - os: linux
           php_ver: '8.1'
+          arch: 'x86'
+        - os: linux
+          php_ver: '8.1-zts'
           arch: 'x86'
     steps:
       - name: Checkout Repo 

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -42,7 +42,7 @@ jobs:
         arch: ['x64', 'x86']
         exclude:
         # Excludes PHP 5.x, 7.x on linux 32-bit
-	# Excludes PHP 8.x as only 64bit is supported for these versions
+        # Excludes PHP 8.x as only 64bit is supported for these versions
         - os: linux
           php_ver: '7.0'
           arch: 'x86'


### PR DESCRIPTION
The agent does not support 32 bit environments running PHP 8.x so we can disable these test builds.

This is the corrected version of PR #335 which was improperly setup targeting 'main' instead of the 'dev' branch.