### PR TITLE
docs: refactor/formatting of dev env guide

### DIFF
--- a/docs/dev_environment.md
+++ b/docs/dev_environment.md
@@ -14,7 +14,7 @@ PHP_VER can also be set, but hasn’t been tested beyond `8.0`.
 
 Set all environment variables prior to running the development environment.  
 
-#Options for using the environment
+## Options for using the environment
 
 ## With a shell environment
 
@@ -22,7 +22,9 @@ To start the dev environment type `make dev-shell`.  This will create a set of d
 A prompt will open and you’ll be able to compile and run all `make` commands right away with no additional setup (for example: `make -j4 all` or `make -j4 valgrind` or `make -j4 run_tests`).
 
 After compiling the agent, the integration tests can be run using the `integration_runner`.
+
 To run all integration tests, from the prompt, run: `./bin/integration_runner -agent ./agent/.libs/newrelic.so`
+
 To run `redis` only: `./bin/integration_runner -agent ./agent/.libs/newrelic.so -pattern tests/integration/redis/*`
 
 To end the session type `exit`.  You can run `make dev-stop` to stop the docker-compose containers.
@@ -39,7 +41,7 @@ In the shell, you can run all `make` commands as you normally would.
 
 ## Integration Tests only
 
-`make dev-integration-tests
+`make dev-integration-tests`
 
 ## Build and test all
 
@@ -47,17 +49,17 @@ In the shell, you can run all `make` commands as you normally would.
 
 ## Stop all containers
 
-`make dev-all`
+`make dev-stop`
 
 # Next steps and issues
 
-## Currently only `mysql` and `redis` containers are integrated.  Other databases need to be added to the docker-compose.yml, but many of the tests cases run as-is.
+## Currently only `mysql` and `redis` containers are integrated.  
+ Other databases need to be added to the docker-compose.yml, but many of the tests cases run as-is.
 
-## The explain plan in the sql tests contain partition/filtered properties
- but the tests can't currently be updated  to reflect that since the sql 
- database on our CI doesn't include those values.
+## The explain plan in the sql tests contain partition/filtered properties but the tests can't currently be updated to reflect that since the sql database on our CI doesn't include those values. 
  RUN docker-php-ext-install pdo pdo_mysql
 
-## There is possibly some incompatibility with mysql in the main build container.  It might make sense at a future point to have the integration tests run from a different container than the build container.
+## There is possibly some incompatibility with mysql in the main build container.  
+ It might make sense at a future point to have the integration tests run from a different container than the build container.
 
 ## There are currently 0 known failing integration tests with this prototype.


### PR DESCRIPTION
Found some incorrect information and formatting issues in the dev_environment.md doc.
Also took some liberty to clean up some other formatting to make it easier to read.