### PR TITLE
Configurable span reservoir size

### DIFF
--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -445,7 +445,7 @@ nrinibool_t
     distributed_tracing_exclude_newrelic_header; /* newrelic.distributed_tracing_exclude_newrelic_header
                                                   */
 nrinibool_t span_events_enabled; /* newrelic.span_events_enabled */
-nriniuint_t max_span_events;     /* newrelic.special.max_span_events */
+nriniuint_t span_events_max_samples_stored; /* newrelic.span_events.max_samples_stored */
 nrinistr_t
     trace_observer_host; /* newrelic.infinite_tracing.trace_observer.host */
 nriniuint_t

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2586,11 +2586,11 @@ STD_PHP_INI_ENTRY_EX("newrelic.span_events_enabled",
                      newrelic_globals,
                      0)
 
-STD_PHP_INI_ENTRY_EX("newrelic.special.max_span_events",
+STD_PHP_INI_ENTRY_EX("newrelic.span_events.max_samples_stored",
                      "0",
                      NR_PHP_REQUEST,
                      nr_unsigned_int_mh,
-                     max_span_events,
+                     span_events_max_samples_stored,
                      zend_newrelic_globals,
                      newrelic_globals,
                      0)

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -682,7 +682,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   opts.distributed_tracing_exclude_newrelic_header
       = NRINI(distributed_tracing_exclude_newrelic_header);
   opts.span_events_enabled = NRINI(span_events_enabled);
-  opts.max_span_events = NRINI(max_span_events);
+  opts.span_events_max_samples_stored = NRINI(span_events_max_samples_stored);
   opts.max_segments
       = is_cli ? NRINI(tt_max_segments_cli) : NRINI(tt_max_segments_web);
   opts.span_queue_batch_size = NRINI(agent_span_queue_size);

--- a/agent/scripts/newrelic.ini.private.template
+++ b/agent/scripts/newrelic.ini.private.template
@@ -128,15 +128,6 @@
 ;
 ;newrelic.special.enable_extension_instrumentation = false
 
-; Setting: newrelic.special.max_span_events
-; Type   : unsigned integer
-; Scope  : per-directory
-; Default: 0 
-; Info   : The maximum number of span events added to the span event reservoir
-;          per transaction. A value of 0 will use the agent default.
-;
-;newrelic.special.max_span_events = 0
-
 ; Setting: newrelic.browser_monitoring.debug
 ; Type   : boolean
 ; Scope  : per-directory

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -898,6 +898,16 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;newrelic.span_events_enabled = true
 
+; Setting: newrelic.span_events.max_samples_stored
+; Type   : unsigned integer
+; Scope  : per-directory
+; Default: 0
+; Info   : The maximum number of span events added to the span event reservoir
+;          per transaction. A value of 0 will use the agent default.
+;
+;newrelic.span_events.max_samples_stored = 0
+
+
 ; Setting: newrelic.infinite_tracing.trace_observer.host
 ; Type   : string
 ; Scope  : per-directory

--- a/axiom/cmd_appinfo_transmit.c
+++ b/axiom/cmd_appinfo_transmit.c
@@ -396,7 +396,7 @@ void nr_cmd_appinfo_process_event_harvest_config(const nrobj_t* config,
   app_limits->error_events = nr_cmd_appinfo_process_get_harvest_limit(
       harvest_limits, "error_event_data", NR_MAX_ERRORS);
   app_limits->span_events = nr_cmd_appinfo_process_get_harvest_limit(
-      harvest_limits, "span_event_data", NR_MAX_SPAN_EVENTS);
+      harvest_limits, "span_event_data", NR_SPAN_EVENTS_DEFAULT_MAX_SAMPLES_STORED);
 }
 
 int nr_cmd_appinfo_process_get_harvest_limit(const nrobj_t* limits,

--- a/axiom/nr_limits.h
+++ b/axiom/nr_limits.h
@@ -33,9 +33,9 @@
 #define NR_MAX_SEGMENTS 2000
 
 /*
- * The maximum number of span events in a transaction.
+ * The default maximum number of span events in a transaction.
  */
-#define NR_MAX_SPAN_EVENTS 1000
+#define NR_SPAN_EVENTS_DEFAULT_MAX_SAMPLES_STORED 2000
 
 /*
  * The maximum number of span events in an 8T span batch.

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -1424,9 +1424,9 @@ void nr_txn_end(nrtxn_t* txn) {
    * Finalise the segment tree.
    */
   txn->final_data = nr_segment_tree_finalise(txn, NR_MAX_SEGMENTS,
-                                             (0 != txn->options.max_span_events)
-                                                 ? txn->options.max_span_events
-                                                 : NR_MAX_SPAN_EVENTS,
+                                             (0 != txn->options.span_events_max_samples_stored)
+                                                 ? txn->options.span_events_max_samples_stored
+                                                 : NR_SPAN_EVENTS_DEFAULT_MAX_SAMPLES_STORED,
                                              nr_txn_handle_total_time, NULL);
 }
 

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -93,9 +93,9 @@ typedef struct _nrtxnopt_t {
                                                        W3C trace context headers
                                                      */
   int span_events_enabled; /* Whether span events are enabled */
-  size_t max_span_events;  /* The maximum number of span events per transaction.
-                              When set to 0, the app harvest's span event limit
-                              is used. */
+  size_t span_events_max_samples_stored;  /* The maximum number of span events per transaction.
+                                             When set to 0, the app harvest's span event limit
+                                             is used. */
   size_t max_segments; /* The maximum number of segments that are kept in the
                           segment tree at a time. When set to 0 or 1, no maximum
                           is applied. */

--- a/src/newrelic/limits/limits.go
+++ b/src/newrelic/limits/limits.go
@@ -30,7 +30,7 @@ const (
 	MaxTxnEvents          = 10 * 1000
 	MaxCustomEvents       = 10 * 1000
 	MaxErrorEvents        = 100
-	MaxSpanEvents         = 1000
+	MaxSpanEvents         = 10000
 	MaxErrors             = 20
 	MaxSlowSQLs           = 10
 	MaxRegularTraces      = 1

--- a/tests/integration/api/add_custom_parameter/test_span_event.php
+++ b/tests/integration/api/add_custom_parameter/test_span_event.php
@@ -58,7 +58,7 @@ ok - double attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_disabled.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_disabled.php
@@ -27,7 +27,7 @@ ok - double attribute not added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_duplicate.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_duplicate.php
@@ -64,7 +64,7 @@ ok - double attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_duplicate_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_duplicate_te_off.php
@@ -38,7 +38,7 @@ null
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_filter.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_filter.php
@@ -29,7 +29,7 @@ ok - double attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_invalid.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_invalid.php
@@ -28,7 +28,7 @@ ok - hash value
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 1
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_key.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_key.php
@@ -27,7 +27,7 @@ ok - double attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_key_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_key_te_off.php
@@ -32,7 +32,7 @@ null
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_parameters.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_parameters.php
@@ -88,7 +88,7 @@ ok - string attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_value.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_value.php
@@ -26,7 +26,7 @@ ok - double attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_value_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_value_te_off.php
@@ -36,7 +36,7 @@ null
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_parameters.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_parameters.php
@@ -88,7 +88,7 @@ ok - string attribute NOT added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_parameters_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_parameters_te_off.php
@@ -94,7 +94,7 @@ null
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_span_and_te.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_span_and_te.php
@@ -214,7 +214,7 @@ ok - string attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_span_and_te_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_span_and_te_te_off.php
@@ -128,7 +128,7 @@ null
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_overwrite.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_overwrite.php
@@ -27,7 +27,7 @@ ok - transaction event attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_te_off.php
@@ -28,7 +28,7 @@ ok - double attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_types.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_types.php
@@ -27,7 +27,7 @@ ok - double attribute added
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/api/distributed_trace/newrelic/test_keep_span_with_payload.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_keep_span_with_payload.php
@@ -25,7 +25,7 @@ newrelic.special.expensive_node_min = 0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/attributes/test_transaction_non_web.php
+++ b/tests/integration/attributes/test_transaction_non_web.php
@@ -99,7 +99,7 @@ newrelic.cross_application_tracer.enabled=false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 1
   },
   [

--- a/tests/integration/attributes/test_transaction_web.php
+++ b/tests/integration/attributes/test_transaction_web.php
@@ -160,7 +160,7 @@ CONTENT_LENGTH=348
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 1
   },
   [

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_no_sampled.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_no_sampled.php
@@ -88,7 +88,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 1
   },
   [

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_non_newrelic.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_non_newrelic.php
@@ -87,7 +87,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 1
   },
   [

--- a/tests/integration/distributed_tracing/w3c/test_valid_no_nr_state.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_no_nr_state.php
@@ -77,7 +77,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 1
   },
   [

--- a/tests/integration/external/curl_exec/test_dt_correct_span_is_external.php
+++ b/tests/integration/external/curl_exec/test_dt_correct_span_is_external.php
@@ -26,7 +26,7 @@ if (!extension_loaded("curl")) {
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/external/curl_exec/test_dt_span_customrequest.php
+++ b/tests/integration/external/curl_exec/test_dt_span_customrequest.php
@@ -30,7 +30,7 @@ if (version_compare(PHP_VERSION, "7.4", ">=")) {
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/external/curl_exec/test_span_sets_method.php
+++ b/tests/integration/external/curl_exec/test_span_sets_method.php
@@ -26,7 +26,7 @@ if (!extension_loaded("curl")) {
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 5
   },
   [

--- a/tests/integration/external/curl_multi_exec/test_span_sets_method.php
+++ b/tests/integration/external/curl_multi_exec/test_span_sets_method.php
@@ -25,7 +25,7 @@ if (!extension_loaded("curl")) {
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 5
   },
   [

--- a/tests/integration/external/file_get_contents/test_spans_are_created_correctly.php
+++ b/tests/integration/external/file_get_contents/test_spans_are_created_correctly.php
@@ -18,7 +18,7 @@ newrelic.transaction_tracer.threshold = 0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/external/guzzle5/test_spans_external.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php
@@ -32,7 +32,7 @@ newrelic.transaction_tracer.detail = 0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 4
   },
   [

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
@@ -32,7 +32,7 @@ newrelic.transaction_tracer.detail = 0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_are_created_from_segments.php
+++ b/tests/integration/span_events/test_span_events_are_created_from_segments.php
@@ -19,7 +19,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_are_created_upon_caught_error.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_caught_error.php
@@ -22,7 +22,7 @@ log_errors=0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 4
   },
   [

--- a/tests/integration/span_events/test_span_events_are_created_upon_caught_exception.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_caught_exception.php
@@ -24,7 +24,7 @@ null
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 4
   },
   [

--- a/tests/integration/span_events/test_span_events_are_created_upon_exit.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_exit.php
@@ -20,7 +20,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_error.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_error.php
@@ -22,7 +22,7 @@ log_errors=0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_exception.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_exception.php
@@ -22,7 +22,7 @@ log_errors=0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_error_collector_disabled.php
+++ b/tests/integration/span_events/test_span_events_error_collector_disabled.php
@@ -21,7 +21,7 @@ log_errors=0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_exception_caught_nested.php
+++ b/tests/integration/span_events/test_span_events_exception_caught_nested.php
@@ -23,7 +23,7 @@ null
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 6
   },
   [

--- a/tests/integration/span_events/test_span_events_exception_caught_nested_rethrown.php
+++ b/tests/integration/span_events/test_span_events_exception_caught_nested_rethrown.php
@@ -50,7 +50,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 4
   },
   [

--- a/tests/integration/span_events/test_span_events_exception_caught_notice_error.php
+++ b/tests/integration/span_events/test_span_events_exception_caught_notice_error.php
@@ -50,7 +50,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_exception_caught_notice_error_nested.php
+++ b/tests/integration/span_events/test_span_events_exception_caught_notice_error_nested.php
@@ -50,7 +50,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 6
   },
   [

--- a/tests/integration/span_events/test_span_events_exception_caught_same_span.php
+++ b/tests/integration/span_events/test_span_events_exception_caught_same_span.php
@@ -23,7 +23,7 @@ null
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_exception_uncaught_nested.php
+++ b/tests/integration/span_events/test_span_events_exception_uncaught_nested.php
@@ -52,7 +52,7 @@ log_errors=0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 5
   },
   [

--- a/tests/integration/span_events/test_span_events_exist_when_no_segments.php
+++ b/tests/integration/span_events/test_span_events_exist_when_no_segments.php
@@ -19,7 +19,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 1
   },
   [

--- a/tests/integration/span_events/test_span_events_hsm_error.php
+++ b/tests/integration/span_events/test_span_events_hsm_error.php
@@ -52,7 +52,7 @@ log_errors=0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/span_events/test_span_events_notice_error.php
+++ b/tests/integration/span_events/test_span_events_notice_error.php
@@ -49,7 +49,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 3
   },
   [

--- a/tests/integration/span_events/test_span_events_on_dt_on.php
+++ b/tests/integration/span_events/test_span_events_on_dt_on.php
@@ -18,7 +18,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/span_events/test_span_events_root_parent.php
+++ b/tests/integration/span_events/test_span_events_root_parent.php
@@ -27,7 +27,7 @@ newrelic.cross_application_tracer.enabled = false
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2
   },
   [

--- a/tests/integration/span_events/test_span_events_special_max_10.php
+++ b/tests/integration/span_events/test_span_events_special_max_10.php
@@ -19,7 +19,7 @@ newrelic.span_events.max_samples_stored = 10
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 10
   },
   "??"

--- a/tests/integration/span_events/test_span_events_special_max_10.php
+++ b/tests/integration/span_events/test_span_events_special_max_10.php
@@ -12,7 +12,7 @@ Only 10 span events must be sent when the limit is set to 10.
 newrelic.distributed_tracing_enabled = 1
 newrelic.transaction_tracer.threshold = 0
 newrelic.cross_application_tracer.enabled = false
-newrelic.special.max_span_events = 10
+newrelic.span_events.max_samples_stored = 10
 */
 
 /*EXPECT_SPAN_EVENTS

--- a/tests/integration/span_events/test_span_events_special_max_disabled.php
+++ b/tests/integration/span_events/test_span_events_special_max_disabled.php
@@ -11,7 +11,7 @@
 newrelic.distributed_tracing_enabled = 1
 newrelic.transaction_tracer.threshold = 0
 newrelic.cross_application_tracer.enabled = false
-newrelic.special.max_span_events = 0
+newrelic.span_events.max_samples_stored = 0
 */
 
 /*EXPECT_SPAN_EVENTS
@@ -19,13 +19,13 @@ newrelic.special.max_span_events = 0
   "?? agent run id",
   {
     "reservoir_size": 1000,
-    "events_seen": 1000 
+    "events_seen": 2000
   },
   "??"
 ]
  */
 
-$NEWRELIC_SPAN_EVENTS_MAX = 1000; // The agent internal maximum of span events 
+$NEWRELIC_SPAN_EVENTS_MAX = 3000; // The agent internal maximum of span events
 				  // per transaction.
 
 newrelic_add_custom_tracer('main');

--- a/tests/integration/span_events/test_span_events_special_max_disabled.php
+++ b/tests/integration/span_events/test_span_events_special_max_disabled.php
@@ -18,7 +18,7 @@ newrelic.span_events.max_samples_stored = 0
 [
   "?? agent run id",
   {
-    "reservoir_size": 1000,
+    "reservoir_size": 10000,
     "events_seen": 2000
   },
   "??"


### PR DESCRIPTION
Adjust span reservoir variable to conform to the agent spec and be in the normal newrelic.ini
Change default span_events_max_samples_stored to be 2000
change max span_events_max_samples_stored to be 10000
adjust tests to exercise new value