### PR TITLE
fix(agent): Improve handling TT, 8T and DT configuration dependencies

### DIFF
--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -236,7 +236,7 @@ static char* nr_php_check_for_upgrade_license_key(void) {
   return 0;
 }
 
-static nr_status_t nr_php_check_8T_DT_config(void) {
+static nr_status_t nr_php_check_8T_DT_config(TSRMLS_D) {
   /* check if infinite tracing is enabled and DT disabled */
   if (!nr_strempty(NRINI(trace_observer_host))
       && !NRINI(distributed_tracing_enabled)) {
@@ -577,7 +577,7 @@ PHP_MINIT_FUNCTION(newrelic) {
    * axiom/nr_segment.c::nr_segment_to_span_event() Output a warning about this
    * config issue and also that 8T will be disabled
    */
-  nr_php_check_8T_DT_config();
+  nr_php_check_8T_DT_config(TSRMLS_C);
 
   /*
    * Save the original PHP hooks and then apply our own hooks. The agent is

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -717,7 +717,12 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   info.security_policies_token = nr_strdup(NRINI(security_policies_token));
   info.supported_security_policies
       = nr_php_txn_get_supported_security_policy_settings(&opts);
-  info.trace_observer_host = nr_strdup(NRINI(trace_observer_host));
+  /* if DT is disabled we cannot stream 8T events so disable observer host */
+  if (NRINI(distributed_tracing_enabled))
+    info.trace_observer_host = nr_strdup(NRINI(trace_observer_host));
+  else
+    info.trace_observer_host = nr_strdup("");
+  /* observer port setting does not really depend on DT being enabled */
   info.trace_observer_port = NRINI(trace_observer_port);
   info.span_queue_size = NRINI(span_queue_size);
   info.span_events_max_samples_stored = NRINI(span_events_max_samples_stored);

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -607,7 +607,7 @@ nrobj_t* nr_php_txn_get_supported_security_policy_settings(nrtxnopt_t* opts) {
 
 #define NR_APP_ERROR_DT_ON_TT_OFF_BACKOFF_SECONDS 60
 
-static void nr_segment_log_error_dt_on_tt_off(void) {
+static void nr_php_txn_log_error_dt_on_tt_off(void) {
   static unsigned n_occur = 0;
   static time_t last_warn = (time_t)(0);
   time_t now = time(0);
@@ -867,7 +867,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
 
   if (NRPRG(txn)->options.distributed_tracing_enabled
       && !NRPRG(txn)->options.tt_enabled) {
-    nr_segment_log_error_dt_on_tt_off();
+    nr_php_txn_log_error_dt_on_tt_off();
   }
 
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -352,6 +352,26 @@ static nr_status_t add_agent_attribute_to_span_event(const char* key,
   return NR_SUCCESS;
 }
 
+#define NR_APP_LOG_SEGMENT_ID_FAILURE_BACKOFF_SECONDS 60
+
+static void nr_segment_log_segment_id_missing(void) {
+  static unsigned n_occur = 0;
+  static time_t last_warn = (time_t)(0);
+  time_t now = time(0);
+
+  n_occur++;
+
+  if ((now - last_warn) > NR_APP_LOG_SEGMENT_ID_FAILURE_BACKOFF_SECONDS) {
+    last_warn = now;
+    nrl_warning(
+        NRL_SEGMENT,
+        "cannot create a span event when a segment ID cannot be "
+        "generated; is distributed tracing enabled?  Occurred %u times.",
+        n_occur);
+    n_occur = 0;
+  }
+}
+
 nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
   nr_span_event_t* event;
   char* trace_id;
@@ -378,9 +398,7 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
   }
 
   if (NULL == nr_segment_ensure_id(segment, segment->txn)) {
-    nrl_warning(NRL_SEGMENT,
-                "cannot create a span event when a segment ID cannot be "
-                "generated; is distributed tracing enabled?");
+    nr_segment_log_segment_id_missing();
     return NULL;
   }
 
@@ -433,7 +451,8 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
           event, NR_SPAN_PARENT_TRANSPORT_TYPE,
           nr_distributed_trace_inbound_get_transport_type(
               segment->txn->distributed_trace));
-      if (nr_distributed_trace_inbound_has_timestamp(segment->txn->distributed_trace)) {
+      if (nr_distributed_trace_inbound_has_timestamp(
+              segment->txn->distributed_trace)) {
         nr_span_event_set_parent_transport_duration(
             event, nr_distributed_trace_inbound_get_timestamp_delta(
                        segment->txn->distributed_trace,

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -352,16 +352,17 @@ static nr_status_t add_agent_attribute_to_span_event(const char* key,
   return NR_SUCCESS;
 }
 
-#define NR_APP_LOG_SEGMENT_ID_FAILURE_BACKOFF_SECONDS 60
+#define NR_APP_LOG_WARNING_SEGMENT_ID_FAILURE_BACKOFF_SECONDS 60
 
-static void nr_segment_log_segment_id_missing(void) {
+static void nr_segment_log_warning_segment_id_missing(void) {
   static unsigned n_occur = 0;
   static time_t last_warn = (time_t)(0);
   time_t now = time(0);
 
   n_occur++;
 
-  if ((now - last_warn) > NR_APP_LOG_SEGMENT_ID_FAILURE_BACKOFF_SECONDS) {
+  if ((now - last_warn)
+      > NR_APP_LOG_WARNING_SEGMENT_ID_FAILURE_BACKOFF_SECONDS) {
     last_warn = now;
     nrl_warning(
         NRL_SEGMENT,
@@ -398,7 +399,7 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
   }
 
   if (NULL == nr_segment_ensure_id(segment, segment->txn)) {
-    nr_segment_log_segment_id_missing();
+    nr_segment_log_warning_segment_id_missing();
     return NULL;
   }
 


### PR DESCRIPTION
This PR improves handling TT, 8T and DT configuration dependencies. In particular:
- If 8T is enabled and DT is disabled then this PR will:
   + Output a warning that 8T will be disabled because DT is disabled.
   + Sets the trace observer host to "" if DT is disabled.
   + If for some reason the previous mitigation failed then it will batch together the previous warning message which occurred each time the creation of a span was attempted which created significant log file output.  Now the message will appear at most once every 60 seconds with a count of the number of times it occurred in the past 60 seconds.
- If DT is enabled and the transaction tracer is disabled it will also batch together the error message which occurs each time the creation of a transaction is created and outputs a summary every 60 seconds (like above).  Otherwise a log error message occurs each time the creation of a transaction is attempted which can lead to significant log file growth.

Closes #452.