### PR TITLE
feat(agent): Registered function begin/end and error handlers with Observer API

### DIFF
--- a/agent/php_error.c
+++ b/agent/php_error.c
@@ -455,8 +455,6 @@ static int nr_php_should_record_error(int type, const char* format TSRMLS_DC) {
  * HOWEVER, when code level metrics(CLM) are incorporated, these values can be
  * used to add lineno and filename to error traces.
  */
-void(error_filename);
-void(error_lineno);
 void nr_php_error_cb(int type,
                      zend_string* error_filename NRUNUSED,
                      uint error_lineno NRUNUSED,

--- a/agent/php_error.c
+++ b/agent/php_error.c
@@ -449,14 +449,22 @@ static int nr_php_should_record_error(int type, const char* format TSRMLS_DC) {
 }
 
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+/* Prior to PHP8 these error_filename and error_lineno were only used to pass
+ * on to the error handler that the agent overwrote.  With PHP8+, these values
+ * are currently unused since the agent is already recording the stack trace.
+ * HOWEVER, when code level metrics(CLM) are incorporated, these values can be
+ * used to add lineno and filename to error traces.
+ */
+void(error_filename);
+void(error_lineno);
 void nr_php_error_cb(int type,
-                     zend_string* error_filename,
-                     uint error_lineno,
+                     zend_string* error_filename NRUNUSED,
+                     uint error_lineno NRUNUSED,
                      zend_string* message) {
 #elif ZEND_MODULE_API_NO == ZEND_8_0_X_API_NO
 void nr_php_error_cb(int type,
-                     const char* error_filename,
-                     uint error_lineno,
+                     const char* error_filename NRUNUSED,
+                     uint error_lineno NRUNUSED,
                      zend_string* message) {
 #else
 void nr_php_error_cb(int type,
@@ -502,15 +510,14 @@ void nr_php_error_cb(int type,
   }
 
   /*
-   * Call through to the actual error handler.
+   * Call through to the actual error handler for PHP 7.4 and below.
+   * For PHP 8+ we have registered our error handler with the Observer
+   * API so there is no need to callback to the original.
    */
   if (0 != NR_PHP_PROCESS_GLOBALS(orig_error_cb)) {
 #if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
     NR_PHP_PROCESS_GLOBALS(orig_error_cb)
     (type, error_filename, error_lineno, format, args);
-#else
-    NR_PHP_PROCESS_GLOBALS(orig_error_cb)
-    (type, error_filename, error_lineno, message);
 #endif /* PHP < 8.0 */
   }
 }

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1537,7 +1537,7 @@ end:
  *
  * Without overwriting the execute function and therefore being responsible for
  * continuing the execution of ALL functions that we intercepted,  the agent is
- * provide zend_execute_data on each function start/end and is then able to use
+ * provided zend_execute_data on each function start/end and is then able to use
  * it with our currently existing logic and instrumentation.
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
@@ -1548,7 +1548,12 @@ void nr_php_execute_observer_fcall_begin(zend_execute_data* execute_data) {
    * nr_php_execute_enabled
    * nr_php_execute
    * nr_php_execute_show
+   * When fully implemented, remove NRUNUSED from the function sig.
    */
+
+  if (NULL == execute_data) {
+    return;
+  }
 }
 
 void nr_php_execute_observer_fcall_end(zend_execute_data* execute_data,
@@ -1559,6 +1564,10 @@ void nr_php_execute_observer_fcall_end(zend_execute_data* execute_data,
    * nr_php_execute_enabled
    * nr_php_execute
    * nr_php_execute_show
+   * When fully implemented, remove NRUNUSED from the function sig.
    */
+  if ((NULL == execute_data) || (NULL == return_value)) {
+    return;
+  }
 }
 #endif

--- a/agent/php_execute.h
+++ b/agent/php_execute.h
@@ -64,6 +64,42 @@ extern void nr_framework_create_metric(TSRMLS_D);
  *           This is necessary to correctly instrument frameworks and libraries
  *           that are preloaded.
  */
+
 extern void nr_php_user_instrumentation_from_opcache(TSRMLS_D);
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+/*
+ * Purpose : Call the necessary functions needed to instrument a function by
+ *           starting a transaction for a function that has just started.  This
+ *           function is registered via the Observer API and will be called by
+ *           the zend engine every time a function begins.  The zend engine
+ *           directly provides the zend_execute_data which has all details we
+ *           need to know about the function.
+ *
+ *
+ * Params  : 1. zend_execute_data: everything we need to know about the
+ * function.
+ *
+ * Returns : Void.
+ */
+void nr_php_execute_observer_fcall_begin(zend_execute_data* execute_data);
+/*
+ * Purpose : Call the necessary functions needed to instrument a function when
+ *           ending a transaction for a function that has just ended.  This
+ *           function is registered via the Observer API and will be called by
+ *           the zend engine every time a function ends.  The zend engine
+ *           directly provides the zend_execute_data and teh return_value
+ *           pointer, both of which have all details that the agent needs to
+ *           know about the function.
+ *
+ *
+ * Params  : 1. zend_execute_data: everything to know about the function.
+ *           2. return_value: function return value information
+ *
+ * Returns : Void.
+ */
+void nr_php_execute_observer_fcall_end(zend_execute_data* execute_data,
+                                       zval* return_value);
+#endif
 
 #endif /* PHP_EXECUTE_HDR */

--- a/agent/php_hooks.h
+++ b/agent/php_hooks.h
@@ -21,7 +21,11 @@ extern void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC);
 /*
  * Purpose : Our own error callback function, used to capture the PHP stack
  *           trace. This function is bound to zend_error_cb, and is typically
- *           called from within the guts of zend_error.
+ *           called from within the guts of zend_error.  For PHP8+ the agent no
+longer
+ *           needs to overwrite the error handler; instead, it registers our
+error
+ *           handler with Observer API error handling notifications.
  *
  * Params  : 1. A bitset encoding the type of the error, taken from
  *           E_ERROR ... E_USER_DEPRECATED
@@ -44,7 +48,7 @@ void my_error_notify_cb(int type,
                         uint32_t error_lineno,
                         zend_string *message) {
                 }
-                zend_register_error_notify_callback(my_error_notify_cb);
+                zend_register_error_notify_callback(nr_php_error_cb);
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
 extern void nr_php_error_cb(int type,

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -36,9 +36,6 @@
 
 #include "ext/pdo/php_pdo_driver.h"
 #include "ext/standard/info.h"
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
-#include "Zend/zend_observer.h"
-#endif
 
 /*
  * Zend Engine API numbers.
@@ -55,6 +52,10 @@
 #define ZEND_7_4_X_API_NO 20190902
 #define ZEND_8_0_X_API_NO 20200930
 #define ZEND_8_1_X_API_NO 20210902
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+#include "Zend/zend_observer.h"
+#endif
 
 #if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
 #include "Zend/zend_virtual_cwd.h"

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -36,6 +36,9 @@
 
 #include "ext/pdo/php_pdo_driver.h"
 #include "ext/standard/info.h"
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+#include "Zend/zend_observer.h"
+#endif
 
 /*
  * Zend Engine API numbers.


### PR DESCRIPTION
1) Registered function begin/end handlers with Observer API
2) Created the function begin/end handler stubs.  Full functionality is schedule for another ticket.
3) Registered currently existing error handler with Observer API

Testing:
1) Verified new function begin/end handlers were registered correctly and received zend_execute_data from PHP engine.
2) Current test cases verified that registering our current error handler directly caused no change in functionality.