### PR TITLE
fix(agent): Rework Dockerfile to improve composer installation

### DIFF
--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -101,10 +101,20 @@ RUN if [ -z "$(grep '^8\.' /etc/debian_version)" ]; then \
 
 # install composer
 WORKDIR /usr/src
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '906a84df04cea2aa72f40b5f787e49f22d4c2f19492ac310e8cba5b96ac8b64115ac402c8cd292b8a03482574915d1a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
+
+# based on https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+RUN \
+ EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')" \
+ && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+ && ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" \
+ && if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; \
+  then \
+    >&2 echo 'ERROR: Invalid installer checksum'; \
+    rm composer-setup.php; \
+    exit 1; \
+  fi \
+ && php composer-setup.php \
+ && php -r "unlink('composer-setup.php');"
 
 #
 # The explain plan in the sql tests contain partition/filtered properties


### PR DESCRIPTION
The existing Dockerfile for creating the agent image for the dockerized agents and services dev env had the composer installer checksum hard codes.  Recently the installer was updated so the docker compose would fail when the checksum didn't match.  This update changes how the composer installation is handles to match the best practice defined [here](https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md) which involves downloaded the expected checksum as well as the installer payload and comparing.