### PR TITLE
docs(agent): fix `detect_kubernetes` path in template ini

### DIFF
--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -342,7 +342,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ; Info   : Enable detection of whether the system is running in a Kubernetes 
 ;          cluster.
 ;
-;newrelic.utilization.detect_kubernetes = true
+;newrelic.daemon.utilization.detect_kubernetes = true
 
 
 ; Setting: newrelic.daemon.app_timeout


### PR DESCRIPTION
Found what appears to be a bug in the 'path' for the detect_kubernetes INI config option while investigating for logging.