### PR TITLE
tests(integration): Fixes mysql container to start properly [DO NOT MERGE]

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,9 +13,10 @@ services:
       MYSQL_DATABASE: database
       MYSQL_USER: admin
       MYSQL_PASSWORD: admin
-      MYSQL_HOST: mysqldb
     ports:
       - "33061:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
     container_name: mysqldb
   redisdb:
     build:
@@ -77,3 +78,6 @@ services:
     stdin_open: true
     tty: true
     container_name: agent
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
The mysql container was not starting properly without having a volume defined for storage of the database.  This change adds a local volume which is mapped to the location the mysql image expects.  
Also an unneeded environment variable (MYSQL_HOST) has been removed.