### PR TITLE
span_event_max_samples_stored test cases

### DIFF
--- a/axiom/cmd_appinfo_transmit.c
+++ b/axiom/cmd_appinfo_transmit.c
@@ -398,7 +398,6 @@ void nr_cmd_appinfo_process_event_harvest_config(const nrobj_t* config,
   app_limits->span_events = nr_cmd_appinfo_process_get_harvest_limit(
       harvest_limits, "span_event_data",
      NR_MAX_SPAN_EVENTS_MAX_SAMPLES_STORED);
-//      NR_DEFAULT_SPAN_EVENTS_MAX_SAMPLES_STORED);
 }
 
 int nr_cmd_appinfo_process_get_harvest_limit(const nrobj_t* limits,

--- a/axiom/cmd_appinfo_transmit.c
+++ b/axiom/cmd_appinfo_transmit.c
@@ -397,7 +397,8 @@ void nr_cmd_appinfo_process_event_harvest_config(const nrobj_t* config,
       harvest_limits, "error_event_data", NR_MAX_ERRORS);
   app_limits->span_events = nr_cmd_appinfo_process_get_harvest_limit(
       harvest_limits, "span_event_data",
-      NR_DEFAULT_SPAN_EVENTS_MAX_SAMPLES_STORED);
+     NR_MAX_SPAN_EVENTS_MAX_SAMPLES_STORED);
+//      NR_DEFAULT_SPAN_EVENTS_MAX_SAMPLES_STORED);
 }
 
 int nr_cmd_appinfo_process_get_harvest_limit(const nrobj_t* limits,

--- a/tests/integration/span_events/test_span_events_max_samples_stored1.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored1.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Only 101 span events must be sent when the limit is set to 101.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+newrelic.span_events.max_samples_stored = 101
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 101
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10000;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored2.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored2.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+When sending 5 span events, 5(+ 1 transactional)  must be sent when the limit is set to greater than 5.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+newrelic.span_events.max_samples_stored = 10000
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 5;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored3.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored3.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+When the span events max_samples_stored limit is set to any integer 
+less than 1 or greater than 10000(max value)
+the max_samples_stored value should be treated as the default (2000) value.
+Setting a value of 0 should result in the default value of 2000 being seen.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+newrelic.span_events.max_samples_stored = 0
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2000
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10000;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored4.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored4.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+When the span events max_samples_stored limit is set to any integer 
+less than 1 or greater than 10000(max value)
+the max_samples_stored value should be treated as the default (2000) value.
+Setting a value of -10 should result in the default value of 2000 being seen.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+newrelic.span_events.max_samples_stored = -10
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2000
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10000;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored5.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored5.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+This is the max that can be sent with DT only.  With span limit < 7000,
+infinite tracing NEEDS to be enabled; otherwise, the daemon will
+error out with the following type message:
+`Error: listener: closing connection: maximum message size exceeded, (2886388 > 2097152)`
+The maximum without DT is 7200; however, it causes 
+the listener to slow down so much that it will cause intermittent failures on other samples_stored tests.
+Only 7000 span events must be sent when the limit is set to 7000.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+newrelic.span_events.max_samples_stored = 7000
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 7000
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10000;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored6.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored6.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+When the span events max_samples_stored limit is set to any integer 
+less than 1 or greater than 10000(max value)
+the max_samples_stored value should be treated as the default (2000) value.
+Setting a value of 101010 should result in the default value of 2000 being seen.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+newrelic.span_events.max_samples_stored = 101010
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2000
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10005;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored7.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored7.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+When the span events max_samples_stored limit is set to any integer 
+less than 1 or greater than 10000(max value)
+the max_samples_stored value should be treated as the default (2000) value.
+Setting a value of 0 should result in the default value of 2000 being seen
+even when cat is enabled.  DT by default should disable CAT.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = true
+newrelic.span_events.max_samples_stored = 0
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2000
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10000;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored8.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored8.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+When the span events max_samples_stored limit is set to any integer 
+less than 1 or greater than 10000(max value)
+the max_samples_stored value should be treated as the default (2000) value.
+Setting a value of 3000 should result in the value 3000 being seen
+even if CAT is enabled (which should be ignored).
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = true
+newrelic.span_events.max_samples_stored = 3000
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3000
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10000;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored_invalid1.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored_invalid1.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+When the span events max_samples_stored limit is set to any integer 
+less than 1 or greater than 10000(max value)
+the max_samples_stored value should be treated as the default (2000) value.
+Setting a invalid value should result in the default value of 2000 being seen.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+newrelic.span_events.max_samples_stored = 0.4
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2000
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10000;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}

--- a/tests/integration/span_events/test_span_events_max_samples_stored_invalid2.php
+++ b/tests/integration/span_events/test_span_events_max_samples_stored_invalid2.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+When the span events max_samples_stored limit is set to any integer 
+less than 1 or greater than 10000(max value)
+the max_samples_stored value should be treated as the default (2000) value.
+Setting an invalid value should result in the default value of 2000 being seen.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+newrelic.span_events.max_samples_stored = a
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2000
+  },
+  "??"
+]
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  usleep(10);
+}
+
+$sample_size = 10000;
+
+for ($i = 0; $i < $sample_size; $i++) {
+  main();
+}


### PR DESCRIPTION
* Added test cases to exercise the new configurable value `span_event_max_samples_stored`
* Modified `axiom/cmd_appinfo_transmit.c` because this value needs to represent the absolute max the daemon can handle to determine the limit.  If the backend gives a lower number, that number is used to determine the limit.  That limit determines the number of spans the daemon can send.


Things of note for documentation purposes:

In general, DT plus 7000+ spans caused instability in the small subset of integration tests when running back to back because of when the message size exceeded the max (error message `Error: listener: closing connection: maximum message size exceeded, (2886388 > 2097152)
`, the daemon would then close the listener.  

The maximum with DT only is around 7200. Would never recommend using this setting this high for DT only.  If setting 7200+, you MUST use it with infinite tracing.
