### PR TITLE
Fix typo passing a char to a const void * argument.

### DIFF
--- a/axiom/util_object.c
+++ b/axiom/util_object.c
@@ -1938,7 +1938,7 @@ char* nro_stringify(const nrobj_t* found) {
   }
 
   nr_buffer_add_escape_json(buf, tmp);
-  nr_buffer_add(buf, '\0', 1);
+  nr_buffer_add(buf, "\0", 1);
 
   ret = nr_strdup((const char*)nr_buffer_cptr(buf));
 


### PR DESCRIPTION
Fix what looks like a small typo.