### PR TITLE
feat(daemon): Implement New Relic payload size limit

### DIFF
--- a/src/newrelic/app.go
+++ b/src/newrelic/app.go
@@ -296,7 +296,7 @@ func combineEventConfig (ehc collector.EventHarvestConfig, sehc collector.SpanEv
 }
 
 func parseConnectReply(rawConnectReply []byte) (*ConnectReply, error) {
-	var c ConnectReply
+	c := ConnectReply{MaxPayloadSizeInBytes: limits.DefaultMaxPayloadSizeInBytes}
 
 	err := json.Unmarshal(rawConnectReply, &c)
 	if nil != err {

--- a/src/newrelic/app.go
+++ b/src/newrelic/app.go
@@ -125,6 +125,7 @@ type ConnectReply struct {
 	EventHarvestConfig collector.EventHarvestConfig         `json:"event_harvest_config"`
 	SpanEventHarvestConfig collector.SpanEventHarvestConfig `json:"span_event_harvest_config"`
 	RequestHeadersMap map[string]string                     `json:"request_headers_map"`
+	MaxPayloadSizeInBytes int                               `json:"max_payload_size_in_bytes"`
 }
 
 // An App represents the state of an application.

--- a/src/newrelic/app_test.go
+++ b/src/newrelic/app_test.go
@@ -6,6 +6,7 @@
 package newrelic
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 	"strconv"
@@ -440,4 +441,30 @@ func TestConnectPayloadEncoded(t *testing.T) {
 		t.Errorf("expected: %s\nactual: %s", expected, string(b))
 	}
 
+}
+
+func TestMaxPayloadSizeInBytesFromDefault(t *testing.T) {
+	expectedMaxPayloadSizeInBytes := limits.DefaultMaxPayloadSizeInBytes
+	id := AgentRunID("1") // parseConnectReply expects at least agent_run_id in collector reply
+	cannedConnectReply, _ := json.Marshal(ConnectReply{ID: &id})
+
+	c, err := parseConnectReply(cannedConnectReply)
+	if err != nil {
+		t.Error(err)
+	} else if c.MaxPayloadSizeInBytes != expectedMaxPayloadSizeInBytes {
+		t.Errorf("expected [%v], got [%v]", expectedMaxPayloadSizeInBytes, c.MaxPayloadSizeInBytes)
+	}
+}
+
+func TestMaxPayloadSizeInBytesFromConnectReply(t *testing.T) {
+	expectedMaxPayloadSizeInBytes := 1000
+	id := AgentRunID("1") // parseConnectReply expects at least agent_run_id in collector reply
+	cannedConnectReply, _ := json.Marshal(ConnectReply{ID: &id, MaxPayloadSizeInBytes: expectedMaxPayloadSizeInBytes})
+
+	c, err := parseConnectReply(cannedConnectReply)
+	if err != nil {
+		t.Error(err)
+	} else if c.MaxPayloadSizeInBytes != expectedMaxPayloadSizeInBytes {
+		t.Errorf("expected [%v], got [%v]", expectedMaxPayloadSizeInBytes, c.MaxPayloadSizeInBytes)
+	}
 }

--- a/src/newrelic/app_test.go
+++ b/src/newrelic/app_test.go
@@ -6,6 +6,7 @@
 package newrelic
 
 import (
+	"fmt"
 	"testing"
 	"time"
 	"strconv"
@@ -456,7 +457,7 @@ func TestMaxPayloadSizeInBytesFromDefault(t *testing.T) {
 
 func TestMaxPayloadSizeInBytesFromConnectReply(t *testing.T) {
 	expectedMaxPayloadSizeInBytes := 1000
-	cannedConnectReply := []byte(`{"agent_run_id":"1", "max_payload_size_in_bytes":1000}`)
+	cannedConnectReply := []byte(`{"agent_run_id":"1", "max_payload_size_in_bytes":`+fmt.Sprint(expectedMaxPayloadSizeInBytes)+`}`)
 
 	c, err := parseConnectReply(cannedConnectReply)
 	if err != nil {

--- a/src/newrelic/app_test.go
+++ b/src/newrelic/app_test.go
@@ -452,7 +452,7 @@ func TestMaxPayloadSizeInBytesFromDefault(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	} else if c.MaxPayloadSizeInBytes != expectedMaxPayloadSizeInBytes {
-		t.Errorf("expected [%v], got [%v]", expectedMaxPayloadSizeInBytes, c.MaxPayloadSizeInBytes)
+		t.Errorf("parseConnectReply(nothing), got [%v], expected [%v]", c.MaxPayloadSizeInBytes, expectedMaxPayloadSizeInBytes)
 	}
 }
 
@@ -465,6 +465,6 @@ func TestMaxPayloadSizeInBytesFromConnectReply(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	} else if c.MaxPayloadSizeInBytes != expectedMaxPayloadSizeInBytes {
-		t.Errorf("expected [%v], got [%v]", expectedMaxPayloadSizeInBytes, c.MaxPayloadSizeInBytes)
+		t.Errorf("parseConnectReply(something), got [%v], expected [%v]", c.MaxPayloadSizeInBytes, expectedMaxPayloadSizeInBytes)
 	}
 }

--- a/src/newrelic/app_test.go
+++ b/src/newrelic/app_test.go
@@ -6,7 +6,6 @@
 package newrelic
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 	"strconv"
@@ -445,8 +444,7 @@ func TestConnectPayloadEncoded(t *testing.T) {
 
 func TestMaxPayloadSizeInBytesFromDefault(t *testing.T) {
 	expectedMaxPayloadSizeInBytes := limits.DefaultMaxPayloadSizeInBytes
-	id := AgentRunID("1") // parseConnectReply expects at least agent_run_id in collector reply
-	cannedConnectReply, _ := json.Marshal(ConnectReply{ID: &id})
+	cannedConnectReply := []byte(`{"agent_run_id":"1"}`) // parseConnectReply expects at least agent_run_id in collector reply
 
 	c, err := parseConnectReply(cannedConnectReply)
 	if err != nil {
@@ -458,8 +456,7 @@ func TestMaxPayloadSizeInBytesFromDefault(t *testing.T) {
 
 func TestMaxPayloadSizeInBytesFromConnectReply(t *testing.T) {
 	expectedMaxPayloadSizeInBytes := 1000
-	id := AgentRunID("1") // parseConnectReply expects at least agent_run_id in collector reply
-	cannedConnectReply, _ := json.Marshal(ConnectReply{ID: &id, MaxPayloadSizeInBytes: expectedMaxPayloadSizeInBytes})
+	cannedConnectReply := []byte(`{"agent_run_id":"1", "max_payload_size_in_bytes":1000}`)
 
 	c, err := parseConnectReply(cannedConnectReply)
 	if err != nil {

--- a/src/newrelic/collector/client.go
+++ b/src/newrelic/collector/client.go
@@ -40,6 +40,7 @@ type RpmCmd struct {
 	Data              []byte
 	License           LicenseKey
 	RequestHeadersMap map[string]string
+	MaxPayloadSize    int
 }
 
 // RpmControls contains fields which will be the same for all calls made
@@ -321,6 +322,10 @@ func (c *clientImpl) perform(url string, cmd RpmCmd, cs RpmControls) RPMResponse
 	deflated, err := Compress(cmd.Data)
 	if nil != err {
 		return RPMResponse{Err: err}
+	}
+
+	if l := deflated.Len(); l > cmd.MaxPayloadSize {
+		return RPMResponse{Err: fmt.Errorf("Payload size for %s too large: %d greater than %d", cmd.Name, l, cmd.MaxPayloadSize)}
 	}
 
 	req, err := http.NewRequest("POST", url, deflated)

--- a/src/newrelic/collector/client.go
+++ b/src/newrelic/collector/client.go
@@ -325,7 +325,7 @@ func (c *clientImpl) perform(url string, cmd RpmCmd, cs RpmControls) RPMResponse
 	}
 
 	if l := deflated.Len(); l > cmd.MaxPayloadSize {
-		return RPMResponse{Err: fmt.Errorf("Payload size for %s too large: %d greater than %d", cmd.Name, l, cmd.MaxPayloadSize)}
+		return RPMResponse{Err: fmt.Errorf("payload size too large: %d greater than %d", l, cmd.MaxPayloadSize)}
 	}
 
 	req, err := http.NewRequest("POST", url, deflated)
@@ -420,7 +420,7 @@ func (c *clientImpl) Execute(cmd RpmCmd, cs RpmControls) RPMResponse {
 	cleanURL := cmd.url(true)
 
 	log.Audit("command='%s' url='%s' payload={%s}", cmd.Name, url, audit)
-	log.Debugf("command='%s' url='%s' payload={%s}", cmd.Name, cleanURL, data)
+	log.Debugf("command='%s' url='%s' max_payload_size_in_bytes='%d' payload={%s}", cmd.Name, cleanURL, cmd.MaxPayloadSize, data)
 
 	resp := c.perform(url, cmd, cs)
 	if err != nil {

--- a/src/newrelic/collector/collector_test.go
+++ b/src/newrelic/collector/collector_test.go
@@ -87,6 +87,7 @@ func TestCollectorRequest(t *testing.T) {
 		Data:              nil,
 		License:           "the_license",
 		RequestHeadersMap: map[string]string{"zip": "zap"},
+		MaxPayloadSize:    1000 * 1000,
 	}
 	testField := func(name, v1, v2 string) {
 		if v1 != v2 {

--- a/src/newrelic/limits/limits.go
+++ b/src/newrelic/limits/limits.go
@@ -36,6 +36,7 @@ const (
 	MaxRegularTraces      = 1
 	MaxForcePersistTraces = 10
 	MaxSyntheticsTraces   = 20
+	DefaultMaxPayloadSizeInBytes = 1000 * 1000
 
 	// Failed Harvest Data Rollover Limits
 	// Use the same harvest failure limit for custom events and txn events

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -179,6 +179,8 @@ func ConnectApplication(args *ConnectArgs) ConnectAttempt {
 		Name:      collector.CommandPreconnect,
 		Collector: collectorHostname,
 		License:   args.License,
+		// Use default maximum, because we don't know the collector limit yet
+		MaxPayloadSize: limits.DefaultMaxPayloadSizeInBytes,
 	}
 
 	// Make call to preconnect
@@ -463,6 +465,7 @@ type harvestArgs struct {
 	client              collector.Client
 	splitLargePayloads  bool
 	RequestHeadersMap   map[string]string
+	maxPayloadSize      int
 
 	// Used for final harvest before daemon exit
 	blocking bool
@@ -475,6 +478,7 @@ func harvestPayload(p PayloadCreator, args *harvestArgs) {
 		License:           args.license,
 		RunID:             args.id.String(),
 		RequestHeadersMap: args.RequestHeadersMap,
+		MaxPayloadSize:    args.maxPayloadSize,
 	}
 	cs := collector.RpmControls{
 		AgentLanguage: args.agentLanguage,
@@ -657,6 +661,7 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 		harvestErrorChannel: p.harvestErrorChannel,
 		client:              p.cfg.Client,
 		RequestHeadersMap:   app.connectReply.RequestHeadersMap,
+		maxPayloadSize:      app.connectReply.MaxPayloadSizeInBytes,
 		// Splitting large payloads is limited to applications that have
 		// distributed tracing on. That restriction is a saftey measure
 		// to not overload the backend by sending two payloads instead


### PR DESCRIPTION
This PR implements following Agent's specification:

Agents MUST default to sending no more than 1000000 bytes in any payload
sent to New Relic for any method. The connect response contains the
max_payload_size_in_bytes field which MUST override the default value.
    
Immediately prior to transmitting a payload to New Relic (after
compression, prior to transmission), the size of the payload in bytes
should be compared against max_payload_size_in_bytes. If the payload
size is larger than max_payload_size_in_bytes, the agent should
immediately discard that payload. A payload larger than
max_payload_size_in_bytes MUST NOT be transmitted.

Following tests have been added to cover changed code:
1. Test if default payload limit is preserved if collector doesn't provide any value.
2. Test if default payload limit is overridden if collector provides limit value in connect reply.
3. Test if payload is dropped if its size is larger than max_payload_size_in_bytes.
4. Test if payload is not dropped if its size is smaller than max_payload_size_in_bytes.

Closes #440 
