### PR TITLE
Get zed

### DIFF
--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -216,7 +216,7 @@ NR_PHP_WRAPPER(nr_drupal_http_request_exec) {
     goto end;
   }
 
-  return_value = nr_php_get_return_value_ptr(TSRMLS_C);
+  return_value = NR_GET_RETURN_VALUE_PTR;
 
   /*
    * We only want to create a metric here if this isn't a recursive call to

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -152,7 +152,7 @@ out:
  *           ControllerResolver::getControllerFromDefinition().
  */
 NR_PHP_WRAPPER(nr_drupal8_name_the_wt) {
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
@@ -201,7 +201,7 @@ NR_PHP_WRAPPER_END
 
 NR_PHP_WRAPPER(nr_drupal8_name_the_wt_cached) {
   const char* name = "page_cache";
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   (void)wraprec;
 
@@ -300,7 +300,7 @@ static int nr_drupal8_apply_hook(zval* element,
  */
 NR_PHP_WRAPPER(nr_drupal8_post_get_implementations) {
   zval* hook = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   (void)wraprec;
 
@@ -334,7 +334,7 @@ NR_PHP_WRAPPER_END
 NR_PHP_WRAPPER(nr_drupal8_post_implements_hook) {
   zval* hook = NULL;
   zval* module = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   (void)wraprec;
 
@@ -367,7 +367,7 @@ NR_PHP_WRAPPER_END
  */
 NR_PHP_WRAPPER(nr_drupal8_module_handler) {
   zend_class_entry* ce = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -1073,7 +1073,7 @@ NR_PHP_WRAPPER(nr_laravel_routes_get_route_for_methods) {
    * Start by calling the original method, and if it doesn't return a
    * route then we don't need to do any extra work.
    */
-  route = nr_php_get_return_value_ptr(TSRMLS_C);
+  route = NR_GET_RETURN_VALUE_PTR;
   NR_PHP_WRAPPER_CALL;
 
   /* If the method did not return a route, then end gracefully. */

--- a/agent/fw_laravel_queue.c
+++ b/agent/fw_laravel_queue.c
@@ -695,7 +695,7 @@ static char* nr_laravel_get_payload_header_mq(char* header) {
 NR_PHP_WRAPPER(nr_laravel_queue_queue_createpayload) {
   zval* json = NULL;
   zval* payload = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
   nr_hashmap_t* outbound_headers = NULL;
   nr_vector_t* header_keys = NULL;
   char* header = NULL;

--- a/agent/fw_magento2.c
+++ b/agent/fw_magento2.c
@@ -129,7 +129,7 @@ NR_PHP_WRAPPER(nr_magento2_pagecache_kernel_load) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MAGENTO2);
 
-  response = nr_php_get_return_value_ptr(TSRMLS_C);
+  response = NR_GET_RETURN_VALUE_PTR;
 
   NR_PHP_WRAPPER_CALL;
 
@@ -167,7 +167,7 @@ NR_PHP_WRAPPER(nr_magento2_objectmanager_get) {
      */
     goto leave;
   }
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
   NR_PHP_WRAPPER_CALL;
 
   if ((NULL == retval_ptr) || !nr_php_is_zval_valid_object(*retval_ptr)) {
@@ -251,7 +251,7 @@ NR_PHP_WRAPPER(nr_magento2_soap_iswsdlrequest) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MAGENTO2);
 
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
   NR_PHP_WRAPPER_CALL;
 
   if (retval_ptr && nr_php_is_zval_true(*retval_ptr)) {
@@ -268,7 +268,7 @@ NR_PHP_WRAPPER(nr_magento2_soap_iswsdllistrequest) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MAGENTO2);
 
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
   NR_PHP_WRAPPER_CALL;
 
   if (retval_ptr && nr_php_is_zval_true(*retval_ptr)) {
@@ -322,7 +322,7 @@ NR_PHP_WRAPPER(nr_magento2_soap_handler_prepareoperationinput) {
 
   svc_class = nr_php_arg_get(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   method_metadata = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  /* 
+  /*
    * We expect method_metadata to be an array.  At index 'method', if we see
    * a method name, we'll pass it to the transaction naming.
    * See:

--- a/agent/fw_mediawiki.c
+++ b/agent/fw_mediawiki.c
@@ -142,7 +142,7 @@ NR_PHP_WRAPPER(nr_mediawiki_getaction) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MEDIAWIKI);
 
-  return_value = nr_php_get_return_value_ptr(TSRMLS_C);
+  return_value = NR_GET_RETURN_VALUE_PTR;
 
   NR_PHP_WRAPPER_CALL;
 

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -54,7 +54,7 @@ NR_PHP_WRAPPER(nr_slim2_route_dispatch) {
   txn_name = nr_slim_path_from_route(this_var TSRMLS_CC);
   nr_php_scope_release(&this_var);
 
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   NR_PHP_WRAPPER_CALL;
 

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -543,7 +543,7 @@ static void nr_wordpress_name_the_wt(const zval* tag,
  */
 NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
   zval* tag = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -596,7 +596,7 @@ end:
 NR_PHP_WRAPPER_END
 
 NR_PHP_WRAPPER(nr_predis_aggregateconnection_getConnection) {
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   (void)wraprec;
 

--- a/agent/lib_zend_http.c
+++ b/agent/lib_zend_http.c
@@ -33,8 +33,8 @@ typedef enum _nr_zend_http_adapter {
  */
 #define LIB_NAME_Z "Zend"
 #define CURL_ADAPTER_Z "Zend_Http_Client_Adapter_Curl"
-#define URI_HTTP_Z  "Zend_Uri_Http"
-#define HTTP_CLIENT_Z  "Zend_Http_Client"
+#define URI_HTTP_Z "Zend_Uri_Http"
+#define HTTP_CLIENT_Z "Zend_Http_Client"
 #define HTTP_CLIENT_REQUEST_Z "Zend_Http_Client::request"
 
 #define LIB_NAME_L "Laminas"
@@ -338,7 +338,7 @@ NR_PHP_WRAPPER_START(nr_zend_http_client_request) {
   (void)wraprec;
 
   this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   /* Avoid double counting if CURL is used. */
   adapter = nr_zend_check_adapter(this_var TSRMLS_CC);
@@ -456,4 +456,3 @@ void nr_laminas_http_enable(TSRMLS_D) {
                               nr_zend_http_client_request TSRMLS_CC);
   }
 }
-

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -275,6 +275,18 @@ zend_function* nr_php_zval_to_function(zval* zv TSRMLS_DC) {
 }
 
 zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC) {
+  NR_UNUSED_FUNC_RETURN_VALUE;
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+
+  /*
+   * There is no other recourse.  We must return what OAPI gave us.  This should
+   * theoretically never be NULL since we check for NULL before calling the
+   * handlers; however, if it was NULL, there is nothing we can do about it.
+   */
+  return execute_data;
+#endif
   zend_execute_data* ptrg
       = EG(current_execute_data); /* via zend engine global data structure */
   NR_UNUSED_SPECIALFN;

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -277,15 +277,15 @@ zend_function* nr_php_zval_to_function(zval* zv TSRMLS_DC) {
 zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC) {
   zend_execute_data* ptrg
       = EG(current_execute_data); /* via zend engine global data structure */
-
   NR_UNUSED_SPECIALFN;
+  NR_UNUSED_FUNC_RETURN_VALUE;
 #if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
   {
     /*
      * ptra is argument passed in to us, it might be NULL if the caller doesn't
      * have that info.
      */
-    zend_execute_data* ptra = NR_EXECUTE_ORIG_ARGS;
+    zend_execute_data* ptra = execute_data;
     if (NULL != ptra) {
       return ptra;
     } else {
@@ -419,6 +419,8 @@ zval* nr_php_get_user_func_arg(size_t requested_arg_index,
   zval* arg_via_h = 0;
   int arg_count_via_h = -1;
 
+  NR_UNUSED_FUNC_RETURN_VALUE;
+
   if (requested_arg_index < 1) {
     return NULL;
   }
@@ -441,6 +443,7 @@ zval* nr_php_get_user_func_arg(size_t requested_arg_index,
 
 size_t nr_php_get_user_func_arg_count(NR_EXECUTE_PROTO TSRMLS_DC) {
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+  NR_UNUSED_FUNC_RETURN_VALUE;
   return (size_t)ZEND_CALL_NUM_ARGS(execute_data);
 #else
   int arg_count_via_h = -1;

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -336,14 +336,13 @@ static inline zval* nr_php_get_return_value(NR_EXECUTE_PROTO TSRMLS_DC) {
    * If the agent is still overwriting zend_execute_data extract oldfashioned
    * way; otherwise, pass the observer given return value.
    */
-  if
-    nrunlikely(NULL == execute_data) {
-      /*
-       * Shouldn't theoretically ever have a NULL execute_data with valid
-       * return_value.
-       */
-      return NULL;
-    }
+  if (nrunlikely(NULL == execute_data)) {
+    /*
+     * Shouldn't theoretically ever have a NULL execute_data with valid
+     * return_value.
+     */
+    return NULL;
+  }
   return func_return_value;
 #elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
   NR_UNUSED_FUNC_RETURN_VALUE;

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -330,7 +330,23 @@ extern zend_function* nr_php_zval_to_function(zval* zv TSRMLS_DC);
  *           won't help you!
  */
 static inline zval* nr_php_get_return_value(NR_EXECUTE_PROTO TSRMLS_DC) {
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+#if (ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+     && !defined OVERWRITE_ZEND_EXECUTE_DATA) /* PHP 8.0+ and OAPI */
+  /*
+   * If the agent is still overwriting zend_execute_data extract oldfashioned
+   * way; otherwise, pass the observer given return value.
+   */
+  if
+    nrunlikely(NULL == execute_data) {
+      /*
+       * Shouldn't theoretically ever have a NULL execute_data with valid
+       * return_value.
+       */
+      return NULL;
+    }
+  return func_return_value;
+#elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+  NR_UNUSED_FUNC_RETURN_VALUE;
   if (NULL == execute_data) {
     /*
      * This function shouldn't be called from outside a function context, so
@@ -378,6 +394,7 @@ extern size_t nr_php_get_user_func_arg_count(NR_EXECUTE_PROTO TSRMLS_DC);
 static inline zend_function* nr_php_execute_function(
     NR_EXECUTE_PROTO TSRMLS_DC) {
   NR_UNUSED_TSRMLS;
+  NR_UNUSED_FUNC_RETURN_VALUE;
 
 #if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
   if (NULL == execute_data) {

--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -259,7 +259,10 @@ void nr_php_call_user_func_array_handler(nrphpcufafn_t handler,
     caller = prev_execute_data->function_state.function;
 #endif /* PHP7 */
   } else {
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+    caller = nr_php_get_caller(EG(current_execute_data), NULL, 1 TSRMLS_CC);
+#elif ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
     caller = nr_php_get_caller(EG(current_execute_data), 1 TSRMLS_CC);
 #else
     caller = nr_php_get_caller(NULL, 1 TSRMLS_CC);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -29,7 +29,6 @@
 #include "util_url.h"
 #include "util_metrics.h"
 #include "util_number_converter.h"
-#include "php_execute.h"
 #include "fw_support.h"
 #include "fw_hooks.h"
 
@@ -898,6 +897,8 @@ static void nr_php_execute_file(const zend_op_array* op_array,
                                 NR_EXECUTE_PROTO TSRMLS_DC) {
   const char* filename = nr_php_op_array_file_name(op_array);
 
+  NR_UNUSED_FUNC_RETURN_VALUE;
+
   if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_loaded_files)) {
     nrl_debug(NRL_AGENT, "loaded file=" NRP_FMT, NRP_FILENAME(filename));
   }
@@ -909,7 +910,8 @@ static void nr_php_execute_file(const zend_op_array* op_array,
 
   nr_txn_match_file(NRPRG(txn), filename);
 
-  NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  NR_PHP_PROCESS_GLOBALS(orig_execute)
+  (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
 
   if (0 == nr_php_recording(TSRMLS_C)) {
     return;
@@ -1249,7 +1251,8 @@ static void nr_php_execute_enabled(NR_EXECUTE_PROTO TSRMLS_DC) {
     /*
      * This is the case for New Relic is enabled, but we're not recording.
      */
-    NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    NR_PHP_PROCESS_GLOBALS(orig_execute)
+    (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
   }
 }
 
@@ -1302,7 +1305,7 @@ static void nr_php_max_nesting_level_reached(TSRMLS_D) {
  * the presence of longjmp as from zend_bailout when processing zend internal
  * errors, as for example when calling php_error.
  */
-void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
+void nr_php_execute(NR_EXECUTE_PROTO_OVERWRITE TSRMLS_DC) {
   /*
    * We do not use zend_try { ... } mechanisms here because zend_try
    * involves a setjmp, and so may be too expensive along this oft-used
@@ -1319,6 +1322,10 @@ void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
    * zend_catch is called to avoid catastrophe on the way to a premature
    * exit, maintaining this counter perfectly is not a necessity.
    */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+  zval* func_return_value = NULL;
+#endif
 
   NRPRG(php_cur_stack_depth) += 1;
 
@@ -1328,7 +1335,8 @@ void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
   }
 
   if (nrunlikely(0 == nr_php_recording(TSRMLS_C))) {
-    NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    NR_PHP_PROCESS_GLOBALS(orig_execute)
+    (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
   } else {
     int show_executes
         = NR_PHP_PROCESS_GLOBALS(special_flags).show_executes
@@ -1345,12 +1353,17 @@ void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
   return;
 }
 
-static void nr_php_show_exec_internal(NR_EXECUTE_PROTO,
+static void nr_php_show_exec_internal(NR_EXECUTE_PROTO_OVERWRITE,
                                       const zend_function* func TSRMLS_DC) {
   char argstr[NR_EXECUTE_DEBUG_STRBUFSZ] = {'\0'};
   const char* name = nr_php_function_debug_name(func);
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+  zval* func_return_value = NULL;
+#endif
 
   nr_show_execute_params(NR_EXECUTE_ORIG_ARGS, argstr TSRMLS_CC);
+
   nrl_verbosedebug(
       NRL_AGENT,
       "execute: %.*s function={" NRP_FMT_UQ "} params={" NRP_FMT_UQ "}",
@@ -1418,7 +1431,7 @@ void nr_php_execute_internal(zend_execute_data* execute_data,
    */
   if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_executes)) {
 #if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
-    nr_php_show_exec_internal(NR_EXECUTE_ORIG_ARGS, func TSRMLS_CC);
+    nr_php_show_exec_internal(NR_EXECUTE_ORIG_ARGS_OVERWRITE, func TSRMLS_CC);
 #else
     /*
      * We're passing the same pointer twice. This is inefficient. However, no

--- a/agent/php_hooks.h
+++ b/agent/php_hooks.h
@@ -16,7 +16,7 @@
  *           See http://www.php.net/manual/en/migration55.internals.php
  *           for a discussion of what/how to override.
  */
-extern void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC);
+extern void nr_php_execute(NR_EXECUTE_PROTO_OVERWRITE TSRMLS_DC);
 
 /*
  * Purpose : Our own error callback function, used to capture the PHP stack
@@ -38,13 +38,9 @@ extern void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC);
  * are strongly encouraged to use the new error notification API instead.
  * Error notification callbacks are guaranteed to be called regardless of the
  * users error_reporting setting or userland error handler return values.
- * Register notification callbacks during MINIT of an extension:
-void my_error_notify_cb(int type,
-                const char *error_filename,
-                        uint32_t error_lineno,
-                        zend_string *message) {
-                }
-                zend_register_error_notify_callback(my_error_notify_cb);
+ *
+ * The register notification callbacks during MINIT of an extension are done in
+ * `nr_php_observer.c`.
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
 extern void nr_php_error_cb(int type,

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -1169,7 +1169,11 @@ NR_INNER_WRAPPER(mysqli_stmt_bind_param) {
   argc = (size_t)ZEND_NUM_ARGS();
   argv = (zval**)nr_calloc(argc, sizeof(zval*));
   for (i = 0; i < argc; i++) {
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+    argv[i] = nr_php_get_user_func_arg(i + 1, EG(current_execute_data),
+                                       NULL TSRMLS_CC);
+#elif ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
     argv[i]
         = nr_php_get_user_func_arg(i + 1, EG(current_execute_data) TSRMLS_CC);
 #else /* PHP < 5.5 */
@@ -1560,9 +1564,8 @@ static char* nr_php_prepared_statement_make_pgsql_key(
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO /* PHP 8.1+ */
   if (nr_php_is_zval_valid_object(conn)) {
-    key = nr_formatf("type=pgsql id=%ld name=%.*s",
-                     nr_php_zval_object_id(conn), NRSAFELEN(stmtname_len),
-                     stmtname);
+    key = nr_formatf("type=pgsql id=%ld name=%.*s", nr_php_zval_object_id(conn),
+                     NRSAFELEN(stmtname_len), stmtname);
   }
 #else
   if (nr_php_is_zval_valid_resource(conn)) {

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -38,7 +38,35 @@ extern zend_module_entry newrelic_module_entry;
  * majority of those changes so the rest of the code can simply use the macros
  * and not have to take the different APIs into account.
  */
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+
+/* OVERWRITE_ZEND_EXECUTE_DATA allows testing of components with the previous
+ * method of overwriting until the handler functions are complete.
+ * Additionally, gives us flexibility of toggling back to previous method of
+ * instrumentation. When checking in, leave this toggled on to have the CI work
+ * as long as possible until the handler functionality is implemented.*/
+#define OVERWRITE_ZEND_EXECUTE_DATA true
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+#define NR_SPECIALFNPTR_PROTO                              \
+  struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
+      zend_execute_data *execute_data, zval *func_return_value
+#define NR_SPECIALFNPTR_ORIG_ARGS \
+  wraprec, auto_segment, execute_data, func_return_value
+#define NR_SPECIALFN_PROTO                                \
+  nruserfn_t *wraprec, zend_execute_data *execute_data, , \
+      zval *func_return_value
+#define NR_OP_ARRAY (&execute_data->func->op_array)
+#define NR_EXECUTE_PROTO \
+  zend_execute_data *execute_data, zval *func_return_value
+#define NR_EXECUTE_PROTO_OVERWRITE zend_execute_data* execute_data
+#define NR_EXECUTE_ORIG_ARGS_OVERWRITE execute_data
+#define NR_EXECUTE_ORIG_ARGS execute_data, func_return_value
+#define NR_UNUSED_SPECIALFN (void)execute_data
+#define NR_UNUSED_FUNC_RETURN_VALUE (void)func_return_value
+/* NR_ZEND_EXECUTE_HOOK to be removed in future ticket */
+#define NR_ZEND_EXECUTE_HOOK zend_execute_ex
+
+#elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ and overwrite hook*/
 #define NR_SPECIALFNPTR_PROTO                              \
   struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
       zend_execute_data *execute_data
@@ -46,9 +74,13 @@ extern zend_module_entry newrelic_module_entry;
 #define NR_SPECIALFN_PROTO nruserfn_t *wraprec, zend_execute_data *execute_data
 #define NR_OP_ARRAY (&execute_data->func->op_array)
 #define NR_EXECUTE_PROTO zend_execute_data* execute_data
+#define NR_EXECUTE_PROTO_OVERWRITE zend_execute_data* execute_data
+#define NR_EXECUTE_ORIG_ARGS_OVERWRITE execute_data
 #define NR_EXECUTE_ORIG_ARGS execute_data
 #define NR_UNUSED_SPECIALFN (void)execute_data
+#define NR_UNUSED_FUNC_RETURN_VALUE
 #define NR_ZEND_EXECUTE_HOOK zend_execute_ex
+
 #elif ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
 #define NR_SPECIALFNPTR_PROTO                              \
   struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
@@ -57,9 +89,13 @@ extern zend_module_entry newrelic_module_entry;
 #define NR_SPECIALFN_PROTO nruserfn_t *wraprec, zend_execute_data *execute_data
 #define NR_OP_ARRAY (execute_data->op_array)
 #define NR_EXECUTE_PROTO zend_execute_data* execute_data
+#define NR_EXECUTE_PROTO_OVERWRITE zend_execute_data* execute_data
+#define NR_EXECUTE_ORIG_ARGS_OVERWRITE execute_data
 #define NR_EXECUTE_ORIG_ARGS execute_data
 #define NR_UNUSED_SPECIALFN (void)execute_data
+#define NR_UNUSED_FUNC_RETURN_VALUE
 #define NR_ZEND_EXECUTE_HOOK zend_execute_ex
+
 #else /* PHP < 5.5 */
 #define NR_SPECIALFNPTR_PROTO                              \
   struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
@@ -68,9 +104,19 @@ extern zend_module_entry newrelic_module_entry;
 #define NR_SPECIALFN_PROTO nruserfn_t *wraprec, zend_op_array *op_array_arg
 #define NR_OP_ARRAY (op_array_arg)
 #define NR_EXECUTE_PROTO zend_op_array* op_array_arg
+#define NR_EXECUTE_PROTO_OVERWRITE zend_op_array* op_array_arg
+#define NR_EXECUTE_ORIG_ARGS_OVERWRITE op_array_arg
 #define NR_EXECUTE_ORIG_ARGS op_array_arg
 #define NR_UNUSED_SPECIALFN (void)op_array_arg
+#define NR_UNUSED_FUNC_RETURN_VALUE
 #define NR_ZEND_EXECUTE_HOOK zend_execute
+#endif
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+#define NR_GET_RETURN_VALUE_PTR &func_return_value
+#else
+#define NR_GET_RETURN_VALUE_PTR nr_php_get_return_value_ptr(TSRMLS_C)
 #endif
 
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
@@ -202,7 +248,7 @@ typedef zend_op_array* (*nrphpcfile_t)(zend_file_handle* file_handle,
                                        int type TSRMLS_DC);
 typedef zend_op_array* (*nrphpcstr_t)(zval* source_string,
                                       char* filename TSRMLS_DC);
-typedef void (*nrphpexecfn_t)(NR_EXECUTE_PROTO TSRMLS_DC);
+typedef void (*nrphpexecfn_t)(NR_EXECUTE_PROTO_OVERWRITE TSRMLS_DC);
 typedef void (*nrphpcufafn_t)(zend_function* func,
                               const zend_function* caller TSRMLS_DC);
 typedef int (*nrphphdrfn_t)(sapi_header_struct* sapi_header,
@@ -465,11 +511,13 @@ nrinitime_t
  * configuration options for handling application logging
  */
 
-nrinibool_t logging_enabled;        /* newrelic.application_logging.enabled */
-nrinibool_t log_forwarding_enabled; /* newrelic.application_logging.forwarding.enabled
-                                     */
-nriniuint_t log_events_max_samples_stored; /* newrelic.application_logging.forwarding.max_samples_stored
-                                            */
+nrinibool_t logging_enabled; /* newrelic.application_logging.enabled */
+nrinibool_t
+    log_forwarding_enabled; /* newrelic.application_logging.forwarding.enabled
+                             */
+nriniuint_t
+    log_events_max_samples_stored; /* newrelic.application_logging.forwarding.max_samples_stored
+                                    */
 nrinibool_t
     log_metrics_enabled; /* newrelic.application_logging.metrics.enabled */
 

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -50,8 +50,10 @@
  */
 int nr_zend_call_orig_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
   volatile int zcaught = 0;
+  NR_UNUSED_FUNC_RETURN_VALUE;
   zend_try {
-    NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    NR_PHP_PROCESS_GLOBALS(orig_execute)
+    (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
   }
   zend_catch { zcaught = 1; }
   zend_end_try();
@@ -62,12 +64,14 @@ int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
                                       nr_segment_t* segment,
                                       NR_EXECUTE_PROTO TSRMLS_DC) {
   volatile int zcaught = 0;
+  NR_UNUSED_FUNC_RETURN_VALUE;
   zend_try {
     if (wraprec && wraprec->special_instrumentation) {
       wraprec->special_instrumentation(wraprec, segment,
                                        NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
     } else {
-      NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+      NR_PHP_PROCESS_GLOBALS(orig_execute)
+      (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
     }
   }
   zend_catch { zcaught = 1; }

--- a/agent/php_wrapper.c
+++ b/agent/php_wrapper.c
@@ -77,7 +77,7 @@ inline static void release_zval(zval** ppzv) {
 
 zval* nr_php_arg_get(ssize_t index, NR_EXECUTE_PROTO TSRMLS_DC) {
   zval* arg;
-
+  NR_UNUSED_FUNC_RETURN_VALUE;
 #ifdef PHP7
   {
     zval* orig;
@@ -203,6 +203,7 @@ void nr_php_arg_release(zval** ppzv) {
 zval* nr_php_scope_get(NR_EXECUTE_PROTO TSRMLS_DC) {
   zval* this_obj;
   zval* this_copy;
+  NR_UNUSED_FUNC_RETURN_VALUE;
 
   this_obj = NR_PHP_USER_FN_THIS();
   if (NULL == this_obj) {


### PR DESCRIPTION
This is based off the work done in https://github.com/newrelic/newrelic-php-agent/pull/516.
The work for this PR starts with commit: https://github.com/newrelic/newrelic-php-agent/commit/4efe06ccbf18f579128dcee983f704e8bcf1cd43

`nr_php_call_user_func_array_handler` calls a global which eventually calls `nr_get_zend_execute_data`

agent/php_call.c
264: caller = nr_php_get_caller(EG(current_execute_data), NULL, 1 TSRMLS_CC);
266: caller = nr_php_get_caller(EG(current_execute_data), 1 TSRMLS_CC);
268: caller = nr_php_get_caller(NULL, 1 TSRMLS_CC);

This will be addressed in the globals ticket/PR.