### PR TITLE
ci: allow multiple symbol defs at agent test link

### DIFF
--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -77,12 +77,12 @@ if [ "$(uname)" = Linux ] && [ ! -e /etc/alpine-release ] && [ $PHP_SAPIS_EMBED 
   do_valgrind=yes
   printf \\n
   printf 'grinding axiom tests\n'
-  make -r -s -j $(nproc) axiom-valgrind "ARCH=${ARCH}"
+  make -r -j $(nproc) axiom-valgrind "ARCH=${ARCH}"
 else
   do_valgrind=
   printf \\n
   printf 'running axiom tests\n'
-  make -r -s -j $(nproc) axiom-run-tests "ARCH=${ARCH}"
+  make -r -j $(nproc) axiom-run-tests "ARCH=${ARCH}"
 fi
 
 #
@@ -128,7 +128,7 @@ EOF
   printf \\n
   printf "building agent (PHP=%s)\n" "$PHPS"
   make agent-clean
-  make -r -s -j $(nproc) agent "ARCH=${ARCH}"
+  make -r -j $(nproc) agent "ARCH=${ARCH}"
 
 
   printf \\n
@@ -157,10 +157,10 @@ EOF
       *embed*)
         if [ -n "$do_valgrind" ]; then
           printf 'grinding agent unit tests\n'
-          make -r -s -j $(nproc) agent-valgrind "ARCH=${ARCH}"
+          make -r -j $(nproc) agent-valgrind "ARCH=${ARCH}"
         else
           printf 'running agent unit tests\n'
-          make -r -s -j $(nproc) agent-check "ARCH=${ARCH}"
+          make -r -j $(nproc) agent-check "ARCH=${ARCH}"
         fi
 	;;
       *)

--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -157,10 +157,10 @@ EOF
       *embed*)
         if [ -n "$do_valgrind" ]; then
           printf 'grinding agent unit tests\n'
-          make -r -j $(nproc) agent-valgrind "ARCH=${ARCH}"
+          make -r -j $(nproc) agent-valgrind "ARCH=${ARCH}" LDFLAGS='-Wl,-z,muldefs'
         else
           printf 'running agent unit tests\n'
-          make -r -j $(nproc) agent-check "ARCH=${ARCH}"
+          make -r -j $(nproc) agent-check "ARCH=${ARCH}" LDFLAGS='-Wl,-z,muldefs'
         fi
 	;;
       *)

--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -157,10 +157,10 @@ EOF
       *embed*)
         if [ -n "$do_valgrind" ]; then
           printf 'grinding agent unit tests\n'
-          make -r -j $(nproc) agent-valgrind "ARCH=${ARCH}" LDFLAGS='-Wl,-z,muldefs'
+          make -r -j $(nproc) agent-valgrind "ARCH=${ARCH}" USER_LDFLAGS='-Wl,-z,muldefs'
         else
           printf 'running agent unit tests\n'
-          make -r -j $(nproc) agent-check "ARCH=${ARCH}" LDFLAGS='-Wl,-z,muldefs'
+          make -r -j $(nproc) agent-check "ARCH=${ARCH}" USER_LDFLAGS='-Wl,-z,muldefs'
         fi
 	;;
       *)

--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -261,6 +261,7 @@ endif
 #
 TEST_LIBS := $(PHP_EMBED_LIBRARY) $(shell $(PHP_CONFIG) --libs)
 TEST_LDFLAGS := $(shell $(PHP_CONFIG) --ldflags) $(EXPORT_DYNAMIC)
+TEST_LDFLAGS += $(USER_LDFLAGS)
 
 #
 # Implicit rule to build test object files with the appropriate flags.


### PR DESCRIPTION
PHP embed SAPI (libphp) embeds PCRE library. So does axiom library.
Agent unit tests require both: PHP embed SAPI and axiom library. PHPs
5.5, 5.6, 7.0, 7.1, and 7.2 embed older version of PCRE and this causes
linker to find PCRE symbols in two places: PHP embed SAPI (libphp) and
axiom library. This causes the linker to report a fatal error and abort.
This change allows for multiple definitions and the first definition
found will be used.

Note: PHP embed SAPIs 7.3+ come with PCRE2, which uses different symbol
names and does not create conflict with PCRE embedded in axiom library.