### PR TITLE
feat(agent): add log level config option

### DIFF
--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -465,13 +465,18 @@ nrinitime_t
  * configuration options for handling application logging
  */
 
-nrinibool_t logging_enabled;        /* newrelic.application_logging.enabled */
-nrinibool_t log_forwarding_enabled; /* newrelic.application_logging.forwarding.enabled
-                                     */
-nriniuint_t log_events_max_samples_stored; /* newrelic.application_logging.forwarding.max_samples_stored
-                                            */
+nrinibool_t logging_enabled; /* newrelic.application_logging.enabled */
+nrinibool_t
+    log_forwarding_enabled; /* newrelic.application_logging.forwarding.enabled
+                             */
+nriniuint_t
+    log_events_max_samples_stored; /* newrelic.application_logging.forwarding.max_samples_stored
+                                    */
 nrinibool_t
     log_metrics_enabled; /* newrelic.application_logging.metrics.enabled */
+
+nriniuint_t log_forwarding_log_level; /* newrelic.application_logging.forwarding.log_level
+                                       */
 
 /*
  * pid and user_function_wrappers are used to store user function wrappers.

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -708,6 +708,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   opts.span_queue_batch_timeout = NRINI(agent_span_queue_timeout);
   opts.logging_enabled = NRINI(logging_enabled);
   opts.log_forwarding_enabled = NRINI(log_forwarding_enabled);
+  opts.log_forwarding_log_level = NRINI(log_forwarding_log_level);
   opts.log_events_max_samples_stored = NRINI(log_events_max_samples_stored);
   opts.log_metrics_enabled = NRINI(log_metrics_enabled);
 

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1174,6 +1174,29 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;newrelic.application_logging.forwarding.max_samples_stored = 10000
 
+; Setting: newrelic.application_logging.forwarding.log_level
+; Type   : string
+; Scope  : per-directory
+; Default: "WARNING"
+; Info   : Sets the minimum log level to be collected when log forwarding
+;          is enabled. 
+;
+;          Based on
+;           https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel
+;           https://datatracker.ietf.org/doc/html/rfc5424
+;
+;          Valid settings (ordered highest to lowest):
+;           "EMERGENCY"
+;           "ALERT"
+;           "CRITICAL"
+;           "ERROR"
+;           "WARNING"
+;           "NOTICE"
+;           "INFO"
+;           "DEBUG"
+;          
+;newrelic.application_logging.forwarding.log_level = "WARNING"
+
 ; Setting: newrelic.application_logging.metrics.enabled
 ; Type   : boolean
 ; Scope  : per-directory

--- a/axiom/Makefile
+++ b/axiom/Makefile
@@ -104,6 +104,7 @@ OBJS := \
 	nr_header.o \
 	nr_log_event.o \
 	nr_log_events.o \
+	nr_log_level.o \
 	nr_mysqli_metadata.o \
 	nr_postgres.o \
 	nr_rules.o \

--- a/axiom/nr_log_level.c
+++ b/axiom/nr_log_level.c
@@ -14,6 +14,11 @@
 
 int nr_log_level_str_to_int(const char* str) {
   int level;
+  bool err = false;
+
+  if (NULL == str) {
+    err = true;
+  }
 
 #define LEVELCMP(x) (0 == nr_stricmp(str, x))
 
@@ -34,14 +39,18 @@ int nr_log_level_str_to_int(const char* str) {
   } else if (LEVELCMP(LL_DEBU_STR)) {
     level = LOG_LEVEL_DEBUG;
   } else {
+    err = true;
+  }
+
+#undef LEVELCMP
+
+  if (err) {
     nrl_warning(
         NRL_INIT,
         "Unknown Log Forwarding Log Level Specified; Defaulting to \"%s\"",
         nr_log_level_rfc_to_psr(LOG_LEVEL_UNKNOWN));
     level = LOG_LEVEL_UNKNOWN;
   }
-
-#undef LEVELCMP
 
   return level;
 }

--- a/axiom/nr_log_level.c
+++ b/axiom/nr_log_level.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nr_axiom.h"
+
+#include <stddef.h>
+
+#include "nr_log_level.h"
+#include "util_strings.h"
+#include "util_logging.h"
+#include "util_memory.h"
+
+int nr_log_level_str_to_int(const char* str) {
+  int level;
+
+#define LEVELCMP(x) (0 == nr_stricmp(str, x))
+
+  if (LEVELCMP(LL_EMER_STR)) {
+    level = LOG_LEVEL_EMERGENCY;
+  } else if (LEVELCMP(LL_ALER_STR)) {
+    level = LOG_LEVEL_ALERT;
+  } else if (LEVELCMP(LL_CRIT_STR)) {
+    level = LOG_LEVEL_CRITICAL;
+  } else if (LEVELCMP(LL_ERRO_STR)) {
+    level = LOG_LEVEL_ERROR;
+  } else if (LEVELCMP(LL_WARN_STR)) {
+    level = LOG_LEVEL_WARNING;
+  } else if (LEVELCMP(LL_NOTI_STR)) {
+    level = LOG_LEVEL_NOTICE;
+  } else if (LEVELCMP(LL_INFO_STR)) {
+    level = LOG_LEVEL_INFO;
+  } else if (LEVELCMP(LL_DEBU_STR)) {
+    level = LOG_LEVEL_DEBUG;
+  } else {
+    nrl_warning(
+        NRL_INIT,
+        "Unknown Log Forwarding Log Level Specified; Defaulting to \"%s\"",
+        nr_log_level_rfc_to_psr(LOG_LEVEL_UNKNOWN));
+    level = LOG_LEVEL_UNKNOWN;
+  }
+
+#undef LEVELCMP
+
+  return level;
+}
+
+char* nr_log_level_rfc_to_psr(int level) {
+  char* psr = NULL;
+
+#define COPY(s) (psr = nr_strdup(s));
+
+  switch (level) {
+    case LOG_LEVEL_EMERGENCY:
+      COPY(LL_EMER_STR)
+      break;
+    case LOG_LEVEL_ALERT:
+      COPY(LL_ALER_STR)
+      break;
+    case LOG_LEVEL_CRITICAL:
+      COPY(LL_CRIT_STR)
+      break;
+    case LOG_LEVEL_ERROR:
+      COPY(LL_ERRO_STR)
+      break;
+    case LOG_LEVEL_WARNING:
+      COPY(LL_WARN_STR)
+      break;
+    case LOG_LEVEL_NOTICE:
+      COPY(LL_NOTI_STR)
+      break;
+    case LOG_LEVEL_INFO:
+      COPY(LL_INFO_STR)
+      break;
+    case LOG_LEVEL_DEBUG:
+      COPY(LL_DEBU_STR)
+      break;
+    default:
+      nrl_warning(NRL_INIT,
+                  "ERROR converting Log Level rfc to psr; Defaulting to \"%s\"",
+                  LL_UNKN_STR);
+      COPY(LL_UNKN_STR)
+      break;
+  }
+
+#undef COPY
+
+  return psr;
+}

--- a/axiom/nr_log_level.c
+++ b/axiom/nr_log_level.c
@@ -22,24 +22,26 @@ int nr_log_level_str_to_int(const char* str) {
 
 #define LEVELCMP(x) (0 == nr_stricmp(str, x))
 
-  if (LEVELCMP(LL_EMER_STR)) {
-    level = LOG_LEVEL_EMERGENCY;
-  } else if (LEVELCMP(LL_ALER_STR)) {
-    level = LOG_LEVEL_ALERT;
-  } else if (LEVELCMP(LL_CRIT_STR)) {
-    level = LOG_LEVEL_CRITICAL;
-  } else if (LEVELCMP(LL_ERRO_STR)) {
-    level = LOG_LEVEL_ERROR;
-  } else if (LEVELCMP(LL_WARN_STR)) {
-    level = LOG_LEVEL_WARNING;
-  } else if (LEVELCMP(LL_NOTI_STR)) {
-    level = LOG_LEVEL_NOTICE;
-  } else if (LEVELCMP(LL_INFO_STR)) {
-    level = LOG_LEVEL_INFO;
-  } else if (LEVELCMP(LL_DEBU_STR)) {
-    level = LOG_LEVEL_DEBUG;
-  } else {
-    err = true;
+  if (!err) {
+    if (LEVELCMP(LL_EMER_STR)) {
+      level = LOG_LEVEL_EMERGENCY;
+    } else if (LEVELCMP(LL_ALER_STR)) {
+      level = LOG_LEVEL_ALERT;
+    } else if (LEVELCMP(LL_CRIT_STR)) {
+      level = LOG_LEVEL_CRITICAL;
+    } else if (LEVELCMP(LL_ERRO_STR)) {
+      level = LOG_LEVEL_ERROR;
+    } else if (LEVELCMP(LL_WARN_STR)) {
+      level = LOG_LEVEL_WARNING;
+    } else if (LEVELCMP(LL_NOTI_STR)) {
+      level = LOG_LEVEL_NOTICE;
+    } else if (LEVELCMP(LL_INFO_STR)) {
+      level = LOG_LEVEL_INFO;
+    } else if (LEVELCMP(LL_DEBU_STR)) {
+      level = LOG_LEVEL_DEBUG;
+    } else {
+      err = true;
+    }
   }
 
 #undef LEVELCMP

--- a/axiom/nr_log_level.h
+++ b/axiom/nr_log_level.h
@@ -6,6 +6,8 @@
 #ifndef NR_LOG_LEVEL_HDR
 #define NR_LOG_LEVEL_HDR
 
+#include <stdbool.h>
+
 /*
  *  Implementation Based on:
  *      https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel

--- a/axiom/nr_log_level.h
+++ b/axiom/nr_log_level.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NR_LOG_LEVEL_HDR
+#define NR_LOG_LEVEL_HDR
+
+/*
+ *  Implementation Based on:
+ *      https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel
+ *      https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
+ */
+
+#define LOG_LEVEL_EMERGENCY (0)  // system is unusable
+#define LOG_LEVEL_ALERT (1)      // action must be taken immediately
+#define LOG_LEVEL_CRITICAL (2)   // critical conditions
+#define LOG_LEVEL_ERROR (3)      // error conditions
+#define LOG_LEVEL_WARNING (4)    // warning conditions
+#define LOG_LEVEL_NOTICE (5)     // normal but significant conditions
+#define LOG_LEVEL_INFO (6)       // informational messages
+#define LOG_LEVEL_DEBUG (7)      // debug-level messages
+#define LOG_LEVEL_UNKNOWN (8)    // NON PSR- Unknown/Undefined log level
+#define LOG_LEVEL_DEFAULT (LOG_LEVEL_WARNING)
+
+#define LL_EMER_STR ("EMERGENCY")
+#define LL_ALER_STR ("ALERT")
+#define LL_CRIT_STR ("CRITICAL")
+#define LL_ERRO_STR ("ERROR")
+#define LL_WARN_STR ("WARNING")
+#define LL_NOTI_STR ("NOTICE")
+#define LL_INFO_STR ("INFO")
+#define LL_DEBU_STR ("DEBUG")
+#define LL_UNKN_STR ("UNKNOWN")
+
+/*
+ * @brief       Convert PSR-3 string log level to RFC5424 represenation.
+ *
+ * @param       str     String Log Level
+ * @return      int     RFC5424 Log Level numerical code
+ */
+extern int nr_log_level_str_to_int(const char* str);
+
+/*
+ * @brief       Convert RFC5424 log level to PSR-3 string represenation.
+ *
+ * @param       level   RFC5424 Log Level
+ * @return      char*   PSR-3 String Log Level
+ */
+extern char* nr_log_level_rfc_to_psr(int level);
+
+#endif /* NR_LOG_LEVEL_HDR */

--- a/axiom/nr_log_level.h
+++ b/axiom/nr_log_level.h
@@ -25,15 +25,15 @@
 #define LOG_LEVEL_UNKNOWN (8)    // NON PSR- Unknown/Undefined log level
 #define LOG_LEVEL_DEFAULT (LOG_LEVEL_WARNING)
 
-#define LL_EMER_STR ("EMERGENCY")
-#define LL_ALER_STR ("ALERT")
-#define LL_CRIT_STR ("CRITICAL")
-#define LL_ERRO_STR ("ERROR")
-#define LL_WARN_STR ("WARNING")
-#define LL_NOTI_STR ("NOTICE")
-#define LL_INFO_STR ("INFO")
-#define LL_DEBU_STR ("DEBUG")
-#define LL_UNKN_STR ("UNKNOWN")
+#define LL_EMER_STR "EMERGENCY"
+#define LL_ALER_STR "ALERT"
+#define LL_CRIT_STR "CRITICAL"
+#define LL_ERRO_STR "ERROR"
+#define LL_WARN_STR "WARNING"
+#define LL_NOTI_STR "NOTICE"
+#define LL_INFO_STR "INFO"
+#define LL_DEBU_STR "DEBUG"
+#define LL_UNKN_STR "UNKNOWN"
 
 /*
  * @brief       Convert PSR-3 string log level to RFC5424 represenation.

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -23,6 +23,7 @@
 #include "nr_errors.h"
 #include "nr_file_naming.h"
 #include "nr_log_events.h"
+#include "nr_log_level.h"
 #include "nr_segment.h"
 #include "nr_slowsqls.h"
 #include "nr_span_queue.h"
@@ -117,7 +118,9 @@ typedef struct _nrtxnopt_t {
   nrtime_t span_queue_batch_timeout; /* Span queue batch timeout in us. */
   bool logging_enabled; /* An overall configuration for enabling/disabling all
                            application logging features */
-  bool log_forwarding_enabled;          /* Whether log forwarding is enabled */
+  bool log_forwarding_enabled;  /* Whether log forwarding is enabled */
+  int log_forwarding_log_level; /* minimum log level to forward to the collector
+                                 */
   size_t log_events_max_samples_stored; /* The maximum number of log events per
                                            transaction */
   bool log_metrics_enabled;             /* Whether log metrics are enabled */
@@ -616,6 +619,12 @@ extern void nr_txn_record_custom_event(nrtxn_t* txn,
  * Purpose : Check log forwarding configuration
  */
 extern bool nr_txn_log_forwarding_enabled(nrtxn_t* txn);
+
+/*
+ * Purpose : Check log forwarding log level configuration
+ */
+extern bool nr_txn_log_forwarding_log_level_verify(nrtxn_t* txn,
+                                                   const char* log_level_name);
 
 /*
  * Purpose : Check logging metrics configuration

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8100,6 +8100,7 @@ static nrtxn_t* new_txn_for_record_log_event_test(char* entity_name) {
   nr_memset(&opts, 0, sizeof(opts));
   opts.logging_enabled = true;
   opts.log_forwarding_enabled = true;
+  opts.log_forwarding_log_level = LOG_LEVEL_WARNING;
   opts.log_events_max_samples_stored = 10;
   opts.log_metrics_enabled = true;
 
@@ -8117,7 +8118,7 @@ static nrtxn_t* new_txn_for_record_log_event_test(char* entity_name) {
 }
 
 static void test_record_log_event(void) {
-#define LOG_LEVEL "INFO"
+#define LOG_LEVEL LL_WARN_STR
 #define LOG_MESSAGE "Sample log message"
 #define LOG_TIMESTAMP 1234
 #define LOG_EVENT_PARAMS \
@@ -8180,7 +8181,8 @@ static void test_record_log_event(void) {
       = "[{"
         "\"message\":\"" LOG_MESSAGE
         "\","
-        "\"log.level\":\"UNKNOWN\","
+        "\"log.level\":\"" LL_UNKN_STR
+        "\","
         "\"timestamp\":0,"
         "\"trace.id\":\"0000000000000000\","
         "\"span.id\":\"0000000000000000\","


### PR DESCRIPTION
This PR addresses adding the ability for a user to configure a "minimum" log level to forward to the collector, based on the following PHP Log Level standards:
- https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
- https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel

