### PR TITLE
feat(agent): Deprecate CAT

### DIFF
--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -336,7 +336,8 @@ nrinitime_t ep_threshold; /* newrelic.transaction_tracer.explain_threshold */
 nrinitime_t
     ss_threshold; /* newrelic.transaction_tracer.stack_trace_threshold */
 nrinibool_t
-    cross_process_enabled; /* DEPRECATED newrelic.cross_application_tracer.enabled */
+    cross_process_enabled; /* DEPRECATED
+                              newrelic.cross_application_tracer.enabled */
 
 nriniuint_t max_nesting_level; /* newrelic.special.max_nesting_level (named
                                   after like-used variable in xdebug) */
@@ -444,8 +445,9 @@ nrinibool_t
 nrinibool_t
     distributed_tracing_exclude_newrelic_header; /* newrelic.distributed_tracing_exclude_newrelic_header
                                                   */
-nrinibool_t span_events_enabled; /* newrelic.span_events_enabled */
-nriniuint_t span_events_max_samples_stored; /* newrelic.span_events.max_samples_stored */
+nrinibool_t span_events_enabled;            /* newrelic.span_events_enabled */
+nriniuint_t span_events_max_samples_stored; /* newrelic.span_events.max_samples_stored
+                                             */
 nrinistr_t
     trace_observer_host; /* newrelic.infinite_tracing.trace_observer.host */
 nriniuint_t

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -336,7 +336,7 @@ nrinitime_t ep_threshold; /* newrelic.transaction_tracer.explain_threshold */
 nrinitime_t
     ss_threshold; /* newrelic.transaction_tracer.stack_trace_threshold */
 nrinibool_t
-    cross_process_enabled; /* newrelic.cross_application_tracer.enabled */
+    cross_process_enabled; /* DEPRECATED newrelic.cross_application_tracer.enabled */
 
 nriniuint_t max_nesting_level; /* newrelic.special.max_nesting_level (named
                                   after like-used variable in xdebug) */

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1239,9 +1239,10 @@ static PHP_INI_MH(nr_cat_enabled_mh) {
   }
 
   if (0 != val) {
-    nrl_warning(NRL_INIT, "Cross Application Training (CAT) has been enabled.  "
-                          "Note that CAT has been deprecated and will be removed "
-                          "in a future release.");
+    nrl_warning(NRL_INIT,
+                "Cross Application Training (CAT) has been enabled.  "
+                "Note that CAT has been deprecated and will be removed "
+                "in a future release.");
   }
 
   p->value = (zend_bool)val;
@@ -2930,11 +2931,10 @@ void zm_info_newrelic(void); /* ctags landing pad only */
 PHP_MINFO_FUNCTION(newrelic) {
   php_info_print_table_start();
   php_info_print_table_header(2, "New Relic RPM Monitoring",
-                              NR_PHP_PROCESS_GLOBALS(enabled)
-                                  ? "enabled"
-                                  : NR_PHP_PROCESS_GLOBALS(mpm_bad)
-                                        ? "disabled due to threaded MPM"
-                                        : "disabled");
+                              NR_PHP_PROCESS_GLOBALS(enabled) ? "enabled"
+                              : NR_PHP_PROCESS_GLOBALS(mpm_bad)
+                                  ? "disabled due to threaded MPM"
+                                  : "disabled");
   php_info_print_table_row(2, "New Relic Version", nr_version_verbose());
   php_info_print_table_end();
 

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1213,6 +1213,43 @@ static PHP_INI_MH(nr_boolean_mh) {
   return SUCCESS;
 }
 
+static PHP_INI_MH(nr_cat_enabled_mh) {
+  nrinibool_t* p;
+  int val = 0;
+
+#ifndef ZTS
+  char* base = (char*)mh_arg2;
+#else
+  char* base = (char*)ts_resource(*((int*)mh_arg2));
+#endif
+
+  p = (nrinibool_t*)(base + (size_t)mh_arg1);
+
+  (void)entry;
+  (void)mh_arg3;
+  (void)NEW_VALUE_LEN;
+  NR_UNUSED_TSRMLS;
+
+  p->where = 0;
+
+  val = nr_bool_from_str(NEW_VALUE);
+
+  if (-1 == val) {
+    return FAILURE;
+  }
+
+  if (0 != val) {
+    nrl_warning(NRL_INIT, "Cross Application Training (CAT) has been enabled.  "
+                          "Note that CAT has been deprecated and will be removed "
+                          "in a future release.");
+  }
+
+  p->value = (zend_bool)val;
+  p->where = stage;
+
+  return SUCCESS;
+}
+
 static PHP_INI_MH(nr_tt_detail_mh) {
   nriniuint_t* p;
   int val = 1;
@@ -2018,10 +2055,11 @@ STD_PHP_INI_ENTRY_EX("newrelic.framework",
                      zend_newrelic_globals,
                      newrelic_globals,
                      nr_framework_dh)
+/* DEPRECATED */
 STD_PHP_INI_ENTRY_EX("newrelic.cross_application_tracer.enabled",
-                     "1",
+                     "0",
                      NR_PHP_REQUEST,
-                     nr_boolean_mh,
+                     nr_cat_enabled_mh,
                      cross_process_enabled,
                      zend_newrelic_globals,
                      newrelic_globals,

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -856,10 +856,11 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ; Setting: newrelic.cross_application_tracer.enabled
 ; Type   : boolean
 ; Scope  : per-directory
-; Default: true
+; Default: false
 ; Info   : Enables or disables support for Cross Application Tracing, aka "CAT".
+;          NOTE: As of April 2022 CAT has been deprecated and will be removed at a future date.
 ;
-;newrelic.cross_application_tracer.enabled = true
+;newrelic.cross_application_tracer.enabled = false
 
 ; Setting: newrelic.distributed_tracing_enabled
 ; Type   : boolean

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -78,7 +78,7 @@ typedef struct _nrtxnopt_t {
   int tt_is_apdex_f; /* tt_threshold is 4 * apdex_t */
   nrtime_t ep_threshold;     /* Explain Plan threshold in usec */
   nrtime_t ss_threshold;     /* Slow SQL stack threshold in usec */
-  int cross_process_enabled; /* Whether or not to read and modify headers */
+  int cross_process_enabled; /* DEPRECATED Whether or not to read and modify headers */
   int allow_raw_exception_messages; /* Whether to replace the error/exception
                                        messages with generic text */
   int custom_parameters_enabled;    /* Whether to allow recording of custom

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -78,7 +78,8 @@ typedef struct _nrtxnopt_t {
   int tt_is_apdex_f; /* tt_threshold is 4 * apdex_t */
   nrtime_t ep_threshold;     /* Explain Plan threshold in usec */
   nrtime_t ss_threshold;     /* Slow SQL stack threshold in usec */
-  int cross_process_enabled; /* DEPRECATED Whether or not to read and modify headers */
+  int cross_process_enabled; /* DEPRECATED Whether or not to read and modify
+                                headers */
   int allow_raw_exception_messages; /* Whether to replace the error/exception
                                        messages with generic text */
   int custom_parameters_enabled;    /* Whether to allow recording of custom

--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -171,6 +171,7 @@ func merge(a, b map[string]string) map[string]string {
 func catRequest(w http.ResponseWriter, r *http.Request) {
 	catFile := r.URL.Query().Get("file")
 	dtEnabled := r.URL.Query().Get("dt_enabled");
+	catEnabled := r.URL.Query().Get("cat_enabled");
 	if "" == catFile {
 		http.Error(w, "cat failure: no file provided", http.StatusBadRequest)
 		return
@@ -185,6 +186,15 @@ func catRequest(w http.ResponseWriter, r *http.Request) {
 		settings["newrelic.distributed_tracing_enabled"] = "true";
 	} else {
 		http.Error(w, "cat request: invalid value of dt_enabled - expected 'true' or 'false', got '" + dtEnabled +"'.", http.StatusBadRequest)
+		return
+	}
+
+	if ("false" == catEnabled) {
+	    settings["newrelic.cross_application_tracer.enabled"] = "false";
+	} else if ("true" == catEnabled) {
+		settings["newrelic.cross_application_tracer.enabled"] = "true";
+	} else {
+		http.Error(w, "cat request: invalid value of cat_enabled - expected 'true' or 'false', got '" + catEnabled +"'.", http.StatusBadRequest)
 		return
 	}
 

--- a/tests/include/config.php
+++ b/tests/include/config.php
@@ -60,12 +60,21 @@ function make_dt_enabled_param()
     return "dt_enabled=" . $value;
 }
 
+function make_cat_enabled_param()
+{
+    $value = "false";
+    if (ini_get("newrelic.cross_application_tracer.enabled"))
+        $value = "true";
+
+    return "cat_enabled=" . $value;
+}
+
 function make_tracing_url($file)
 {
     global $EXTERNAL_TRACING_URL;
 
     return $EXTERNAL_TRACING_URL . '?file=' . $file .
-            '&' . make_dt_enabled_param();
+            '&' . make_dt_enabled_param() . '&' . make_cat_enabled_param();
 }
 
 $PG_USER       = isset_or('PG_USER', 'postgres');

--- a/tests/integration/api/internal/test_get_request_metadata_cat.php
+++ b/tests/integration/api/internal/test_get_request_metadata_cat.php
@@ -9,8 +9,8 @@ newrelic_get_request_metadata() should return CAT headers for use in a request.
  */
 
 /*INI
-newrelic.cross_process_enabled=1
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/errors/test_large_error_message.php
+++ b/tests/integration/errors/test_large_error_message.php
@@ -45,7 +45,12 @@ The agent should capture and report unhandled exceptions with large error messag
         "error.message": "Uncaught exception 'Exception' with message 'this is a very large error message that will extend beyond a 256 character limit by rambling about the size of the error, as well as inserting random characters. ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz It will also repeat... this is a very large error message that will extend beyond a 256 character limit by rambling about the size of the error, as well as inserting random characters. ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz It will also repeat...this is a very large error message that will extend beyond a 256 character limit by rambling about the size of the error, as well as inserting random characters. ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz It will also repeat... this is a very large error message that will extend beyond a 256 character limit by rambling about the size of the error, as well as inserting random characters. ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz It will also repeat...this is a very large error message that will extend beyond a 256 character limit by rambling about the size of the error, as well as inserting random characters. ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz It will also repeat... this is a very large error message that will extend beyond a 256 character limit by rambling about the size of the error, as well as inserting random characters. ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz It will also repeat...' in __FILE__:??",
         "transactionName": "OtherTransaction\/php__FILE__",
         "duration": "??",
-        "nr.transactionGuid": "??"
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
       },
       {},
       {}

--- a/tests/integration/external/curl_exec/test_cat_disabled_by_default.php
+++ b/tests/integration/external/curl_exec/test_cat_disabled_by_default.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent SHALL NOT add X-NewRelic-ID and X-NewRelic-Transaction headers
+to external calls when distributed tracing is disabled because CAT is
+supposed to be disabled by default.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = false
+*/
+
+/*EXPECT
+X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
+ok - execute request
+*/
+
+/*EXPECT_RESPONSE_HEADERS
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? start time",
+  "?? stop time",
+  [
+    [{"name":"External/all"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name":"External/allOther"},                     [1, "??", "??", "??", "??", "??"]],
+    [{"name":"External/127.0.0.1/all"},                [1, "??", "??", "??", "??", "??"]],
+    [{"name":"External/127.0.0.1/all",
+      "scope":"OtherTransaction/php__FILE__"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransaction/all"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransaction/php__FILE__"},          [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransactionTotalTime"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransactionTotalTime/php__FILE__"}, [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+if (!extension_loaded("curl")) {
+  die("skip: curl extension required");
+}
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+
+function test_curl() {
+  $url = "http://" . make_tracing_url(realpath(dirname(__FILE__)) . '/../../../include/tracing_endpoint.php');
+  $ch = curl_init($url);
+
+  $result = curl_exec($ch);
+  if (false !== $result) {
+    tap_ok("execute request");
+  } else {
+    tap_not_ok("execute request", true, $result);
+    tap_diagnostic("errno=" . curl_errno($ch));
+    tap_diagnostic("error=" . curl_error($ch));
+  }
+
+  curl_close($ch);
+}
+
+test_curl();

--- a/tests/integration/external/curl_exec/test_cat_request_headers_empty_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_empty_array.php
@@ -22,6 +22,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/curl_exec/test_cat_request_headers_present.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_present.php
@@ -22,6 +22,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/curl_exec/test_cat_request_headers_present_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_present_array.php
@@ -22,6 +22,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/curl_exec/test_cat_request_headers_referenced_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_referenced_array.php
@@ -22,6 +22,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/curl_exec/test_cat_response_header_anonymous.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_anonymous.php
@@ -18,6 +18,7 @@ if (!extension_loaded("curl")) {
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/curl_exec/test_cat_response_header_function.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_function.php
@@ -22,6 +22,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/curl_exec/test_cat_response_header_returned.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_returned.php
@@ -21,6 +21,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT_REGEX

--- a/tests/integration/external/curl_exec/test_cat_response_header_to_stdout.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_to_stdout.php
@@ -21,6 +21,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT_REGEX

--- a/tests/integration/external/curl_exec/test_cat_simple.php
+++ b/tests/integration/external/curl_exec/test_cat_simple.php
@@ -21,6 +21,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/curl_exec/test_synthetics.php
+++ b/tests/integration/external/curl_exec/test_synthetics.php
@@ -29,6 +29,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*HEADERS
@@ -80,7 +81,7 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 function test_curl() {
   $url = "http://" . make_tracing_url(realpath(dirname(__FILE__)) . '/../../../include/tracing_endpoint.php');
   $ch = curl_init($url);
-
+  
   $result = curl_exec($ch);
   if (false !== $result) {
     tap_ok("execute request");

--- a/tests/integration/external/curl_exec/test_synthetics_disabled.php
+++ b/tests/integration/external/curl_exec/test_synthetics_disabled.php
@@ -19,6 +19,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.synthetics.enabled = false
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*

--- a/tests/integration/external/curl_multi_exec/test_cat_simple.php
+++ b/tests/integration/external/curl_multi_exec/test_cat_simple.php
@@ -21,6 +21,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/file_get_contents/test_cat_context_provided.php
+++ b/tests/integration/external/file_get_contents/test_cat_context_provided.php
@@ -18,6 +18,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/file_get_contents/test_cat_default_context.php
+++ b/tests/integration/external/file_get_contents/test_cat_default_context.php
@@ -18,6 +18,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/file_get_contents/test_cat_no_context.php
+++ b/tests/integration/external/file_get_contents/test_cat_no_context.php
@@ -17,6 +17,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/file_get_contents/test_dt_disabled.php
+++ b/tests/integration/external/file_get_contents/test_dt_disabled.php
@@ -18,6 +18,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/file_get_contents/test_http_response_header_cv.php
+++ b/tests/integration/external/file_get_contents/test_http_response_header_cv.php
@@ -18,6 +18,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/file_get_contents/test_synthetics_context_provided.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_context_provided.php
@@ -29,6 +29,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*HEADERS

--- a/tests/integration/external/file_get_contents/test_synthetics_default_context.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_default_context.php
@@ -29,6 +29,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*HEADERS

--- a/tests/integration/external/file_get_contents/test_synthetics_disabled.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_disabled.php
@@ -12,6 +12,7 @@ calls when the Synthetics feature is disabled.
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.synthetics.enabled = false
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*

--- a/tests/integration/external/file_get_contents/test_synthetics_no_context.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_no_context.php
@@ -29,6 +29,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*HEADERS

--- a/tests/integration/external/guzzle5/test_cat.php
+++ b/tests/integration/external/guzzle5/test_cat.php
@@ -25,6 +25,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/guzzle6/test_cat.php
+++ b/tests/integration/external/guzzle6/test_cat.php
@@ -27,6 +27,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/http/test_v1_cat.php
+++ b/tests/integration/external/http/test_v1_cat.php
@@ -27,6 +27,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/external/http/test_v1_synthetics.php
+++ b/tests/integration/external/http/test_v1_synthetics.php
@@ -27,6 +27,7 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*

--- a/tests/integration/external/http/test_v2_cat.php
+++ b/tests/integration/external/http/test_v2_cat.php
@@ -22,6 +22,7 @@ if (version_compare(phpversion('http'), '2.0.0', '<')) {
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.cross_application_tracer.enabled = true
 */
 
 /*EXPECT

--- a/tests/integration/ini/test_dt_enabled_default.php
+++ b/tests/integration/ini/test_dt_enabled_default.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Distributed tracing should be enabled by default.  Verify by seeing 
+that span events are sent when span events are enabled and no other 
+configuration is given.
+*/
+
+/*INI
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled = 1
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??", 
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??", 
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/main",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  echo 'Hello';
+}
+main();
+

--- a/tests/integration/memcached/test_cas.php7.php
+++ b/tests/integration/memcached/test_cas.php7.php
@@ -33,6 +33,10 @@ ok - delete
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [5, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [5, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Memcached/all"},               [5, "??", "??", "??", "??", "??"]],

--- a/tests/integration/memcached/test_cas_by_key.php7.php
+++ b/tests/integration/memcached/test_cas_by_key.php7.php
@@ -33,6 +33,10 @@ ok - deleteByKey
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [5, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [5, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Memcached/all"},               [5, "??", "??", "??", "??", "??"]],

--- a/tests/integration/pgsql/test_pg_execute_with_resource.php
+++ b/tests/integration/pgsql/test_pg_execute_with_resource.php
@@ -30,6 +30,10 @@ pg_roles
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                            [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                              [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                         [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Postgres/all"},                     [2, "??", "??", "??", "??", "??"]],

--- a/tests/integration/pgsql/test_pg_execute_without_resource.php
+++ b/tests/integration/pgsql/test_pg_execute_without_resource.php
@@ -32,6 +32,10 @@ pg_roles
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                            [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                              [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                         [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Postgres/all"},                     [2, "??", "??", "??", "??", "??"]],

--- a/tests/integration/pgsql/test_pg_query_params_with_resource.php
+++ b/tests/integration/pgsql/test_pg_query_params_with_resource.php
@@ -30,6 +30,10 @@ ok - pg_query_params successful
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Postgres/select"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/statement/Postgres/pg_user/select"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/statement/Postgres/pg_user/select",

--- a/tests/integration/pgsql/test_pg_query_params_without_resource.php
+++ b/tests/integration/pgsql/test_pg_query_params_without_resource.php
@@ -32,6 +32,10 @@ ok - pg_query_params successful
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Postgres/select"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/statement/Postgres/pg_user/select"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/statement/Postgres/pg_user/select",

--- a/tests/integration/pgsql/test_pg_query_with_resource.php
+++ b/tests/integration/pgsql/test_pg_query_with_resource.php
@@ -30,6 +30,10 @@ ok - pg_query successful
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Postgres/select"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/statement/Postgres/pg_user/select"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/statement/Postgres/pg_user/select",

--- a/tests/integration/pgsql/test_pg_query_without_resource.php
+++ b/tests/integration/pgsql/test_pg_query_without_resource.php
@@ -32,6 +32,10 @@ ok - pg_query successful
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Postgres/select"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/statement/Postgres/pg_user/select"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/statement/Postgres/pg_user/select",

--- a/tests/integration/predis/test_basic.php
+++ b/tests/integration/predis/test_basic.php
@@ -25,6 +25,8 @@ ok - delete key
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                    [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},               [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                                                           [8, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                                                      [8, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Redis/all"},                                                     [8, "??", "??", "??", "??", "??"]],

--- a/tests/integration/predis/test_cross_transaction.php
+++ b/tests/integration/predis/test_cross_transaction.php
@@ -21,6 +21,8 @@ ok - delete key
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"/Datastore/all/"},                                                           [4, "??", "??", "??", "??", "??"]],
     [{"name":"/Datastore/allOther/"},                                                      [4, "??", "??", "??", "??", "??"]],
     [{"name":"/Datastore/Redis/all/"},                                                     [4, "??", "??", "??", "??", "??"]],

--- a/tests/integration/predis/test_pipeline.php
+++ b/tests/integration/predis/test_pipeline.php
@@ -15,6 +15,8 @@ are being run, so they are instrumented as "pipeline".
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                     [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                                                            [12, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                                                       [12, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Redis/all"},                                                      [12, "??", "??", "??", "??", "??"]],

--- a/tests/integration/predis/test_pipeline_atomic.php
+++ b/tests/integration/predis/test_pipeline_atomic.php
@@ -15,6 +15,8 @@ an atomic operation.
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                     [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                                                            [12, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                                                       [12, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Redis/all"},                                                      [12, "??", "??", "??", "??", "??"]],

--- a/tests/integration/predis/test_pipeline_fire_and_forget.php
+++ b/tests/integration/predis/test_pipeline_fire_and_forget.php
@@ -15,6 +15,8 @@ are being run, so they are instrumented as "pipeline".
   "?? start time",
   "?? stop time",
   [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                     [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                                                            [12, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                                                       [12, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Redis/all"},                                                      [12, "??", "??", "??", "??", "??"]],


### PR DESCRIPTION
Sets cross application tracing (CAT) off by default as required by #368.

* Switches newrelic.ini template to have CAT disabled.
* Changes default for CAT INI field in PHP extension to disabled.
* Fixes numerous integration tests to enable CAT explicitly as required.
* Adds tests to confirm DT is enabled and CAT is disabled by default.