### PR TITLE
fix(agent): only instrument when logging enabled

### DIFF
--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -83,6 +83,7 @@ TEST_BINARIES = \
 	tests/test_environment \
 	tests/test_fw_codeigniter \
 	tests/test_fw_drupal \
+	tests/test_fw_support \
 	tests/test_fw_wordpress \
 	tests/test_globals \
 	tests/test_internal_instrument \

--- a/agent/fw_support.c
+++ b/agent/fw_support.c
@@ -27,3 +27,28 @@ void nr_php_framework_add_supportability_metric(const char* framework_name,
 
   nrm_force_add(NRPRG(txn) ? NRTXN(unscoped_metrics) : 0, buf, 0);
 }
+
+void nr_fw_support_add_library_supportability_metric(nrtxn_t* txn,
+                                                     const char* library_name) {
+  if (NULL == txn || NULL == library_name) {
+    return;
+  }
+
+  char* metname
+      = nr_formatf("Supportability/library/%s/detected", library_name);
+  nrm_force_add(txn->unscoped_metrics, metname, 0);
+  nr_free(metname);
+}
+
+void nr_fw_support_add_logging_supportability_metric(nrtxn_t* txn,
+                                                     const char* library_name,
+                                                     const bool is_enabled) {
+  if (NULL == txn || NULL == library_name) {
+    return;
+  }
+
+  char* metname = nr_formatf("Supportability/Logging/PHP/%s/%s", library_name,
+                             is_enabled ? "enabled" : "disabled");
+  nrm_force_add(txn->unscoped_metrics, metname, 0);
+  nr_free(metname);
+}

--- a/agent/fw_support.h
+++ b/agent/fw_support.h
@@ -13,4 +13,29 @@ extern void nr_php_framework_add_supportability_metric(
     const char* framework_name,
     const char* name TSRMLS_DC);
 
+/*
+ * Purpose: Add `Supportability/library/{library}/detected` unscoped metric
+ *
+ * Params  : 1. Transaction object
+ *           2. Library name
+ *
+ */
+extern void nr_fw_support_add_library_supportability_metric(
+    nrtxn_t* txn,
+    const char* library_name);
+
+/*
+ * Purpose: Add `Supportability/Logging/PHP/{library}/{enabled|disabled}`
+ * unscoped metric
+ *
+ * Params  : 1. Transaction object
+ *           2. Library name
+ *           3. Instrumentation status
+ *
+ */
+extern void nr_fw_support_add_logging_supportability_metric(
+    nrtxn_t* txn,
+    const char* library_name,
+    const bool is_enabled);
+
 #endif /* FW_SUPPORT_HDR */

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -354,6 +354,11 @@ static nrtime_t nr_monolog_get_timestamp(const int monolog_api,
 NR_PHP_WRAPPER(nr_monolog_logger_addrecord) {
   (void)wraprec;
 
+  if (!nr_txn_log_forwarding_enabled(NRPRG(txn))
+      && !nr_txn_log_metrics_enabled(NRPRG(txn))) {
+    goto skip_instrumentation;
+  }
+
   /* Get Monolog API level */
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   int api = nr_monolog_version(this_var TSRMLS_CC);
@@ -381,9 +386,10 @@ NR_PHP_WRAPPER(nr_monolog_logger_addrecord) {
   nr_free(level_name);
   nr_free(message);
 
-  NR_PHP_WRAPPER_CALL
-
   nr_php_scope_release(&this_var);
+
+skip_instrumentation:
+  NR_PHP_WRAPPER_CALL
 }
 NR_PHP_WRAPPER_END
 

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -359,26 +359,31 @@ NR_PHP_WRAPPER(nr_monolog_logger_addrecord) {
     goto skip_instrumentation;
   }
 
-  /* Get Monolog API level */
+  /* This code executes when at least one logging feature is enabled and
+   * log level is neeeded in both features so agent will always need
+   * to get the log level value */
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  int api = nr_monolog_version(this_var TSRMLS_CC);
-
-  /* Get values of $level and $message arguments */
-
   char* level_name
       = nr_monolog_get_level_name(this_var, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  int api = 0;
+  size_t argc = 0;
+  char* message = NULL;
+  nrtime_t timestamp = nr_get_time();
 
-  size_t argc = nr_php_get_user_func_arg_count(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  char* message
-      = nr_monolog_build_message(argc, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  /* Values of $message and $timestamp arguments are needed only if log
+   * forwarding is enabled so agent will get them conditionally */
+  if (nr_txn_log_forwarding_enabled(NRPRG(txn))) {
+    argc = nr_php_get_user_func_arg_count(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    message = nr_monolog_build_message(argc, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    api = nr_monolog_version(this_var TSRMLS_CC);
+    timestamp
+        = nr_monolog_get_timestamp(api, argc, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
 
-  nrtime_t timestamp
-      = nr_monolog_get_timestamp(api, argc, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-
-  nrl_verbosedebug(NRL_INSTRUMENT,
-                   "%s: #args = %zu, Monolog API: [%d], level=[%s], "
-                   "message=[%s], timestamp=[%" PRIu64 "]",
-                   __func__, argc, api, level_name, message, timestamp);
+    nrl_verbosedebug(NRL_INSTRUMENT,
+                     "%s: #args = %zu, Monolog API: [%d], level=[%s], "
+                     "message=[%s], timestamp=[%" PRIu64 "]",
+                     __func__, argc, api, level_name, message, timestamp);
+  }
 
   /* Record the log event */
   nr_txn_record_log_event(NRPRG(txn), level_name, message, timestamp, NRPRG(app));

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -912,11 +912,9 @@ static void nr_execute_handle_logging_framework(
       nr_php_execute_add_library_supportability_metric(
           NRTXN(unscoped_metrics), logging_frameworks[i].library_name);
 
-      if (NRINI(logging_enabled)) {
+      if (NRINI(logging_enabled) && NULL != logging_frameworks[i].enable) {
         support_metric_value = "enabled";
-        if (NULL != logging_frameworks[i].enable) {
-          logging_frameworks[i].enable(TSRMLS_C);
-        }
+        logging_frameworks[i].enable(TSRMLS_C);
       }
       nr_php_execute_add_logging_supportability_metric(
           NRTXN(unscoped_metrics), logging_frameworks[i].library_name,

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -901,14 +901,22 @@ static void nr_execute_handle_logging_framework(
       nr_php_execute_add_library_supportability_metric(
           NRTXN(unscoped_metrics), logging_frameworks[i].library_name);
 
-      char* metname = nr_formatf("Supportability/Logging/PHP/%s/enabled",
-                                 logging_frameworks[i].library_name);
+      if (NRINI(logging_enabled)) {
+        char* metname = nr_formatf("Supportability/Logging/PHP/%s/enabled",
+                                   logging_frameworks[i].library_name);
 
-      nrm_force_add(NRTXN(unscoped_metrics), metname, 0);
-      nr_free(metname);
+        nrm_force_add(NRTXN(unscoped_metrics), metname, 0);
+        nr_free(metname);
 
-      if (NULL != logging_frameworks[i].enable) {
-        logging_frameworks[i].enable(TSRMLS_C);
+        if (NULL != logging_frameworks[i].enable) {
+          logging_frameworks[i].enable(TSRMLS_C);
+        }
+      } else {
+        char* metname = nr_formatf("Supportability/Logging/PHP/%s/disabled",
+                                   logging_frameworks[i].library_name);
+
+        nrm_force_add(NRTXN(unscoped_metrics), metname, 0);
+        nr_free(metname);
       }
     }
   }

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -867,6 +867,16 @@ static void nr_php_execute_add_library_supportability_metric(
   nr_free(metname);
 }
 
+static void nr_php_execute_add_logging_supportability_metric(
+    nrmtable_t* unscoped_metrics,
+    const char* library_name,
+    const char* instrumentation_status) {
+  char* metname = nr_formatf("Supportability/Logging/PHP/%s/%s", library_name,
+                             instrumentation_status);
+  nrm_force_add(unscoped_metrics, metname, 0);
+  nr_free(metname);
+}
+
 static void nr_execute_handle_library(const char* filename TSRMLS_DC) {
   char* filename_lower = nr_string_to_lowercase(filename);
   size_t i;
@@ -891,6 +901,7 @@ static void nr_execute_handle_library(const char* filename TSRMLS_DC) {
 static void nr_execute_handle_logging_framework(
     const char* filename TSRMLS_DC) {
   char* filename_lower = nr_string_to_lowercase(filename);
+  char* support_metric_value = "disabled";
   size_t i;
 
   for (i = 0; i < num_logging_frameworks; i++) {
@@ -902,22 +913,14 @@ static void nr_execute_handle_logging_framework(
           NRTXN(unscoped_metrics), logging_frameworks[i].library_name);
 
       if (NRINI(logging_enabled)) {
-        char* metname = nr_formatf("Supportability/Logging/PHP/%s/enabled",
-                                   logging_frameworks[i].library_name);
-
-        nrm_force_add(NRTXN(unscoped_metrics), metname, 0);
-        nr_free(metname);
-
+        support_metric_value = "enabled";
         if (NULL != logging_frameworks[i].enable) {
           logging_frameworks[i].enable(TSRMLS_C);
         }
-      } else {
-        char* metname = nr_formatf("Supportability/Logging/PHP/%s/disabled",
-                                   logging_frameworks[i].library_name);
-
-        nrm_force_add(NRTXN(unscoped_metrics), metname, 0);
-        nr_free(metname);
       }
+      nr_php_execute_add_logging_supportability_metric(
+          NRTXN(unscoped_metrics), logging_frameworks[i].library_name,
+          support_metric_value);
     }
   }
 

--- a/agent/tests/test_fw_support.c
+++ b/agent/tests/test_fw_support.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "tlib_php.h"
+
+#include "php_agent.h"
+#include "fw_support.h"
+
+tlib_parallel_info_t parallel_info
+    = {.suggested_nthreads = -1, .state_size = 0};
+
+static void test_fw_supportability_metrics(void) {
+#define LIBRARY_NAME "php-package"
+#define LIBRARY_METRIC "Supportability/library/" LIBRARY_NAME "/detected"
+#define LOGGING_LIBRARY_METRIC "Supportability/Logging/PHP/" LIBRARY_NAME
+  nrtxn_t t;
+  nrtxn_t* txn = &t;
+  txn->unscoped_metrics = nrm_table_create(10);
+
+  /* NULL tests - don't blow up */
+  nr_fw_support_add_library_supportability_metric(NULL, LIBRARY_NAME);
+  tlib_pass_if_int_equal("library metric not created in NULL metrics", 0,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  nr_fw_support_add_library_supportability_metric(txn, NULL);
+  tlib_pass_if_int_equal("NULL library metric not created", 0,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  nr_fw_support_add_logging_supportability_metric(NULL, LIBRARY_NAME, true);
+  tlib_pass_if_int_equal("logging library metric not created in NULL metrics",
+                         0, nrm_table_size(txn->unscoped_metrics));
+
+  nr_fw_support_add_logging_supportability_metric(txn, NULL, true);
+  tlib_pass_if_int_equal("NULL logging library metric not created", 0,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  /* Happy path */
+  nr_fw_support_add_library_supportability_metric(txn, LIBRARY_NAME);
+  tlib_pass_if_not_null("happy path: library metric created",
+                        nrm_find(txn->unscoped_metrics, LIBRARY_METRIC));
+
+  nr_fw_support_add_logging_supportability_metric(txn, LIBRARY_NAME, true);
+  tlib_pass_if_not_null(
+      "happy path: logging library metric created",
+      nrm_find(txn->unscoped_metrics, LOGGING_LIBRARY_METRIC "/enabled"));
+
+  nr_fw_support_add_logging_supportability_metric(txn, LIBRARY_NAME, false);
+  tlib_pass_if_not_null(
+      "happy path: logging library metric created",
+      nrm_find(txn->unscoped_metrics, LOGGING_LIBRARY_METRIC "/disabled"));
+
+  nrm_table_destroy(&txn->unscoped_metrics);
+}
+
+void test_main(void* p NRUNUSED) {
+  test_fw_supportability_metrics();
+}

--- a/tests/integration/logging/monolog2/test_monolog_disable_logging.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_logging.php
@@ -46,7 +46,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/disabled"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog3/test_monolog_disable_logging.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_logging.php
@@ -46,7 +46,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/disabled"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]


### PR DESCRIPTION
This PR will improve agent performance (save on execution time) because:

* Logging libraries will be instrumented only when the global flag, controling logging feature,
(`newrelic.application_logging.enabled`) is true. This has additional benefit that the value
for `Supportability/Logging/PHP/%s/{enabled|disabled}` metric will also depend on that 
configuration flag.

* Monolog instrumentation will execute only when the at least one flag controlling logging feature (`newrelic.application_logging.forwarding.enabled` or `newrelic.application_logging.metrics.enabled`) 
is true.

* Only the necessary parts of Monolog will be instrumented, depending on flags controlling logging features.