### PR TITLE
feat(agent): Honor collect_span_events server config

### DIFF
--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -501,6 +501,12 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
       = nt->options.span_events_enabled && app->limits.span_events;
 
   /*
+   * Enforce SSC and LASP if enabled
+   */
+  nr_txn_enforce_security_settings(&nt->options, app->connect_reply,
+                                   app->security_policies);
+
+  /*
    * Update the options based on the 8T configuration.
    */
   if (nt->options.span_events_enabled) {
@@ -525,12 +531,6 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nt->intrinsics = nro_new_hash();
 
   nt->custom_events = nr_analytics_events_create(app->limits.custom_events);
-
-  /*
-   * Enforce SSC and LASP if enabled
-   */
-  nr_txn_enforce_security_settings(&nt->options, app->connect_reply,
-                                   app->security_policies);
 
   /*
    * Set the status fields to their defaults.

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -291,6 +291,12 @@ void nr_txn_enforce_security_settings(nrtxnopt_t* opts,
         NRL_TXN, "Setting newrelic.analytics_events.enabled = false by server");
   }
 
+  if (0 == nr_reply_get_bool(connect_reply, "collect_span_events", 1)) {
+    opts->span_events_enabled = 0;
+    nrl_verbosedebug(NRL_TXN,
+                     "Setting newrelic.span_events_enabled = false by server");
+  }
+
   // LASP also modifies this setting. Kept seperate for readability.
   if (0 == nr_reply_get_bool(connect_reply, "collect_custom_events", 1)) {
     opts->custom_events_enabled = 0;

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -1777,6 +1777,15 @@ static void test_begin(void) {
   nr_txn_destroy(&rv);
 
   /*
+   * Test : App turns off span events
+   */
+  nro_set_hash_boolean(app->connect_reply, "collect_span_events", 0);
+  correct.span_events_enabled = 0;
+  rv = nr_txn_begin(app, opts, attribute_config);
+  test_created_txn("app turns off span events", rv, &correct);
+  nr_txn_destroy(&rv);
+
+  /*
    * Test : High security off
    */
   app->info.high_security = 0;


### PR DESCRIPTION
Agent will honor server side configuration and will not collect span 
events if this feature is disabled in the configuration received from 
the server. Server side configuration takes precedence over application's
local configuration. However server side configuration can only be used 
to turn off collecting span events.

Closes #443