### PR TITLE
feat(agent): Add/Update functions to utilize the OAPI zend_execute_data.

### DIFF
--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -1142,7 +1142,7 @@ bool nr_php_function_is_static_method(const zend_function* func) {
   return (func->common.fn_flags & ZEND_ACC_STATIC);
 }
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
 extern const char* nr_php_zend_execute_data_function_name(
     const zend_execute_data* execute_data) {
   zend_string* function_name = NULL;
@@ -1204,4 +1204,4 @@ extern uint32_t nr_php_zend_execute_data_lineno(
   return 0;
 }
 
-#endif /* PHP 8+ */
+#endif /* PHP 7+ */

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -1143,7 +1143,7 @@ bool nr_php_function_is_static_method(const zend_function* func) {
 }
 
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
-extern const char* nr_php_zend_execute_data_function_name(
+const char* nr_php_zend_execute_data_function_name(
     const zend_execute_data* execute_data) {
   zend_string* function_name = NULL;
 
@@ -1160,7 +1160,7 @@ extern const char* nr_php_zend_execute_data_function_name(
   return function_name ? ZSTR_VAL(function_name) : NULL;
 }
 
-extern const char* nr_php_zend_execute_data_filename(
+const char* nr_php_zend_execute_data_filename(
     const zend_execute_data* execute_data) {
   zend_string* filename = NULL;
   while (
@@ -1174,7 +1174,7 @@ extern const char* nr_php_zend_execute_data_filename(
   return filename ? ZSTR_VAL(filename) : NULL;
 }
 
-extern const char* nr_php_zend_execute_data_scope_name(
+const char* nr_php_zend_execute_data_scope_name(
     const zend_execute_data* execute_data) {
   zend_class_entry* ce = NULL;
 
@@ -1191,7 +1191,7 @@ extern const char* nr_php_zend_execute_data_scope_name(
   return ce ? ZSTR_VAL(ce->name) : NULL;
 }
 
-extern uint32_t nr_php_zend_execute_data_lineno(
+uint32_t nr_php_zend_execute_data_lineno(
     const zend_execute_data* execute_data) {
   while (
       execute_data

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -810,7 +810,7 @@ extern bool nr_php_function_is_static_method(const zend_function* func);
  */
 extern zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC);
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP7+ */
 /*
  * Purpose : Return a pointer to the function name of zend_execute_data.
  *
@@ -862,6 +862,6 @@ extern const char* nr_php_zend_execute_data_scope_name(
 extern uint32_t nr_php_zend_execute_data_lineno(
     const zend_execute_data* execute_data);
 
-#endif /* PHP 8+ */
+#endif /* PHP 7+ */
 
 #endif /* PHP_AGENT_HDR */

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -810,7 +810,7 @@ extern bool nr_php_function_is_static_method(const zend_function* func);
  */
 extern zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC);
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP7+ */
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
 /*
  * Purpose : Return a pointer to the function name of zend_execute_data.
  *
@@ -858,10 +858,8 @@ extern const char* nr_php_zend_execute_data_scope_name(
  * Returns : uint32_t lineno value
  *
  */
-
 extern uint32_t nr_php_zend_execute_data_lineno(
     const zend_execute_data* execute_data);
-
 #endif /* PHP 7+ */
 
 #endif /* PHP_AGENT_HDR */

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -404,7 +404,23 @@ static inline zval* nr_php_execute_scope(zend_execute_data* execute_data) {
     return NULL;
   }
 
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  while (execute_data) {
+    if ((Z_TYPE(execute_data->This) == IS_OBJECT)
+        || (Z_CE(execute_data->This))) {
+      return &execute_data->This;
+    } else if (execute_data->func) {
+      if (execute_data->func->type != ZEND_INTERNAL_FUNCTION
+          || execute_data->func->common.scope) {
+        return NULL;
+      }
+    }
+    execute_data = execute_data->prev_execute_data;
+  }
+  return NULL;
+
+#elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO \
+    && ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO /* PHP 7.0 - 7.4 */
   return &execute_data->This;
 #else
   return execute_data->object;
@@ -715,7 +731,10 @@ nr_php_ini_entry_name_length(const zend_ini_entry* entry) {
 
 #define NR_PHP_INTERNAL_FN_THIS() getThis()
 
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+#define NR_PHP_USER_FN_THIS() nr_php_execute_scope(execute_data)
+#elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO \
+    && ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO /* PHP 7.0 - 7.4 */
 #define NR_PHP_USER_FN_THIS() getThis()
 #else
 #define NR_PHP_USER_FN_THIS() EG(This)
@@ -790,5 +809,59 @@ extern bool nr_php_function_is_static_method(const zend_function* func);
  *           (current_execute_path).
  */
 extern zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC);
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+/*
+ * Purpose : Return a pointer to the function name of zend_execute_data.
+ *
+ * Params  : 1. zend_execute_data.
+ *
+ * Returns : A pointer to string, ownership of does NOT pass to the caller and
+ *           string must be dupped if it needs to persist,
+ *           or NULL if the zend_execute_data is invalid.
+ *
+ */
+extern const char* nr_php_zend_execute_data_function_name(
+    const zend_execute_data* execute_data);
+/*
+ * Purpose : Return a pointer to the filename of zend_execute_data.
+ *
+ * Params  : 1. zend_execute_data.
+ *
+ * Returns : A pointer to string, ownership of does NOT pass to the caller and
+ *           string must be dupped if it needs to persist,
+ *           or NULL if the zend_execute_data is invalid.
+ *
+ */
+extern const char* nr_php_zend_execute_data_filename(
+    const zend_execute_data* execute_data);
+
+/*
+ * Purpose : Return a pointer to the scope(i.e., class) name of
+ * zend_execute_data.
+ *
+ * Params  : 1. zend_execute_data.
+ *
+ * Returns : A pointer to string, ownership of does NOT pass to the caller and
+ *           string must be dupped if it needs to persist,
+ *           or NULL if the zend_execute_data is invalid.
+ *
+ */
+extern const char* nr_php_zend_execute_data_scope_name(
+    const zend_execute_data* execute_data);
+
+/*
+ * Purpose : Return a uint32_t line number value of zend_execute_data.
+ *
+ * Params  : 1. zend_execute_data.
+ *
+ * Returns : uint32_t lineno value
+ *
+ */
+
+extern uint32_t nr_php_zend_execute_data_lineno(
+    const zend_execute_data* execute_data);
+
+#endif /* PHP 8+ */
 
 #endif /* PHP_AGENT_HDR */

--- a/agent/tests/test_agent.c
+++ b/agent/tests/test_agent.c
@@ -558,7 +558,7 @@ static void test_default_address() {
 #endif
 }
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
 
 static void test_nr_php_zend_execute_data_function_name() {
   zend_function* func;
@@ -694,7 +694,7 @@ static void test_nr_php_zend_execute_data_lineno() {
       nr_php_zend_execute_data_lineno(&execute_data TSRMLS_CC));
 }
 
-#endif /* PHP 8+ */
+#endif /* PHP 7+ */
 
 void test_main(void* p NRUNUSED) {
 #if defined(ZTS) && !defined(PHP7)
@@ -719,12 +719,12 @@ void test_main(void* p NRUNUSED) {
    * Tests that require state and will handle their own request startup and
    * shutdown.
    */
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
   test_nr_php_zend_execute_data_function_name();
   test_nr_php_zend_execute_data_filename();
   test_nr_php_zend_execute_data_lineno();
   test_nr_php_zend_execute_data_scope_name();
-#endif /* PHP 8+ */
+#endif /* PHP 7+ */
 
   test_function_debug_name(TSRMLS_C);
   test_get_zval_object_property(TSRMLS_C);

--- a/agent/tests/test_agent.c
+++ b/agent/tests/test_agent.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "tlib_php.h"
+#include "tlib_main.h"
 
 #include "php_agent.h"
 #include "php_call.h"
@@ -557,6 +558,144 @@ static void test_default_address() {
 #endif
 }
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+
+static void test_nr_php_zend_execute_data_function_name() {
+  zend_function* func;
+  zend_execute_data execute_data = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_null("NULL zend_execute_data should return NULL",
+                    nr_php_zend_execute_data_function_name(NULL));
+
+  /*
+   * Test : Invalid arguments.
+   */
+  tlib_pass_if_null("NULL zend_function should return NULL",
+                    nr_php_zend_execute_data_function_name(&execute_data));
+
+  /*
+   * Test : Normal operation.
+   */
+  func = nr_php_find_function("newrelic_get_request_metadata");
+  execute_data.func = func;
+  tlib_pass_if_str_equal(
+      "Unexpected function name", "newrelic_get_request_metadata",
+      nr_php_zend_execute_data_function_name(&execute_data TSRMLS_CC));
+}
+
+static void test_nr_php_zend_execute_data_filename() {
+  zend_function func = {0};
+  zend_string* filename = NULL;
+  zend_execute_data execute_data = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_null("NULL zend_execute_data should return NULL",
+                    nr_php_zend_execute_data_filename(NULL TSRMLS_CC));
+
+  /*
+   * Test : Null function.
+   */
+  tlib_pass_if_null("NULL zend_function should return NULL",
+                    nr_php_zend_execute_data_filename(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Function exists, op_array doesn't.
+   */
+  execute_data.func = &func;
+  tlib_pass_if_null("NULL op_array should return NULL",
+                    nr_php_zend_execute_data_filename(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Function exists, op_array exists.
+   */
+  filename = zend_string_init("myfilename\\is\\here",
+                              strlen("myfilename\\is\\here"), 0);
+  func.op_array.filename = filename;
+  execute_data.func = &func;
+  tlib_pass_if_str_equal(
+      "Filename should be displayed", ZSTR_VAL(filename),
+      nr_php_zend_execute_data_filename(&execute_data TSRMLS_CC));
+  zend_string_release(filename);
+}
+
+static void test_nr_php_zend_execute_data_scope_name() {
+  zend_function func = {0};
+  zend_string* scope_name = NULL;
+  zend_execute_data execute_data = {0};
+  zend_class_entry ce = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_null("NULL zend_execute_data should return NULL",
+                    nr_php_zend_execute_data_scope_name(NULL TSRMLS_CC));
+
+  /*
+   * Test : Invalid arguments.
+   */
+  tlib_pass_if_null(
+      "NULL zend_function should return NULL",
+      nr_php_zend_execute_data_scope_name(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Function exists, but no class scope.
+   */
+  execute_data.func = &func;
+  tlib_pass_if_null(
+      "NULL op_array should return NULL",
+      nr_php_zend_execute_data_scope_name(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Function exists, class scope exists.
+   */
+  execute_data.func = &func;
+  scope_name = zend_string_init("NewRelic\\Integration",
+                                strlen("NewRelic\\Integration"), 0);
+  ce.name = scope_name;
+  execute_data.func->common.scope = &ce;
+  tlib_pass_if_str_equal(
+      "Unexpected scope name", ZSTR_VAL(scope_name),
+      nr_php_zend_execute_data_scope_name(&execute_data TSRMLS_CC));
+  zend_string_release(scope_name);
+}
+
+static void test_nr_php_zend_execute_data_lineno() {
+  zend_function func = {0};
+  zend_op opline = {0};
+  zend_execute_data execute_data = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_uint32_t_equal("NULL zend_execute_data should return 0", 0,
+                              nr_php_zend_execute_data_lineno(NULL TSRMLS_CC));
+
+  /*
+   * Test : Invalid arguments.
+   */
+  tlib_pass_if_uint32_t_equal(
+      "NULL zend_function should return 0", 0,
+      nr_php_zend_execute_data_lineno(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Normal operation.
+   */
+  execute_data.func = &func;
+
+  opline.lineno = 4;
+  execute_data.opline = &opline;
+  tlib_pass_if_uint32_t_equal(
+      "Unexpected lineno name", 4,
+      nr_php_zend_execute_data_lineno(&execute_data TSRMLS_CC));
+}
+
+#endif /* PHP 8+ */
+
 void test_main(void* p NRUNUSED) {
 #if defined(ZTS) && !defined(PHP7)
   void*** tsrm_ls = NULL;
@@ -580,6 +719,13 @@ void test_main(void* p NRUNUSED) {
    * Tests that require state and will handle their own request startup and
    * shutdown.
    */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+  test_nr_php_zend_execute_data_function_name();
+  test_nr_php_zend_execute_data_filename();
+  test_nr_php_zend_execute_data_lineno();
+  test_nr_php_zend_execute_data_scope_name();
+#endif /* PHP 8+ */
+
   test_function_debug_name(TSRMLS_C);
   test_get_zval_object_property(TSRMLS_C);
   test_get_zval_object_property_with_class(TSRMLS_C);


### PR DESCRIPTION
1) Added 4 new functions for use with OAPI instrumentation:
extern const char* nr_php_zend_execute_data_function_name(
    const zend_execute_data* execute_data);

extern const char* nr_php_zend_execute_data_filename(
    const zend_execute_data* execute_data);

extern const char* nr_php_zend_execute_data_scope_name(
    const zend_execute_data* execute_data);

extern uint32_t nr_php_zend_execute_data_lineno(
    const zend_execute_data* execute_data);
2) Added test cases to test new functionality.
3) Updated the following to reflect new OAPI paradigm and add additional checks for robustness:
* #define NR_PHP_USER_FN_THIS()
* nr_php_execute_scope
3) Added unit test cases to test the 4 new functions.  Currently existing functions are being called and used in current tests and will automatically be tested with php8+.
4) Also verified functionality via integration tests.