### PR TITLE
PHP: Laravel 8+ updates

### DIFF
--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -348,34 +348,35 @@ static void nr_laravel_name_transaction(zval* router, zval* request TSRMLS_DC) {
       route_name_zv = nr_php_call(route, "getName");
       if (nr_php_is_zval_valid_string(route_name_zv)) {
         const char generated_prefix[] = "generated::";
-        nr_string_len_t generated_prefix_len
-            = sizeof(generated_prefix) - 1;
+        nr_string_len_t generated_prefix_len = sizeof(generated_prefix) - 1;
 
-        if (nr_strncmp(generated_prefix, Z_STRVAL_P(route_name_zv), generated_prefix_len) != 0) {
-          char* route_name
-              = nr_strndup(Z_STRVAL_P(route_name_zv), Z_STRLEN_P(route_name_zv));
+        if (nr_strncmp(generated_prefix, Z_STRVAL_P(route_name_zv),
+                       generated_prefix_len)
+            != 0) {
+          char* route_name = nr_strndup(Z_STRVAL_P(route_name_zv),
+                                        Z_STRLEN_P(route_name_zv));
 
           nrl_debug(NRL_FRAMEWORK,
                     "%s: using Route::getName() for transaction naming",
                     __func__);
-          nr_txn_set_path("Laravel", NRPRG(txn), route_name, NR_PATH_TYPE_ACTION,
-                          NR_OK_TO_OVERWRITE);
+          nr_txn_set_path("Laravel", NRPRG(txn), route_name,
+                          NR_PATH_TYPE_ACTION, NR_OK_TO_OVERWRITE);
 
           nr_php_zval_free(&route_name_zv);
           nr_free(route_name);
           goto leave;
         } else {
-          nrl_verbosedebug(
-            NRL_FRAMEWORK,
-            "%s: Route::getName() returned a randomly generated route name, skipping. ",
-            __func__);
-            nr_php_zval_free(&route_name_zv);
+          nrl_verbosedebug(NRL_FRAMEWORK,
+                           "%s: Route::getName() returned a randomly generated "
+                           "route name, skipping. ",
+                           __func__);
+          nr_php_zval_free(&route_name_zv);
         }
       } else {
-        nrl_verbosedebug(
-            NRL_FRAMEWORK,
-            "%s: Route::getName() returned an unexpected value/type, skipping. ",
-            __func__);
+        nrl_verbosedebug(NRL_FRAMEWORK,
+                         "%s: Route::getName() returned an unexpected "
+                         "value/type, skipping. ",
+                         __func__);
         nr_php_zval_free(&route_name_zv);
       }
     }
@@ -1201,7 +1202,7 @@ void nr_laravel_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Illuminate\\Routing\\RouteCollection::getRouteForMethods"),
       nr_laravel_routes_get_route_for_methods TSRMLS_CC);
-
+  
   /*
    * Listen for Artisan commands so we can name those appropriately.
    */

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -373,8 +373,11 @@ static const nr_framework_table_t all_frameworks[] = {
      NR_FW_LARAVEL}, /* 5.0.15-5.0.x */
     {"Laravel", "laravel", "bootstrap/cache/compiled.php", 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 5.1.0-x */
+    {"Laravel", "laravel", "bootstrap/app.php", 0, nr_laravel_enable,
+     NR_FW_LARAVEL}, /* 8+ */
 
-    {"Lumen", "lumen", "lumen-framework/src/helpers.php", 0, nr_lumen_enable, NR_FW_LUMEN},
+    {"Lumen", "lumen", "lumen-framework/src/helpers.php", 0, nr_lumen_enable,
+     NR_FW_LUMEN},
 
     {"Magento", "magento", "app/mage.php", 0, nr_magento1_enable,
      NR_FW_MAGENTO1},
@@ -895,6 +898,8 @@ static void nr_php_execute_file(const zend_op_array* op_array,
                                 NR_EXECUTE_PROTO TSRMLS_DC) {
   const char* filename = nr_php_op_array_file_name(op_array);
 
+  nrl_debug(NRL_AGENT, "loaded file=" NRP_FMT, NRP_FILENAME(filename));
+
   if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_loaded_files)) {
     nrl_debug(NRL_AGENT, "loaded file=" NRP_FMT, NRP_FILENAME(filename));
   }
@@ -1072,8 +1077,7 @@ static inline void nr_php_execute_segment_end(
   duration = nr_time_duration(stacked->start_time, stacked->stop_time);
 
   if (create_metric || (duration >= NR_PHP_PROCESS_GLOBALS(expensive_min))
-      || nr_vector_size(stacked->metrics) || stacked->id
-      || stacked->attributes
+      || nr_vector_size(stacked->metrics) || stacked->id || stacked->attributes
       || stacked->error) {
     nr_segment_t* s = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
     nr_php_execute_segment_add_metric(s, metadata, create_metric);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -898,8 +898,6 @@ static void nr_php_execute_file(const zend_op_array* op_array,
                                 NR_EXECUTE_PROTO TSRMLS_DC) {
   const char* filename = nr_php_op_array_file_name(op_array);
 
-  nrl_debug(NRL_AGENT, "loaded file=" NRP_FMT, NRP_FILENAME(filename));
-
   if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_loaded_files)) {
     nrl_debug(NRL_AGENT, "loaded file=" NRP_FMT, NRP_FILENAME(filename));
   }

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -42,7 +42,14 @@ typedef struct _nrphpglobals_t {
                                       mode */
   int daemon_special_integration; /* Cause daemon to dump special log entries to
                                      help integration testing. */
-  int zend_offset;                /* Zend extension offset */
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO /* PHP 8.1+ */
+  zend_long zend_offset;                    /* Zend extension offset */
+  zend_long
+      zend_op_array_offset; /* Zend extension op_array to modify reserved */
+#else
+  int zend_offset;          /* Zend extension offset */
+  int zend_op_array_offset; /* Zend extension op_array to modify reserved */
+#endif
   int done_instrumentation;  /* Set to true if we have installed instrumentation
                                 handlers */
   nrtime_t expensive_min;    /* newrelic.special.expensive_node_min */

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -848,10 +848,17 @@ nr_status_t nr_php_txn_begin(const char* appnames,
               "to use distributed tracing");
   }
 
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+  if (nr_php_ini_setting_is_set_by_user("opcache.enable")
+      && NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
+    nr_php_user_instrumentation_from_opcache(TSRMLS_C);
+  }
+#else
   if (nr_php_ini_setting_is_set_by_user("opcache.preload")
       && NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
     nr_php_user_instrumentation_from_opcache(TSRMLS_C);
   }
+#endif
 
   return NR_SUCCESS;
 }

--- a/agent/php_vm.c
+++ b/agent/php_vm.c
@@ -88,6 +88,7 @@ static int nr_php_handle_cufa_fcall(zend_execute_data* execute_data) {
   nr_php_opcode_handler_entry_t prev_handler;
   const zend_op* prev_opline;
 
+  nrl_verbosedebug(NRL_AGENT, "%s: cannot get function from call", __func__);
   /*
    * We should have execute_data (and there isn't a realistic case where we
    * wouldn't other than memory corruption), so if we don't, we should bail as
@@ -191,6 +192,14 @@ call_previous_and_return:
   }
   opcode = execute_data->opline->opcode;
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+  prev_opline = execute_data->opline - 1;
+  if (ZEND_CHECK_UNDEF_ARGS == prev_opline->opcode) {
+    prev_opline = execute_data->opline - 2;
+  }
+#else
+  prev_opline = execute_data->opline - 1;
+#endif
   /*
    * Now we have the opcode, let's see if there's a handler and, if so, call
    * it.

--- a/agent/php_vm.c
+++ b/agent/php_vm.c
@@ -192,14 +192,6 @@ call_previous_and_return:
   }
   opcode = execute_data->opline->opcode;
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
-  prev_opline = execute_data->opline - 1;
-  if (ZEND_CHECK_UNDEF_ARGS == prev_opline->opcode) {
-    prev_opline = execute_data->opline - 2;
-  }
-#else
-  prev_opline = execute_data->opline - 1;
-#endif
   /*
    * Now we have the opcode, let's see if there's a handler and, if so, call
    * it.


### PR DESCRIPTION
* Updated Laravel detection
* Updated preload behavior
* Updated types of zend resource

This was a hard one to debug and analyze due to a few other issues going on.
Summary of details:
One caveat regarding our solution.  While there was an error on our side, there does seem to be some instability with laravel and another process which is not related to NR as the following events were observed with NR disabled.  If the underlying zend memory structures have been corrupted, the agent will be unable to function correctly.  Some of the "unknown" issues were because we queried zend for a class and the underlying structures reported it did not exist.  Once it has been corrupted, for proper naming, the opache needs to be reset.

Again, we've observed this issue with the NR agent disabled.  If opcache is required, the recommendation would be to use PHP 8.0 with Laravel 8+ since we observed frequent segfaults with apache. However, some portion of the issue appears to be something to bring up with the laravel and/or PHP and/or apache teams.

1) apache segfaults:
From a browsing/usage perspective, this would be nearly unnoticeable, but the segfaults leave the opcache in a state that we aren't able to query about classes anymore and without the ability to query for classes in the opcache, we are unable to name the transaction properly (although the URI shows correctly and all subsequent segments are properly labeled) and hence it shows as unknown.  Once corrupted, the opcache needs to be reset to provide the agent with the proper classes for naming again.

This instability was observed without the agent installed as well.  I tried with php 8.1.1, 8.1.2, 8.1.3, and 8.1.4 and while all exhibited segfaults, they appeared to decrease as the PHP version increased.

Sometimes only one apache process will segfault at a time, sometimes all of them will:
```
laravel_web    | [Mon Apr 18 21:11:26.760412 2022] [core:notice] [pid 1] AH00052: child pid 33 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:11:29.764021 2022] [core:notice] [pid 1] AH00052: child pid 55 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:11:31.766644 2022] [core:notice] [pid 1] AH00052: child pid 56 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:11:34.772210 2022] [core:notice] [pid 1] AH00052: child pid 27 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:11:36.775568 2022] [core:notice] [pid 1] AH00052: child pid 28 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:11:38.778298 2022] [core:notice] [pid 1] AH00052: child pid 29 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:11:45.793312 2022] [core:notice] [pid 1] AH00052: child pid 63 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:11:47.798363 2022] [core:notice] [pid 1] AH00052: child pid 64 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:11:50.768259 2022] [core:notice] [pid 1] AH00052: child pid 65 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:12:06.805142 2022] [core:notice] [pid 1] AH00052: child pid 66 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:12:08.808704 2022] [core:notice] [pid 1] AH00052: child pid 67 exit signal Segmentation fault (11)
laravel_web    | [Mon Apr 18 21:12:10.810495 2022] [core:notice] [pid 1] AH00052: child pid 68 exit signal Segmentation fault (11)
```

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.1  0.3 216704 31472 ?        Ss   21:08   0:00 apache2 -DFOREGROUND
root        25  0.0  0.1 1157788 10676 ?       Sl   21:08   0:00 /usr/bin/newrelic-daemon --agent --pidfile /var/run/newrelic-daemon.pid --logfile /var/log/newrelic/
root        37  0.8  0.3 1382056 28448 ?       Sl   21:08   0:01 /usr/bin/newrelic-daemon --agent --pidfile /var/run/newrelic-daemon.pid --logfile /var/log/newrelic/
root        47  0.0  0.0   2420   528 pts/0    Ss   21:08   0:00 /bin/sh
www-data    64  3.0  0.3 222088 28928 ?        R    21:11   0:00 apache2 -DFOREGROUND
www-data    65  0.0  0.0 216744  8356 ?        S    21:11   0:00 apache2 -DFOREGROUND
www-data    66  0.0  0.0 216744  8356 ?        S    21:11   0:00 apache2 -DFOREGROUND
www-data    67  0.0  0.0 216744  8356 ?        S    21:11   0:00 apache2 -DFOREGROUND
www-data    68  0.0  0.0 216744  8356 ?        S    21:11   0:00 apache2 -DFOREGROUND
www-data    69  0.0  0.0 216744  8356 ?        S    21:11   0:00 apache2 -DFOREGROUND
root        70  0.0  0.0   6700  2988 pts/0    R+   21:11   0:00 ps aux
```

2) there is another process (laravel? apache?) also dealing with the opcache in the same areas we are.  This is apparent in the `zend_get_resource_handle` handle the agent gets.  For all php version 8 and under, we get the same handle of 0 meaning no other entities requested a handle before us.  For PHP 8.1, we get a higher numbered handle indicating the presence of another entity manipulating the opache in the same way the agent does.  The agent and this entity appear to be clashing.

3) laravel also exhibited instability under these conditions:
```
Fatal error: Uncaught Illuminate\Contracts\Container\BindingResolutionException: Target [Illuminate\Contracts\Http\Kernel] is not instantiable. in /var/www/app/vendor/laravel/framework/src/Illuminate/Container/Container.php:1089 Stack trace: #0 /var/www/app/vendor/laravel/framework/src/Illuminate/Container/Container.php(886): Illuminate\Container\Container->notInstantiable('Illuminate\\Cont...') #1 /var/www/app/vendor/laravel/framework/src/Illuminate/Container/Container.php(758): Illuminate\Container\Container->build('Illuminate\\Cont...') #2 /var/www/app/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(851): Illuminate\Container\Container->resolve('Illuminate\\Cont...', Array, true) #3 /var/www/app/vendor/laravel/framework/src/Illuminate/Container/Container.php(694): Illuminate\Foundation\Application->resolve('Illuminate\\Cont...', Array) #4 /var/www/app/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(836): Illuminate\Container\Container->make('Illuminate\\Cont...', Array) #5 /var/www/app/vendor/laravel/framework/src/Illuminate/Container/Container.php(1419): Illuminate\Foundation\Application->make('Illuminate\\Cont...') #6 /var/www/app/bootstrap/app.php(15): Illuminate\Container\Container->offsetGet('Illuminate\\Cont...') #7 /var/www/app/public/index.php(47): require_once('/var/www/app/bo...') #8 {main} thrown in /var/www/app/vendor/laravel/framework/src/Illuminate/Container/Container.php on line 1089
```

Possible related issues:
```
https://github.com/php/php-src/issues/8064
https://bugs.php.net/bug.php?id=81380
https://bugs.php.net/bug.php?id=81678
```