### PR TITLE
feat(daemon): add data usage metrics

### DIFF
--- a/src/newrelic/collector/client.go
+++ b/src/newrelic/collector/client.go
@@ -184,12 +184,12 @@ func (control *RpmControls) userAgent() string {
 }
 
 type Client interface {
-	Execute(cmd RpmCmd, cs RpmControls) RPMResponse
+	Execute(cmd *RpmCmd, cs RpmControls) RPMResponse
 }
 
-type ClientFn func(cmd RpmCmd, cs RpmControls) RPMResponse
+type ClientFn func(cmd *RpmCmd, cs RpmControls) RPMResponse
 
-func (fn ClientFn) Execute(cmd RpmCmd, cs RpmControls) RPMResponse {
+func (fn ClientFn) Execute(cmd *RpmCmd, cs RpmControls) RPMResponse {
 	return fn(cmd, cs)
 }
 
@@ -199,7 +199,7 @@ type limitClient struct {
 	semaphore chan bool
 }
 
-func (l *limitClient) Execute(cmd RpmCmd, cs RpmControls) RPMResponse {
+func (l *limitClient) Execute(cmd *RpmCmd, cs RpmControls) RPMResponse {
 	var timer <-chan time.Time
 
 	if 0 != l.timeout {
@@ -398,7 +398,8 @@ func parseResponse(b []byte) ([]byte, error) {
 	return r.ReturnValue, nil
 }
 
-func (c *clientImpl) Execute(cmd RpmCmd, cs RpmControls) RPMResponse {
+func (c *clientImpl) Execute(cmd *RpmCmd, cs RpmControls) RPMResponse {
+	// Create the JSON payload
 	data, err := cs.Collectible.CollectorJSON(false)
 	if nil != err {
 		return RPMResponse{Err: err}
@@ -406,15 +407,14 @@ func (c *clientImpl) Execute(cmd RpmCmd, cs RpmControls) RPMResponse {
 	cmd.Data = data
 
 	var audit []byte
-
 	if log.Auditing() {
 		audit, err = cs.Collectible.CollectorJSON(true)
 		if nil != err {
 			log.Errorf("unable to create audit json payload for '%s': %s", cmd.Name, err)
-			audit = data
+			audit = cmd.Data
 		}
 		if nil == audit {
-			audit = data
+			audit = cmd.Data
 		}
 	}
 
@@ -422,12 +422,12 @@ func (c *clientImpl) Execute(cmd RpmCmd, cs RpmControls) RPMResponse {
 	cleanURL := cmd.url(true)
 
 	log.Audit("command='%s' url='%s' payload={%s}", cmd.Name, url, audit)
-	log.Debugf("command='%s' url='%s' max_payload_size_in_bytes='%d' payload={%s}", cmd.Name, cleanURL, cmd.MaxPayloadSize, data)
+	log.Debugf("command='%s' url='%s' max_payload_size_in_bytes='%d' payload={%s}", cmd.Name, cleanURL, cmd.MaxPayloadSize, cmd.Data)
 
-	resp := c.perform(url, cmd, cs)
-	if err != nil {
+	resp := c.perform(url, *cmd, cs)
+	if nil != resp.Err {
 		log.Debugf("attempt to perform %s failed: %q, url=%s",
-			cmd.Name, err.Error(), cleanURL)
+			cmd.Name, resp.Err.Error(), cleanURL)
 	}
 
 	log.Audit("command='%s' url='%s', status=%d, response={%s}", cmd.Name, url, resp.StatusCode, string(resp.Body))

--- a/src/newrelic/collector/client_test.go
+++ b/src/newrelic/collector/client_test.go
@@ -123,7 +123,7 @@ func TestExecuteWhenMaxPayloadSizeExceeded(t *testing.T) {
 		},
 	}
 
-	resp := client.Execute(cmd, cs)
+	resp := client.Execute(&cmd, cs)
 	if resp.Body != nil {
 		t.Errorf("%s, got [%v], want [%v]", testedFn, resp.Body, wantResponseBody)
 	} else if resp.Err == nil {
@@ -167,7 +167,7 @@ func TestExecuteWhenMaxPayloadSizeNotExceeded(t *testing.T) {
 	// This test ensures there's no error if payload does
 	// not exceed configured max_payload_size_in_bytes.
 	// That's why the body is ignored here.
-	resp := client.Execute(cmd, cs)
+	resp := client.Execute(&cmd, cs)
 	if resp.Err != nil {
 		t.Errorf("%s, got [%v], want [%v]", testedFn, resp.Err, wantErr)
 	}

--- a/src/newrelic/collector/collector_test.go
+++ b/src/newrelic/collector/collector_test.go
@@ -119,7 +119,7 @@ func TestCollectorRequest(t *testing.T) {
 			}),
 		},
 	}
-	resp := client.Execute(cmd, cs)
+	resp := client.Execute(&cmd, cs)
 	if nil != resp.Err {
 		t.Error(resp.Err)
 	}

--- a/src/newrelic/harvest.go
+++ b/src/newrelic/harvest.go
@@ -71,7 +71,7 @@ func createTraceObserverMetrics(to *infinite_tracing.TraceObserver, metrics *Met
 	}
 
 	for name, val := range to.DumpSupportabilityMetrics() {
-		metrics.AddCount(name, "", val, Forced)
+		metrics.AddRaw([]byte(name), "", "", val, Forced)
 	}
 }
 

--- a/src/newrelic/infinite_tracing/trace_observer.go
+++ b/src/newrelic/infinite_tracing/trace_observer.go
@@ -365,14 +365,14 @@ func (to *TraceObserver) handleSupportability() {
 		case inc := <-to.supportability.increment:
 			v, ok := metrics[inc.name]
 			if !ok {
-				v = [6]float64{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}
+				v = newEmptyMetric()
 			}
 			v[0] += inc.count
 			metrics[inc.name] = v
 		case batchCount := <-to.supportability.incrementSent:
 			v, ok := metrics[supportabilitySent]
 			if !ok {
-				v = [6]float64{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}
+				v = newEmptyMetric()
 			}
 			// Since we're sending span batches, we increment by the number of spans in the batch.
 			v[0] += batchCount
@@ -380,7 +380,7 @@ func (to *TraceObserver) handleSupportability() {
 		case dataUsage := <-to.supportability.dataUsage:
 			v, ok := metrics[supportabilityDataUsage]
 			if !ok {
-				v = [6]float64{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}
+				v = newEmptyMetric()
 			}
 			v[0] += 1
 			v[1] += dataUsage
@@ -393,13 +393,21 @@ func (to *TraceObserver) handleSupportability() {
 	}
 }
 
+func newEmptyMetric() [6]float64 {
+	// [0] count
+	// [1] bytes sent
+	// [2] bytes received
+	// [3:] unused
+	return [6]float64{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}
+}
+
 func newSupportabilityMetrics() map[string][6]float64 {
 	// grpc codes, plus 1 for sent, 1 for data usage,  and 1 for response errs
 	// Sending full metrics for AddRaw() (6 floats instead of just for AddCount())
 	// because dataUsage metrics requires multiple fields
 	metrics := make(map[string][6]float64, numCodes+3)
 	// supportabilitySent metric must always be sent
-	metrics[supportabilitySent] = [6]float64{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}
+	metrics[supportabilitySent] = newEmptyMetric()
 	return metrics
 }
 

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -8,8 +8,8 @@ package newrelic
 import (
 	"encoding/json"
 	"strings"
-	"time"
 	"sync"
+	"time"
 
 	"newrelic/collector"
 	"newrelic/infinite_tracing"
@@ -165,7 +165,7 @@ func ConnectApplication(args *ConnectArgs) ConnectAttempt {
 
 	args.Payload, err = EncodePayload(&RawPreconnectPayload{SecurityPolicyToken: args.SecurityPolicyToken, HighSecurity: args.HighSecurity})
 	if err != nil {
-		log.Errorf("unable to connect application: %v", err)
+		log.Errorf("Unable to connect application: %v", err)
 		rep.Err = err
 		return rep
 	}
@@ -533,32 +533,32 @@ type harvestArgs struct {
 // Has all usage stats needed for the spec
 type dataUsageInfo struct {
 	endpoint_name string
-	payloadSize int
-	responseSize int
+	payloadSize   int
+	responseSize  int
 }
 
 type dataUsageController struct {
 	duc chan dataUsageInfo
-	wg *sync.WaitGroup
+	wg  *sync.WaitGroup
 }
 
 func newDataUsageController(du_chan chan dataUsageInfo) dataUsageController {
-	return dataUsageController {
+	return dataUsageController{
 		duc: du_chan,
-		wg: new(sync.WaitGroup),
+		wg:  new(sync.WaitGroup),
 	}
 }
 
 func addDataUsage(duc chan dataUsageInfo, endpoint string, data_stored int, data_received int) {
 	select {
-		case duc <- dataUsageInfo{
-			         endpoint_name: endpoint,
-			         payloadSize: data_stored,
-			         responseSize: data_received,
-			        }:
-			// data stored
-		default:
-			// channel full, don't store
+	case duc <- dataUsageInfo{
+		endpoint_name: endpoint,
+		payloadSize:   data_stored,
+		responseSize:  data_received,
+	}:
+		// data stored
+	default:
+		// channel full, don't store
 	}
 }
 
@@ -758,14 +758,16 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType, du_chan ch
 
 func harvestDataUsage(args *harvestArgs, duc dataUsageController) {
 	duc.wg.Wait()
-	if len(duc.duc) == 0 {return} // no usage metrics found
+	if len(duc.duc) == 0 {
+		return
+	} // no usage metrics found
 
 	sumPayload := 0
 	sumResponse := 0
 	sumAttempts := 0
 	type dataUsageMetrics struct {
-		attempts int
-		payloadSize int
+		attempts     int
+		payloadSize  int
 		responseSize int
 	}
 	dataUsageMap := make(map[string]dataUsageMetrics)
@@ -790,12 +792,12 @@ func harvestDataUsage(args *harvestArgs, duc dataUsageController) {
 	}
 
 	metrics := NewMetricTable(limits.MaxMetrics, time.Now())
-	for name, data := range(dataUsageMap) {
-		metrics.AddRaw([]byte("Supportability/" + args.agentLanguage + "/" + args.collector + "/" + name + "/Output/Bytes"),
-					   "", "", [6]float64{float64(data.attempts), float64(data.payloadSize), float64(data.responseSize), 0.0, 0.0, 0.0}, Forced)
+	for name, data := range dataUsageMap {
+		metrics.AddRaw([]byte("Supportability/"+args.agentLanguage+"/"+args.collector+"/"+name+"/Output/Bytes"),
+			"", "", [6]float64{float64(data.attempts), float64(data.payloadSize), float64(data.responseSize), 0.0, 0.0, 0.0}, Forced)
 	}
-	metrics.AddRaw([]byte("Supportability/" + args.agentLanguage + "/" + args.collector + "/Output/Bytes"),
-				   "", "", [6]float64{float64(sumAttempts), float64(sumPayload), float64(sumResponse), 0.0, 0.0, 0.0}, Forced)
+	metrics.AddRaw([]byte("Supportability/"+args.agentLanguage+"/"+args.collector+"/Output/Bytes"),
+		"", "", [6]float64{float64(sumAttempts), float64(sumPayload), float64(sumResponse), 0.0, 0.0, 0.0}, Forced)
 	metrics = metrics.ApplyRules(args.rules)
 	considerHarvestPayload(metrics, args, duc)
 }
@@ -882,9 +884,9 @@ func NewProcessor(cfg ProcessorConfig) *Processor {
 		processorHarvestChan:  make(chan ProcessorHarvest),
 		// We don't want data usage collection to ever block, so we create a
 		// sized buffer that will drop any excess data once filled
-		dataUsageChannel:      make(chan dataUsageInfo, 25),
-		appConnectBackoff:     limits.AppConnectAttemptBackoff,
-		cfg:                   cfg,
+		dataUsageChannel:  make(chan dataUsageInfo, 25),
+		appConnectBackoff: limits.AppConnectAttemptBackoff,
+		cfg:               cfg,
 	}
 }
 

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -793,10 +793,10 @@ func harvestDataUsage(args *harvestArgs, duc dataUsageController) {
 
 	metrics := NewMetricTable(limits.MaxMetrics, time.Now())
 	for name, data := range dataUsageMap {
-		metrics.AddRaw([]byte("Supportability/"+args.agentLanguage+"/"+args.collector+"/"+name+"/Output/Bytes"),
+		metrics.AddRaw([]byte("Supportability/"+args.agentLanguage+"/Collector/"+name+"/Output/Bytes"),
 			"", "", [6]float64{float64(data.attempts), float64(data.payloadSize), float64(data.responseSize), 0.0, 0.0, 0.0}, Forced)
 	}
-	metrics.AddRaw([]byte("Supportability/"+args.agentLanguage+"/"+args.collector+"/Output/Bytes"),
+	metrics.AddRaw([]byte("Supportability/"+args.agentLanguage+"/Collector/Output/Bytes"),
 		"", "", [6]float64{float64(sumAttempts), float64(sumPayload), float64(sumResponse), 0.0, 0.0, 0.0}, Forced)
 	metrics = metrics.ApplyRules(args.rules)
 	considerHarvestPayload(metrics, args, duc)

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -654,6 +654,12 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType, du_chan ch
 	// function harvests by type.
 	harvest := ah.Harvest
 
+	// This needs to be determined here, as even an empty harvest needs
+	// to be overwritten with new containers for the next harvest.
+	skip_data_usage := false
+	if (harvest.empty()) {
+		skip_data_usage = true
+	}
 	// In many cases, all types are harvested
 	//    at the same time
 	//       at the same rate.
@@ -748,10 +754,12 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType, du_chan ch
 	}
 	// Only harvest data usage metrics if metrics are being harvested
 	if ht&HarvestDefaultData == HarvestDefaultData {
-		if args.blocking {
-			harvestDataUsage(args, duc)
-		} else {
-			go harvestDataUsage(args, duc)
+		if !skip_data_usage {
+			if args.blocking {
+				harvestDataUsage(args, duc)
+			} else {
+				go harvestDataUsage(args, duc)
+			}
 		}
 	}
 }

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -801,10 +801,10 @@ func harvestDataUsage(args *harvestArgs, duc dataUsageController) {
 
 	metrics := NewMetricTable(limits.MaxMetrics, time.Now())
 	for name, data := range dataUsageMap {
-		metrics.AddRaw([]byte("Supportability/"+args.agentLanguage+"/Collector/"+name+"/Output/Bytes"),
+		metrics.AddRaw([]byte("Supportability/"+strings.ToUpper(args.agentLanguage)+"/Collector/"+name+"/Output/Bytes"),
 			"", "", [6]float64{float64(data.attempts), float64(data.payloadSize), float64(data.responseSize), 0.0, 0.0, 0.0}, Forced)
 	}
-	metrics.AddRaw([]byte("Supportability/"+args.agentLanguage+"/Collector/Output/Bytes"),
+	metrics.AddRaw([]byte("Supportability/"+strings.ToUpper(args.agentLanguage)+"/Collector/Output/Bytes"),
 		"", "", [6]float64{float64(sumAttempts), float64(sumPayload), float64(sumResponse), 0.0, 0.0, 0.0}, Forced)
 	metrics = metrics.ApplyRules(args.rules)
 	considerHarvestPayload(metrics, args, duc)

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -930,6 +930,7 @@ func (p *Processor) Run() error {
 		}
 
 		// This is only used for testing
+		// During testing, blocks the processor until trackProgress is read
 		if nil != p.trackProgress {
 			p.trackProgress <- struct{}{}
 		}

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -192,7 +192,7 @@ func ConnectApplication(args *ConnectArgs) ConnectAttempt {
 	// expects this field value to contain any errors which occurred
 	// during the connect attempt and will not inspect the RawReply
 	// field for an error value
-	rep.RawReply = args.Client.Execute(cmd, cs)
+	rep.RawReply = args.Client.Execute(&cmd, cs)
 
 	if nil != rep.RawReply.Err {
 		rep.Err = rep.RawReply.Err
@@ -262,7 +262,7 @@ func ConnectApplication(args *ConnectArgs) ConnectAttempt {
 	cmd.Name = collector.CommandConnect
 
 	// Make call to connect
-	rep.RawReply = args.Client.Execute(cmd, cs)
+	rep.RawReply = args.Client.Execute(&cmd, cs)
 	if nil != rep.RawReply.Err {
 		rep.Err = rep.RawReply.Err
 		return rep
@@ -548,7 +548,7 @@ func harvestPayload(p PayloadCreator, args *harvestArgs) {
 		}),
 	}
 
-	reply := args.client.Execute(cmd, cs)
+	reply := args.client.Execute(&cmd, cs)
 
 	// We don't need to process the response to a harvest command unless an
 	// error happened.  (Note that this may change if we have to support metric

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"strings"
 	"time"
+	"sync"
 
 	"newrelic/collector"
 	"newrelic/infinite_tracing"
@@ -108,6 +109,7 @@ type Processor struct {
 	quitChan              chan struct{}
 	processorHarvestChan  chan ProcessorHarvest
 	trackProgress         chan struct{} // Usually nil, used for testing
+	dataUsageChannel      chan dataUsageInfo
 	appConnectBackoff     time.Duration
 	cfg                   ProcessorConfig
 	util                  *utilization.Data
@@ -528,7 +530,40 @@ type harvestArgs struct {
 	blocking bool
 }
 
-func harvestPayload(p PayloadCreator, args *harvestArgs) {
+// Has all usage stats needed for the spec
+type dataUsageInfo struct {
+	endpoint_name string
+	payloadSize int
+	responseSize int
+}
+
+type dataUsageController struct {
+	duc chan dataUsageInfo
+	wg *sync.WaitGroup
+}
+
+func newDataUsageController(du_chan chan dataUsageInfo) dataUsageController {
+	return dataUsageController {
+		duc: du_chan,
+		wg: new(sync.WaitGroup),
+	}
+}
+
+func addDataUsage(duc chan dataUsageInfo, endpoint string, data_stored int, data_received int) {
+	select {
+		case duc <- dataUsageInfo{
+			         endpoint_name: endpoint,
+			         payloadSize: data_stored,
+			         responseSize: data_received,
+			        }:
+			// data stored
+		default:
+			// channel full, don't store
+	}
+}
+
+func harvestPayload(p PayloadCreator, args *harvestArgs, duc dataUsageController) {
+	defer duc.wg.Done()
 	cmd := collector.RpmCmd{
 		Name:              p.Cmd(),
 		Collector:         args.collector,
@@ -554,8 +589,11 @@ func harvestPayload(p PayloadCreator, args *harvestArgs) {
 	// error happened.  (Note that this may change if we have to support metric
 	// cache ids).
 	if nil == reply.Err {
+		addDataUsage(duc.duc, cmd.Name, len(cmd.Data), len(reply.Body))
 		return
 	}
+	// If we receive an error, the data was not stored into the collector
+	addDataUsage(duc.duc, cmd.Name, 0, len(reply.Body))
 
 	args.harvestErrorChannel <- HarvestError{
 		Reply: reply,
@@ -564,48 +602,53 @@ func harvestPayload(p PayloadCreator, args *harvestArgs) {
 	}
 }
 
-func considerHarvestPayload(p PayloadCreator, args *harvestArgs) {
+func considerHarvestPayload(p PayloadCreator, args *harvestArgs, duc dataUsageController) {
 	if p.Empty() {
 		return
 	}
 
+	duc.wg.Add(1)
 	if args.blocking {
 		// Invoked primarily by CleanExit
-		harvestPayload(p, args)
+		harvestPayload(p, args, duc)
 	} else {
-		go harvestPayload(p, args)
+		go harvestPayload(p, args, duc)
 	}
 }
 
-func considerHarvestPayloadTxnEvents(txnEvents *TxnEvents, args *harvestArgs) {
+func considerHarvestPayloadTxnEvents(txnEvents *TxnEvents, args *harvestArgs, duc dataUsageController) {
 	if args.splitLargePayloads && (txnEvents.events.Len() >= (limits.MaxTxnEvents / 2)) {
 		events1, events2 := txnEvents.Split()
-		considerHarvestPayload(&TxnEvents{events1}, args)
-		considerHarvestPayload(&TxnEvents{events2}, args)
+		considerHarvestPayload(&TxnEvents{events1}, args, duc)
+		considerHarvestPayload(&TxnEvents{events2}, args, duc)
 	} else {
-		considerHarvestPayload(txnEvents, args)
+		considerHarvestPayload(txnEvents, args, duc)
 	}
 }
 
-func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver) {
+func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, du_chan chan dataUsageInfo) {
 	log.Debugf("harvesting %d commands processed", harvest.commandsProcessed)
 
 	harvest.createFinalMetrics(harvestLimits, to)
 	harvest.Metrics = harvest.Metrics.ApplyRules(args.rules)
-
-	considerHarvestPayload(harvest.Metrics, args)
-	considerHarvestPayload(harvest.CustomEvents, args)
-	considerHarvestPayload(harvest.ErrorEvents, args)
-	considerHarvestPayload(harvest.Errors, args)
-	considerHarvestPayload(harvest.SlowSQLs, args)
-	considerHarvestPayload(harvest.TxnTraces, args)
-	considerHarvestPayloadTxnEvents(harvest.TxnEvents, args)
-	considerHarvestPayload(harvest.SpanEvents, args)
-	considerHarvestPayload(harvest.LogEvents, args)
+	duc := newDataUsageController(du_chan)
+	considerHarvestPayload(harvest.Metrics, args, duc)
+	considerHarvestPayload(harvest.CustomEvents, args, duc)
+	considerHarvestPayload(harvest.ErrorEvents, args, duc)
+	considerHarvestPayload(harvest.Errors, args, duc)
+	considerHarvestPayload(harvest.SlowSQLs, args, duc)
+	considerHarvestPayload(harvest.TxnTraces, args, duc)
+	considerHarvestPayloadTxnEvents(harvest.TxnEvents, args, duc)
+	considerHarvestPayload(harvest.SpanEvents, args, duc)
+	considerHarvestPayload(harvest.LogEvents, args, duc)
+	if args.blocking {
+		harvestDataUsage(args, duc)
+	} else {
+		go harvestDataUsage(args, duc)
+	}
 }
 
-func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
-
+func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType, du_chan chan dataUsageInfo) {
 	// The collector may provide custom reporting periods for harvesting
 	// TxnEvents, CustomEvents, or ErrorEvents.  As a result, this
 	// function harvests by type.
@@ -619,9 +662,9 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		ah.Harvest = NewHarvest(time.Now(), ah.App.connectReply.EventHarvestConfig.EventConfigs)
 		if args.blocking {
 			// Invoked primarily by CleanExit
-			harvestAll(harvest, args, ah.connectReply.EventHarvestConfig, ah.TraceObserver)
+			harvestAll(harvest, args, ah.connectReply.EventHarvestConfig, ah.TraceObserver, du_chan)
 		} else {
-			go harvestAll(harvest, args, ah.connectReply.EventHarvestConfig, ah.TraceObserver)
+			go harvestAll(harvest, args, ah.connectReply.EventHarvestConfig, ah.TraceObserver, du_chan)
 		}
 		return
 	}
@@ -629,6 +672,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 	// Otherwise, harvest by type.  The first type is DefaultData.  This
 	// comprises the Metrics, Errors, SlowSQLs, and TxnTraces whose
 	// reporting periods have no custom reporting periods.
+	duc := newDataUsageController(du_chan)
 	if ht&HarvestDefaultData == HarvestDefaultData {
 
 		log.Debugf("harvesting %d commands processed", harvest.commandsProcessed)
@@ -650,12 +694,12 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		harvest.commandsProcessed = 0
 		harvest.pidSet = make(map[int]struct{})
 
-		considerHarvestPayload(metrics, args)
-		considerHarvestPayload(errors, args)
-		considerHarvestPayload(slowSQLs, args)
-		considerHarvestPayload(txnTraces, args)
-		considerHarvestPayload(spanEvents, args)
-		considerHarvestPayload(logEvents, args)
+		considerHarvestPayload(metrics, args, duc)
+		considerHarvestPayload(errors, args, duc)
+		considerHarvestPayload(slowSQLs, args, duc)
+		considerHarvestPayload(txnTraces, args, duc)
+		considerHarvestPayload(spanEvents, args, duc)
+		considerHarvestPayload(logEvents, args, duc)
 	}
 
 	eventConfigs := ah.App.connectReply.EventHarvestConfig.EventConfigs
@@ -667,7 +711,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		customEvents := harvest.CustomEvents
 		harvest.CustomEvents = NewCustomEvents(eventConfigs.CustomEventConfig.Limit)
-		considerHarvestPayload(customEvents, args)
+		considerHarvestPayload(customEvents, args, duc)
 	}
 
 	if ht&HarvestErrorEvents == HarvestErrorEvents && eventConfigs.ErrorEventConfig.Limit != 0 {
@@ -675,7 +719,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		errorEvents := harvest.ErrorEvents
 		harvest.ErrorEvents = NewErrorEvents(eventConfigs.ErrorEventConfig.Limit)
-		considerHarvestPayload(errorEvents, args)
+		considerHarvestPayload(errorEvents, args, duc)
 	}
 
 	if ht&HarvestTxnEvents == HarvestTxnEvents && eventConfigs.AnalyticEventConfig.Limit != 0 {
@@ -683,7 +727,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		txnEvents := harvest.TxnEvents
 		harvest.TxnEvents = NewTxnEvents(eventConfigs.AnalyticEventConfig.Limit)
-		considerHarvestPayloadTxnEvents(txnEvents, args)
+		considerHarvestPayloadTxnEvents(txnEvents, args, duc)
 	}
 
 	if ht&HarvestSpanEvents == HarvestSpanEvents && eventConfigs.SpanEventConfig.Limit != 0 {
@@ -691,8 +735,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		spanEvents := harvest.SpanEvents
 		harvest.SpanEvents = NewSpanEvents(eventConfigs.SpanEventConfig.Limit)
-		considerHarvestPayload(spanEvents, args)
-
+		considerHarvestPayload(spanEvents, args, duc)
 	}
 
 	if ht&HarvestLogEvents == HarvestLogEvents && eventConfigs.LogEventConfig.Limit != 0 {
@@ -700,8 +743,61 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 		logEvents := harvest.LogEvents
 		harvest.LogEvents = NewLogEvents(eventConfigs.LogEventConfig.Limit)
-		considerHarvestPayload(logEvents, args)
+		considerHarvestPayload(logEvents, args, duc)
+
 	}
+	// Only harvest data usage metrics if metrics are being harvested
+	if ht&HarvestDefaultData == HarvestDefaultData {
+		if args.blocking {
+			harvestDataUsage(args, duc)
+		} else {
+			go harvestDataUsage(args, duc)
+		}
+	}
+}
+
+func harvestDataUsage(args *harvestArgs, duc dataUsageController) {
+	duc.wg.Wait()
+	if len(duc.duc) == 0 {return} // no usage metrics found
+
+	sumPayload := 0
+	sumResponse := 0
+	sumAttempts := 0
+	type dataUsageMetrics struct {
+		attempts int
+		payloadSize int
+		responseSize int
+	}
+	dataUsageMap := make(map[string]dataUsageMetrics)
+
+	loop := true
+	for loop {
+		select {
+		case d, ok := <-duc.duc:
+			if ok {
+				usage := dataUsageMap[d.endpoint_name]
+				usage.payloadSize += d.payloadSize
+				usage.responseSize += d.responseSize
+				usage.attempts += 1
+				dataUsageMap[d.endpoint_name] = usage
+				sumPayload += d.payloadSize
+				sumResponse += d.responseSize
+				sumAttempts += 1
+			}
+		default:
+			loop = false
+		}
+	}
+
+	metrics := NewMetricTable(limits.MaxMetrics, time.Now())
+	for name, data := range(dataUsageMap) {
+		metrics.AddRaw([]byte("Supportability/" + args.agentLanguage + "/" + args.collector + "/" + name + "/Output/Bytes"),
+					   "", "", [6]float64{float64(data.attempts), float64(data.payloadSize), float64(data.responseSize), 0.0, 0.0, 0.0}, Forced)
+	}
+	metrics.AddRaw([]byte("Supportability/" + args.agentLanguage + "/" + args.collector + "/Output/Bytes"),
+				   "", "", [6]float64{float64(sumAttempts), float64(sumPayload), float64(sumResponse), 0.0, 0.0, 0.0}, Forced)
+	metrics = metrics.ApplyRules(args.rules)
+	considerHarvestPayload(metrics, args, duc)
 }
 
 func (p *Processor) doHarvest(ph ProcessorHarvest) {
@@ -741,7 +837,7 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 		splitLargePayloads: app.info.Settings["newrelic.distributed_tracing_enabled"] == true,
 		blocking:           ph.Blocking,
 	}
-	harvestByType(ph.AppHarvest, &args, harvestType)
+	harvestByType(ph.AppHarvest, &args, harvestType, p.dataUsageChannel)
 }
 
 func (p *Processor) processHarvestError(d HarvestError) {
@@ -784,6 +880,9 @@ func NewProcessor(cfg ProcessorConfig) *Processor {
 		harvestErrorChannel:   make(chan HarvestError),
 		quitChan:              make(chan struct{}),
 		processorHarvestChan:  make(chan ProcessorHarvest),
+		// We don't want data usage collection to ever block, so we create a
+		// sized buffer that will drop any excess data once filled
+		dataUsageChannel:      make(chan dataUsageInfo, 25),
 		appConnectBackoff:     limits.AppConnectAttemptBackoff,
 		cfg:                   cfg,
 	}

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -424,12 +424,14 @@ func TestUsageHarvestExceedChannel(t *testing.T) {
 	m.DoAppInfo(t, nil, AppStateConnected)
 
 	// Harvest enough data that the data usage channel overflows and drops data
+	// Make the harvest blocking so that we are guaranteed channel fills before accessing it
 	for i := 0; i < 30; i++ {
 		m.TxnData(t, idOne, txnEventSample1Times(10))
 		m.processorHarvestChan <- ProcessorHarvest{
 			AppHarvest: m.p.harvests[idOne],
 			ID:         idOne,
 			Type:       HarvestTxnEvents,
+			Blocking:	true,
 		}
 		/* collect txn data */
 		<-m.clientParams

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -823,7 +823,6 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 	}
 
 	// 8001 events. Split into two payloads of 4000 and 4001.
-	// We do not know which payload arrives first.
 	// Test that data usage metrics count properly in this case
 	m.TxnData(t, idOne, txnEventSample1Times(8001))
 	m.processorHarvestChan <- ProcessorHarvest{
@@ -831,6 +830,8 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		ID:         idOne,
 		// harvest both txn events and metrics
 		Type: HarvestTxnEvents | HarvestDefaultData,
+		// needs to be blocking to know order of clientParams
+		Blocking: true,
 	}
 	/* metrics */
 	<-m.clientParams

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -247,9 +247,9 @@ func TestProcessorHarvestDefaultData(t *testing.T) {
 	}
 	time := strings.Split(string(cp3.data), ",")[1]
 	usageMetrics := `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1333,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/transaction_sample_data/Output/Bytes"},[1,80,0,0,0,0]]]]`
+		`[[{"name":"Supportability/C/Collector/Output/Bytes"},[2,1333,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/transaction_sample_data/Output/Bytes"},[1,80,0,0,0,0]]]]`
 	if got, _ := OrderScrubMetrics(cp3.data, nil); string(got) != usageMetrics {
 		t.Fatal(string(got))
 	}
@@ -348,9 +348,9 @@ func TestProcessorHarvestCleanExit(t *testing.T) {
 
 	time := strings.Split(string(cp2.data), ",")[1]
 	usageMetrics := `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1313,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/custom_event_data/Output/Bytes"},[1,60,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]]]]`
+		`[[{"name":"Supportability/C/Collector/Output/Bytes"},[2,1313,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/custom_event_data/Output/Bytes"},[1,60,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]]]]`
 	if got, _ := OrderScrubMetrics(cp2.data, nil); string(got) != usageMetrics {
 		t.Fatal(string(got))
 	}
@@ -403,8 +403,8 @@ func TestUsageHarvest(t *testing.T) {
 		`[{"name":"Supportability/SpanEvent/TotalEventsSent"},[0,0,0,0,0,0]]]]`
 	time = strings.Split(string(cp2.data), ",")[1]
 	var expectedJSON2 = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[1,1253,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]]]]`
+		`[[{"name":"Supportability/C/Collector/Output/Bytes"},[1,1253,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]]]]`
 
 	if got1, _ := OrderScrubMetrics(cp1.data, nil); string(got1) != expectedJSON1 {
 		t.Errorf("\ngot=%q \nwant=%q", got1, expectedJSON1)
@@ -458,8 +458,8 @@ func TestUsageHarvestExceedChannel(t *testing.T) {
 	time := strings.Split(string(cp.data), ",")[1]
 	// The data usage channel only holds 25 points until dropping data
 	var expectedJSON = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[25,5275,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/analytic_event_data/Output/Bytes"},[25,5275,0,0,0,0]]]]`
+		`[[{"name":"Supportability/C/Collector/Output/Bytes"},[25,5275,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/analytic_event_data/Output/Bytes"},[25,5275,0,0,0,0]]]]`
 
 	if got, _ := OrderScrubMetrics(cp.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)
@@ -539,8 +539,8 @@ func TestSupportabilityHarvest(t *testing.T) {
 	time = strings.Split(string(cp2.data), ",")[1]
 	// includes usage of the first data usage metrics sent
 	var expectedJSON2 = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1584,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[2,1584,0,0,0,0]]]]`
+		`[[{"name":"Supportability/C/Collector/Output/Bytes"},[2,1584,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/metric_data/Output/Bytes"},[2,1584,0,0,0,0]]]]`
 
 	if got, _ := OrderScrubMetrics(cp1.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)
@@ -868,9 +868,9 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 	// usage metrics comparison
 	time := strings.Split(string(cp3.data), ",")[1]
 	var expectedJSON = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[6,289520,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/analytic_event_data/Output/Bytes"},[5,288261,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1259,0,0,0,0]]]]`
+		`[[{"name":"Supportability/C/Collector/Output/Bytes"},[6,289520,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/analytic_event_data/Output/Bytes"},[5,288261,0,0,0,0]],` +
+		`[{"name":"Supportability/C/Collector/metric_data/Output/Bytes"},[1,1259,0,0,0,0]]]]`
 
 	if got, _ := OrderScrubMetrics(cp3.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -153,10 +153,10 @@ func (m *MockedProcessor) QuitTestProcessor() {
 	// blocking, as a new harvest was triggered and then the trackProgress
 	// channel is waiting to be consumed
 	select {
-		case <-m.p.trackProgress:
-			// receive harvest notice
-		default:
-			// nothing on channel
+	case <-m.p.trackProgress:
+		// receive harvest notice
+	default:
+		// nothing on channel
 	}
 	m.p.quit()
 }
@@ -227,13 +227,13 @@ func TestProcessorHarvestDefaultData(t *testing.T) {
 	// this code path will trigger three `harvestPayload` calls, so we need
 	// to pluck three items out of the clientParams channels
 	/* collect txn */
-	m.clientReturn <- ClientReturn{nil,nil,202}
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp := <-m.clientParams
 	/* collect metrics */
-	m.clientReturn <- ClientReturn{nil,nil,202}
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp2 := <-m.clientParams
 	/* collect usage metrics */
-	m.clientReturn <- ClientReturn{nil,nil,202}
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp3 := <-m.clientParams
 
 	<-m.p.trackProgress // unblock processor after harvest
@@ -273,7 +273,7 @@ func TestProcessorHarvestCustomEvents(t *testing.T) {
 		Type:       HarvestCustomEvents,
 	}
 	/* collect metrics */
-	m.clientReturn <- ClientReturn{nil,nil,202}
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp := <-m.clientParams
 
 	<-m.p.trackProgress // unblock processor after harvest
@@ -305,7 +305,7 @@ func TestProcessorHarvestLogEvents(t *testing.T) {
 		Type:       HarvestLogEvents,
 	}
 	/* collect logs */
-	m.clientReturn <- ClientReturn{nil,nil,202}
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp := <-m.clientParams
 
 	<-m.p.trackProgress // unblock processor after harvest
@@ -337,8 +337,8 @@ func TestProcessorHarvestCleanExit(t *testing.T) {
 
 	m.p.CleanExit()
 
-	<-m.clientParams /* ditch metrics */
-	cp := <-m.clientParams /* custom events */
+	<-m.clientParams        /* ditch metrics */
+	cp := <-m.clientParams  /* custom events */
 	cp2 := <-m.clientParams /* usage metrics */
 
 	expected := `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]`
@@ -373,10 +373,10 @@ func TestUsageHarvest(t *testing.T) {
 	}
 	/* collect metrics */
 	cp1 := <-m.clientParams
-	m.clientReturn <- ClientReturn{nil,nil,202}
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	/* collect usage metrics */
 	cp2 := <-m.clientParams
-	m.clientReturn <- ClientReturn{nil,nil,202}
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 
 	<-m.p.trackProgress // unblock processor after harvest
 
@@ -433,7 +433,7 @@ func TestUsageHarvestExceedChannel(t *testing.T) {
 		}
 		/* collect txn data */
 		<-m.clientParams
-		m.clientReturn <- ClientReturn{nil,nil,202}
+		m.clientReturn <- ClientReturn{nil, nil, 202}
 		<-m.p.trackProgress // unblock processor after harvest
 	}
 
@@ -445,7 +445,7 @@ func TestUsageHarvestExceedChannel(t *testing.T) {
 	// No other payloads are sent because the harvest is empty
 	/* collect usage metrics */
 	cp := <-m.clientParams
-	m.clientReturn <- ClientReturn{nil,nil,202}
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 
 	<-m.p.trackProgress // unblock processor after harvest
 
@@ -828,7 +828,7 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		AppHarvest: m.p.harvests[idOne],
 		ID:         idOne,
 		// harvest both txn events and metrics
-		Type:       HarvestTxnEvents|HarvestDefaultData,
+		Type: HarvestTxnEvents | HarvestDefaultData,
 	}
 	/* metrics */
 	<-m.clientParams
@@ -895,7 +895,7 @@ func TestForceRestart(t *testing.T) {
 		t.Fatal(string(cp.data))
 	}
 
-    // Reconnect after restart exception
+	// Reconnect after restart exception
 	m.DoConnect(t, &idTwo)
 	m.DoAppInfo(t, &idOne, AppStateConnected)
 

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -41,10 +41,10 @@ const (
 
 // These clients exist for testing.
 var (
-	DisconnectClient = collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
+	DisconnectClient = collector.ClientFn(func(cmd *collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
 		return collector.RPMResponse{Body: nil, Err: SampleDisonnectException, StatusCode: 410}
 	})
-	LicenseInvalidClient = collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
+	LicenseInvalidClient = collector.ClientFn(func(cmd *collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
 		return collector.RPMResponse{Body: nil, Err: SampleLicenseInvalidException, StatusCode: 401}
 	})
 	SampleRestartException        = &rpmException{ErrorType: forceRestartType}
@@ -89,8 +89,9 @@ func NewMockedProcessor(numberOfHarvestPayload int) *MockedProcessor {
 	clientReturn := make(chan ClientReturn, numberOfHarvestPayload)
 	clientParams := make(chan ClientParams, numberOfHarvestPayload)
 
-	client := collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
+	client := collector.ClientFn(func(cmd *collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
 		data, err := cs.Collectible.CollectorJSON(false)
+		cmd.Data = data
 		if nil != err {
 			return collector.RPMResponse{Err: err}
 		}
@@ -145,6 +146,19 @@ func (m *MockedProcessor) DoConnectConfiguredReply(t *testing.T, reply string) {
 func (m *MockedProcessor) TxnData(t *testing.T, id AgentRunID, sample AggregaterInto) {
 	m.p.IncomingTxnData(id, sample)
 	<-m.p.trackProgress
+}
+
+func (m *MockedProcessor) QuitTestProcessor() {
+	// If the test took a while to run, it's possible that the processor is
+	// blocking, as a new harvest was triggered and then the trackProgress
+	// channel is waiting to be consumed
+	select {
+		case <-m.p.trackProgress:
+			// receive harvest notice
+		default:
+			// nothing on channel
+	}
+	m.p.quit()
 }
 
 type AggregaterIntoFn func(*Harvest)
@@ -210,11 +224,19 @@ func TestProcessorHarvestDefaultData(t *testing.T) {
 		Type:       HarvestDefaultData,
 	}
 
-	// this code path will trigger two `harvestPayload` calls, so we need
-	// to pluck two items out of the clientParams channels
+	// this code path will trigger three `harvestPayload` calls, so we need
+	// to pluck three items out of the clientParams channels
+	/* collect txn */
+	m.clientReturn <- ClientReturn{nil,nil,202}
 	cp := <-m.clientParams
+	/* collect metrics */
+	m.clientReturn <- ClientReturn{nil,nil,202}
 	cp2 := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice
+	/* collect usage metrics */
+	m.clientReturn <- ClientReturn{nil,nil,202}
+	cp3 := <-m.clientParams
+
+	<-m.p.trackProgress // unblock processor after harvest
 
 	toTest := `["one",[[0,0,"","",` + encoded + `,"",null,false,null,null]]]`
 
@@ -223,8 +245,16 @@ func TestProcessorHarvestDefaultData(t *testing.T) {
 			t.Fatal(string(append(cp.data, cp2.data...)))
 		}
 	}
+	time := strings.Split(string(cp3.data), ",")[1]
+	usageMetrics := `["one",` + time + `,` + time + `,` +
+		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[2,1335,0,0,0,0]],` +
+		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[1,1255,0,0,0,0]],` +
+		`[{"name":"Supportability/c/specific_collector.com/transaction_sample_data/Output/Bytes"},[1,80,0,0,0,0]]]]`
+	if got, _ := OrderScrubMetrics(cp3.data, nil); string(got) != usageMetrics {
+		t.Fatal(string(got))
+	}
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestCustomEvents(t *testing.T) {
@@ -242,14 +272,18 @@ func TestProcessorHarvestCustomEvents(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestCustomEvents,
 	}
+	/* collect metrics */
+	m.clientReturn <- ClientReturn{nil,nil,202}
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice
+
+	<-m.p.trackProgress // unblock processor after harvest
+
 	expected := `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]`
 	if string(cp.data) != expected {
 		t.Fatalf("expected: %s \ngot: %s", expected, string(cp.data))
 	}
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestLogEvents(t *testing.T) {
@@ -270,14 +304,18 @@ func TestProcessorHarvestLogEvents(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestLogEvents,
 	}
+	/* collect logs */
+	m.clientReturn <- ClientReturn{nil,nil,202}
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice
+
+	<-m.p.trackProgress // unblock processor after harvest
+
 	expected := `[{"common": {"attributes": {}},"logs": [log event test birthday]}]`
 	if string(cp.data) != expected {
 		t.Fatalf("expected: %s \ngot: %s", expected, string(cp.data))
 	}
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestCleanExit(t *testing.T) {
@@ -295,16 +333,86 @@ func TestProcessorHarvestCleanExit(t *testing.T) {
 	// supportability and reporting metrics are added
 	m.clientReturn <- ClientReturn{} /* metrics */
 	m.clientReturn <- ClientReturn{} /* events */
+	m.clientReturn <- ClientReturn{} /* usage metrics */
 
 	m.p.CleanExit()
 
 	<-m.clientParams /* ditch metrics */
-	cp := <-m.clientParams
+	cp := <-m.clientParams /* custom events */
+	cp2 := <-m.clientParams /* usage metrics */
 
 	expected := `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]`
 	if string(cp.data) != expected {
 		t.Fatalf("expected: %s \ngot: %s", expected, string(cp.data))
 	}
+
+	time := strings.Split(string(cp2.data), ",")[1]
+	usageMetrics := `["one",` + time + `,` + time + `,` +
+		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[2,1315,0,0,0,0]],` +
+		`[{"name":"Supportability/c/specific_collector.com/custom_event_data/Output/Bytes"},[1,60,0,0,0,0]],` +
+		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[1,1255,0,0,0,0]]]]`
+	if got, _ := OrderScrubMetrics(cp2.data, nil); string(got) != usageMetrics {
+		t.Fatal(string(got))
+	}
+}
+
+func TestUsageHarvest(t *testing.T) {
+	m := NewMockedProcessor(1)
+
+	m.DoAppInfo(t, nil, AppStateUnknown)
+
+	m.DoConnect(t, &idOne)
+	m.DoAppInfo(t, nil, AppStateConnected)
+
+	m.TxnData(t, idOne, txnErrorEventSample)
+
+	m.processorHarvestChan <- ProcessorHarvest{
+		AppHarvest: m.p.harvests[idOne],
+		ID:         idOne,
+		Type:       HarvestDefaultData,
+	}
+	/* collect metrics */
+	cp1 := <-m.clientParams
+	m.clientReturn <- ClientReturn{nil,nil,202}
+	/* collect usage metrics */
+	cp2 := <-m.clientParams
+	m.clientReturn <- ClientReturn{nil,nil,202}
+
+	<-m.p.trackProgress // unblock processor after harvest
+
+	// Because MockedProcessor wraps a real processor, we have no way to directly set the time
+	//   of harvests. So we extract the time from what we receive
+	time := strings.Split(string(cp1.data), ",")[1]
+	var expectedJSON1 = `["one",` + time + `,` + time + `,` +
+		`[[{"name":"Instance/Reporting"},[1,0,0,0,0,0]],` +
+		`[{"name":"Supportability/AnalyticsEvents/TotalEventsSeen"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/AnalyticsEvents/TotalEventsSent"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/AnalyticEventData/HarvestLimit"},[10000,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/CustomEventData/HarvestLimit"},[5,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/ErrorEventData/HarvestLimit"},[5,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/LogEventData/HarvestLimit"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/ReportPeriod"},[5000000000,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/SpanEventData/HarvestLimit"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Events/Customer/Seen"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Events/Customer/Sent"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Events/TransactionError/Seen"},[1,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Events/TransactionError/Sent"},[1,0,0,0,0,0]],` +
+		`[{"name":"Supportability/LogEvent/TotalEventsSeen"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/LogEvent/TotalEventsSent"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/SpanEvent/TotalEventsSeen"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/SpanEvent/TotalEventsSent"},[0,0,0,0,0,0]]]]`
+	time = strings.Split(string(cp2.data), ",")[1]
+	var expectedJSON2 = `["one",` + time + `,` + time + `,` +
+		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[1,1255,0,0,0,0]],` +
+		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[1,1255,0,0,0,0]]]]`
+
+	if got1, _ := OrderScrubMetrics(cp1.data, nil); string(got1) != expectedJSON1 {
+		t.Errorf("\ngot=%q \nwant=%q", got1, expectedJSON1)
+	}
+	if got2, _ := OrderScrubMetrics(cp2.data, nil); string(got2) != expectedJSON2 {
+		t.Errorf("\ngot=%q \nwant=%q", got2, expectedJSON2)
+	}
+	m.QuitTestProcessor()
 }
 
 func TestSupportabilityHarvest(t *testing.T) {
@@ -325,59 +433,49 @@ func TestSupportabilityHarvest(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestDefaultData,
 	}
-	<-m.p.trackProgress              // receive harvest notice
-	m.clientReturn <- ClientReturn{} /* metrics */
-	//<-m.p.trackProgress // receive harvest
+
+	<-m.p.trackProgress // unblock processor after harvest to receive error
+
+	/* metrics */
+	// Add timeout error response code
+	<-m.clientParams
+	m.clientReturn <- ClientReturn{nil, ErrUnsupportedMedia, 408}
+	/* usage metrics */
+	<-m.clientParams
+	m.clientReturn <- ClientReturn{nil, nil, 202}
+
+	<-m.p.trackProgress // unblock processor after harvest error
 
 	m.processorHarvestChan <- ProcessorHarvest{
 		AppHarvest: m.p.harvests[idOne],
 		ID:         idOne,
 		Type:       HarvestDefaultData,
 	}
-	<-m.p.trackProgress // receive harvest notice
 
-	cp := <-m.clientParams
-	// Add timeout error response code for second harvest
-	m.clientReturn <- ClientReturn{nil, ErrUnsupportedMedia, 408}
-	<-m.p.trackProgress // receive harvest error
+	/* error event */
+	cp1 := <-m.clientParams
+	m.clientReturn <- ClientReturn{}
+	/* usage metrics */
+	cp2 := <-m.clientParams
+	m.clientReturn <- ClientReturn{}
 
-	harvest := m.p.harvests[idOne]
-	limits := collector.EventHarvestConfig{
-		ReportPeriod: 1234,
-		EventConfigs: collector.EventConfigs{
-			ErrorEventConfig: collector.Event{
-				Limit: 1,
-			},
-			AnalyticEventConfig: collector.Event{
-				Limit: 2,
-			},
-			CustomEventConfig: collector.Event{
-				Limit: 3,
-			},
-			SpanEventConfig: collector.Event{
-				Limit: 4,
-			},
-			LogEventConfig: collector.Event{
-				Limit: 5,
-			},
-		},
-	}
-	harvest.createFinalMetrics(limits, nil)
+	<-m.p.trackProgress // unblock processor after harvest
+
 	// Because MockedProcessor wraps a real processor, we have no way to directly set the time
 	//   of harvests. So we extract the time from what we receive
-	time := strings.Split(string(cp.data), ",")[1]
-	var expectedJSON = `["one",` + time + `,1417136520,` +
+	time := strings.Split(string(cp1.data), ",")[1]
+	var expectedJSON = `["one",` + time + `,` + time + `,` +
 		`[[{"name":"Instance/Reporting"},[2,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Agent/Collector/HTTPError/408"},[1,0,0,0,0,0]],` + // Check for HTTPError Supportability metric
 		`[{"name":"Supportability/Agent/Collector/metric_data/Attempts"},[1,0,0,0,0,0]],` + //	Metrics were sent first when the 408 error occurred, so check for the metric failure.
 		`[{"name":"Supportability/AnalyticsEvents/TotalEventsSeen"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/AnalyticsEvents/TotalEventsSent"},[0,0,0,0,0,0]],` +
-		`[{"name":"Supportability/EventHarvest/AnalyticEventData/HarvestLimit"},[10002,0,0,0,0,0]],` +
-		`[{"name":"Supportability/EventHarvest/CustomEventData/HarvestLimit"},[8,0,0,0,0,0]],` +
-		`[{"name":"Supportability/EventHarvest/ErrorEventData/HarvestLimit"},[6,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/AnalyticEventData/HarvestLimit"},[20000,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/CustomEventData/HarvestLimit"},[10,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/ErrorEventData/HarvestLimit"},[10,0,0,0,0,0]],` +
 		`[{"name":"Supportability/EventHarvest/LogEventData/HarvestLimit"},[10,0,0,0,0,0]],` +
-		`[{"name":"Supportability/EventHarvest/ReportPeriod"},[5000001234,0,0,0,0,0]],` +
-		`[{"name":"Supportability/EventHarvest/SpanEventData/HarvestLimit"},[4,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/ReportPeriod"},[10000000000,0,0,0,0,0]],` +
+		`[{"name":"Supportability/EventHarvest/SpanEventData/HarvestLimit"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Events/Customer/Seen"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Events/Customer/Sent"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Events/TransactionError/Seen"},[2,0,0,0,0,0]],` +
@@ -386,15 +484,19 @@ func TestSupportabilityHarvest(t *testing.T) {
 		`[{"name":"Supportability/Logging/Forwarding/Sent"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/SpanEvent/TotalEventsSeen"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/SpanEvent/TotalEventsSent"},[0,0,0,0,0,0]]]]`
+	time = strings.Split(string(cp2.data), ",")[1]
+	// includes usage of the first data usage metrics sent
+	var expectedJSON2 = `["one",` + time + `,` + time + `,` +
+		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[2,1612,0,0,0,0]],` +
+		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[2,1612,0,0,0,0]]]]`
 
-	json, err := harvest.Metrics.CollectorJSONSorted(AgentRunID(idOne), end)
-	if nil != err {
-		t.Fatal(err)
-	}
-	if got := string(json); got != expectedJSON {
+	if got, _ := OrderScrubMetrics(cp1.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)
 	}
-	m.p.quit()
+	if got2, _ := OrderScrubMetrics(cp2.data, nil); string(got2) != expectedJSON2 {
+		t.Errorf("\ngot=%q \nwant=%q", got2, expectedJSON2)
+	}
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestErrorEvents(t *testing.T) {
@@ -412,13 +514,17 @@ func TestProcessorHarvestErrorEvents(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestErrorEvents,
 	}
+
+	<-m.p.trackProgress // unblock processor after harvest
+	/* error events */
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice
+	m.clientReturn <- ClientReturn{nil, nil, 202}
+
 	if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[forgotten birthday]]` {
 		t.Fatal(string(cp.data))
 	}
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestSpanEvents(t *testing.T) {
@@ -440,13 +546,15 @@ func TestProcessorHarvestSpanEvents(t *testing.T) {
 		Type:       HarvestSpanEvents,
 	}
 
+	<-m.p.trackProgress // unblock processor after harvest
+	/* span events */
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice, two span events in the data
+	m.clientReturn <- ClientReturn{nil, nil, 202}
+
 	if string(cp.data) != `["one",{"reservoir_size":7,"events_seen":2},[belated birthday,belated birthday]]` {
 		t.Fatal(string(cp.data))
 	}
-	m.p.quit()
-
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestSpanEventsZeroReservoir(t *testing.T) {
@@ -472,7 +580,7 @@ func TestProcessorHarvestSpanEventsZeroReservoir(t *testing.T) {
 
 	// No check of m.clientParams here because we expect no harvest to occur
 	// due to the zero error_event_data limit.
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock processor after harvest
 
 	// Now we'll force a harvest for a different event type, and make sure we
 	// receive that harvest (and not a span event harvest).
@@ -481,14 +589,16 @@ func TestProcessorHarvestSpanEventsZeroReservoir(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestCustomEvents,
 	}
+	<-m.p.trackProgress // unblock processor after harvest
 
+	/* custom events */
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice
+
 	if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]` {
 		t.Fatal(string(cp.data))
 	}
-	m.p.quit()
-
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestSpanEventsExceedReservoir(t *testing.T) {
@@ -510,13 +620,16 @@ func TestProcessorHarvestSpanEventsExceedReservoir(t *testing.T) {
 		Type:       HarvestSpanEvents,
 	}
 
+	<-m.p.trackProgress // unblock processor after harvest, with 2 span events seen, but only one span sent
+
+	/* span event */
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice with 2 span events seen, but only one span sent
+
 	if string(cp.data) != `["one",{"reservoir_size":1,"events_seen":2},[belated birthday]]` {
 		t.Fatal(string(cp.data))
 	}
-	m.p.quit()
-
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestZeroErrorEvents(t *testing.T) {
@@ -539,7 +652,7 @@ func TestProcessorHarvestZeroErrorEvents(t *testing.T) {
 	}
 	// No check of m.clientParams here because we expect no harvest to occur
 	// due to the zero error_event_data limit.
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock processor
 
 	// Now we'll force a harvest for a different event type, and make sure we
 	// receive that harvest (and not an error event harvest).
@@ -548,14 +661,16 @@ func TestProcessorHarvestZeroErrorEvents(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestCustomEvents,
 	}
+	<-m.p.trackProgress // unblock processor
 
+	/* custom events */
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice
+
 	if string(cp.data) != `["one",{"reservoir_size":5,"events_seen":1},[half birthday]]` {
 		t.Fatal(string(cp.data))
 	}
-	m.p.quit()
-
+	m.QuitTestProcessor()
 }
 
 func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
@@ -591,14 +706,18 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
+
+	<-m.p.trackProgress // unblock processor
+	/* txn events */
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp1 := <-m.clientParams
-	<-m.p.trackProgress
+
 	cp1Events := getEventsSeen(cp1.data)
 	if cp1Events != 9000 {
 		t.Fatal("Expected 9000 events")
 	}
 
-	m.p.quit()
+	m.QuitTestProcessor()
 
 	// Distributed tracing activated.
 	// ------------------------------
@@ -620,8 +739,11 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
+	/* txn events */
 	cp1 = <-m.clientParams
-	<-m.p.trackProgress
+	m.clientReturn <- ClientReturn{}
+	<-m.p.trackProgress // unblock processor
+
 	cp1Events = getEventsSeen(cp1.data)
 	if cp1Events != 4999 {
 		t.Fatal("Expected 4999 events")
@@ -634,9 +756,15 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
+	/* txn events first payload */
 	cp1 = <-m.clientParams
+	m.clientReturn <- ClientReturn{}
+	/* txn events second payload */
 	cp2 := <-m.clientParams
-	<-m.p.trackProgress
+	m.clientReturn <- ClientReturn{}
+
+	<-m.p.trackProgress // unblock processor
+
 	cp1Events = getEventsSeen(cp1.data)
 	cp2Events := getEventsSeen(cp2.data)
 	if cp1Events != 2500 {
@@ -654,9 +782,16 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
+	/* txn events first payload */
 	cp1 = <-m.clientParams
+	m.clientReturn <- ClientReturn{}
+	/* txn events second payload */
 	cp2 = <-m.clientParams
 	<-m.p.trackProgress
+	m.clientReturn <- ClientReturn{}
+
+	<-m.p.trackProgress // unblock processor
+
 	cp1Events = getEventsSeen(cp1.data)
 	cp2Events = getEventsSeen(cp2.data)
 	if cp1Events != 4000 && cp2Events != 4000 {
@@ -666,7 +801,7 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		t.Fatal("Payload sum of 8001 events expected, got ", cp1Events, " and ", cp2Events)
 	}
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestForceRestart(t *testing.T) {
@@ -684,17 +819,20 @@ func TestForceRestart(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
+	<-m.p.trackProgress // unblock processor
+
+	// Test processor receiving restart exception
+	/* txn events */
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice
+	m.clientReturn <- ClientReturn{nil, SampleRestartException, 401}
+	<-m.p.trackProgress // unblock processor after handling harvest restart error
+
 	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
 
-	m.clientReturn <- ClientReturn{nil, SampleRestartException, 401}
-	<-m.p.trackProgress // receive harvest error
-
+    // Reconnect after restart exception
 	m.DoConnect(t, &idTwo)
-
 	m.DoAppInfo(t, &idOne, AppStateConnected)
 
 	m.TxnData(t, idOne, txnEventSample1)
@@ -706,13 +844,16 @@ func TestForceRestart(t *testing.T) {
 		Type:       HarvestTxnEvents,
 	}
 
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock processor after  harvest notice
+	/* txn events */
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	cp = <-m.clientParams
+
 	if string(cp.data) != `["two",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestDisconnectAtPreconnect(t *testing.T) {
@@ -726,7 +867,7 @@ func TestDisconnectAtPreconnect(t *testing.T) {
 
 	m.DoAppInfo(t, nil, AppStateDisconnected)
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestLicenseExceptionAtPreconnect(t *testing.T) {
@@ -740,7 +881,7 @@ func TestLicenseExceptionAtPreconnect(t *testing.T) {
 
 	m.DoAppInfo(t, nil, AppStateInvalidLicense)
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestDisconnectAtConnect(t *testing.T) {
@@ -756,7 +897,7 @@ func TestDisconnectAtConnect(t *testing.T) {
 
 	m.DoAppInfo(t, nil, AppStateDisconnected)
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestDisconnectAtHarvest(t *testing.T) {
@@ -777,19 +918,26 @@ func TestDisconnectAtHarvest(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestAll,
 	}
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock after harvest notice
 
+	/* txn data */
 	<-m.clientParams
 	m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
-	<-m.p.trackProgress // receive harvest error
+	<-m.p.trackProgress // unblock after harvest error
 
+	/* metrics */
 	<-m.clientParams
 	m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
-	<-m.p.trackProgress // receive harvest error
+	<-m.p.trackProgress // unblock after harvest error
+
+	/* usage metrics */
+	<-m.clientParams
+	m.clientReturn <- ClientReturn{nil, SampleDisonnectException, 410}
+	<-m.p.trackProgress // unblock after harvest error
 
 	m.DoAppInfo(t, nil, AppStateDisconnected)
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestLicenseExceptionAtHarvest(t *testing.T) {
@@ -807,19 +955,21 @@ func TestLicenseExceptionAtHarvest(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
+	<-m.p.trackProgress // unblock after harvest notice
+
+	/* txn */
 	cp := <-m.clientParams
-	<-m.p.trackProgress // receive harvest notice
+	m.clientReturn <- ClientReturn{nil, SampleLicenseInvalidException, 401}
+	<-m.p.trackProgress // unblock after harvest error
+
 	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
 
-	m.clientReturn <- ClientReturn{nil, SampleLicenseInvalidException, 401}
-	<-m.p.trackProgress // receive harvest error
-
 	// Unknown app state triggered immediately following AppStateRestart
 	m.DoAppInfo(t, nil, AppStateUnknown)
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestMalformedConnectReply(t *testing.T) {
@@ -835,7 +985,7 @@ func TestMalformedConnectReply(t *testing.T) {
 
 	m.DoAppInfo(t, nil, AppStateUnknown)
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestMalformedCollector(t *testing.T) {
@@ -849,7 +999,7 @@ func TestMalformedCollector(t *testing.T) {
 
 	m.DoAppInfo(t, nil, AppStateUnknown)
 
-	m.p.quit()
+	m.QuitTestProcessor()
 }
 
 func TestDataSavedOnHarvestError(t *testing.T) {
@@ -867,24 +1017,28 @@ func TestDataSavedOnHarvestError(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock after harvest notice
 
+	/* txn events */
 	cp := <-m.clientParams
 	m.clientReturn <- ClientReturn{nil, errors.New("unusual error"), 500}
+	<-m.p.trackProgress // unblock after harvest error
+
 	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
-	<-m.p.trackProgress // receive harvest error
 
 	m.processorHarvestChan <- ProcessorHarvest{
 		AppHarvest: m.p.harvests[idOne],
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock after harvest notice
 
+	/* txn events */
 	cp = <-m.clientParams
 	m.clientReturn <- ClientReturn{nil, nil, 202}
+
 	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
@@ -905,14 +1059,15 @@ func TestNoDataSavedOnPayloadTooLarge(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock after harvest notice
 
+	/* txn events */
 	cp := <-m.clientParams
 	m.clientReturn <- ClientReturn{nil, ErrPayloadTooLarge, 413}
 	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
-	<-m.p.trackProgress // receive harvest error
+	<-m.p.trackProgress // unblock after harvest error
 
 	m.TxnData(t, idOne, txnEventSample2)
 
@@ -921,10 +1076,12 @@ func TestNoDataSavedOnPayloadTooLarge(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock after harvest notice
 
+	/* txn events */
 	cp = <-m.clientParams
 	m.clientReturn <- ClientReturn{nil, nil, 202}
+
 	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
@@ -945,14 +1102,15 @@ func TestNoDataSavedOnErrUnsupportedMedia(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock after harvest notice
 
+	/* txn events */
 	cp := <-m.clientParams
 	m.clientReturn <- ClientReturn{nil, ErrUnsupportedMedia, 415}
 	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":1},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
-	<-m.p.trackProgress // receive harvest error
+	<-m.p.trackProgress // unblock after harvest error
 
 	m.TxnData(t, idOne, txnEventSample2)
 
@@ -961,10 +1119,12 @@ func TestNoDataSavedOnErrUnsupportedMedia(t *testing.T) {
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
 	}
-	<-m.p.trackProgress // receive harvest notice
+	<-m.p.trackProgress // unblock after harvest notice
 
+	/* txn events */
 	cp = <-m.clientParams
 	m.clientReturn <- ClientReturn{nil, nil, 202}
+
 	if string(cp.data) != `["one",{"reservoir_size":10000,"events_seen":1},[[{"x":2},{},{}]]]` {
 		t.Fatal(string(cp.data))
 	}
@@ -986,7 +1146,7 @@ var (
 		HighSecurity:      true,
 		Hostname:          "agent-hostname",
 	}
-	connectClient = collector.ClientFn(func(cmd collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
+	connectClient = collector.ClientFn(func(cmd *collector.RpmCmd, cs collector.RpmControls) collector.RPMResponse {
 		if cmd.Name == collector.CommandPreconnect {
 			return collector.RPMResponse{Body: []byte(`{"redirect_host":"specific_collector.com"}`), Err: nil, StatusCode: 202}
 		}

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -247,8 +247,8 @@ func TestProcessorHarvestDefaultData(t *testing.T) {
 	}
 	time := strings.Split(string(cp3.data), ",")[1]
 	usageMetrics := `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1335,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1255,0,0,0,0]],` +
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1333,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]],` +
 		`[{"name":"Supportability/c/Collector/transaction_sample_data/Output/Bytes"},[1,80,0,0,0,0]]]]`
 	if got, _ := OrderScrubMetrics(cp3.data, nil); string(got) != usageMetrics {
 		t.Fatal(string(got))
@@ -348,9 +348,9 @@ func TestProcessorHarvestCleanExit(t *testing.T) {
 
 	time := strings.Split(string(cp2.data), ",")[1]
 	usageMetrics := `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1315,0,0,0,0]],` +
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1313,0,0,0,0]],` +
 		`[{"name":"Supportability/c/Collector/custom_event_data/Output/Bytes"},[1,60,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1255,0,0,0,0]]]]`
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]]]]`
 	if got, _ := OrderScrubMetrics(cp2.data, nil); string(got) != usageMetrics {
 		t.Fatal(string(got))
 	}
@@ -397,14 +397,14 @@ func TestUsageHarvest(t *testing.T) {
 		`[{"name":"Supportability/Events/Customer/Sent"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Events/TransactionError/Seen"},[1,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Events/TransactionError/Sent"},[1,0,0,0,0,0]],` +
-		`[{"name":"Supportability/LogEvent/TotalEventsSeen"},[0,0,0,0,0,0]],` +
-		`[{"name":"Supportability/LogEvent/TotalEventsSent"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Logging/Forwarding/Seen"},[0,0,0,0,0,0]],` +
+		`[{"name":"Supportability/Logging/Forwarding/Sent"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/SpanEvent/TotalEventsSeen"},[0,0,0,0,0,0]],` +
 		`[{"name":"Supportability/SpanEvent/TotalEventsSent"},[0,0,0,0,0,0]]]]`
 	time = strings.Split(string(cp2.data), ",")[1]
 	var expectedJSON2 = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[1,1255,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1255,0,0,0,0]]]]`
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[1,1253,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1253,0,0,0,0]]]]`
 
 	if got1, _ := OrderScrubMetrics(cp1.data, nil); string(got1) != expectedJSON1 {
 		t.Errorf("\ngot=%q \nwant=%q", got1, expectedJSON1)
@@ -535,8 +535,8 @@ func TestSupportabilityHarvest(t *testing.T) {
 	time = strings.Split(string(cp2.data), ",")[1]
 	// includes usage of the first data usage metrics sent
 	var expectedJSON2 = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1586,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[2,1586,0,0,0,0]]]]`
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1584,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[2,1584,0,0,0,0]]]]`
 
 	if got, _ := OrderScrubMetrics(cp1.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)
@@ -864,9 +864,9 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 	// usage metrics comparison
 	time := strings.Split(string(cp3.data), ",")[1]
 	var expectedJSON = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[6,289522,0,0,0,0]],` +
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[6,289520,0,0,0,0]],` +
 		`[{"name":"Supportability/c/Collector/analytic_event_data/Output/Bytes"},[5,288261,0,0,0,0]],` +
-		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1261,0,0,0,0]]]]`
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1259,0,0,0,0]]]]`
 
 	if got, _ := OrderScrubMetrics(cp3.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -247,9 +247,9 @@ func TestProcessorHarvestDefaultData(t *testing.T) {
 	}
 	time := strings.Split(string(cp3.data), ",")[1]
 	usageMetrics := `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[2,1335,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[1,1255,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/transaction_sample_data/Output/Bytes"},[1,80,0,0,0,0]]]]`
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1335,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1255,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/transaction_sample_data/Output/Bytes"},[1,80,0,0,0,0]]]]`
 	if got, _ := OrderScrubMetrics(cp3.data, nil); string(got) != usageMetrics {
 		t.Fatal(string(got))
 	}
@@ -348,9 +348,9 @@ func TestProcessorHarvestCleanExit(t *testing.T) {
 
 	time := strings.Split(string(cp2.data), ",")[1]
 	usageMetrics := `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[2,1315,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/custom_event_data/Output/Bytes"},[1,60,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[1,1255,0,0,0,0]]]]`
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1315,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/custom_event_data/Output/Bytes"},[1,60,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1255,0,0,0,0]]]]`
 	if got, _ := OrderScrubMetrics(cp2.data, nil); string(got) != usageMetrics {
 		t.Fatal(string(got))
 	}
@@ -403,8 +403,8 @@ func TestUsageHarvest(t *testing.T) {
 		`[{"name":"Supportability/SpanEvent/TotalEventsSent"},[0,0,0,0,0,0]]]]`
 	time = strings.Split(string(cp2.data), ",")[1]
 	var expectedJSON2 = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[1,1255,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[1,1255,0,0,0,0]]]]`
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[1,1255,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1255,0,0,0,0]]]]`
 
 	if got1, _ := OrderScrubMetrics(cp1.data, nil); string(got1) != expectedJSON1 {
 		t.Errorf("\ngot=%q \nwant=%q", got1, expectedJSON1)
@@ -454,8 +454,8 @@ func TestUsageHarvestExceedChannel(t *testing.T) {
 	time := strings.Split(string(cp.data), ",")[1]
 	// The data usage channel only holds 25 points until dropping data
 	var expectedJSON = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[25,5275,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/analytic_event_data/Output/Bytes"},[25,5275,0,0,0,0]]]]`
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[25,5275,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/analytic_event_data/Output/Bytes"},[25,5275,0,0,0,0]]]]`
 
 	if got, _ := OrderScrubMetrics(cp.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)
@@ -535,8 +535,8 @@ func TestSupportabilityHarvest(t *testing.T) {
 	time = strings.Split(string(cp2.data), ",")[1]
 	// includes usage of the first data usage metrics sent
 	var expectedJSON2 = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[2,1612,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[2,1612,0,0,0,0]]]]`
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[2,1586,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[2,1586,0,0,0,0]]]]`
 
 	if got, _ := OrderScrubMetrics(cp1.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)
@@ -860,9 +860,9 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 	// usage metrics comparison
 	time := strings.Split(string(cp3.data), ",")[1]
 	var expectedJSON = `["one",` + time + `,` + time + `,` +
-		`[[{"name":"Supportability/c/specific_collector.com/Output/Bytes"},[6,289522,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/analytic_event_data/Output/Bytes"},[5,288261,0,0,0,0]],` +
-		`[{"name":"Supportability/c/specific_collector.com/metric_data/Output/Bytes"},[1,1261,0,0,0,0]]]]`
+		`[[{"name":"Supportability/c/Collector/Output/Bytes"},[6,289522,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/analytic_event_data/Output/Bytes"},[5,288261,0,0,0,0]],` +
+		`[{"name":"Supportability/c/Collector/metric_data/Output/Bytes"},[1,1261,0,0,0,0]]]]`
 
 	if got, _ := OrderScrubMetrics(cp3.data, nil); string(got) != expectedJSON {
 		t.Errorf("\ngot=%q \nwant=%q", got, expectedJSON)

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -439,12 +439,16 @@ func TestUsageHarvestExceedChannel(t *testing.T) {
 		<-m.p.trackProgress // unblock processor after harvest
 	}
 
+	m.TxnData(t, idOne, txnEventSample1Times(10))
 	m.processorHarvestChan <- ProcessorHarvest{
 		AppHarvest: m.p.harvests[idOne],
 		ID:         idOne,
 		Type:       HarvestDefaultData,
 	}
-	// No other payloads are sent because the harvest is empty
+	// Need to have other data, because data usage is not harvested on empty harvest
+	/* collect txn data */
+	<-m.clientParams
+	m.clientReturn <- ClientReturn{nil, nil, 202}
 	/* collect usage metrics */
 	cp := <-m.clientParams
 	m.clientReturn <- ClientReturn{nil, nil, 202}

--- a/src/newrelic/processor_test.go
+++ b/src/newrelic/processor_test.go
@@ -786,6 +786,8 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		AppHarvest: m.p.harvests[idOne],
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
+		// blocking to get data usage correct
+		Blocking: true,
 	}
 	/* txn events */
 	cp1 = <-m.clientParams
@@ -803,6 +805,8 @@ func TestProcessorHarvestSplitTxnEvents(t *testing.T) {
 		AppHarvest: m.p.harvests[idOne],
 		ID:         idOne,
 		Type:       HarvestTxnEvents,
+		// blocking to get data usage correct
+		Blocking: true,
 	}
 	/* txn events first payload */
 	cp1 = <-m.clientParams


### PR DESCRIPTION
Adds the collection of data usage metrics into a separate channel in the processor. The JSON payload is now extracted from the http client (by passing the command structure by pointer), so we are able to get its size.

There is a maximum amount of data usage metrics that will be stored in between metrics harvests. If many other harvests happen in between a metric harvest, or if the metrics harvest stalls for any number of reasons, usage data will be dropped.

Clarifies, reformats, and updates comments lots of the tests and infrastructure for processor.go/processor_test.go