### PR TITLE
feat(daemon): add supportability metrics for new response codes and for harvest endpoints

### DIFF
--- a/src/newrelic/analytics_events.go
+++ b/src/newrelic/analytics_events.go
@@ -61,6 +61,14 @@ func (events *analyticsEvents) Split() (*analyticsEvents, *analyticsEvents) {
 	return e1, e2
 }
 
+// NumAttempts returns the total number of attempts sent to this endpoint
+// The value is the number of times the agent attempted to call the given endpoint before it was successful.
+// This metric MUST NOT be generated if only one attempt was made.
+// Does not include the successful attempt
+func (events *analyticsEvents) NumFailedAttempts() float64 {
+	return float64(events.failedHarvests)
+}
+
 // NumSeen returns the total number of analytics events observed.
 func (events *analyticsEvents) NumSeen() float64 {
 	return float64(events.numSeen)

--- a/src/newrelic/analytics_events.go
+++ b/src/newrelic/analytics_events.go
@@ -61,10 +61,10 @@ func (events *analyticsEvents) Split() (*analyticsEvents, *analyticsEvents) {
 	return e1, e2
 }
 
-// NumAttempts returns the total number of attempts sent to this endpoint
+// NumAttempts returns the total number of attempts sent to this endpoint.
 // The value is the number of times the agent attempted to call the given endpoint before it was successful.
 // This metric MUST NOT be generated if only one attempt was made.
-// Does not include the successful attempt
+// Does not include the successful attempt.
 func (events *analyticsEvents) NumFailedAttempts() float64 {
 	return float64(events.failedHarvests)
 }

--- a/src/newrelic/harvest.go
+++ b/src/newrelic/harvest.go
@@ -45,7 +45,6 @@ func NewHarvest(now time.Time, hl collector.EventConfigs) *Harvest {
 		SpanEvents:        NewSpanEvents(hl.SpanEventConfig.Limit),
 		commandsProcessed: 0,
 		pidSet:            make(map[int]struct{}),
-		//amber
         httpErrorSet:      make(map[int]float64),
         endpointsAttemptedSet: make(map[string]float64),
 	}
@@ -72,8 +71,6 @@ func createTraceObserverMetrics(to *infinite_tracing.TraceObserver, metrics *Met
 		metrics.AddCount(name, "", val, Forced)
 	}
 }
-
-//amber
 
 func (h *Harvest) createHttpErrorMetrics() {
 	if h.empty() {
@@ -132,7 +129,6 @@ func (h *Harvest) IncrementEndpointsAttempted(cmd string) {
         h.endpointsAttemptedSet[cmd] = 1
     }
 }
-//amber end
 
 func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver) {
 	if h.empty() {

--- a/src/newrelic/harvest.go
+++ b/src/newrelic/harvest.go
@@ -6,8 +6,8 @@
 package newrelic
 
 import (
-	"time"
 	"strconv"
+	"time"
 
 	"newrelic/collector"
 	"newrelic/infinite_tracing"
@@ -78,7 +78,7 @@ func (h *Harvest) createHttpErrorMetrics() {
 	}
 
 	for code, val := range h.httpErrorSet {
-		h.Metrics.AddCount("Supportability/Agent/Collector/HTTPError/" + strconv.Itoa(code), "", val, Forced)
+		h.Metrics.AddCount("Supportability/Agent/Collector/HTTPError/"+strconv.Itoa(code), "", val, Forced)
 	}
 }
 
@@ -92,22 +92,22 @@ func (h *Harvest) IncrementHttpErrors(statusCode int) {
 	counter, isPresent := h.httpErrorSet[statusCode]
 
 	if isPresent {
-		h.httpErrorSet[statusCode] = counter+1
+		h.httpErrorSet[statusCode] = counter + 1
 	} else {
 		h.httpErrorSet[statusCode] = 1
 	}
 }
 
-func (h *Harvest) createEndpointAttemptsMetric( endpoint string, val float64) {
+func (h *Harvest) createEndpointAttemptsMetric(endpoint string, val float64) {
 	if h.empty() {
 		// No agent data received, do not create derived metrics. This allows
 		// upstream to detect inactivity sooner.
 		return
 	}
 
-	if (val > 0) {
-		h.Metrics.AddCount("Supportability/Agent/Collector/" + endpoint + "/Attempts", "", val, Forced)
-    }
+	if val > 0 {
+		h.Metrics.AddCount("Supportability/Agent/Collector/"+endpoint+"/Attempts", "", val, Forced)
+	}
 
 }
 

--- a/src/newrelic/harvest.go
+++ b/src/newrelic/harvest.go
@@ -131,7 +131,7 @@ func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig,
 	// Custom Events Supportability Metrics
 	h.Metrics.AddCount("Supportability/Events/Customer/Seen", "", h.CustomEvents.NumSeen(), Forced)
 	h.Metrics.AddCount("Supportability/Events/Customer/Sent", "", h.CustomEvents.NumSaved(), Forced)
-    h.createEndpointAttemptsMetric(h.CustomEvents.Cmd(), h.CustomEvents.NumFailedAttempts())
+	h.createEndpointAttemptsMetric(h.CustomEvents.Cmd(), h.CustomEvents.NumFailedAttempts())
 
 	// Transaction Events Supportability Metrics
 	// Note that these metrics used to have different names:
@@ -140,12 +140,12 @@ func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig,
 
 	h.Metrics.AddCount("Supportability/AnalyticsEvents/TotalEventsSeen", "", h.TxnEvents.NumSeen(), Forced)
 	h.Metrics.AddCount("Supportability/AnalyticsEvents/TotalEventsSent", "", h.TxnEvents.NumSaved(), Forced)
-    h.createEndpointAttemptsMetric(h.TxnEvents.Cmd(), h.TxnEvents.NumFailedAttempts())
+	h.createEndpointAttemptsMetric(h.TxnEvents.Cmd(), h.TxnEvents.NumFailedAttempts())
 
 	// Error Events Supportability Metrics
 	h.Metrics.AddCount("Supportability/Events/TransactionError/Seen", "", h.ErrorEvents.NumSeen(), Forced)
 	h.Metrics.AddCount("Supportability/Events/TransactionError/Sent", "", h.ErrorEvents.NumSaved(), Forced)
-    h.createEndpointAttemptsMetric(h.ErrorEvents.Cmd(), h.ErrorEvents.NumFailedAttempts())
+	h.createEndpointAttemptsMetric(h.ErrorEvents.Cmd(), h.ErrorEvents.NumFailedAttempts())
 
 	if h.Metrics.numDropped > 0 {
 		h.Metrics.AddCount("Supportability/MetricsDropped", "", float64(h.Metrics.numDropped), Forced)
@@ -154,7 +154,7 @@ func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig,
 	// Span Events Supportability Metrics
 	h.Metrics.AddCount("Supportability/SpanEvent/TotalEventsSeen", "", h.SpanEvents.analyticsEvents.NumSeen(), Forced)
 	h.Metrics.AddCount("Supportability/SpanEvent/TotalEventsSent", "", h.SpanEvents.analyticsEvents.NumSaved(), Forced)
-    h.createEndpointAttemptsMetric(h.SpanEvents.Cmd(), h.SpanEvents.analyticsEvents.NumFailedAttempts())
+	h.createEndpointAttemptsMetric(h.SpanEvents.Cmd(), h.SpanEvents.analyticsEvents.NumFailedAttempts())
 
 	// Certificate supportability metrics.
 	if collector.CertPoolState == collector.SystemCertPoolMissing {
@@ -168,7 +168,7 @@ func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig,
 	h.Metrics.AddCount("Supportability/EventHarvest/ErrorEventData/HarvestLimit", "", float64(harvestLimits.EventConfigs.ErrorEventConfig.Limit), Forced)
 	h.Metrics.AddCount("Supportability/EventHarvest/SpanEventData/HarvestLimit", "", float64(harvestLimits.EventConfigs.SpanEventConfig.Limit), Forced)
 
-    h.createEndpointAttemptsMetric(h.Metrics.Cmd(), h.Metrics.NumFailedAttempts())
+	h.createEndpointAttemptsMetric(h.Metrics.Cmd(), h.Metrics.NumFailedAttempts())
 
 	createTraceObserverMetrics(to, h.Metrics)
 

--- a/src/newrelic/harvest.go
+++ b/src/newrelic/harvest.go
@@ -89,13 +89,13 @@ func (h *Harvest) IncrementHttpErrors(statusCode int) {
 		// upstream to detect inactivity sooner.
 		return
 	}
-    counter, isPresent := h.httpErrorSet[statusCode]
+	counter, isPresent := h.httpErrorSet[statusCode]
 
-    if isPresent {
-        h.httpErrorSet[statusCode] = counter+1
-    } else {
-        h.httpErrorSet[statusCode] = 1
-    }
+	if isPresent {
+		h.httpErrorSet[statusCode] = counter+1
+	} else {
+		h.httpErrorSet[statusCode] = 1
+	}
 }
 
 func (h *Harvest) createEndpointAttemptsMetric( endpoint string, val float64) {

--- a/src/newrelic/harvest_test.go
+++ b/src/newrelic/harvest_test.go
@@ -61,11 +61,11 @@ func TestCreateFinalMetricsWithLotsOfMetrics(t *testing.T) {
 	// which means only send the metric if the harvest failed at some point and needed collector
 	// re-attempted
 
-    // For PHP, only metricEvents, ErrorEvents, CustomEvents, TxnEvents, and SpanEvents are retried,
-    // therefore only those will ever have a count higher than 0 failed attemps.  For more details, see:
-    // The Data Collection Limits section of Collector-Response-Handling.md in the agent-specs.
+	// For PHP, only metricEvents, ErrorEvents, CustomEvents, TxnEvents, and SpanEvents are retried,
+	// therefore only those will ever have a count higher than 0 failed attemps.  For more details, see:
+	// The Data Collection Limits section of Collector-Response-Handling.md in the agent-specs.
 
-    // TxnEvents will succeed on the first attempt and should not generate a metric
+	// TxnEvents will succeed on the first attempt and should not generate a metric
 
 	// Have CustomEvents fail once
 	harvest.CustomEvents.FailedHarvest(harvest)
@@ -99,26 +99,7 @@ func TestCreateFinalMetricsWithLotsOfMetrics(t *testing.T) {
 		`[{"name":"Supportability/Events/TransactionError/Sent"},[28,0,0,0,0,0]],` +
 		`[{"name":"Supportability/SpanEvent/TotalEventsSeen"},[24,0,0,0,0,0]],` +
 		`[{"name":"Supportability/SpanEvent/TotalEventsSent"},[24,0,0,0,0,0]]]]`
-/*
-		[\"12345\",1447203720,1417136520,
-		[[{\"name\":\"Instance/Reporting\"},[1,0,0,0,0,0]],
-		[{\"name\":\"Supportability/Agent/Collector/custom_event_data/Attempts\"},[2,0,0,0,0,0]],
-		[{\"name\":\"Supportability/Agent/Collector/error_event_data/Attempts\"},[3,0,0,0,0,0]],
-		[{\"name\":\"Supportability/Agent/Collector/span_event_data/Attempts\"},[4,0,0,0,0,0]],
-		[{\"name\":\"Supportability/AnalyticsEvents/TotalEventsSeen\"},[8,0,0,0,0,0]],
-		[{\"name\":\"Supportability/AnalyticsEvents/TotalEventsSent\"},[8,0,0,0,0,0]],
-		[{\"name\":\"Supportability/EventHarvest/AnalyticEventData/HarvestLimit\"},[2,0,0,0,0,0]],
-		[{\"name\":\"Supportability/EventHarvest/CustomEventData/HarvestLimit\"},[3,0,0,0,0,0]],
-		[{\"name\":\"Supportability/EventHarvest/ErrorEventData/HarvestLimit\"},[1,0,0,0,0,0]],
-		[{\"name\":\"Supportability/EventHarvest/ReportPeriod\"},[1234,0,0,0,0,0]],
-		[{\"name\":\"Supportability/EventHarvest/SpanEventData/HarvestLimit\"},[4,0,0,0,0,0]],
-		[{\"name\":\"Supportability/Events/Customer/Seen\"},[8,0,0,0,0,0]],
-		[{\"name\":\"Supportability/Events/Customer/Sent\"},[8,0,0,0,0,0]],
-		[{\"name\":\"Supportability/Events/TransactionError/Seen\"},[28,0,0,0,0,0]],
-		[{\"name\":\"Supportability/Events/TransactionError/Sent\"},[28,0,0,0,0,0]],
-		[{\"name\":\"Supportability/SpanEvent/TotalEventsSeen\"},[24,0,0,0,0,0]],
-		[{\"name\":\"Supportability/SpanEvent/TotalEventsSent\"},[24,0,0,0,0,0]]]]
-*/
+
 	json, err := harvest.Metrics.CollectorJSONSorted(AgentRunID(`12345`), end)
 	if nil != err {
 		t.Fatal(err)

--- a/src/newrelic/harvest_test.go
+++ b/src/newrelic/harvest_test.go
@@ -56,10 +56,36 @@ func TestCreateFinalMetricsWithLotsOfMetrics(t *testing.T) {
 			},
 		},
 	}
+	// Harvest will fail and retry depending on the response code from the backend
+	// The specs say create a metric ONLY IF the total attempts are greater than 1
+	// which means only send the metric if the harvest failed at some point and needed collector
+	// re-attempted
+
+    // For PHP, only metricEvents, ErrorEvents, CustomEvents, TxnEvents, and SpanEvents are retried,
+    // therefore only those will ever have a count higher than 0 failed attemps.  For more details, see:
+    // The Data Collection Limits section of Collector-Response-Handling.md in the agent-specs.
+
+    // TxnEvents will succeed on the first attempt and should not generate a metric
+
+	// Have CustomEvents fail once
+	harvest.CustomEvents.FailedHarvest(harvest)
+
+	// Have ErrorEvents fail twice for a total of 2
+	harvest.ErrorEvents.FailedHarvest(harvest)
+	harvest.ErrorEvents.FailedHarvest(harvest)
+
+	// Have ErrorEvents fail twice for a total of 3
+	harvest.SpanEvents.FailedHarvest(harvest)
+	harvest.SpanEvents.FailedHarvest(harvest)
+	harvest.SpanEvents.FailedHarvest(harvest)
+
 	harvest.createFinalMetrics(limits, nil)
 
 	var expectedJSON = `["12345",1447203720,1417136520,` +
 		`[[{"name":"Instance/Reporting"},[1,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Agent/Collector/custom_event_data/Attempts"},[1,0,0,0,0,0]],` + // Check for Connect attempt supportability metrics
+		`[{"name":"Supportability/Agent/Collector/error_event_data/Attempts"},[2,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Agent/Collector/span_event_data/Attempts"},[3,0,0,0,0,0]],` +
 		`[{"name":"Supportability/AnalyticsEvents/TotalEventsSeen"},[8,0,0,0,0,0]],` +
 		`[{"name":"Supportability/AnalyticsEvents/TotalEventsSent"},[8,0,0,0,0,0]],` +
 		`[{"name":"Supportability/EventHarvest/AnalyticEventData/HarvestLimit"},[2,0,0,0,0,0]],` +
@@ -67,13 +93,32 @@ func TestCreateFinalMetricsWithLotsOfMetrics(t *testing.T) {
 		`[{"name":"Supportability/EventHarvest/ErrorEventData/HarvestLimit"},[1,0,0,0,0,0]],` +
 		`[{"name":"Supportability/EventHarvest/ReportPeriod"},[1234,0,0,0,0,0]],` +
 		`[{"name":"Supportability/EventHarvest/SpanEventData/HarvestLimit"},[4,0,0,0,0,0]],` +
-		`[{"name":"Supportability/Events/Customer/Seen"},[4,0,0,0,0,0]],` +
-		`[{"name":"Supportability/Events/Customer/Sent"},[4,0,0,0,0,0]],` +
-		`[{"name":"Supportability/Events/TransactionError/Seen"},[7,0,0,0,0,0]],` +
-		`[{"name":"Supportability/Events/TransactionError/Sent"},[7,0,0,0,0,0]],` +
-		`[{"name":"Supportability/SpanEvent/TotalEventsSeen"},[3,0,0,0,0,0]],` +
-		`[{"name":"Supportability/SpanEvent/TotalEventsSent"},[3,0,0,0,0,0]]]]`
-
+		`[{"name":"Supportability/Events/Customer/Seen"},[8,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Events/Customer/Sent"},[8,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Events/TransactionError/Seen"},[28,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Events/TransactionError/Sent"},[28,0,0,0,0,0]],` +
+		`[{"name":"Supportability/SpanEvent/TotalEventsSeen"},[24,0,0,0,0,0]],` +
+		`[{"name":"Supportability/SpanEvent/TotalEventsSent"},[24,0,0,0,0,0]]]]`
+/*
+		[\"12345\",1447203720,1417136520,
+		[[{\"name\":\"Instance/Reporting\"},[1,0,0,0,0,0]],
+		[{\"name\":\"Supportability/Agent/Collector/custom_event_data/Attempts\"},[2,0,0,0,0,0]],
+		[{\"name\":\"Supportability/Agent/Collector/error_event_data/Attempts\"},[3,0,0,0,0,0]],
+		[{\"name\":\"Supportability/Agent/Collector/span_event_data/Attempts\"},[4,0,0,0,0,0]],
+		[{\"name\":\"Supportability/AnalyticsEvents/TotalEventsSeen\"},[8,0,0,0,0,0]],
+		[{\"name\":\"Supportability/AnalyticsEvents/TotalEventsSent\"},[8,0,0,0,0,0]],
+		[{\"name\":\"Supportability/EventHarvest/AnalyticEventData/HarvestLimit\"},[2,0,0,0,0,0]],
+		[{\"name\":\"Supportability/EventHarvest/CustomEventData/HarvestLimit\"},[3,0,0,0,0,0]],
+		[{\"name\":\"Supportability/EventHarvest/ErrorEventData/HarvestLimit\"},[1,0,0,0,0,0]],
+		[{\"name\":\"Supportability/EventHarvest/ReportPeriod\"},[1234,0,0,0,0,0]],
+		[{\"name\":\"Supportability/EventHarvest/SpanEventData/HarvestLimit\"},[4,0,0,0,0,0]],
+		[{\"name\":\"Supportability/Events/Customer/Seen\"},[8,0,0,0,0,0]],
+		[{\"name\":\"Supportability/Events/Customer/Sent\"},[8,0,0,0,0,0]],
+		[{\"name\":\"Supportability/Events/TransactionError/Seen\"},[28,0,0,0,0,0]],
+		[{\"name\":\"Supportability/Events/TransactionError/Sent\"},[28,0,0,0,0,0]],
+		[{\"name\":\"Supportability/SpanEvent/TotalEventsSeen\"},[24,0,0,0,0,0]],
+		[{\"name\":\"Supportability/SpanEvent/TotalEventsSent\"},[24,0,0,0,0,0]]]]
+*/
 	json, err := harvest.Metrics.CollectorJSONSorted(AgentRunID(`12345`), end)
 	if nil != err {
 		t.Fatal(err)

--- a/src/newrelic/metrics.go
+++ b/src/newrelic/metrics.go
@@ -109,10 +109,10 @@ func (data *metricData) aggregate(src *metricData) {
 	data.sumSquares += src.sumSquares
 }
 
-// NumAttempts returns the total number of attempts sent to this endpoint
+// NumAttempts returns the total number of attempts sent to this endpoint.
 // The value is the number of times the agent attempted to call the given endpoint before it was successful.
 // This metric MUST NOT be generated if only one attempt was made.
-// Does not include the successful attempt
+// Does not include the successful attempt.
 func (mt *MetricTable) NumFailedAttempts() float64 {
 	return float64(mt.failedHarvests)
 }

--- a/src/newrelic/metrics.go
+++ b/src/newrelic/metrics.go
@@ -109,6 +109,14 @@ func (data *metricData) aggregate(src *metricData) {
 	data.sumSquares += src.sumSquares
 }
 
+// NumAttempts returns the total number of attempts sent to this endpoint
+// The value is the number of times the agent attempted to call the given endpoint before it was successful.
+// This metric MUST NOT be generated if only one attempt was made.
+// Does not include the successful attempt
+func (mt *MetricTable) NumFailedAttempts() float64 {
+	return float64(mt.failedHarvests)
+}
+
 func (mt *MetricTable) mergeMetric(nameSlice []byte, nameString, scope string,
 	m *metric) {
 	var s map[string]*metric

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -536,14 +536,6 @@ func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.Eve
 	harvest.createFinalMetrics(harvestLimits, to)
 	harvest.Metrics = harvest.Metrics.ApplyRules(args.rules)
 
-    harvest.IncrementEndpointsAttempted(harvest.Metrics.Cmd())
-    harvest.IncrementEndpointsAttempted(harvest.CustomEvents.Cmd())
-    harvest.IncrementEndpointsAttempted(harvest.ErrorEvents.Cmd())
-    harvest.IncrementEndpointsAttempted(harvest.Errors.Cmd())
-    harvest.IncrementEndpointsAttempted(harvest.SlowSQLs.Cmd())
-    harvest.IncrementEndpointsAttempted(harvest.TxnTraces.Cmd())
-    harvest.IncrementEndpointsAttempted(harvest.SpanEvents.Cmd())
-
 	considerHarvestPayload(harvest.Metrics, args)
 	considerHarvestPayload(harvest.CustomEvents, args)
 	considerHarvestPayload(harvest.ErrorEvents, args)
@@ -600,12 +592,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		harvest.commandsProcessed = 0
 		harvest.pidSet = make(map[int]struct{})
 
-        harvest.IncrementEndpointsAttempted(metrics.Cmd())
-        harvest.IncrementEndpointsAttempted(errors.Cmd())
-        harvest.IncrementEndpointsAttempted(slowSQLs.Cmd())
-        harvest.IncrementEndpointsAttempted(txnTraces.Cmd())
-        harvest.IncrementEndpointsAttempted(spanEvents.Cmd())
-
 		considerHarvestPayload(metrics, args)
 		considerHarvestPayload(errors, args)
 		considerHarvestPayload(slowSQLs, args)
@@ -623,7 +609,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		customEvents := harvest.CustomEvents
 		harvest.CustomEvents = NewCustomEvents(eventConfigs.CustomEventConfig.Limit)
-		harvest.IncrementEndpointsAttempted(customEvents.Cmd())
 		considerHarvestPayload(customEvents, args)
 	}
 
@@ -632,7 +617,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		errorEvents := harvest.ErrorEvents
 		harvest.ErrorEvents = NewErrorEvents(eventConfigs.ErrorEventConfig.Limit)
-		harvest.IncrementEndpointsAttempted(errorEvents.Cmd())
 		considerHarvestPayload(errorEvents, args)
 	}
 
@@ -641,7 +625,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		txnEvents := harvest.TxnEvents
 		harvest.TxnEvents = NewTxnEvents(eventConfigs.AnalyticEventConfig.Limit)
-		harvest.IncrementEndpointsAttempted(txnEvents.Cmd())
 		considerHarvestPayloadTxnEvents(txnEvents, args)
 	}
 
@@ -650,7 +633,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		spanEvents := harvest.SpanEvents
 		harvest.SpanEvents = NewSpanEvents(eventConfigs.SpanEventConfig.Limit)
-		harvest.IncrementEndpointsAttempted(spanEvents.Cmd())
 		considerHarvestPayload(spanEvents, args)
 
 	}

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -544,7 +544,6 @@ func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.Eve
 	considerHarvestPayload(harvest.TxnTraces, args)
 	considerHarvestPayloadTxnEvents(harvest.TxnEvents, args)
 	considerHarvestPayload(harvest.SpanEvents, args)
-
 }
 
 func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
@@ -597,7 +596,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		considerHarvestPayload(slowSQLs, args)
 		considerHarvestPayload(txnTraces, args)
 		considerHarvestPayload(spanEvents, args)
-
 	}
 
 	eventConfigs := ah.App.connectReply.EventHarvestConfig.EventConfigs
@@ -671,6 +669,7 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 		splitLargePayloads: app.info.Settings["newrelic.distributed_tracing_enabled"] == true,
 		blocking:           ph.Blocking,
 	}
+	
 	harvestByType(ph.AppHarvest, &args, harvestType)
 }
 

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -685,7 +685,7 @@ func (p *Processor) processHarvestError(d HarvestError) {
 	app := h.App
 	log.Warnf("app %q with run id %q received %s", app, d.id, d.Reply.Err)
 
-    h.Harvest.IncrementHttpErrors(d.Reply.StatusCode)
+	h.Harvest.IncrementHttpErrors(d.Reply.StatusCode)
 
 	if d.Reply.ShouldSaveHarvestData() {
 		d.data.FailedHarvest(h.Harvest)

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -121,7 +121,6 @@ func (p *Processor) processTxnData(d TxnData) {
 	}
 
 	h.Harvest.commandsProcessed++
-//amber	h.Harvest.IncrementEndpointsAttempted(d.Cmd())
 	h.App.LastActivity = time.Now()
 	d.Sample.AggregateInto(h.Harvest)
 }
@@ -536,7 +535,6 @@ func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.Eve
 
 	harvest.createFinalMetrics(harvestLimits, to)
 	harvest.Metrics = harvest.Metrics.ApplyRules(args.rules)
-//amber
 
     harvest.IncrementEndpointsAttempted(harvest.Metrics.Cmd())
     harvest.IncrementEndpointsAttempted(harvest.CustomEvents.Cmd())
@@ -691,7 +689,6 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 		splitLargePayloads: app.info.Settings["newrelic.distributed_tracing_enabled"] == true,
 		blocking:           ph.Blocking,
 	}
-
 	harvestByType(ph.AppHarvest, &args, harvestType)
 }
 
@@ -708,7 +705,6 @@ func (p *Processor) processHarvestError(d HarvestError) {
 	app := h.App
 	log.Warnf("app %q with run id %q received %s", app, d.id, d.Reply.Err)
 
-//amber
     h.Harvest.IncrementHttpErrors(d.Reply.StatusCode)
 
 	if d.Reply.ShouldSaveHarvestData() {

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -669,7 +669,6 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 		splitLargePayloads: app.info.Settings["newrelic.distributed_tracing_enabled"] == true,
 		blocking:           ph.Blocking,
 	}
-	
 	harvestByType(ph.AppHarvest, &args, harvestType)
 }
 

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -9,8 +9,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"testing"
 	"strings"
+	"testing"
 	"time"
 
 	"newrelic/collector"
@@ -21,13 +21,16 @@ import (
 var ErrPayloadTooLarge = errors.New("payload too large")
 var ErrUnauthorized = errors.New("unauthorized")
 var ErrUnsupportedMedia = errors.New("unsupported media")
+
 type rpmException struct {
 	Message   string `json:"message"`
 	ErrorType string `json:"error_type"`
 }
+
 func (e *rpmException) Error() string {
 	return fmt.Sprintf("%s: %s", e.ErrorType, e.Message)
 }
+
 const (
 	forceRestartType   = "NewRelic::Agent::ForceRestartException"
 	disconnectType     = "NewRelic::Agent::ForceDisconnectException"
@@ -38,10 +41,10 @@ const (
 // These clients exist for testing.
 var (
 	DisconnectClient = collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
-        return collector.RPMResponse{Body: nil, Err: SampleDisonnectException, StatusCode: 410}
+		return collector.RPMResponse{Body: nil, Err: SampleDisonnectException, StatusCode: 410}
 	})
 	LicenseInvalidClient = collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
-        return collector.RPMResponse{Body: nil, Err: SampleLicenseInvalidException, StatusCode: 401}
+		return collector.RPMResponse{Body: nil, Err: SampleLicenseInvalidException, StatusCode: 401}
 	})
 	SampleRestartException        = &rpmException{ErrorType: forceRestartType}
 	SampleDisonnectException      = &rpmException{ErrorType: disconnectType}
@@ -49,97 +52,97 @@ var (
 )
 
 var (
-    idOne = AgentRunID("one")
-    idTwo = AgentRunID("two")
+	idOne = AgentRunID("one")
+	idTwo = AgentRunID("two")
 
-    data        = JSONString(`{"age":29}`)
-    encoded     = `"eJyqVkpMT1WyMrKsBQQAAP//EVgDDw=="`
-    sampleTrace = &TxnTrace{Data: data}
+	data        = JSONString(`{"age":29}`)
+	encoded     = `"eJyqVkpMT1WyMrKsBQQAAP//EVgDDw=="`
+	sampleTrace = &TxnTrace{Data: data}
 
-    sampleCustomEvent = []byte("half birthday")
-    sampleSpanEvent = []byte("belated birthday")
-    sampleErrorEvent  = []byte("forgotten birthday")
+	sampleCustomEvent = []byte("half birthday")
+	sampleSpanEvent   = []byte("belated birthday")
+	sampleErrorEvent  = []byte("forgotten birthday")
 )
 
 type ClientReturn struct {
-    reply []byte
-    err   error
-    code  int
+	reply []byte
+	err   error
+	code  int
 }
 
 type ClientParams struct {
-    name string
-    data []byte
+	name string
+	data []byte
 }
 
 type MockedProcessor struct {
-    processorHarvestChan chan ProcessorHarvest
-    clientReturn         chan ClientReturn
-    clientParams         chan ClientParams
-    p                    *Processor
+	processorHarvestChan chan ProcessorHarvest
+	clientReturn         chan ClientReturn
+	clientParams         chan ClientParams
+	p                    *Processor
 }
 
 func NewMockedProcessor(numberOfHarvestPayload int) *MockedProcessor {
-    processorHarvestChan := make(chan ProcessorHarvest)
-    clientReturn := make(chan ClientReturn, numberOfHarvestPayload)
-    clientParams := make(chan ClientParams, numberOfHarvestPayload)
+	processorHarvestChan := make(chan ProcessorHarvest)
+	clientReturn := make(chan ClientReturn, numberOfHarvestPayload)
+	clientParams := make(chan ClientParams, numberOfHarvestPayload)
 
-    client := collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
-        data, err := cs.Collectible.CollectorJSON(false)
-        if nil != err {
-            return collector.RPMResponse{Err: err}
-        }
-        clientParams <- ClientParams{cmd.Name, data}
-        r := <-clientReturn
-        return collector.RPMResponse{Body: r.reply, Err: r.err, StatusCode: r.code}
-    })
+	client := collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
+		data, err := cs.Collectible.CollectorJSON(false)
+		if nil != err {
+			return collector.RPMResponse{Err: err}
+		}
+		clientParams <- ClientParams{cmd.Name, data}
+		r := <-clientReturn
+		return collector.RPMResponse{Body: r.reply, Err: r.err, StatusCode: r.code}
+	})
 
-    p := NewProcessor(ProcessorConfig{Client: client})
-    p.processorHarvestChan = processorHarvestChan
-    p.trackProgress = make(chan struct{})
-    p.appConnectBackoff = 0
-    go p.Run()
-    <-p.trackProgress // Wait for utilization
+	p := NewProcessor(ProcessorConfig{Client: client})
+	p.processorHarvestChan = processorHarvestChan
+	p.trackProgress = make(chan struct{})
+	p.appConnectBackoff = 0
+	go p.Run()
+	<-p.trackProgress // Wait for utilization
 
-    return &MockedProcessor{
-        processorHarvestChan: processorHarvestChan,
-        clientReturn:         clientReturn,
-        clientParams:         clientParams,
-        p:                    p,
-    }
+	return &MockedProcessor{
+		processorHarvestChan: processorHarvestChan,
+		clientReturn:         clientReturn,
+		clientParams:         clientParams,
+		p:                    p,
+	}
 }
 
 func (m *MockedProcessor) DoAppInfoCustom(t *testing.T, id *AgentRunID, expectState AppState, info *AppInfo) {
-    reply := m.p.IncomingAppInfo(id, info)
-    <-m.p.trackProgress // receive app info
-    if reply.State != expectState {
-        t.Fatal(reply, expectState)
-    }
+	reply := m.p.IncomingAppInfo(id, info)
+	<-m.p.trackProgress // receive app info
+	if reply.State != expectState {
+		t.Fatal(reply, expectState)
+	}
 }
 
 func (m *MockedProcessor) DoAppInfo(t *testing.T, id *AgentRunID, expectState AppState) {
-    m.DoAppInfoCustom(t, id, expectState, &sampleAppInfo)
+	m.DoAppInfoCustom(t, id, expectState, &sampleAppInfo)
 }
 
 func (m *MockedProcessor) DoConnect(t *testing.T, id *AgentRunID) {
-    <-m.clientParams // preconnect
-    m.clientReturn <- ClientReturn{[]byte(`{"redirect_host":"specific_collector.com"}`), nil, 200}
-    <-m.clientParams // connect
-    m.clientReturn <- ClientReturn{[]byte(`{"agent_run_id":"` + id.String() + `","zip":"zap","event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":5,"span_event_data":5}}}`), nil, 200}
-    <-m.p.trackProgress // receive connect reply
+	<-m.clientParams // preconnect
+	m.clientReturn <- ClientReturn{[]byte(`{"redirect_host":"specific_collector.com"}`), nil, 200}
+	<-m.clientParams // connect
+	m.clientReturn <- ClientReturn{[]byte(`{"agent_run_id":"` + id.String() + `","zip":"zap","event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":5,"span_event_data":5}}}`), nil, 200}
+	<-m.p.trackProgress // receive connect reply
 }
 
 func (m *MockedProcessor) DoConnectConfiguredReply(t *testing.T, reply string) {
-    <-m.clientParams // preconnect
-    m.clientReturn <- ClientReturn{[]byte(`{"redirect_host":"specific_collector.com"}`), nil, 200}
-    <-m.clientParams // connect
-    m.clientReturn <- ClientReturn{[]byte(reply), nil, 200}
-    <-m.p.trackProgress // receive connect reply
+	<-m.clientParams // preconnect
+	m.clientReturn <- ClientReturn{[]byte(`{"redirect_host":"specific_collector.com"}`), nil, 200}
+	<-m.clientParams // connect
+	m.clientReturn <- ClientReturn{[]byte(reply), nil, 200}
+	<-m.p.trackProgress // receive connect reply
 }
 
 func (m *MockedProcessor) TxnData(t *testing.T, id AgentRunID, sample AggregaterInto) {
-    m.p.IncomingTxnData(id, sample)
-    <-m.p.trackProgress
+	m.p.IncomingTxnData(id, sample)
+	<-m.p.trackProgress
 }
 
 type AggregaterIntoFn func(*Harvest)
@@ -147,116 +150,116 @@ type AggregaterIntoFn func(*Harvest)
 func (fn AggregaterIntoFn) AggregateInto(h *Harvest) { fn(h) }
 
 var (
-    txnEventSample1 = AggregaterIntoFn(func(h *Harvest) {
-        h.TxnEvents.AddTxnEvent([]byte(`[{"x":1},{},{}]`), SamplingPriority(0.8))
-    })
-    txnEventSample2 = AggregaterIntoFn(func(h *Harvest) {
-        h.TxnEvents.AddTxnEvent([]byte(`[{"x":2},{},{}]`), SamplingPriority(0.8))
-    })
-    txnTraceSample = AggregaterIntoFn(func(h *Harvest) {
-        h.TxnTraces.AddTxnTrace(sampleTrace)
-    })
-    txnCustomEventSample = AggregaterIntoFn(func(h *Harvest) {
-        h.CustomEvents.AddEventFromData(sampleCustomEvent, SamplingPriority(0.8))
-    })
-    txnErrorEventSample = AggregaterIntoFn(func(h *Harvest) {
-        h.ErrorEvents.AddEventFromData(sampleErrorEvent, SamplingPriority(0.8))
-    })
-    txnSpanEventSample = AggregaterIntoFn(func(h *Harvest) {
-        h.SpanEvents.AddEventFromData(sampleSpanEvent, SamplingPriority(0.8))
-    })
-    txnEventSample1Times = func(times int) AggregaterIntoFn {
-        return AggregaterIntoFn(func(h *Harvest) {
-            for i := 0; i < times; i++ {
-                h.TxnEvents.AddTxnEvent([]byte(`[{"x":1},{},{}]`), SamplingPriority(0.8))
-            }
-        })
-    }
+	txnEventSample1 = AggregaterIntoFn(func(h *Harvest) {
+		h.TxnEvents.AddTxnEvent([]byte(`[{"x":1},{},{}]`), SamplingPriority(0.8))
+	})
+	txnEventSample2 = AggregaterIntoFn(func(h *Harvest) {
+		h.TxnEvents.AddTxnEvent([]byte(`[{"x":2},{},{}]`), SamplingPriority(0.8))
+	})
+	txnTraceSample = AggregaterIntoFn(func(h *Harvest) {
+		h.TxnTraces.AddTxnTrace(sampleTrace)
+	})
+	txnCustomEventSample = AggregaterIntoFn(func(h *Harvest) {
+		h.CustomEvents.AddEventFromData(sampleCustomEvent, SamplingPriority(0.8))
+	})
+	txnErrorEventSample = AggregaterIntoFn(func(h *Harvest) {
+		h.ErrorEvents.AddEventFromData(sampleErrorEvent, SamplingPriority(0.8))
+	})
+	txnSpanEventSample = AggregaterIntoFn(func(h *Harvest) {
+		h.SpanEvents.AddEventFromData(sampleSpanEvent, SamplingPriority(0.8))
+	})
+	txnEventSample1Times = func(times int) AggregaterIntoFn {
+		return AggregaterIntoFn(func(h *Harvest) {
+			for i := 0; i < times; i++ {
+				h.TxnEvents.AddTxnEvent([]byte(`[{"x":1},{},{}]`), SamplingPriority(0.8))
+			}
+		})
+	}
 )
 
 func TestProcessorHarvestDefaultData(t *testing.T) {
-    m := NewMockedProcessor(2)
+	m := NewMockedProcessor(2)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnTraceSample)
+	m.TxnData(t, idOne, txnTraceSample)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestDefaultData,
-    }
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestDefaultData,
+	}
 
-    // this code path will trigger two `harvestPayload` calls, so we need
-    // to pluck two items out of the clientParams channels
-    cp := <-m.clientParams
-    cp2 := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice
+	// this code path will trigger two `harvestPayload` calls, so we need
+	// to pluck two items out of the clientParams channels
+	cp := <-m.clientParams
+	cp2 := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice
 
-    toTest := `["one",[[0,0,"","",` + encoded + `,"",null,false,null,null]]]`
+	toTest := `["one",[[0,0,"","",` + encoded + `,"",null,false,null,null]]]`
 
-    if string(cp.data) != toTest {
-        if string(cp2.data) != toTest {
-            t.Fatal(string(append(cp.data, cp2.data...)))
-        }
-    }
+	if string(cp.data) != toTest {
+		if string(cp2.data) != toTest {
+			t.Fatal(string(append(cp.data, cp2.data...)))
+		}
+	}
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestProcessorHarvestCustomEvents(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnCustomEventSample)
+	m.TxnData(t, idOne, txnCustomEventSample)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestCustomEvents,
-    }
-    cp := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice
-    expected := `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]`
-    if string(cp.data) != expected {
-        t.Fatalf("expected: %s \ngot: %s", expected, string(cp.data))
-    }
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestCustomEvents,
+	}
+	cp := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice
+	expected := `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]`
+	if string(cp.data) != expected {
+		t.Fatalf("expected: %s \ngot: %s", expected, string(cp.data))
+	}
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestProcessorHarvestCleanExit(t *testing.T) {
-    m := NewMockedProcessor(20)
+	m := NewMockedProcessor(20)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnCustomEventSample)
+	m.TxnData(t, idOne, txnCustomEventSample)
 
-    // Although only an event was inserted in this test, CleanExit triggers a path of execution
-    // that eventually makes its way to Harvest's createFinalMetrics.  In this function, various
-    // supportability and reporting metrics are added
-    m.clientReturn <- ClientReturn{} /* metrics */
-    m.clientReturn <- ClientReturn{} /* events */
+	// Although only an event was inserted in this test, CleanExit triggers a path of execution
+	// that eventually makes its way to Harvest's createFinalMetrics.  In this function, various
+	// supportability and reporting metrics are added
+	m.clientReturn <- ClientReturn{} /* metrics */
+	m.clientReturn <- ClientReturn{} /* events */
 
-    m.p.CleanExit()
+	m.p.CleanExit()
 
-    <-m.clientParams /* ditch metrics */
-    cp := <-m.clientParams
+	<-m.clientParams /* ditch metrics */
+	cp := <-m.clientParams
 
-    expected := `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]`
-    if string(cp.data) != expected {
-        t.Fatalf("expected: %s \ngot: %s", expected, string(cp.data))
-    }
+	expected := `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]`
+	if string(cp.data) != expected {
+		t.Fatalf("expected: %s \ngot: %s", expected, string(cp.data))
+	}
 }
 
 func TestSupportabilityHarvest(t *testing.T) {
@@ -274,7 +277,7 @@ func TestSupportabilityHarvest(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestDefaultData,
 	}
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress              // receive harvest notice
 	m.clientReturn <- ClientReturn{} /* metrics */
 	//<-m.p.trackProgress // receive harvest
 
@@ -345,763 +348,763 @@ func TestSupportabilityHarvest(t *testing.T) {
 }
 
 func TestProcessorHarvestErrorEvents(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnErrorEventSample)
+	m.TxnData(t, idOne, txnErrorEventSample)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestErrorEvents,
-    }
-    cp := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice
-    if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[forgotten birthday]]` {
-        t.Fatal(string(cp.data))
-    }
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestErrorEvents,
+	}
+	cp := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice
+	if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[forgotten birthday]]` {
+		t.Fatal(string(cp.data))
+	}
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestProcessorHarvestSpanEvents(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnectConfiguredReply(t, `{"agent_run_id":"` + idOne.String() + `","zip":"zap","span_event_harvest_config":{"report_period_ms":5000,"harvest_limit":7},"event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":0,"span_event_data":5}}}`)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnectConfiguredReply(t, `{"agent_run_id":"`+idOne.String()+`","zip":"zap","span_event_harvest_config":{"report_period_ms":5000,"harvest_limit":7},"event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":0,"span_event_data":5}}}`)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnSpanEventSample)
-    m.TxnData(t, idOne, txnSpanEventSample)
+	m.TxnData(t, idOne, txnSpanEventSample)
+	m.TxnData(t, idOne, txnSpanEventSample)
 
-    // Now we'll force a harvest for a span event type, and make sure we
-    // receive that harvest.
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestSpanEvents,
-    }
+	// Now we'll force a harvest for a span event type, and make sure we
+	// receive that harvest.
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestSpanEvents,
+	}
 
-    cp := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice, two span events in the data
-    if string(cp.data) != `["one",{"reservoir_size":7,"events_seen":2},[belated birthday,belated birthday]]` {
-        t.Fatal(string(cp.data))
-    }
-    m.p.quit()
+	cp := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice, two span events in the data
+	if string(cp.data) != `["one",{"reservoir_size":7,"events_seen":2},[belated birthday,belated birthday]]` {
+		t.Fatal(string(cp.data))
+	}
+	m.p.quit()
 
 }
 
 func TestProcessorHarvestSpanEventsZeroReservoir(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnectConfiguredReply(t, `{"agent_run_id":"` + idOne.String() + `","zip":"zap","span_event_harvest_config":{"report_period_ms":5000,"harvest_limit":0},"event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":0,"span_event_data":5}}}`)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnectConfiguredReply(t, `{"agent_run_id":"`+idOne.String()+`","zip":"zap","span_event_harvest_config":{"report_period_ms":5000,"harvest_limit":0},"event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":0,"span_event_data":5}}}`)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnSpanEventSample)
-    m.TxnData(t, idOne, txnSpanEventSample)
-    m.TxnData(t, idOne, txnCustomEventSample)
+	m.TxnData(t, idOne, txnSpanEventSample)
+	m.TxnData(t, idOne, txnSpanEventSample)
+	m.TxnData(t, idOne, txnCustomEventSample)
 
-    // Trigger a span event harvest. Due to the span_event_data limit being
-    // zero, no harvest should actually occur here.
+	// Trigger a span event harvest. Due to the span_event_data limit being
+	// zero, no harvest should actually occur here.
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestSpanEvents,
-    }
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestSpanEvents,
+	}
 
-    // No check of m.clientParams here because we expect no harvest to occur
-    // due to the zero error_event_data limit.
-    <-m.p.trackProgress // receive harvest notice
+	// No check of m.clientParams here because we expect no harvest to occur
+	// due to the zero error_event_data limit.
+	<-m.p.trackProgress // receive harvest notice
 
-    // Now we'll force a harvest for a different event type, and make sure we
-    // receive that harvest (and not a span event harvest).
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestCustomEvents,
-    }
+	// Now we'll force a harvest for a different event type, and make sure we
+	// receive that harvest (and not a span event harvest).
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestCustomEvents,
+	}
 
-    cp := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice
-    if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]` {
-        t.Fatal(string(cp.data))
-    }
-    m.p.quit()
+	cp := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice
+	if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]` {
+		t.Fatal(string(cp.data))
+	}
+	m.p.quit()
 
 }
 
 func TestProcessorHarvestSpanEventsExceedReservoir(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnectConfiguredReply(t, `{"agent_run_id":"` + idOne.String() + `","zip":"zap","span_event_harvest_config":{"report_period_ms":5000,"harvest_limit":1},"event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":0,"span_event_data":5}}}`)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnectConfiguredReply(t, `{"agent_run_id":"`+idOne.String()+`","zip":"zap","span_event_harvest_config":{"report_period_ms":5000,"harvest_limit":1},"event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":0,"span_event_data":5}}}`)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnSpanEventSample)
-    m.TxnData(t, idOne, txnSpanEventSample)
+	m.TxnData(t, idOne, txnSpanEventSample)
+	m.TxnData(t, idOne, txnSpanEventSample)
 
-    // Now we'll force a harvest for a span event type, and make sure we
-    // receive that harvest.
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestSpanEvents,
-    }
+	// Now we'll force a harvest for a span event type, and make sure we
+	// receive that harvest.
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestSpanEvents,
+	}
 
-    cp := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice with 2 span events seen, but only one span sent
-    if string(cp.data) != `["one",{"reservoir_size":1,"events_seen":2},[belated birthday]]` {
-        t.Fatal(string(cp.data))
-    }
-    m.p.quit()
+	cp := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice with 2 span events seen, but only one span sent
+	if string(cp.data) != `["one",{"reservoir_size":1,"events_seen":2},[belated birthday]]` {
+		t.Fatal(string(cp.data))
+	}
+	m.p.quit()
 
 }
 
 func TestProcessorHarvestZeroErrorEvents(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnectConfiguredReply(t, `{"agent_run_id":"` + idOne.String() + `","zip":"zap","span_event_harvest_config":{"report_period_ms":5000,"harvest_limit":7},"event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":0,"span_event_data":5}}}`)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnectConfiguredReply(t, `{"agent_run_id":"`+idOne.String()+`","zip":"zap","span_event_harvest_config":{"report_period_ms":5000,"harvest_limit":7},"event_harvest_config":{"report_period_ms":5000,"harvest_limits":{"analytics_event_data":5,"custom_event_data":5,"error_event_data":0,"span_event_data":5}}}`)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnErrorEventSample)
-    m.TxnData(t, idOne, txnCustomEventSample)
+	m.TxnData(t, idOne, txnErrorEventSample)
+	m.TxnData(t, idOne, txnCustomEventSample)
 
-    // Trigger an error event harvest. Due to the error_event_data limit being
-    // zero, no harvest will actually occur here.
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestErrorEvents,
-    }
-    // No check of m.clientParams here because we expect no harvest to occur
-    // due to the zero error_event_data limit.
-    <-m.p.trackProgress // receive harvest notice
+	// Trigger an error event harvest. Due to the error_event_data limit being
+	// zero, no harvest will actually occur here.
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestErrorEvents,
+	}
+	// No check of m.clientParams here because we expect no harvest to occur
+	// due to the zero error_event_data limit.
+	<-m.p.trackProgress // receive harvest notice
 
-    // Now we'll force a harvest for a different event type, and make sure we
-    // receive that harvest (and not an error event harvest).
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestCustomEvents,
-    }
+	// Now we'll force a harvest for a different event type, and make sure we
+	// receive that harvest (and not an error event harvest).
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestCustomEvents,
+	}
 
-    cp := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice
-    if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]` {
-        t.Fatal(string(cp.data))
-    }
-    m.p.quit()
+	cp := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice
+	if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]` {
+		t.Fatal(string(cp.data))
+	}
+	m.p.quit()
 
 }
 
 func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
-    getEventsSeen := func(data []byte) float64 {
-        var dataDec []interface{}
+	getEventsSeen := func(data []byte) float64 {
+		var dataDec []interface{}
 
-        err := json.Unmarshal(data, &dataDec)
-        if nil != err {
-            t.Fatal("Invalid JSON:", string(data))
-        }
+		err := json.Unmarshal(data, &dataDec)
+		if nil != err {
+			t.Fatal("Invalid JSON:", string(data))
+		}
 
-        metadata := dataDec[1].(map[string]interface{})
-        return metadata["events_seen"].(float64)
-    }
+		metadata := dataDec[1].(map[string]interface{})
+		return metadata["events_seen"].(float64)
+	}
 
-    // Distributed tracing deactivated.
-    // --------------------------------
-    // The event payload should never be split.
+	// Distributed tracing deactivated.
+	// --------------------------------
+	// The event payload should never be split.
 
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    appInfo := sampleAppInfo
-    appInfo.Settings = map[string]interface{}{"newrelic.distributed_tracing_enabled": false}
+	appInfo := sampleAppInfo
+	appInfo.Settings = map[string]interface{}{"newrelic.distributed_tracing_enabled": false}
 
-    m.DoAppInfoCustom(t, nil, AppStateUnknown, &appInfo)
-    m.DoConnect(t, &idOne)
-    m.DoAppInfoCustom(t, nil, AppStateConnected, &appInfo)
+	m.DoAppInfoCustom(t, nil, AppStateUnknown, &appInfo)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfoCustom(t, nil, AppStateConnected, &appInfo)
 
-    // 9000 events, no split.
-    m.TxnData(t, idOne, txnEventSample1Times(9000))
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    cp1 := <-m.clientParams
-    <-m.p.trackProgress
-    cp1Events := getEventsSeen(cp1.data)
-    if cp1Events != 9000 {
-        t.Fatal("Expected 9000 events")
-    }
+	// 9000 events, no split.
+	m.TxnData(t, idOne, txnEventSample1Times(9000))
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	cp1 := <-m.clientParams
+	<-m.p.trackProgress
+	cp1Events := getEventsSeen(cp1.data)
+	if cp1Events != 9000 {
+		t.Fatal("Expected 9000 events")
+	}
 
-    m.p.quit()
+	m.p.quit()
 
-    // Distributed tracing activated.
-    // ------------------------------
-    // The event payload should be split for more than 4999 events.
+	// Distributed tracing activated.
+	// ------------------------------
+	// The event payload should be split for more than 4999 events.
 
-    m = NewMockedProcessor(2)
+	m = NewMockedProcessor(2)
 
-    appInfo = sampleAppInfo
-    appInfo.Settings = map[string]interface{}{"newrelic.distributed_tracing_enabled": true}
+	appInfo = sampleAppInfo
+	appInfo.Settings = map[string]interface{}{"newrelic.distributed_tracing_enabled": true}
 
-    m.DoAppInfoCustom(t, nil, AppStateUnknown, &appInfo)
-    m.DoConnect(t, &idOne)
-    m.DoAppInfoCustom(t, nil, AppStateConnected, &appInfo)
+	m.DoAppInfoCustom(t, nil, AppStateUnknown, &appInfo)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfoCustom(t, nil, AppStateConnected, &appInfo)
 
-    // Less than 5000 events, no split.
-    m.TxnData(t, idOne, txnEventSample1Times(4999))
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    cp1 = <-m.clientParams
-    <-m.p.trackProgress
-    cp1Events = getEventsSeen(cp1.data)
-    if cp1Events != 4999 {
-        t.Fatal("Expected 4999 events")
-    }
+	// Less than 5000 events, no split.
+	m.TxnData(t, idOne, txnEventSample1Times(4999))
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	cp1 = <-m.clientParams
+	<-m.p.trackProgress
+	cp1Events = getEventsSeen(cp1.data)
+	if cp1Events != 4999 {
+		t.Fatal("Expected 4999 events")
+	}
 
-    // 5000 events. Split into two payloads of 2500 each.
-    m.TxnData(t, idOne, txnEventSample1Times(5000))
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    cp1 = <-m.clientParams
-    cp2 := <-m.clientParams
-    <-m.p.trackProgress
-    cp1Events = getEventsSeen(cp1.data)
-    cp2Events := getEventsSeen(cp2.data)
-    if cp1Events != 2500 {
-        t.Fatal("Payload with 2500 events expected, got ", cp1Events)
-    }
-    if cp2Events != 2500 {
-        t.Fatal("Payload with 2500 events expected, got ", cp2Events)
-    }
+	// 5000 events. Split into two payloads of 2500 each.
+	m.TxnData(t, idOne, txnEventSample1Times(5000))
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	cp1 = <-m.clientParams
+	cp2 := <-m.clientParams
+	<-m.p.trackProgress
+	cp1Events = getEventsSeen(cp1.data)
+	cp2Events := getEventsSeen(cp2.data)
+	if cp1Events != 2500 {
+		t.Fatal("Payload with 2500 events expected, got ", cp1Events)
+	}
+	if cp2Events != 2500 {
+		t.Fatal("Payload with 2500 events expected, got ", cp2Events)
+	}
 
-    // 8001 events. Split into two payloads of 4000 and 4001.
-    // We do not know which payload arrives first.
-    m.TxnData(t, idOne, txnEventSample1Times(8001))
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    cp1 = <-m.clientParams
-    cp2 = <-m.clientParams
-    <-m.p.trackProgress
-    cp1Events = getEventsSeen(cp1.data)
-    cp2Events = getEventsSeen(cp2.data)
-    if cp1Events != 4000 && cp2Events != 4000 {
-        t.Fatal("Payloads with 4000 events expected, got ", cp1Events, " and ", cp2Events)
-    }
-    if (cp1Events + cp2Events) != 8001 {
-        t.Fatal("Payload sum of 8001 events expected, got ", cp1Events, " and ", cp2Events)
-    }
+	// 8001 events. Split into two payloads of 4000 and 4001.
+	// We do not know which payload arrives first.
+	m.TxnData(t, idOne, txnEventSample1Times(8001))
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	cp1 = <-m.clientParams
+	cp2 = <-m.clientParams
+	<-m.p.trackProgress
+	cp1Events = getEventsSeen(cp1.data)
+	cp2Events = getEventsSeen(cp2.data)
+	if cp1Events != 4000 && cp2Events != 4000 {
+		t.Fatal("Payloads with 4000 events expected, got ", cp1Events, " and ", cp2Events)
+	}
+	if (cp1Events + cp2Events) != 8001 {
+		t.Fatal("Payload sum of 8001 events expected, got ", cp1Events, " and ", cp2Events)
+	}
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestForceRestart(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnEventSample1)
+	m.TxnData(t, idOne, txnEventSample1)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    cp := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice
-    if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	cp := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice
+	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
 
-    m.clientReturn <- ClientReturn{nil, SampleRestartException, 401}
-    <-m.p.trackProgress // receive harvest error
+	m.clientReturn <- ClientReturn{nil, SampleRestartException, 401}
+	<-m.p.trackProgress // receive harvest error
 
-    m.DoConnect(t, &idTwo)
+	m.DoConnect(t, &idTwo)
 
-    m.DoAppInfo(t, &idOne, AppStateConnected)
+	m.DoAppInfo(t, &idOne, AppStateConnected)
 
-    m.TxnData(t, idOne, txnEventSample1)
-    m.TxnData(t, idTwo, txnEventSample2)
+	m.TxnData(t, idOne, txnEventSample1)
+	m.TxnData(t, idTwo, txnEventSample2)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idTwo],
-        ID:         idTwo,
-        Type:       HarvestTxnEvents,
-    }
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idTwo],
+		ID:         idTwo,
+		Type:       HarvestTxnEvents,
+	}
 
-    <-m.p.trackProgress // receive harvest notice
-    cp = <-m.clientParams
-    if string(cp.data) != `["two",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
+	<-m.p.trackProgress // receive harvest notice
+	cp = <-m.clientParams
+	if string(cp.data) != `["two",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestDisconnectAtPreconnect(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    <-m.clientParams // preconnect
-    m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
-    <-m.p.trackProgress // receive connect reply
+	<-m.clientParams // preconnect
+	m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
+	<-m.p.trackProgress // receive connect reply
 
-    m.DoAppInfo(t, nil, AppStateDisconnected)
+	m.DoAppInfo(t, nil, AppStateDisconnected)
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestLicenseExceptionAtPreconnect(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    <-m.clientParams // preconnect
-    m.clientReturn <- ClientReturn{nil, SampleLicenseInvalidException, 401}
-    <-m.p.trackProgress // receive connect reply
+	<-m.clientParams // preconnect
+	m.clientReturn <- ClientReturn{nil, SampleLicenseInvalidException, 401}
+	<-m.p.trackProgress // receive connect reply
 
-    m.DoAppInfo(t, nil, AppStateInvalidLicense)
+	m.DoAppInfo(t, nil, AppStateInvalidLicense)
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestDisconnectAtConnect(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    <-m.clientParams // preconnect
-    m.clientReturn <- ClientReturn{[]byte(`{"redirect_host":"specific_collector.com"}`), nil, 200}
-    <-m.clientParams // connect
-    m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
-    <-m.p.trackProgress // receive connect reply
+	<-m.clientParams // preconnect
+	m.clientReturn <- ClientReturn{[]byte(`{"redirect_host":"specific_collector.com"}`), nil, 200}
+	<-m.clientParams // connect
+	m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
+	<-m.p.trackProgress // receive connect reply
 
-    m.DoAppInfo(t, nil, AppStateDisconnected)
+	m.DoAppInfo(t, nil, AppStateDisconnected)
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestDisconnectAtHarvest(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnEventSample1)
+	m.TxnData(t, idOne, txnEventSample1)
 
-    // Harvest both (final supportability) metrics and events to trigger
-    // multiple calls to processHarvestError, the second call will have an
-    // outdated run id.
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestAll,
-    }
-    <-m.p.trackProgress // receive harvest notice
+	// Harvest both (final supportability) metrics and events to trigger
+	// multiple calls to processHarvestError, the second call will have an
+	// outdated run id.
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestAll,
+	}
+	<-m.p.trackProgress // receive harvest notice
 
-    <-m.clientParams
-    m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
-    <-m.p.trackProgress // receive harvest error
+	<-m.clientParams
+	m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
+	<-m.p.trackProgress // receive harvest error
 
-    <-m.clientParams
-    m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
-    <-m.p.trackProgress // receive harvest error
+	<-m.clientParams
+	m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
+	<-m.p.trackProgress // receive harvest error
 
-    m.DoAppInfo(t, nil, AppStateDisconnected)
+	m.DoAppInfo(t, nil, AppStateDisconnected)
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestLicenseExceptionAtHarvest(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnEventSample1)
+	m.TxnData(t, idOne, txnEventSample1)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    cp := <-m.clientParams
-    <-m.p.trackProgress // receive harvest notice
-    if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	cp := <-m.clientParams
+	<-m.p.trackProgress // receive harvest notice
+	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
 
-    m.clientReturn <- ClientReturn{nil, SampleLicenseInvalidException, 401}
-    <-m.p.trackProgress // receive harvest error
+	m.clientReturn <- ClientReturn{nil, SampleLicenseInvalidException, 401}
+	<-m.p.trackProgress // receive harvest error
 
-    // Unknown app state triggered immediately following AppStateRestart
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	// Unknown app state triggered immediately following AppStateRestart
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestMalformedConnectReply(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    <-m.clientParams // preconnect
-    m.clientReturn <- ClientReturn{[]byte(`{"redirect_host":"specific_collector.com"}`), nil, 200}
-    <-m.clientParams // connect
-    m.clientReturn <- ClientReturn{[]byte(`{`), nil, 202}
-    <-m.p.trackProgress // receive connect reply
+	<-m.clientParams // preconnect
+	m.clientReturn <- ClientReturn{[]byte(`{"redirect_host":"specific_collector.com"}`), nil, 200}
+	<-m.clientParams // connect
+	m.clientReturn <- ClientReturn{[]byte(`{`), nil, 202}
+	<-m.p.trackProgress // receive connect reply
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestMalformedCollector(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    <-m.clientParams // preconnect
-    m.clientReturn <- ClientReturn{[]byte(`"`), nil, 200}
-    <-m.p.trackProgress // receive connect reply
+	<-m.clientParams // preconnect
+	m.clientReturn <- ClientReturn{[]byte(`"`), nil, 200}
+	<-m.p.trackProgress // receive connect reply
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestDataSavedOnHarvestError(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnEventSample1)
+	m.TxnData(t, idOne, txnEventSample1)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    <-m.p.trackProgress // receive harvest notice
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	<-m.p.trackProgress // receive harvest notice
 
-    cp := <-m.clientParams
-    m.clientReturn <- ClientReturn{nil, errors.New("unusual error"), 500}
-    if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
-    <-m.p.trackProgress // receive harvest error
+	cp := <-m.clientParams
+	m.clientReturn <- ClientReturn{nil, errors.New("unusual error"), 500}
+	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
+	<-m.p.trackProgress // receive harvest error
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    <-m.p.trackProgress // receive harvest notice
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	<-m.p.trackProgress // receive harvest notice
 
-    cp = <-m.clientParams
-    m.clientReturn <- ClientReturn{nil, nil, 202}
-    if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
+	cp = <-m.clientParams
+	m.clientReturn <- ClientReturn{nil, nil, 202}
+	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
 }
 
 func TestNoDataSavedOnPayloadTooLarge(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnEventSample1)
+	m.TxnData(t, idOne, txnEventSample1)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    <-m.p.trackProgress // receive harvest notice
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	<-m.p.trackProgress // receive harvest notice
 
-    cp := <-m.clientParams
-    m.clientReturn <- ClientReturn{nil, ErrPayloadTooLarge, 413}
-    if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
-    <-m.p.trackProgress // receive harvest error
+	cp := <-m.clientParams
+	m.clientReturn <- ClientReturn{nil, ErrPayloadTooLarge, 413}
+	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
+	<-m.p.trackProgress // receive harvest error
 
-    m.TxnData(t, idOne, txnEventSample2)
+	m.TxnData(t, idOne, txnEventSample2)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    <-m.p.trackProgress // receive harvest notice
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	<-m.p.trackProgress // receive harvest notice
 
-    cp = <-m.clientParams
-    m.clientReturn <- ClientReturn{nil, nil, 202}
-    if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
+	cp = <-m.clientParams
+	m.clientReturn <- ClientReturn{nil, nil, 202}
+	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
 }
 
 func TestNoDataSavedOnErrUnsupportedMedia(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnEventSample1)
+	m.TxnData(t, idOne, txnEventSample1)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    <-m.p.trackProgress // receive harvest notice
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	<-m.p.trackProgress // receive harvest notice
 
-    cp := <-m.clientParams
-    m.clientReturn <- ClientReturn{nil, ErrUnsupportedMedia, 415}
-    if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
-    <-m.p.trackProgress // receive harvest error
+	cp := <-m.clientParams
+	m.clientReturn <- ClientReturn{nil, ErrUnsupportedMedia, 415}
+	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
+	<-m.p.trackProgress // receive harvest error
 
-    m.TxnData(t, idOne, txnEventSample2)
+	m.TxnData(t, idOne, txnEventSample2)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestTxnEvents,
-    }
-    <-m.p.trackProgress // receive harvest notice
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestTxnEvents,
+	}
+	<-m.p.trackProgress // receive harvest notice
 
-    cp = <-m.clientParams
-    m.clientReturn <- ClientReturn{nil, nil, 202}
-    if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
-        t.Fatal(string(cp.data))
-    }
+	cp = <-m.clientParams
+	m.clientReturn <- ClientReturn{nil, nil, 202}
+	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
+		t.Fatal(string(cp.data))
+	}
 }
 
 var (
-    id      = AgentRunID("12345")
-    otherId = AgentRunID("67890")
+	id      = AgentRunID("12345")
+	otherId = AgentRunID("67890")
 
-    sampleAppInfo = AppInfo{
-        License:           collector.LicenseKey("12342352345"),
-        Appname:           "Application",
-        AgentLanguage:     "c",
-        AgentVersion:      "0.0.1",
-        Settings:          map[string]interface{}{},
-        Environment:       nil,
-        Labels:            nil,
-        RedirectCollector: "collector.newrelic.com",
-        HighSecurity:      true,
-        Hostname:          "agent-hostname",
-    }
-    connectClient = collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
-        if cmd.Name == collector.CommandPreconnect {
-            return collector.RPMResponse{Body: []byte(`{"redirect_host":"specific_collector.com"}`), Err: nil, StatusCode: 202}
-        }
-        return collector.RPMResponse{Body: []byte(`{"agent_run_id":"12345","zip":"zap"}`), Err: nil, StatusCode: 200}
-    })
+	sampleAppInfo = AppInfo{
+		License:           collector.LicenseKey("12342352345"),
+		Appname:           "Application",
+		AgentLanguage:     "c",
+		AgentVersion:      "0.0.1",
+		Settings:          map[string]interface{}{},
+		Environment:       nil,
+		Labels:            nil,
+		RedirectCollector: "collector.newrelic.com",
+		HighSecurity:      true,
+		Hostname:          "agent-hostname",
+	}
+	connectClient = collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
+		if cmd.Name == collector.CommandPreconnect {
+			return collector.RPMResponse{Body: []byte(`{"redirect_host":"specific_collector.com"}`), Err: nil, StatusCode: 202}
+		}
+		return collector.RPMResponse{Body: []byte(`{"agent_run_id":"12345","zip":"zap"}`), Err: nil, StatusCode: 200}
+	})
 )
 
 func init() {
-    log.Init(log.LogAlways, "stdout") // Avoid ssl mismatch warning
+	log.Init(log.LogAlways, "stdout") // Avoid ssl mismatch warning
 }
 
 func TestAppInfoInvalid(t *testing.T) {
-    p := NewProcessor(ProcessorConfig{Client: LicenseInvalidClient})
-    p.processorHarvestChan = nil
-    p.trackProgress = make(chan struct{}, 100)
-    go p.Run()
-    <-p.trackProgress // Wait for utilization
+	p := NewProcessor(ProcessorConfig{Client: LicenseInvalidClient})
+	p.processorHarvestChan = nil
+	p.trackProgress = make(chan struct{}, 100)
+	go p.Run()
+	<-p.trackProgress // Wait for utilization
 
-    // trigger app creation and connect
-    reply := p.IncomingAppInfo(&id, &sampleAppInfo)
-    if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
-        t.Fatal(reply)
-    }
-    <-p.trackProgress // receive app info
-    <-p.trackProgress // receive connect reply
+	// trigger app creation and connect
+	reply := p.IncomingAppInfo(&id, &sampleAppInfo)
+	if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
+		t.Fatal(reply)
+	}
+	<-p.trackProgress // receive app info
+	<-p.trackProgress // receive connect reply
 
-    reply = p.IncomingAppInfo(&id, &sampleAppInfo)
-    if reply.State != AppStateInvalidLicense || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
-        t.Fatal(reply)
-    }
-    p.quit()
+	reply = p.IncomingAppInfo(&id, &sampleAppInfo)
+	if reply.State != AppStateInvalidLicense || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
+		t.Fatal(reply)
+	}
+	p.quit()
 }
 
 func TestAppInfoDisconnected(t *testing.T) {
-    p := NewProcessor(ProcessorConfig{Client: DisconnectClient})
-    p.processorHarvestChan = nil
-    p.trackProgress = make(chan struct{}, 100)
-    go p.Run()
-    <-p.trackProgress // Wait for utilization
+	p := NewProcessor(ProcessorConfig{Client: DisconnectClient})
+	p.processorHarvestChan = nil
+	p.trackProgress = make(chan struct{}, 100)
+	go p.Run()
+	<-p.trackProgress // Wait for utilization
 
-    // trigger app creation and connect
-    reply := p.IncomingAppInfo(&id, &sampleAppInfo)
-    if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
-        t.Fatal(reply)
-    }
-    <-p.trackProgress // receive app info
-    <-p.trackProgress // receive connect reply
+	// trigger app creation and connect
+	reply := p.IncomingAppInfo(&id, &sampleAppInfo)
+	if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
+		t.Fatal(reply)
+	}
+	<-p.trackProgress // receive app info
+	<-p.trackProgress // receive connect reply
 
-    reply = p.IncomingAppInfo(&id, &sampleAppInfo)
-    if reply.State != AppStateDisconnected || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
-        t.Fatal(reply)
-    }
-    p.quit()
+	reply = p.IncomingAppInfo(&id, &sampleAppInfo)
+	if reply.State != AppStateDisconnected || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
+		t.Fatal(reply)
+	}
+	p.quit()
 }
 
 func TestAppInfoConnected(t *testing.T) {
-    p := NewProcessor(ProcessorConfig{Client: connectClient})
-    p.processorHarvestChan = nil
-    p.trackProgress = make(chan struct{}, 100)
-    go p.Run()
-    <-p.trackProgress // Wait for utilization
+	p := NewProcessor(ProcessorConfig{Client: connectClient})
+	p.processorHarvestChan = nil
+	p.trackProgress = make(chan struct{}, 100)
+	go p.Run()
+	<-p.trackProgress // Wait for utilization
 
-    // trigger app creation and connect
-    reply := p.IncomingAppInfo(&id, &sampleAppInfo)
-    if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
-        t.Fatal(reply)
-    }
-    <-p.trackProgress // receive app info
-    <-p.trackProgress // receive connect reply
+	// trigger app creation and connect
+	reply := p.IncomingAppInfo(&id, &sampleAppInfo)
+	if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid || reply.ConnectTimestamp != 0 || reply.HarvestFrequency != 0 || reply.SamplingTarget != 0 {
+		t.Fatal(reply)
+	}
+	<-p.trackProgress // receive app info
+	<-p.trackProgress // receive connect reply
 
-    // without agent run id
-    reply = p.IncomingAppInfo(nil, &sampleAppInfo)
-    if reply.State != AppStateConnected ||
-    string(reply.ConnectReply) != `{"agent_run_id":"12345","zip":"zap"}` ||
-    reply.RunIDValid ||
-    reply.ConnectTimestamp == 0 ||
-    reply.HarvestFrequency != 60 ||
-    reply.SamplingTarget != 10 {
-        t.Fatal(reply)
-    }
-    // with agent run id
-    reply = p.IncomingAppInfo(&id, &sampleAppInfo)
-    if !reply.RunIDValid {
-        t.Fatal(reply)
-    }
+	// without agent run id
+	reply = p.IncomingAppInfo(nil, &sampleAppInfo)
+	if reply.State != AppStateConnected ||
+		string(reply.ConnectReply) != `{"agent_run_id":"12345","zip":"zap"}` ||
+		reply.RunIDValid ||
+		reply.ConnectTimestamp == 0 ||
+		reply.HarvestFrequency != 60 ||
+		reply.SamplingTarget != 10 {
+		t.Fatal(reply)
+	}
+	// with agent run id
+	reply = p.IncomingAppInfo(&id, &sampleAppInfo)
+	if !reply.RunIDValid {
+		t.Fatal(reply)
+	}
 
-    p.quit()
+	p.quit()
 }
 
 func TestAppInfoRunIdOutOfDate(t *testing.T) {
-    p := NewProcessor(ProcessorConfig{Client: connectClient})
-    p.processorHarvestChan = nil
-    p.trackProgress = make(chan struct{}, 100)
-    go p.Run()
-    <-p.trackProgress // Wait for utilization
+	p := NewProcessor(ProcessorConfig{Client: connectClient})
+	p.processorHarvestChan = nil
+	p.trackProgress = make(chan struct{}, 100)
+	go p.Run()
+	<-p.trackProgress // Wait for utilization
 
-    badID := AgentRunID("bad_id")
-    // trigger app creation and connect
-    reply := p.IncomingAppInfo(&id, &sampleAppInfo)
-    if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid {
-        t.Fatal(reply)
-    }
-    <-p.trackProgress // receive app info
-    <-p.trackProgress // receive connect reply
+	badID := AgentRunID("bad_id")
+	// trigger app creation and connect
+	reply := p.IncomingAppInfo(&id, &sampleAppInfo)
+	if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid {
+		t.Fatal(reply)
+	}
+	<-p.trackProgress // receive app info
+	<-p.trackProgress // receive connect reply
 
-    reply = p.IncomingAppInfo(&badID, &sampleAppInfo)
-    if reply.State != AppStateConnected || string(reply.ConnectReply) != `{"agent_run_id":"12345","zip":"zap"}` ||
-    reply.RunIDValid {
-        t.Fatal(reply)
-    }
-    p.quit()
+	reply = p.IncomingAppInfo(&badID, &sampleAppInfo)
+	if reply.State != AppStateConnected || string(reply.ConnectReply) != `{"agent_run_id":"12345","zip":"zap"}` ||
+		reply.RunIDValid {
+		t.Fatal(reply)
+	}
+	p.quit()
 }
 
 func TestAppInfoDifferentHostname(t *testing.T) {
-    p := NewProcessor(ProcessorConfig{Client: connectClient})
-    p.processorHarvestChan = nil
-    p.trackProgress = make(chan struct{}, 100)
-    go p.Run()
-    <-p.trackProgress // Wait for utilization
+	p := NewProcessor(ProcessorConfig{Client: connectClient})
+	p.processorHarvestChan = nil
+	p.trackProgress = make(chan struct{}, 100)
+	go p.Run()
+	<-p.trackProgress // Wait for utilization
 
-    // Connect with the default sample application info.
+	// Connect with the default sample application info.
 
-    info := sampleAppInfo
+	info := sampleAppInfo
 
-    reply := p.IncomingAppInfo(&id, &info)
-    if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid {
-        t.Fatal(reply)
-    }
-    <-p.trackProgress // receive app info
-    <-p.trackProgress // receive connect reply
+	reply := p.IncomingAppInfo(&id, &info)
+	if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid {
+		t.Fatal(reply)
+	}
+	<-p.trackProgress // receive app info
+	<-p.trackProgress // receive connect reply
 
-    // Connect with the same application info, but a different host name.
-    // This must trigger another connect request.
+	// Connect with the same application info, but a different host name.
+	// This must trigger another connect request.
 
-    info.Hostname = fmt.Sprintf("%s-2", info.Hostname)
+	info.Hostname = fmt.Sprintf("%s-2", info.Hostname)
 
-    reply = p.IncomingAppInfo(&otherId, &info)
-    if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid {
-        t.Fatal(reply)
-    }
-    p.quit()
+	reply = p.IncomingAppInfo(&otherId, &info)
+	if reply.State != AppStateUnknown || reply.ConnectReply != nil || reply.RunIDValid {
+		t.Fatal(reply)
+	}
+	p.quit()
 }
 
 func TestShouldConnect(t *testing.T) {
-    p := NewProcessor(ProcessorConfig{Client: connectClient})
-    now := time.Now()
-    p.appConnectBackoff = 2 * time.Second
+	p := NewProcessor(ProcessorConfig{Client: connectClient})
+	now := time.Now()
+	p.appConnectBackoff = 2 * time.Second
 
-    if p.util != nil {
-        t.Error("Utilization should be nil until connected.")
-    }
+	if p.util != nil {
+		t.Error("Utilization should be nil until connected.")
+	}
 
-    if p.shouldConnect(&App{state: AppStateUnknown}, now) {
-        t.Error("Shouldn't connect app if utilzation data is nil.")
-    }
+	if p.shouldConnect(&App{state: AppStateUnknown}, now) {
+		t.Error("Shouldn't connect app if utilzation data is nil.")
+	}
 
-    p.util = &utilization.Data{}
-    if !p.shouldConnect(&App{state: AppStateUnknown}, now) {
-        t.Error("Should connect app if timeout is valid and app is unknown.")
-    }
-    if p.shouldConnect(&App{state: AppStateUnknown, lastConnectAttempt: now}, now) ||
-    p.shouldConnect(&App{state: AppStateUnknown, lastConnectAttempt: now}, now.Add(time.Second)) {
-        t.Error("Shouldn't connect app if last connect attempt was too recent.")
-    }
-    if !p.shouldConnect(&App{state: AppStateUnknown, lastConnectAttempt: now}, now.Add(3*time.Second)) {
-        t.Error("Should connect app if timeout is small enough.")
-    }
-    if p.shouldConnect(&App{state: AppStateConnected, lastConnectAttempt: now}, now.Add(3*time.Second)) {
-        t.Error("Shouldn't connect app if app is already connected.")
-    }
+	p.util = &utilization.Data{}
+	if !p.shouldConnect(&App{state: AppStateUnknown}, now) {
+		t.Error("Should connect app if timeout is valid and app is unknown.")
+	}
+	if p.shouldConnect(&App{state: AppStateUnknown, lastConnectAttempt: now}, now) ||
+		p.shouldConnect(&App{state: AppStateUnknown, lastConnectAttempt: now}, now.Add(time.Second)) {
+		t.Error("Shouldn't connect app if last connect attempt was too recent.")
+	}
+	if !p.shouldConnect(&App{state: AppStateUnknown, lastConnectAttempt: now}, now.Add(3*time.Second)) {
+		t.Error("Should connect app if timeout is small enough.")
+	}
+	if p.shouldConnect(&App{state: AppStateConnected, lastConnectAttempt: now}, now.Add(3*time.Second)) {
+		t.Error("Shouldn't connect app if app is already connected.")
+	}
 }

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -260,35 +260,35 @@ func TestProcessorHarvestCleanExit(t *testing.T) {
 }
 
 func TestSupportabilityHarvest(t *testing.T) {
-    m := NewMockedProcessor(1)
+	m := NewMockedProcessor(1)
 
-    m.DoAppInfo(t, nil, AppStateUnknown)
+	m.DoAppInfo(t, nil, AppStateUnknown)
 
-    m.DoConnect(t, &idOne)
-    m.DoAppInfo(t, nil, AppStateConnected)
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
 
-    m.TxnData(t, idOne, txnErrorEventSample)
+	m.TxnData(t, idOne, txnErrorEventSample)
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestDefaultData,
-    }
-    <-m.p.trackProgress // receive harvest notice
-    m.clientReturn <- ClientReturn{} /* metrics */
-    //<-m.p.trackProgress // receive harvest
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestDefaultData,
+	}
+	<-m.p.trackProgress // receive harvest notice
+	m.clientReturn <- ClientReturn{} /* metrics */
+	//<-m.p.trackProgress // receive harvest
 
-    m.processorHarvestChan <- ProcessorHarvest{
-        AppHarvest: m.p.harvests[idOne],
-        ID:         idOne,
-        Type:       HarvestDefaultData,
-    }
-    <-m.p.trackProgress // receive harvest notice
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestDefaultData,
+	}
+	<-m.p.trackProgress // receive harvest notice
 
 	cp := <-m.clientParams
 	// Add timeout error response code for second harvest
-    m.clientReturn <- ClientReturn{nil, ErrUnsupportedMedia, 408}
-    <-m.p.trackProgress // receive harvest error
+	m.clientReturn <- ClientReturn{nil, ErrUnsupportedMedia, 408}
+	<-m.p.trackProgress // receive harvest error
 
 	harvest := m.p.harvests[idOne]
 	limits := collector.EventHarvestConfig{
@@ -313,7 +313,7 @@ func TestSupportabilityHarvest(t *testing.T) {
 	//   of harvests. So we extract the time from what we receive
 	time := strings.Split(string(cp.data), ",")[1]
 	var expectedJSON = `["one",` + time + `,1417136520,` +
-	    `[[{"name":"Instance/Reporting"},[2,0,0,0,0,0]],` +
+		`[[{"name":"Instance/Reporting"},[2,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Agent/Collector/HTTPError/408"},[1,0,0,0,0,0]],` + // Check for HTTPError Supportability metric
 		`[{"name":"Supportability/Agent/Collector/error_data/Attempts"},[2,0,0,0,0,0]],` + // Check for Connect attempt supportability metrics
 		`[{"name":"Supportability/Agent/Collector/metric_data/Attempts"},[2,0,0,0,0,0]],` +
@@ -341,7 +341,7 @@ func TestSupportabilityHarvest(t *testing.T) {
 	if got := string(json); got != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)
 	}
-    m.p.quit()
+	m.p.quit()
 }
 
 func TestProcessorHarvestErrorEvents(t *testing.T) {

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -318,11 +318,7 @@ func TestSupportabilityHarvest(t *testing.T) {
 	var expectedJSON = `["one",` + time + `,1417136520,` +
 		`[[{"name":"Instance/Reporting"},[2,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Agent/Collector/HTTPError/408"},[1,0,0,0,0,0]],` + // Check for HTTPError Supportability metric
-		`[{"name":"Supportability/Agent/Collector/error_data/Attempts"},[2,0,0,0,0,0]],` + // Check for Connect attempt supportability metrics
-		`[{"name":"Supportability/Agent/Collector/metric_data/Attempts"},[2,0,0,0,0,0]],` +
-		`[{"name":"Supportability/Agent/Collector/span_event_data/Attempts"},[2,0,0,0,0,0]],` +
-		`[{"name":"Supportability/Agent/Collector/sql_trace_data/Attempts"},[2,0,0,0,0,0]],` +
-		`[{"name":"Supportability/Agent/Collector/transaction_sample_data/Attempts"},[2,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Agent/Collector/metric_data/Attempts"},[1,0,0,0,0,0]],` + //	Metrics were sent first when the 408 error occurred, so check for the metric failure.
 		`[{"name":"Supportability/AnalyticsEvents/TotalEventsSeen"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/AnalyticsEvents/TotalEventsSent"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/EventHarvest/AnalyticEventData/HarvestLimit"},[10002,0,0,0,0,0]],` +


### PR DESCRIPTION
Very rough prototype for addressing issue $445

1) Adds httperror metrics for new response codes
2) Adds metrics for these endpoints: https://github.com/newrelic/newrelic-php-agent/blob/main/src/newrelic/harvest.go#L139

Needs:
1) Validation
2) Test cases
3) has not added duration, but harvest has a start time, so could theoretically be added