### PR TITLE
feat(daemon): Implement Utilization Metadata Spec V5

### DIFF
--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -824,6 +824,7 @@ NR_PHP_UTILIZATION_MH(azure)
 NR_PHP_UTILIZATION_MH(gcp)
 NR_PHP_UTILIZATION_MH(pcf)
 NR_PHP_UTILIZATION_MH(docker)
+NR_PHP_UTILIZATION_MH(kubernetes)
 
 static PHP_INI_MH(nr_daemon_special_curl_verbose_mh) {
   int val;
@@ -1936,7 +1937,11 @@ PHP_INI_ENTRY_EX("newrelic.daemon.utilization.detect_docker",
                  NR_PHP_SYSTEM,
                  NR_PHP_UTILIZATION_MH_NAME(docker),
                  nr_enabled_disabled_dh)
-
+PHP_INI_ENTRY_EX("newrelic.daemon.utilization.detect_kubernetes",
+                 "1",
+                 NR_PHP_SYSTEM,
+                 NR_PHP_UTILIZATION_MH_NAME(kubernetes),
+                 nr_enabled_disabled_dh)
 /*
  * This daemon flag is for internal development use only.  It should not be
  * documented to customers.

--- a/agent/scripts/newrelic.cfg.template
+++ b/agent/scripts/newrelic.cfg.template
@@ -209,8 +209,16 @@
 # Info   : Enable detection of whether the system is running on Pivotal Cloud
 #          Foundry.
 #
-#newrelic.utilization.detect_pcf = true
+#utilization.detect_pcf = true
 
+# Setting: utilization.detect_kubernetes
+# Type   : boolean
+# Scope  : system
+# Default: true
+# Info   : Enable detection of whether the system is running in a Kubernetes 
+#          cluster.
+#
+#utilization.detect_kubernetes = true
 
 # Setting: app_timeout
 # Type   : time specification string ("5m", "1h20m", etc)

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -335,6 +335,16 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;newrelic.daemon.utilization.detect_docker = true
 
+; Setting: newrelic.daemon.utilization.detect_kubernetes
+; Type   : boolean
+; Scope  : system
+; Default: true
+; Info   : Enable detection of whether the system is running in a Kubernetes 
+;          cluster.
+;
+;newrelic.utilization.detect_kubernetes = true
+
+
 ; Setting: newrelic.daemon.app_timeout
 ; Type   : time specification string ("5m", "1h20m", etc)
 ; Scope  : system

--- a/axiom/nr_daemon_spawn.c
+++ b/axiom/nr_daemon_spawn.c
@@ -129,6 +129,8 @@ nr_argv_t* nr_daemon_args_to_argv(const char* name,
                         args->utilization.pcf ? "true" : "false");
     nr_argv_append_flag(argv, "--define", "utilization.detect_docker=%s",
                         args->utilization.docker ? "true" : "false");
+    nr_argv_append_flag(argv, "--define", "utilization.detect_kubernetes=%s",
+                        args->utilization.kubernetes ? "true" : "false");
 
     /* diagnostic and testing flags */
     if (args->integration_mode) {

--- a/axiom/nr_utilization.h
+++ b/axiom/nr_utilization.h
@@ -12,6 +12,7 @@ typedef struct _nr_utilization_t {
   int gcp : 1;
   int pcf : 1;
   int docker : 1;
+  int kubernetes : 1;
 } nr_utilization_t;
 
 static const nr_utilization_t nr_utilization_default = {
@@ -20,6 +21,7 @@ static const nr_utilization_t nr_utilization_default = {
     .gcp = 1,
     .pcf = 1,
     .docker = 1,
+    .kubernetes = 1,
 };
 
 #endif /* NR_UTILIZATION_HDR */

--- a/axiom/tests/reference/test_daemon.cmp
+++ b/axiom/tests/reference/test_daemon.cmp
@@ -26,6 +26,8 @@ verbosedebug: exec[24]='--define'
 verbosedebug: exec[25]='utilization.detect_pcf=false'
 verbosedebug: exec[26]='--define'
 verbosedebug: exec[27]='utilization.detect_docker=true'
-verbosedebug: exec[28]='<NULL>'
+verbosedebug: exec[28]='--define'
+verbosedebug: exec[29]='utilization.detect_kubernetes=false'
+verbosedebug: exec[30]='<NULL>'
 info: stdout should be redirected to the log file
 info: stderr should be redirected to the log file

--- a/src/daemon/main.go
+++ b/src/daemon/main.go
@@ -240,7 +240,7 @@ type Config struct {
 	DetectPCF          bool           `config:"utilization.detect_pcf"`         // Whether to detect if this is running on PCF in utilization
 	DetectDocker       bool           `config:"utilization.detect_docker"`      // Whether to detect if this is in a Docker container in utilization
 	DetectKubernetes   bool		      `config:"utilization.detect_kubernetes"`  // Whether to detect if this is in a Kubernetes cluster
-    LogicalProcessors  int            `config:"utilization.logical_processors"` // Customer provided number of logical processors for pricing control.
+	LogicalProcessors  int            `config:"utilization.logical_processors"` // Customer provided number of logical processors for pricing control.
 	TotalRamMIB        int            `config:"utilization.total_ram_mib"`      // Customer provided total RAM in mebibytes for pricing control.
 	BillingHostname    string         `config:"utilization.billing_hostname"`   // Customer provided hostname for pricing control.
 	Agent              bool           `config:"-"`                              // Used to indicate if spawned by agent

--- a/src/daemon/main.go
+++ b/src/daemon/main.go
@@ -343,6 +343,7 @@ func main() {
 			DetectGCP:    true,
 			DetectPCF:    true,
 			DetectDocker: true,
+			DetectKubernetes: true,
 		})
 		str, err := json.MarshalIndent(util, "", "\t")
 		if err != nil {

--- a/src/daemon/main.go
+++ b/src/daemon/main.go
@@ -240,7 +240,7 @@ type Config struct {
 	DetectPCF          bool           `config:"utilization.detect_pcf"`         // Whether to detect if this is running on PCF in utilization
 	DetectDocker       bool           `config:"utilization.detect_docker"`      // Whether to detect if this is in a Docker container in utilization
 	DetectKubernetes   bool		      `config:"utilization.detect_kubernetes"`  // Whether to detect if this is in a Kubernetes cluster
-        LogicalProcessors  int            `config:"utilization.logical_processors"` // Customer provided number of logical processors for pricing control.
+    LogicalProcessors  int            `config:"utilization.logical_processors"` // Customer provided number of logical processors for pricing control.
 	TotalRamMIB        int            `config:"utilization.total_ram_mib"`      // Customer provided total RAM in mebibytes for pricing control.
 	BillingHostname    string         `config:"utilization.billing_hostname"`   // Customer provided hostname for pricing control.
 	Agent              bool           `config:"-"`                              // Used to indicate if spawned by agent
@@ -340,11 +340,11 @@ func main() {
 
 	if cfg.Utilization {
 		util := utilization.Gather(utilization.Config{
-			DetectAWS:    true,
-			DetectAzure:  true,
-			DetectGCP:    true,
-			DetectPCF:    true,
-			DetectDocker: true,
+			DetectAWS:        true,
+			DetectAzure:      true,
+			DetectGCP:        true,
+			DetectPCF:        true,
+			DetectDocker:     true,
 			DetectKubernetes: true,
 		})
 		str, err := json.MarshalIndent(util, "", "\t")

--- a/src/daemon/main.go
+++ b/src/daemon/main.go
@@ -239,7 +239,8 @@ type Config struct {
 	DetectGCP          bool           `config:"utilization.detect_gcp"`         // Whether to detect if this is running on GCP in utilization
 	DetectPCF          bool           `config:"utilization.detect_pcf"`         // Whether to detect if this is running on PCF in utilization
 	DetectDocker       bool           `config:"utilization.detect_docker"`      // Whether to detect if this is in a Docker container in utilization
-	LogicalProcessors  int            `config:"utilization.logical_processors"` // Customer provided number of logical processors for pricing control.
+	DetectKubernetes   bool		      `config:"utilization.detect_kubernetes"`  // Whether to detect if this is in a Kubernetes cluster
+        LogicalProcessors  int            `config:"utilization.logical_processors"` // Customer provided number of logical processors for pricing control.
 	TotalRamMIB        int            `config:"utilization.total_ram_mib"`      // Customer provided total RAM in mebibytes for pricing control.
 	BillingHostname    string         `config:"utilization.billing_hostname"`   // Customer provided hostname for pricing control.
 	Agent              bool           `config:"-"`                              // Used to indicate if spawned by agent
@@ -259,6 +260,7 @@ func (cfg *Config) MakeUtilConfig() utilization.Config {
 		DetectGCP:         cfg.DetectGCP,
 		DetectPCF:         cfg.DetectPCF,
 		DetectDocker:      cfg.DetectDocker,
+		DetectKubernetes:  cfg.DetectKubernetes,
 		LogicalProcessors: cfg.LogicalProcessors,
 		TotalRamMIB:       cfg.TotalRamMIB,
 		BillingHostname:   cfg.BillingHostname,

--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -651,11 +651,12 @@ func startDaemon(network, address string, securityToken string, securityPolicies
 	client, _ := newrelic.NewClient(&newrelic.ClientConfig{})
 	connectPayload := TestApp.ConnectPayload(utilization.Gather(
 		utilization.Config{
-			DetectAWS:    true,
-			DetectAzure:  true,
-			DetectGCP:    true,
-			DetectPCF:    true,
-			DetectDocker: true,
+			DetectAWS:        true,
+			DetectAzure:      true,
+			DetectGCP:        true,
+			DetectPCF:        true,
+			DetectDocker:     true,
+			DetectKubernetes: true,
 		}))
 
 	policies := newrelic.AgentPolicies{}

--- a/src/newrelic/collector_integration_test.go
+++ b/src/newrelic/collector_integration_test.go
@@ -32,11 +32,12 @@ func sampleConnectPayload(lic collector.LicenseKey) *RawConnectPayload {
 	}
 
 	return info.ConnectPayload(utilization.Gather(utilization.Config{
-		DetectAWS:    false,
-		DetectAzure:  false,
-		DetectGCP:    false,
-		DetectPCF:    false,
-		DetectDocker: false,
+		DetectAWS:        false,
+		DetectAzure:      false,
+		DetectGCP:        false,
+		DetectPCF:        false,
+		DetectDocker:     false,
+		DetectKubernetes: false,
 	}))
 }
 

--- a/src/newrelic/utilization/addresses.go
+++ b/src/newrelic/utilization/addresses.go
@@ -1,0 +1,78 @@
+//
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package utilization
+
+import (
+	"fmt"
+	"net"
+)
+
+func nonlocalIPAddressesByInterface() (map[string][]string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	ips := make(map[string][]string, len(ifaces))
+	for _, ifc := range ifaces {
+		addrs, err := ifc.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch iptype := addr.(type) {
+			case *net.IPAddr:
+				ip = iptype.IP
+			case *net.IPNet:
+				ip = iptype.IP
+			case *net.TCPAddr:
+				ip = iptype.IP
+			case *net.UDPAddr:
+				ip = iptype.IP
+			}
+			if nil != ip && !ip.IsLoopback() && !ip.IsUnspecified() {
+				ips[ifc.Name] = append(ips[ifc.Name], ip.String())
+			}
+		}
+	}
+	return ips, nil
+}
+
+// utilizationIPs gathers IP address which may help identify this entity. This
+// code chooses all IPs from the interface which contains the IP of a UDP
+// connection with NR.  This approach has the following advantages:
+// * Matches the behavior of the Java agent.
+// * Reports fewer IPs to lower linking burden on infrastructure backend.
+// * The UDP connection interface is more likely to contain unique external IPs.
+func utilizationIPs() ([]string, error) {
+	// Port choice designed to match
+	// https://source.datanerd.us/java-agent/java_agent/blob/master/newrelic-agent/src/main/java/com/newrelic/agent/config/Hostname.java#L110
+	conn, err := net.Dial("udp", "newrelic.com:10002")
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+
+	if !ok || nil == addr || addr.IP.IsLoopback() || addr.IP.IsUnspecified() {
+		return nil, fmt.Errorf("unexpected connection address: %v", conn.LocalAddr())
+	}
+	outboundIP := addr.IP.String()
+
+	ipsByInterface, err := nonlocalIPAddressesByInterface()
+	if err != nil {
+		return nil, err
+	}
+	for _, ips := range ipsByInterface {
+		for _, ip := range ips {
+			if ip == outboundIP {
+				return ips, nil
+			}
+		}
+	}
+	return nil, nil
+}

--- a/src/newrelic/utilization/fqdn.go
+++ b/src/newrelic/utilization/fqdn.go
@@ -1,0 +1,29 @@
+//go:build go1.8
+// +build go1.8
+
+package utilization
+
+import (
+	"context"
+	"net"
+	"strings"
+)
+
+func lookupAddr(addr string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), lookupAddrTimeout)
+	defer cancel()
+
+	r := &net.Resolver{}
+
+	return r.LookupAddr(ctx, addr)
+}
+
+func getFQDN(candidateIPs []string) string {
+	for _, ip := range candidateIPs {
+		names, _ := lookupAddr(ip)
+		if len(names) > 0 {
+			return strings.TrimSuffix(names[0], ".")
+		}
+	}
+	return ""
+}

--- a/src/newrelic/utilization/kubernetes.go
+++ b/src/newrelic/utilization/kubernetes.go
@@ -1,0 +1,59 @@
+//
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package utilization
+
+import (
+	"fmt"
+)
+
+type kubernetes struct {
+	KubernetesServiceHost string `json:"kubernetes_service_host",omitempty`	
+
+	// Having a custom getter allows the unit tests to mock os.Getenv().
+	environmentVariableGetter func(key string) string
+}
+
+func GatherKubernetes(v *vendors, getenv func(string) string) error {
+	k8s := newKubernetes(getenv)
+	if err := k8s.Gather(); err != nil {
+		return fmt.Errorf("Kubernetes not detected: %s", err)
+	} else {
+		if k8s.KubernetesServiceHost != "" {
+			v.Kubernetes = k8s
+		}
+	}
+
+	return nil
+}
+
+func newKubernetes(getenv func(string) string) *kubernetes {
+	return &kubernetes{
+		environmentVariableGetter: getenv,
+	}
+}
+
+func (k8s *kubernetes) Gather() error {
+	k8s.KubernetesServiceHost = k8s.environmentVariableGetter("KUBERNETES_SERVICE_HOST")
+
+	fmt.Println("-----------")
+	fmt.Println(k8s)
+	fmt.Println("-----------")
+
+	if err := k8s.validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k8s *kubernetes) validate() (err error) {
+	k8s.KubernetesServiceHost, err = normalizeValue(k8s.KubernetesServiceHost)
+	if err != nil {
+		return fmt.Errorf("Invalid Kubernetes Service Host: %v", err)
+	}
+
+	return
+}

--- a/src/newrelic/utilization/kubernetes.go
+++ b/src/newrelic/utilization/kubernetes.go
@@ -6,6 +6,7 @@
 package utilization
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -51,5 +52,8 @@ func (k8s *kubernetes) validate() (err error) {
 		return fmt.Errorf("Invalid Kubernetes Service Host: %v", err)
 	}
 
+	if k8s.KubernetesServiceHost == "" {
+               err = errors.New("The environment variable KUBERNETES_SERVICE_HOST was unavailable")
+	}
 	return
 }

--- a/src/newrelic/utilization/kubernetes.go
+++ b/src/newrelic/utilization/kubernetes.go
@@ -38,10 +38,6 @@ func newKubernetes(getenv func(string) string) *kubernetes {
 func (k8s *kubernetes) Gather() error {
 	k8s.KubernetesServiceHost = k8s.environmentVariableGetter("KUBERNETES_SERVICE_HOST")
 
-	fmt.Println("-----------")
-	fmt.Println(k8s)
-	fmt.Println("-----------")
-
 	if err := k8s.validate(); err != nil {
 		return err
 	}

--- a/src/newrelic/utilization/provider.go
+++ b/src/newrelic/utilization/provider.go
@@ -19,6 +19,7 @@ const (
 	maxFieldValueSize = 255             // The maximum value size, in bytes.
 	providerTimeout   = 1 * time.Second // The maximum time a HTTP provider
 	// may block.
+	lookupAddrTimeout = 500 * time.Millisecond
 )
 
 // validationError represents a response from a provider endpoint that doesn't

--- a/src/newrelic/utilization/utilization_hash.go
+++ b/src/newrelic/utilization/utilization_hash.go
@@ -153,7 +153,9 @@ func Gather(config Config) *Data {
 	}()
 
 	if config.DetectKubernetes {
-		GatherKubernetes(uDat.Vendors, os.Getenv)
+		if err_k8s := GatherKubernetes(uDat.Vendors, os.Getenv); err_k8s != nil {
+		    log.Debugf("%s", err_k8s)
+		}
 	}
 
 	// Now we wait for everything!

--- a/src/newrelic/utilization/utilization_hash.go
+++ b/src/newrelic/utilization/utilization_hash.go
@@ -9,6 +9,7 @@ package utilization
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"sync"
 
@@ -17,7 +18,7 @@ import (
 )
 
 const (
-	metadataVersion = 3
+	metadataVersion = 5
 )
 
 type Config struct {
@@ -26,6 +27,7 @@ type Config struct {
 	DetectGCP         bool
 	DetectPCF         bool
 	DetectDocker      bool
+	DetectKubernetes  bool
 	LogicalProcessors int
 	TotalRamMIB       int
 	BillingHostname   string
@@ -44,9 +46,11 @@ type Data struct {
 	LogicalProcessors *int      `json:"logical_processors"`
 	RamMiB            *uint64   `json:"total_ram_mib"`
 	Hostname          string    `json:"hostname"`
+	FullHostname      string    `json:"full_hostname,omitempty"`
+	Addresses         []string  `json:"ip_address,omitempty"`
 	BootID            string    `json:"boot_id,omitempty"`
-	Vendors           *vendors  `json:"vendors,omitempty"`
 	Config            *override `json:"config,omitempty"`
+	Vendors           *vendors  `json:"vendors,omitempty"`
 }
 
 type docker struct {
@@ -54,15 +58,16 @@ type docker struct {
 }
 
 type vendors struct {
-	AWS    *aws    `json:"aws,omitempty"`
-	Azure  *azure  `json:"azure,omitempty"`
-	GCP    *gcp    `json:"gcp,omitempty"`
-	PCF    *pcf    `json:"pcf,omitempty"`
-	Docker *docker `json:"docker,omitempty"`
+	AWS        *aws        `json:"aws,omitempty"`
+	Azure      *azure      `json:"azure,omitempty"`
+	GCP        *gcp        `json:"gcp,omitempty"`
+	PCF        *pcf        `json:"pcf,omitempty"`
+	Docker     *docker     `json:"docker,omitempty"`
+	Kubernetes *kubernetes `json:"kubernetes,omitempty"`
 }
 
 func (v *vendors) isEmpty() bool {
-	return v.AWS == nil && v.Azure == nil && v.GCP == nil && v.PCF == nil && v.Docker == nil
+	return nil == v || *v == vendors{}
 }
 
 func overrideFromConfig(config Config) *override {
@@ -112,6 +117,14 @@ func Gather(config Config) *Data {
 	goGather(GatherCPU, uDat)
 	goGather(GatherMemory, uDat)
 
+	// Gather IPs before spawning goroutines since the IPs are used in
+	// gathering full hostname.
+	if ips, err := utilizationIPs(); nil == err {
+		uDat.Addresses = ips
+	} else {
+		log.Debugf("Error gathering addresses: %s", err)
+	}
+
 	// Now things the user can turn off.
 	if config.DetectDocker {
 		goGather(GatherDockerID, uDat)
@@ -131,6 +144,16 @@ func Gather(config Config) *Data {
 
 	if config.DetectPCF {
 		goGather(GatherPCF, uDat)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		uDat.FullHostname = getFQDN(uDat.Addresses)
+	}()
+
+	if config.DetectKubernetes {
+		GatherKubernetes(uDat.Vendors, os.Getenv)
 	}
 
 	// Now we wait for everything!

--- a/src/newrelic/utilization/utilization_hash_test.go
+++ b/src/newrelic/utilization/utilization_hash_test.go
@@ -336,10 +336,6 @@ func runUtilizationCrossAgentTestcase(t *testing.T, tc utilizationCrossAgentTest
 	if string(js) != expect {
 		t.Error(tc.Name, string(js), expect)
 	}
-	t.Log("-------------------")
-	t.Log("actual: ", string(js))
-	t.Log("expected: ", expect)
-	t.Log(tc.Name, " PASSED")
 }
 
 func TestUtilizationCrossAgent(t *testing.T) {

--- a/src/newrelic/utilization/utilization_hash_test.go
+++ b/src/newrelic/utilization/utilization_hash_test.go
@@ -296,10 +296,6 @@ func runUtilizationCrossAgentTestcase(t *testing.T, tc utilizationCrossAgentTest
 
 	err := json.Unmarshal(tc.ExpectedOutput, &v)
 
-	//if err == nil && v.MetadataVersion != 3 {
-	//	t.Skip("Unsupported utilization metdata version: ", v.MetadataVersion)
-	//}
-
 	var ConfigRAWMMIB int
 	if nil != tc.Config.RAWMMIB {
 		json.Unmarshal(tc.Config.RAWMMIB, &ConfigRAWMMIB)

--- a/src/newrelic/utilization/utilization_hash_test.go
+++ b/src/newrelic/utilization/utilization_hash_test.go
@@ -106,19 +106,19 @@ func TestJSONMarshalling(t *testing.T) {
 func TestUtilizationHash(t *testing.T) {
 	configs := []Config{
 		{
-			DetectAWS:    true,
-			DetectAzure:  true,
-			DetectGCP:    true,
-			DetectPCF:    true,
-			DetectDocker: true,
+			DetectAWS:        true,
+			DetectAzure:      true,
+			DetectGCP:        true,
+			DetectPCF:        true,
+			DetectDocker:     true,
 			DetectKubernetes: true,
 		},
 		{
-			DetectAWS:    false,
-			DetectAzure:  false,
-			DetectGCP:    false,
-			DetectPCF:    false,
-			DetectDocker: false,
+			DetectAWS:        false,
+			DetectAzure:      false,
+			DetectGCP:        false,
+			DetectPCF:        false,
+			DetectDocker:     false,
 			DetectKubernetes: false,
 		},
 	}

--- a/src/newrelic/utilization/utilization_hash_test.go
+++ b/src/newrelic/utilization/utilization_hash_test.go
@@ -286,15 +286,19 @@ func compactJSON(js []byte) []byte {
 
 func runUtilizationCrossAgentTestcase(t *testing.T, tc utilizationCrossAgentTestcase) {
 
-	// Skip utilitzation cross agent tests for metadata versions newer than
-	// the supported one (which is version 3).
-	type version struct {
-		MetadataVersion uint64 `json:metadata_version`
+	// check metadata version expected and skip test if beyond the currently supported level
+	var d Data
+
+	err := json.Unmarshal(tc.ExpectedOutput, &d)
+	if nil != err {
+		t.Errorf("Unable to decode expected output for test \"%s\" - %s", tc.Name, err)
+		return
 	}
 
-	var v version
-
-	err := json.Unmarshal(tc.ExpectedOutput, &v)
+	if metadataVersion < d.MetadataVersion {
+		t.Logf("skipping test \"%s\" - test metadata version (%d) > supported (%d)", tc.Name, d.MetadataVersion, metadataVersion)
+		return
+	}
 
 	var ConfigRAWMMIB int
 	if nil != tc.Config.RAWMMIB {


### PR DESCRIPTION
This PR bumps the daemon up to reporting utilization metadata spec Level 5 which specified the inclusion of the full hostname, host ip address(es), and the Kubernetes service host (if available).  It adds a new daemon config option for "utilization.detect_kubernetes" which defaults to ON.

Much of this work is based on the Go agent (v3) commit to add [Utilization v5](https://github.com/newrelic/go-agent/commit/52464a9e9993b9dad4f904f46102debb5ea9bfc2).

This PR addresses issues #414, #415 and #416.

