### PR TITLE
Known issue where install incorrectly detects debian instead of alpin…

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -120,11 +120,9 @@ error() {
 # Get the OS type.
 #
 ostype=
-if [ -f /proc/version ] && [ -n "$(grep 'Alpine' /proc/version)" ]; then
-  ostype=alpine
-elif [ -f /etc/redhat-release -o -f /etc/redhat_version ]; then
+if [ -f /etc/redhat-release -o -f /etc/redhat_version ]; then
   ostype=rhel
-elif [ -d /etc/dpkg ]; then
+elif [ -f /etc/os-release ] && grep -q -i 'Debian' /etc/os-release; then
   ostype=debian
 elif [ -f /etc/alpine-release ] || [ -d /etc/apk ]; then
   ostype=alpine

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -120,7 +120,9 @@ error() {
 # Get the OS type.
 #
 ostype=
-if [ -f /etc/redhat-release -o -f /etc/redhat_version ]; then
+if [ -f /proc/version ] && [ -n "$(grep 'Alpine' /proc/version)" ]; then
+  ostype=alpine
+elif [ -f /etc/redhat-release -o -f /etc/redhat_version ]; then
   ostype=rhel
 elif [ -d /etc/dpkg ]; then
   ostype=debian


### PR DESCRIPTION
Install incorrectly labels alpine as debian when phpize dependencies are installed.

https://discuss.newrelic.com/t/alpine-linux-3-11-new-relic-php-agent-install-fails-to-detect-os-correctly-when-dpkg-installed/101360