### PR TITLE
feat(agent): send logging configuration metrics

### DIFF
--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -624,7 +624,7 @@ static void nr_php_txn_log_error_dt_on_tt_off(void) {
   }
 }
 
-static void nr_php_txn_send_metrics_once(nrtxn_t* txn) {
+static void nr_php_txn_send_metrics_once(nrtxn_t* txn TSRMLS_DC) {
   static unsigned int sent = 0;
   char* metname = NULL;
 
@@ -813,7 +813,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
     return NR_FAILURE;
   }
 
-  nr_php_txn_send_metrics_once(NRPRG(txn));
+  nr_php_txn_send_metrics_once(NRPRG(txn) TSRMLS_CC);
 
   /*
    * Disable automated parenting for the default parent context. See

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_disabled.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_disabled.php
@@ -14,6 +14,9 @@ newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.span_events.attributes.enabled = false
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -87,6 +90,8 @@ ok - double attribute not added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_duplicate.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_duplicate.php
@@ -16,6 +16,9 @@ newrelic.transaction_tracer.threshold = 0
 newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -129,6 +132,8 @@ ok - double attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_parameter"},            [5, 0, 0, 0, 0, 0]]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_duplicate_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_duplicate_te_off.php
@@ -17,6 +17,9 @@ newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
 newrelic.transaction_events.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -103,6 +106,8 @@ null
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_parameter"},       [4, 0, 0, 0, 0, 0]]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_filter.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_filter.php
@@ -16,6 +16,9 @@ newrelic.attributes.exclude = int
 newrelic.span_events.attributes.exclude = bool, string
 newrelic.transaction_events.attributes.exclude = double
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -91,6 +94,8 @@ ok - double attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_key.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_key.php
@@ -14,6 +14,9 @@ newrelic.transaction_tracer.threshold = 0
 newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -91,6 +94,8 @@ ok - double attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_key_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_key_te_off.php
@@ -15,6 +15,9 @@ newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled = 1
 newrelic.transaction_events.enabled = false
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -96,6 +99,8 @@ null
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_parameters.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_parameters.php
@@ -15,6 +15,9 @@ newrelic.transaction_tracer.threshold = 0
 newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -213,6 +216,8 @@ ok - string attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [64, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_value.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_value.php
@@ -13,6 +13,9 @@ newrelic.transaction_tracer.threshold = 0
 newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -91,6 +94,8 @@ ok - double attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_value_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_max_value_te_off.php
@@ -19,6 +19,9 @@ newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
 newrelic.transaction_events.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -101,6 +104,8 @@ null
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_parameters.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_parameters.php
@@ -14,6 +14,9 @@ newrelic.transaction_tracer.threshold = 0
 newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -213,6 +216,8 @@ ok - string attribute NOT added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [65, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_parameters_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_parameters_te_off.php
@@ -16,6 +16,9 @@ newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
 newrelic.transaction_events.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -219,6 +222,8 @@ null
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [65, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_span_and_te.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_span_and_te.php
@@ -15,6 +15,9 @@ newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
 newrelic.loglevel = "verbosedebug"
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -339,6 +342,8 @@ ok - string attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_parameter"},            [65, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [34, 0, 0, 0, 0, 0]]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_span_and_te_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_maxplus_span_and_te_te_off.php
@@ -16,6 +16,9 @@ newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
 newrelic.transaction_events.enabled = false
 newrelic.loglevel = "verbosedebug"
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -253,6 +256,8 @@ null
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_parameter"},            [65, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [34, 0, 0, 0, 0, 0]]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_overwrite.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_overwrite.php
@@ -13,6 +13,9 @@ newrelic.transaction_tracer.threshold = 0
 newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -91,6 +94,8 @@ ok - transaction event attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_parameter"},            [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [2, 0, 0, 0, 0, 0]]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_te_off.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_te_off.php
@@ -15,6 +15,9 @@ newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
 newrelic.transaction_events.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -93,6 +96,8 @@ ok - double attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_types.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_types.php
@@ -14,6 +14,9 @@ newrelic.transaction_tracer.threshold = 0
 newrelic.transaction_tracer.detail = false
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -92,6 +95,8 @@ ok - double attribute added
                                                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},               [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/add_custom_span_parameter"},       [4, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/add_custom_tracer/test_happy.php
+++ b/tests/integration/api/add_custom_tracer/test_happy.php
@@ -8,6 +8,12 @@
 Test normal successful usage of newrelic_add_custom_tracer.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 zip
 zap
@@ -33,6 +39,8 @@ zap
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},   [2, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/add_custom_tracer/test_not_user_function.php
+++ b/tests/integration/api/add_custom_tracer/test_not_user_function.php
@@ -8,6 +8,12 @@
 Test that adding custom tracers for internal functions does not blow up.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
@@ -22,6 +28,8 @@ Test that adding custom tracers for internal functions does not blow up.
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},   [2, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/add_custom_tracer/test_short_segments.php
+++ b/tests/integration/api/add_custom_tracer/test_short_segments.php
@@ -10,6 +10,9 @@ Test that traces will be generated even for very short segments.
 
 /*INI
 newrelic.transaction_tracer.threshold=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_TXN_TRACES
@@ -75,6 +78,8 @@ newrelic.transaction_tracer.threshold=0
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},   [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/custom_metric/test_bad_input.php
+++ b/tests/integration/api/custom_metric/test_bad_input.php
@@ -16,6 +16,12 @@ if (version_compare(PHP_VERSION, "7.4", ">")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - should reject zero args
 ok - should reject one arg
@@ -40,6 +46,8 @@ ok - should reject NaN
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/custom_metric"},       [7, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/custom_metric/test_bad_input.php8.php
+++ b/tests/integration/api/custom_metric/test_bad_input.php8.php
@@ -16,6 +16,12 @@ if (version_compare(PHP_VERSION, "8.0", "<")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - should reject zero args
 ok - should reject one arg
@@ -40,6 +46,8 @@ ok - should reject NaN
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/custom_metric"},       [7, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/custom_metric/test_happy.php
+++ b/tests/integration/api/custom_metric/test_happy.php
@@ -10,6 +10,12 @@ the agent should correctly calculate the count, sum, min, max and sum-of-
 squares.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - min added successfully
 ok - max added successfully
@@ -31,6 +37,8 @@ ok - median added successfully
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/custom_metric"},       [3, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/datastore/test_all_parameters_no_children.php
+++ b/tests/integration/api/datastore/test_all_parameters_no_children.php
@@ -12,6 +12,9 @@ have children.
 /*INI
 newrelic.transaction_tracer.detail = 1
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -37,6 +40,8 @@ newrelic.transaction_tracer.threshold = 0
     [{"name":"OtherTransaction/php__FILE__"},                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_span_parameter"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/record_datastore_segment"},  [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/api/datastore/test_all_parameters_nosql.php
+++ b/tests/integration/api/datastore/test_all_parameters_nosql.php
@@ -12,6 +12,9 @@ datastores.
 /*INI
 newrelic.transaction_tracer.detail = 0
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -37,6 +40,8 @@ newrelic.transaction_tracer.threshold = 0
     [{"name":"OtherTransaction/php__FILE__"},                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/record_datastore_segment"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/datastore/test_all_parameters_sql_no_query.php
+++ b/tests/integration/api/datastore/test_all_parameters_sql_no_query.php
@@ -13,6 +13,9 @@ record_sql option is set to "off".
 newrelic.transaction_tracer.detail = 0
 newrelic.transaction_tracer.record_sql = "off"
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -38,6 +41,8 @@ newrelic.transaction_tracer.threshold = 0
     [{"name":"OtherTransaction/php__FILE__"},                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/record_datastore_segment"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/datastore/test_all_parameters_sql_obfuscated.php
+++ b/tests/integration/api/datastore/test_all_parameters_sql_obfuscated.php
@@ -13,6 +13,9 @@ possible options, while respecting query obfuscation.
 newrelic.transaction_tracer.detail = 0
 newrelic.transaction_tracer.record_sql = "obfuscated"
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -38,6 +41,8 @@ newrelic.transaction_tracer.threshold = 0
     [{"name":"OtherTransaction/php__FILE__"},                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/record_datastore_segment"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/datastore/test_all_parameters_sql_raw.php
+++ b/tests/integration/api/datastore/test_all_parameters_sql_raw.php
@@ -13,6 +13,9 @@ possible options.
 newrelic.transaction_tracer.detail = 0
 newrelic.transaction_tracer.record_sql = "raw"
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -38,6 +41,8 @@ newrelic.transaction_tracer.threshold = 0
     [{"name":"OtherTransaction/php__FILE__"},                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/record_datastore_segment"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/datastore/test_basic.php
+++ b/tests/integration/api/datastore/test_basic.php
@@ -12,6 +12,9 @@ minimum possible options.
 /*INI
 newrelic.transaction_tracer.detail = 0
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -37,6 +40,8 @@ newrelic.transaction_tracer.threshold = 0
     [{"name":"OtherTransaction/php__FILE__"},                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/record_datastore_segment"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/metadata/test_linking_metadata_dt.php
+++ b/tests/integration/api/metadata/test_linking_metadata_dt.php
@@ -13,6 +13,9 @@ when DT is enabled.
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -38,6 +41,8 @@ ok - entity guid
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/CreatePayload/Success"},    
 							  [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/create_distributed_trace_payload"},

--- a/tests/integration/api/metadata/test_linking_metadata_invalid.php
+++ b/tests/integration/api/metadata/test_linking_metadata_invalid.php
@@ -17,6 +17,9 @@ if (version_compare(PHP_VERSION, "7.4", ">")) {
 
 /*INI
 newrelic.distributed_tracing_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*EXPECT_REGEX
@@ -37,6 +40,8 @@ ok - empty metadata
     [{"name":"Errors/all"},                               [1, "??", "??", "??", "??", "??"]],
     [{"name":"Errors/allOther"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"Errors/OtherTransaction/php__FILE__"},      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/get_linking_metadata"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/metadata/test_linking_metadata_invalid.php8.php
+++ b/tests/integration/api/metadata/test_linking_metadata_invalid.php8.php
@@ -18,6 +18,9 @@ if (version_compare(PHP_VERSION, "8.0", "<")) {
 
 /*INI
 newrelic.distributed_tracing_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*EXPECT_REGEX
@@ -37,6 +40,8 @@ newrelic.distributed_tracing_enabled = false
     [{"name":"Errors/all"},                               [1, "??", "??", "??", "??", "??"]],
     [{"name":"Errors/allOther"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"Errors/OtherTransaction/php__FILE__"},      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/get_linking_metadata"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/metadata/test_linking_metadata_no_dt.php
+++ b/tests/integration/api/metadata/test_linking_metadata_no_dt.php
@@ -11,6 +11,9 @@ when DT is disabled.
 
 /*INI
 newrelic.distributed_tracing_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -32,6 +35,8 @@ ok - span id
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/get_linking_metadata"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/metadata/test_trace_metadata_dt.php
+++ b/tests/integration/api/metadata/test_trace_metadata_dt.php
@@ -13,6 +13,9 @@ when Distributed Tracing (DT) is enabled.
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -34,6 +37,8 @@ ok - span id
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/CreatePayload/Success"},    
 							  [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/create_distributed_trace_payload"},

--- a/tests/integration/api/metadata/test_trace_metadata_invalid.php
+++ b/tests/integration/api/metadata/test_trace_metadata_invalid.php
@@ -16,6 +16,9 @@ if (version_compare(PHP_VERSION, "7.4", ">")) {
 
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*EXPECT_REGEX
@@ -44,6 +47,8 @@ ok - empty metadata
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/get_trace_metadata"},    [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/metadata/test_trace_metadata_invalid.php8.php
+++ b/tests/integration/api/metadata/test_trace_metadata_invalid.php8.php
@@ -17,6 +17,9 @@ if (version_compare(PHP_VERSION, "8.0", "<")) {
 
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_REGEX
@@ -44,6 +47,8 @@ newrelic.distributed_tracing_enabled = true
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
                                                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/get_trace_metadata"},    [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/metadata/test_trace_metadata_no_dt.php
+++ b/tests/integration/api/metadata/test_trace_metadata_no_dt.php
@@ -12,6 +12,9 @@ when Distributed Tracing (DT) is disabled.
 /*INI
 newrelic.distributed_tracing_enabled = false
 newrelic.transaction_tracer.threshold = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -28,6 +31,8 @@ ok - empty trace metadata
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/get_trace_metadata"},    [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/other/test_ignore_apdex.php
+++ b/tests/integration/api/other/test_ignore_apdex.php
@@ -8,6 +8,12 @@
 Test that no apdex metrics are created after calling newrelic_ignore_apdex.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
@@ -23,6 +29,8 @@ Test that no apdex metrics are created after calling newrelic_ignore_apdex.
     [{"name":"WebTransaction/Uri__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"WebTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/background_job"},      [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/ignore_apdex"},        [1, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/other/test_is_sampled_cancelled_txn.php
+++ b/tests/integration/api/other/test_is_sampled_cancelled_txn.php
@@ -10,6 +10,9 @@ transaction.
 */
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -26,6 +29,8 @@ newrelic.distributed_tracing_enabled = true
 	  [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
 	  [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
 	  [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
 	  [{"name":"Supportability/api/end_transaction"},		[1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/other/test_is_sampled_dt_disabled.php
+++ b/tests/integration/api/other/test_is_sampled_dt_disabled.php
@@ -10,6 +10,9 @@ Test newrelic_is_sampled() returns false when DT is disabled.
 
 /*INI
 newrelic.distributed_tracing_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -22,6 +25,8 @@ newrelic.distributed_tracing_enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/is_sampled"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/other/test_is_sampled_dt_enabled.php
+++ b/tests/integration/api/other/test_is_sampled_dt_enabled.php
@@ -10,6 +10,9 @@ Test that newrelic_is_sampled() returns true when DT is enabled and it is the so
 
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -26,6 +29,8 @@ newrelic.distributed_tracing_enabled = true
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/is_sampled"},  [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/other/test_is_sampled_extra_param.php
+++ b/tests/integration/api/other/test_is_sampled_extra_param.php
@@ -17,6 +17,9 @@ if (version_compare(PHP_VERSION, "7.4", ">")) {
 
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -40,6 +43,8 @@ newrelic.distributed_tracing_enabled = true
 	  [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
 	  [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
 	  [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
 	  [{"name":"Supportability/api/is_sampled"},			[2, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/other/test_is_sampled_extra_param.php8.php
+++ b/tests/integration/api/other/test_is_sampled_extra_param.php8.php
@@ -17,6 +17,9 @@ if (version_compare(PHP_VERSION, "8.0", "<")) {
 
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -40,6 +43,8 @@ newrelic.distributed_tracing_enabled = true
 		[{"name":"OtherTransaction/php__FILE__"},					[1, "??", "??", "??", "??", "??"]],
 		[{"name":"OtherTransactionTotalTime"},						[1, "??", "??", "??", "??", "??"]],
 		[{"name":"OtherTransactionTotalTime/php__FILE__"},[1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
 		[{"name":"Supportability/api/is_sampled"},				[2, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/api/set_appname/test_bad_params.php
+++ b/tests/integration/api/set_appname/test_bad_params.php
@@ -15,6 +15,12 @@ if (version_compare(PHP_VERSION, "7.4", ">")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_REGEX
 .*Warning:.*newrelic_set_appname\(\) expects at least 1 parameter, 0 given.*
 ok - newrelic_set_appname no params
@@ -46,6 +52,8 @@ ok - newrelic_set_appname too many params
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
     [{"name":"see_me"},                                 [1, 1, 1, 1, 1, 1]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/custom_metric"},       [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/before"},  [5, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/set_appname/test_bad_params.php8.php
+++ b/tests/integration/api/set_appname/test_bad_params.php8.php
@@ -15,6 +15,12 @@ if (version_compare(PHP_VERSION, "8.0", "<")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 newrelic_set_appname no params
 newrelic_set_appname bad appname
@@ -38,6 +44,8 @@ newrelic_set_appname too many params
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
     [{"name":"see_me"},                                 [1, 1, 1, 1, 1, 1]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/custom_metric"},       [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/before"},  [5, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/set_appname/test_transmit_int.php
+++ b/tests/integration/api/set_appname/test_transmit_int.php
@@ -9,6 +9,12 @@ Test that newrelic_set_appname works as expected when the transmit bool is
 set to a value that is of type int or float.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - newrelic_set_appname transmit=1
 ok - newrelic_set_appname transmit=1
@@ -28,6 +34,8 @@ ok - newrelic_set_appname transmit=1
     [{"name":"OtherTransaction/php__FILE__"},           [3, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [3, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [3, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/set_appname/after"},   [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/before"},  [2, 0, 0, 0, 0, 0]]
   ]

--- a/tests/integration/api/set_appname/test_transmit_true.php
+++ b/tests/integration/api/set_appname/test_transmit_true.php
@@ -9,6 +9,12 @@ Test that newrelic_set_appname works as expected when the transmit bool is
 set to true.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - newrelic_set_appname transmit=true
 ok - newrelic_set_appname transmit=1
@@ -28,6 +34,8 @@ ok - newrelic_set_appname transmit=1
     [{"name":"OtherTransaction/php__FILE__"},               [3, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                  [3, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},      [3, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/set_appname/after"},       [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/before"},      [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/with_license"},[2, 0, 0, 0, 0, 0]]

--- a/tests/integration/basic/test_call_user_func_array_0.php
+++ b/tests/integration/basic/test_call_user_func_array_0.php
@@ -11,6 +11,9 @@ CodeIgniter or Drupal is detected/forced.
 
 /*INI
 newrelic.framework=codeigniter   ; cause agent to hook call_user_func_array
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -33,6 +36,8 @@ foo=17
     [{"name":"OtherTransaction/php__FILE__"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/add_custom_tracer"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/framework/CodeIgniter/forced"},              [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/basic/test_dl.php
+++ b/tests/integration/basic/test_dl.php
@@ -8,6 +8,12 @@
 Exercise the instrumentation for the dl() function.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
@@ -29,6 +35,8 @@ Exercise the instrumentation for the dl() function.
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/InstrumentedFunction/dl"}, [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/basic/test_output_buffer.php
+++ b/tests/integration/basic/test_output_buffer.php
@@ -11,6 +11,9 @@ Exercise the wrappers for the various output buffer functions.
 
 /*INI
 error_reporting = E_ERROR | E_CORE_ERROR | E_RECOVERABLE_ERROR
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -40,7 +43,9 @@ block4 <br>
     [{"name":"OtherTransaction/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime/php__FILE__"},            [1, "??", "??", "??", "??", "??"]]
+    [{"name":"OtherTransactionTotalTime/php__FILE__"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/distributed_tracing/newrelic/test_inbound_payload_rejects_if_no_tx_or_id.php
+++ b/tests/integration/distributed_tracing/newrelic/test_inbound_payload_rejects_if_no_tx_or_id.php
@@ -21,6 +21,9 @@ if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -37,6 +40,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_payload"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/ParseException"},

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_exception.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_exception.php
@@ -13,6 +13,9 @@ by setting distributed_trace_enabled to false.
 
 /*INI
 newrelic.distributed_tracing_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -28,6 +31,8 @@ newrelic.distributed_tracing_enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Exception"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/create_distributed_trace_payload"},

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_createBeforeAccept.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_createBeforeAccept.php
@@ -12,6 +12,9 @@ this happens when an accept payload is called and create payload was already cal
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -35,6 +38,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/create_distributed_trace_payload"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_payload"},

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_majorVersion.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_majorVersion.php
@@ -22,6 +22,9 @@ if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -38,6 +41,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_payload"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Ignored/MajorVersion"},

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_multiple.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_multiple.php
@@ -21,6 +21,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -37,6 +40,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_payload"},
                                                           [2, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Ignored/Multiple"},

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_null.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_null.php
@@ -12,6 +12,9 @@ by passing nothing into the newrelic_accept_distributed_trace_payload function.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -37,6 +40,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Ignored/Null"},
                                                           [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_untrustedAccount.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_untrustedAccount.php
@@ -13,6 +13,9 @@ by changing the trusted key to an incorrect key "tk":"12345"
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -29,6 +32,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_payload"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Ignored/UntrustedAccount"},

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_untrustedAccount_httpsafe.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_ignored_untrustedAccount_httpsafe.php
@@ -14,6 +14,9 @@ by changing the trusted key to an incorrect key "tk":"12345"
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -30,6 +33,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_payload"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Ignored/UntrustedAccount"},

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_parseexception.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_parseexception.php
@@ -13,6 +13,9 @@ by removing information from the payload, in this case "ty":"App".
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -29,6 +32,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_payload"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/ParseException"},

--- a/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_success.php
+++ b/tests/integration/distributed_tracing/newrelic/test_supportability_acceptpayload_success.php
@@ -20,6 +20,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -36,6 +39,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Success"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_payload"},

--- a/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_empty_array.php
+++ b/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_empty_array.php
@@ -16,6 +16,9 @@ are created when DT headers are inserted into an empty array via the PHP API
 newrelic.distributed_tracing_enabled = true
 newrelic.distributed_tracing_exclude_newrelic_header = false
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -32,6 +35,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/CreatePayload/Success"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/TraceContext/Create/Success"},

--- a/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_happy.php
+++ b/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_happy.php
@@ -16,6 +16,9 @@ are created when DT headers are inserted into an array via the PHP API
 newrelic.distributed_tracing_enabled = true
 newrelic.distributed_tracing_exclude_newrelic_header = false
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -32,6 +35,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/CreatePayload/Success"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/TraceContext/Create/Success"},

--- a/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_nonref.php
+++ b/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_nonref.php
@@ -8,6 +8,12 @@
 Tests that non-reference arguments are rejected without segfault.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
@@ -28,7 +34,9 @@ Tests that non-reference arguments are rejected without segfault.
     [{"name":"OtherTransaction/all"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]]
+    [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_wrong_arg_type.php
+++ b/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_wrong_arg_type.php
@@ -15,6 +15,12 @@ if (version_compare(PHP_VERSION, "7.4", ">")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
@@ -36,6 +42,8 @@ if (version_compare(PHP_VERSION, "7.4", ">")) {
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/insert_distributed_trace_headers"},
                                                           [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_wrong_arg_type.php8.php
+++ b/tests/integration/distributed_tracing/w3c/test_insert_dt_headers_wrong_arg_type.php8.php
@@ -15,6 +15,12 @@ if (version_compare(PHP_VERSION, "8.0", "<")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
@@ -36,6 +42,8 @@ if (version_compare(PHP_VERSION, "8.0", "<")) {
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/insert_distributed_trace_headers"},
                                                           [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/distributed_tracing/w3c/test_invalid_inbound.php
+++ b/tests/integration/distributed_tracing/w3c/test_invalid_inbound.php
@@ -11,6 +11,9 @@ Tests that a trace context header parses other vendors correctly.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -27,6 +30,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_headers"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/TraceContext/TraceParent/Parse/Exception"},

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_headers.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_headers.php
@@ -19,6 +19,9 @@ if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -35,6 +38,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Success"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/TraceContext/Accept/Success"},

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_headers_parsed_key.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_headers_parsed_key.php
@@ -19,6 +19,9 @@ if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -35,6 +38,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Success"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/TraceContext/Accept/Success"},

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_no_sampled.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_no_sampled.php
@@ -19,6 +19,9 @@ if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -35,6 +38,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Success"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/TraceContext/Accept/Success"},

--- a/tests/integration/distributed_tracing/w3c/test_valid_inbound_non_newrelic.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_inbound_non_newrelic.php
@@ -18,6 +18,9 @@ if (!isset($_ENV["ACCOUNT_supportability_trusted"])) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -34,6 +37,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Success"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/TraceContext/Accept/Success"},

--- a/tests/integration/distributed_tracing/w3c/test_valid_no_nr_state.php
+++ b/tests/integration/distributed_tracing/w3c/test_valid_no_nr_state.php
@@ -11,6 +11,9 @@ Tests that a trace context header parses other vendors correctly.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -27,6 +30,8 @@ newrelic.cross_application_tracer.enabled = false
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/accept_distributed_trace_headers"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/DistributedTrace/AcceptPayload/Success"},

--- a/tests/integration/errors/test_top_level_exception_tracer.php
+++ b/tests/integration/errors/test_top_level_exception_tracer.php
@@ -9,6 +9,12 @@ The agent should not remove a custom tracer from a function when it is no longer
 used as an exception handler.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 NULL
 */
@@ -30,7 +36,9 @@ NULL
     [{"name":"Supportability/api/add_custom_tracer"},   [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/handler"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/handler",
-      "scope":"OtherTransaction/php__FILE__"},          [1, "??", "??", "??", "??", "??"]]
+      "scope":"OtherTransaction/php__FILE__"},          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/external/curl_exec/test_cat_and_synthetics_disabled.php
+++ b/tests/integration/external/curl_exec/test_cat_and_synthetics_disabled.php
@@ -15,6 +15,9 @@
 newrelic.cross_application_tracer.enabled = false
 newrelic.synthetics.enabled = false
 newrelic.distributed_tracing_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -54,6 +57,8 @@ ok - execute request
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                  ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                      ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                           [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_disabled.php
+++ b/tests/integration/external/curl_exec/test_cat_disabled.php
@@ -12,6 +12,9 @@ to external calls when cross application tracing is disabled.
 /*INI
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -28,6 +31,8 @@ ok - execute request
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_disabled_by_default.php
+++ b/tests/integration/external/curl_exec/test_cat_disabled_by_default.php
@@ -12,6 +12,9 @@ supposed to be disabled by default.
 
 /*INI
 newrelic.distributed_tracing_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -28,6 +31,8 @@ ok - execute request
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_request_headers_empty_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_empty_array.php
@@ -23,6 +23,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -44,6 +47,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_request_headers_present.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_present.php
@@ -23,6 +23,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -44,6 +47,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_request_headers_present_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_present_array.php
@@ -23,6 +23,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -44,6 +47,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_request_headers_referenced_array.php
+++ b/tests/integration/external/curl_exec/test_cat_request_headers_referenced_array.php
@@ -23,6 +23,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -44,6 +47,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_response_header_anonymous.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_anonymous.php
@@ -19,6 +19,9 @@ if (!extension_loaded("curl")) {
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -40,6 +43,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_response_header_function.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_function.php
@@ -23,6 +23,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -44,6 +47,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_response_header_returned.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_returned.php
@@ -22,6 +22,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_REGEX
@@ -42,6 +45,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_response_header_to_file.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_to_file.php
@@ -19,6 +19,9 @@ if (!extension_loaded("curl")) {
 /*INI
 newrelic.distributed_tracing_enabled = false
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -40,6 +43,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_response_header_to_stdout.php
+++ b/tests/integration/external/curl_exec/test_cat_response_header_to_stdout.php
@@ -22,6 +22,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_REGEX
@@ -42,6 +45,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_cat_simple.php
+++ b/tests/integration/external/curl_exec/test_cat_simple.php
@@ -22,6 +22,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -43,6 +46,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                                [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/curl_exec/test_dt_newrelic_header_disabled.php
@@ -12,6 +12,9 @@ A simple Distributed Tracing (DT) request.
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_exclude_newrelic_header = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -39,6 +42,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                                [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_dt_request_headers_empty_array.php
+++ b/tests/integration/external/curl_exec/test_dt_request_headers_empty_array.php
@@ -12,6 +12,9 @@ with an empty array.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -39,6 +42,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_dt_request_headers_present.php
+++ b/tests/integration/external/curl_exec/test_dt_request_headers_present.php
@@ -12,6 +12,9 @@ with a non-empty array.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -39,6 +42,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_dt_request_headers_present_array.php
+++ b/tests/integration/external/curl_exec/test_dt_request_headers_present_array.php
@@ -12,6 +12,9 @@ called with a non-empty array.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -39,6 +42,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_dt_request_headers_referenced_array.php
+++ b/tests/integration/external/curl_exec/test_dt_request_headers_referenced_array.php
@@ -13,6 +13,9 @@ with an array that has been iterated over by-reference.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -40,6 +43,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_dt_simple.php
+++ b/tests/integration/external/curl_exec/test_dt_simple.php
@@ -11,6 +11,9 @@ A simple DT request.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -38,6 +41,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                                [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_file_proto.php
+++ b/tests/integration/external/curl_exec/test_file_proto.php
@@ -11,6 +11,9 @@ protocol is used.
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -30,6 +33,8 @@ ok - execute request
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                            [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                       [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_http.php
+++ b/tests/integration/external/curl_exec/test_http.php
@@ -16,6 +16,12 @@ if (!extension_loaded("curl")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - simple hostname
 ok - strip query string
@@ -29,6 +35,8 @@ ok - strip credentials
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/external/curl_exec/test_malformed_url.php
+++ b/tests/integration/external/curl_exec/test_malformed_url.php
@@ -15,6 +15,12 @@ if (!extension_loaded("curl")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - empty string
 ok - type mismatch (boolean)
@@ -26,6 +32,8 @@ ok - type mismatch (boolean)
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/external/curl_exec/test_missing_handle.php
+++ b/tests/integration/external/curl_exec/test_missing_handle.php
@@ -16,12 +16,20 @@ if (!extension_loaded("curl")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/external/curl_exec/test_request_headers_referenced_array.php
+++ b/tests/integration/external/curl_exec/test_request_headers_referenced_array.php
@@ -12,6 +12,9 @@ present when both DT and CAT are disabled.
 /*INI
 newrelic.distributed_tracing_enabled = false
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -32,6 +35,8 @@ ok - tracing successful
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_synthetics.php
+++ b/tests/integration/external/curl_exec/test_synthetics.php
@@ -30,6 +30,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*HEADERS
@@ -51,6 +54,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_synthetics_disabled.php
+++ b/tests/integration/external/curl_exec/test_synthetics_disabled.php
@@ -20,6 +20,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 newrelic.distributed_tracing_enabled=0
 newrelic.synthetics.enabled = false
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -52,6 +55,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_synthetics_with_cat_disabled.php
+++ b/tests/integration/external/curl_exec/test_synthetics_with_cat_disabled.php
@@ -21,6 +21,9 @@ if (!$_ENV["SYNTHETICS_HEADER_supportability"]) {
 
 /*INI
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -52,6 +55,8 @@ ok - execute request
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                  ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                      ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                           [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_synthetics_with_dt.php
+++ b/tests/integration/external/curl_exec/test_synthetics_with_dt.php
@@ -18,6 +18,9 @@ if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
 
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -49,6 +52,8 @@ ok - execute request
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_exec/test_type_mismatch.php
+++ b/tests/integration/external/curl_exec/test_type_mismatch.php
@@ -15,12 +15,20 @@ if (!extension_loaded("curl")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/external/curl_multi_exec/test_cat_simple.php
+++ b/tests/integration/external/curl_multi_exec/test_cat_simple.php
@@ -22,6 +22,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -46,6 +49,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                                [2, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                           [2, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                      [2, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_custom_header.php
+++ b/tests/integration/external/curl_multi_exec/test_custom_header.php
@@ -12,6 +12,9 @@ present when both DT and CAT are disabled.
 /*INI
 newrelic.distributed_tracing_enabled = false
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -32,6 +35,8 @@ ok - tracing successful
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_dt_custom_header.php
+++ b/tests/integration/external/curl_multi_exec/test_dt_custom_header.php
@@ -11,6 +11,9 @@ Test that DT works with curl_multi_exec and that custom headers are passed on.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -38,6 +41,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/curl_multi_exec/test_dt_newrelic_header_disabled.php
@@ -12,6 +12,9 @@ Two simple DT requests in one curl_multi handle.
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_exclude_newrelic_header = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -41,6 +44,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                                [2, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                           [2, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                      [2, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_dt_simple.php
+++ b/tests/integration/external/curl_multi_exec/test_dt_simple.php
@@ -11,6 +11,9 @@ Two simple DT requests in one curl_multi handle.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -40,6 +43,8 @@ null
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                                [2, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                           [2, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                      [2, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_exec_add_handles.php
+++ b/tests/integration/external/curl_multi_exec/test_exec_add_handles.php
@@ -20,6 +20,9 @@ newrelic.transaction_tracer.detail = 0
 newrelic.transaction_tracer.threshold = 0
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_TXN_TRACES
@@ -120,6 +123,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                                [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                           [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                      [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_exec_remove_handles.php
+++ b/tests/integration/external/curl_multi_exec/test_exec_remove_handles.php
@@ -20,6 +20,9 @@ newrelic.transaction_tracer.detail = 0
 newrelic.transaction_tracer.threshold = 0
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_TXN_TRACES
@@ -119,6 +122,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                                [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                           [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                      [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_http.php
+++ b/tests/integration/external/curl_multi_exec/test_http.php
@@ -16,6 +16,12 @@ if (!extension_loaded("curl")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - simple hostname
 ok - strip query string
@@ -29,6 +35,8 @@ ok - strip credentials
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/external/curl_multi_exec/test_malformed_url.php
+++ b/tests/integration/external/curl_multi_exec/test_malformed_url.php
@@ -10,6 +10,9 @@ Test the agent's handling of malformed urls passed to curl_multi_exec().
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -31,6 +34,8 @@ ok - no more errors
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/<unknown>/all"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/<unknown>/all",
       "scope":"OtherTransaction/php__FILE__"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_missing_arg.php
+++ b/tests/integration/external/curl_multi_exec/test_missing_arg.php
@@ -16,12 +16,20 @@ if (!extension_loaded("curl")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/external/curl_multi_exec/test_simple.php
+++ b/tests/integration/external/curl_multi_exec/test_simple.php
@@ -12,6 +12,9 @@ Test that the agent instruments curl_multi_exec.
 newrelic.transaction_tracer.threshold=0
 newrelic.distributed_tracing_enabled = false
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_TXN_TRACES
@@ -124,6 +127,8 @@ Hello world!
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                          ["??", "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                     ["??", "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                ["??", "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/curl_multi_exec/test_txn_restart.php
+++ b/tests/integration/external/curl_multi_exec/test_txn_restart.php
@@ -20,6 +20,9 @@ if (!extension_loaded("curl")) {
 newrelic.transaction_tracer.threshold=0
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT

--- a/tests/integration/external/curl_multi_exec/test_type_mismatch.php
+++ b/tests/integration/external/curl_multi_exec/test_type_mismatch.php
@@ -15,12 +15,20 @@ if (!extension_loaded("curl")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/external/file_get_contents/test_cat_and_synthetics_disabled.php
+++ b/tests/integration/external/file_get_contents/test_cat_and_synthetics_disabled.php
@@ -22,6 +22,9 @@ if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
 newrelic.cross_application_tracer.enabled = false
 newrelic.synthetics.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -52,6 +55,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                  ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                      ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                           [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_cat_context_provided.php
+++ b/tests/integration/external/file_get_contents/test_cat_context_provided.php
@@ -19,6 +19,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -57,6 +60,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [12, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [12, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [12, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_cat_default_context.php
+++ b/tests/integration/external/file_get_contents/test_cat_default_context.php
@@ -19,6 +19,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -39,6 +42,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_cat_disabled.php
+++ b/tests/integration/external/file_get_contents/test_cat_disabled.php
@@ -12,6 +12,9 @@ to external calls when cross application tracing is disabled.
 /*INI
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -27,6 +30,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_cat_no_context.php
+++ b/tests/integration/external/file_get_contents/test_cat_no_context.php
@@ -18,6 +18,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -42,6 +45,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [5, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [5, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [5, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_dt_context_provided.php
+++ b/tests/integration/external/file_get_contents/test_dt_context_provided.php
@@ -13,6 +13,9 @@ call.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -40,6 +43,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [13, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [13, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [13, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_dt_default_context.php
+++ b/tests/integration/external/file_get_contents/test_dt_default_context.php
@@ -12,6 +12,9 @@ when the customer has added a header through the default context.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -29,6 +32,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 

--- a/tests/integration/external/file_get_contents/test_dt_disabled.php
+++ b/tests/integration/external/file_get_contents/test_dt_disabled.php
@@ -19,6 +19,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -35,6 +38,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_dt_disabled_cat_disabled.php
+++ b/tests/integration/external/file_get_contents/test_dt_disabled_cat_disabled.php
@@ -13,6 +13,9 @@ distributed tracing and CAT are disabled.
 /*INI
 newrelic.distributed_tracing_enabled = false
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*EXPECT
@@ -28,6 +31,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/file_get_contents/test_dt_newrelic_header_disabled.php
@@ -11,6 +11,9 @@ Test that distributed tracing works with file_get_contents without a context.
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.distributed_tracing_exclude_newrelic_header = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [5, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [5, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 

--- a/tests/integration/external/file_get_contents/test_dt_no_context.php
+++ b/tests/integration/external/file_get_contents/test_dt_no_context.php
@@ -10,6 +10,9 @@ Test that distributed tracing works with file_get_contents without a context.
 
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -29,6 +32,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [5, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [5, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 

--- a/tests/integration/external/file_get_contents/test_http_response_header_cv.php
+++ b/tests/integration/external/file_get_contents/test_http_response_header_cv.php
@@ -19,6 +19,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -48,6 +51,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [5, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [5, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [5, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_synthetics_context_provided.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_context_provided.php
@@ -30,6 +30,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*HEADERS
@@ -72,6 +75,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [  12, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_synthetics_default_context.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_default_context.php
@@ -30,6 +30,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*HEADERS
@@ -54,6 +57,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_synthetics_disabled.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_disabled.php
@@ -13,6 +13,9 @@ calls when the Synthetics feature is disabled.
 newrelic.distributed_tracing_enabled=0
 newrelic.synthetics.enabled = false
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -51,6 +54,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_synthetics_no_context.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_no_context.php
@@ -30,6 +30,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*HEADERS
@@ -58,6 +61,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   5, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_synthetics_with_cat_disabled.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_with_cat_disabled.php
@@ -21,6 +21,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 
 /*INI
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -52,6 +55,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/file_get_contents/test_synthetics_with_dt.php
+++ b/tests/integration/external/file_get_contents/test_synthetics_with_dt.php
@@ -12,6 +12,9 @@ enabled.
 
 /*INI
 newrelic.distributed_tracing_enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -51,6 +54,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [  3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_cat.php
+++ b/tests/integration/external/guzzle5/test_cat.php
@@ -26,6 +26,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -46,6 +49,8 @@ X-NewRelic-App-Data=??
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt.php
+++ b/tests/integration/external/guzzle5/test_dt.php
@@ -22,6 +22,9 @@ if (version_compare(phpversion(), '5.5.0', '<')) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*EXPECT
@@ -37,6 +40,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 
       "scope":"OtherTransaction/php__FILE__"},            [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
@@ -23,6 +23,9 @@ if (version_compare(phpversion(), '5.5.0', '<')) {
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_exclude_newrelic_header = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*EXPECT
@@ -38,6 +41,8 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 
       "scope":"OtherTransaction/php__FILE__"},            [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics.php
@@ -26,6 +26,9 @@ if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*
@@ -65,6 +68,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle5/test_no_cat_no_dt.php
@@ -22,6 +22,9 @@ if (version_compare(phpversion(), '5.4.0', '<')) {
 /*INI
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -39,6 +42,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 
       "scope":"OtherTransaction/php__FILE__"},            [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_cat.php
+++ b/tests/integration/external/guzzle6/test_cat.php
@@ -28,6 +28,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -48,6 +51,8 @@ X-NewRelic-App-Data=??
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt.php
+++ b/tests/integration/external/guzzle6/test_dt.php
@@ -24,6 +24,9 @@ if (!unpack_guzzle(6)) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*EXPECT
@@ -41,6 +44,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 
       "scope":"OtherTransaction/php__FILE__"},            [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
@@ -25,6 +25,9 @@ if (!unpack_guzzle(6)) {
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_exclude_newrelic_header = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*EXPECT
@@ -42,6 +45,8 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 
       "scope":"OtherTransaction/php__FILE__"},            [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics.php
@@ -28,6 +28,9 @@ if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.cross_application_tracer.enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
  */
 
 /*
@@ -61,6 +64,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle6/test_no_cat_no_dt.php
@@ -24,6 +24,9 @@ if (!unpack_guzzle(6)) {
 /*INI
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -41,6 +44,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [3, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all", 
       "scope":"OtherTransaction/php__FILE__"},            [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/http/test_v1_cat.php
+++ b/tests/integration/external/http/test_v1_cat.php
@@ -28,6 +28,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -44,6 +47,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/http/test_v1_cat_and_synthetics_disabled.php
+++ b/tests/integration/external/http/test_v1_cat_and_synthetics_disabled.php
@@ -31,6 +31,9 @@ if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
 newrelic.cross_application_tracer.enabled = false
 newrelic.synthetics.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -61,6 +64,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                  ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                      ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                           [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/http/test_v1_cat_disabled.php
+++ b/tests/integration/external/http/test_v1_cat_disabled.php
@@ -27,6 +27,9 @@ if (version_compare(phpversion('http'), '2.0.0', '>=')) {
 /*INI
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -35,6 +38,8 @@ newrelic.distributed_tracing_enabled=0
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/all"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/allOther"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"External/127.0.0.1/all"},                [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/http/test_v1_synthetics.php
+++ b/tests/integration/external/http/test_v1_synthetics.php
@@ -28,6 +28,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -59,6 +62,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/http/test_v1_synthetics_disabled.php
+++ b/tests/integration/external/http/test_v1_synthetics_disabled.php
@@ -31,6 +31,9 @@ if (!isset($_ENV["ACCOUNT_supportability"]) || !isset($_ENV["APP_supportability"
 newrelic.cross_application_tracer.enabled = true
 newrelic.synthetics.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -62,6 +65,8 @@ X-NewRelic-App-Data=??
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                                    ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                        ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                             [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/http/test_v1_synthetics_with_cat_disabled.php
+++ b/tests/integration/external/http/test_v1_synthetics_with_cat_disabled.php
@@ -33,6 +33,9 @@ if (!isset($_ENV["SYNTHETICS_HEADER_supportability"])) {
 /*INI
 newrelic.cross_application_tracer.enabled = false
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*
@@ -63,6 +66,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing X-NewRelic-Synthetics=found
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Apdex"},                               ["??", "??", "??", "??", "??",    0]],
     [{"name":"Apdex/Uri__FILE__"},                   ["??", "??", "??", "??", "??",    0]],
     [{"name":"External/all"},                        [   1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/http/test_v2_cat.php
+++ b/tests/integration/external/http/test_v2_cat.php
@@ -23,6 +23,9 @@ if (version_compare(phpversion('http'), '2.0.0', '<')) {
 /*INI
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -38,6 +41,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},             [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/test_curl_multi_add_remove_handles.php
+++ b/tests/integration/external/test_curl_multi_add_remove_handles.php
@@ -15,6 +15,12 @@ if (!extension_loaded("curl")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - curl handle added
 ok - curl handle added
@@ -27,6 +33,8 @@ ok - curl handle removed
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/frameworks/laravel/test_artisan_name.php
+++ b/tests/integration/frameworks/laravel/test_artisan_name.php
@@ -11,6 +11,9 @@ according to that command.
 
 /*INI
 newrelic.framework = laravel
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -19,6 +22,8 @@ newrelic.framework = laravel
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                   [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/frameworks/laravel/test_artisan_name_non_input.php
+++ b/tests/integration/frameworks/laravel/test_artisan_name_non_input.php
@@ -11,6 +11,9 @@ result in the transaction being named "unknown".
 
 /*INI
 newrelic.framework = laravel
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -19,6 +22,8 @@ newrelic.framework = laravel
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/frameworks/laravel/test_artisan_name_non_string.php
+++ b/tests/integration/frameworks/laravel/test_artisan_name_non_string.php
@@ -11,6 +11,9 @@ transaction being named "list".
 
 /*INI
 newrelic.framework=laravel
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -19,6 +22,8 @@ newrelic.framework=laravel
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/frameworks/magento/test_temp_tables.php
+++ b/tests/integration/frameworks/magento/test_temp_tables.php
@@ -19,6 +19,9 @@ if (!extension_loaded("sqlite3")) {
 
 /*INI
 newrelic.framework = magento2
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -27,6 +30,8 @@ newrelic.framework = magento2
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                   [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/frameworks/silex/test_basic.php
+++ b/tests/integration/frameworks/silex/test_basic.php
@@ -10,12 +10,20 @@ The agent should name Silex transactions that have _route attributes.
 
 /*SKIPIF <?php require('skipif.inc'); */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/frameworks/silex/test_invalid_attributes.php
+++ b/tests/integration/frameworks/silex/test_invalid_attributes.php
@@ -10,12 +10,20 @@ The agent should handle an invalid Silex request attributes object.
 
 /*SKIPIF <?php require('skipif.inc'); */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/frameworks/silex/test_invalid_request.php
+++ b/tests/integration/frameworks/silex/test_invalid_request.php
@@ -10,6 +10,9 @@ The agent should handle an invalid Silex request object.
 
 /*INI
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF <?php require('skipif.inc'); */
@@ -20,6 +23,8 @@ newrelic.distributed_tracing_enabled=0
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/frameworks/wordpress/test_site_specific_tables.php
+++ b/tests/integration/frameworks/wordpress/test_site_specific_tables.php
@@ -19,6 +19,9 @@ if (!extension_loaded("sqlite3")) {
 
 /*INI
 newrelic.framework = wordpress
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -27,6 +30,8 @@ newrelic.framework = wordpress
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                   [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_force_framework_0.php
+++ b/tests/integration/ini/test_force_framework_0.php
@@ -10,6 +10,9 @@ Forcing the framework to 'no_framework' should generate a forced framework metri
 
 /*INI
 newrelic.framework = no_framework
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -18,6 +21,8 @@ newrelic.framework = no_framework
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_force_framework_1.php
+++ b/tests/integration/ini/test_force_framework_1.php
@@ -11,6 +11,9 @@ a forced framework metric.
 
 /*INI
 newrelic.framework = bogus_framework_name
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -19,6 +22,8 @@ newrelic.framework = bogus_framework_name
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_force_framework_2.php
+++ b/tests/integration/ini/test_force_framework_2.php
@@ -11,6 +11,9 @@ enable the Drupal tab in APM.
 
 /*INI
 newrelic.framework = drupal8
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -19,6 +22,8 @@ newrelic.framework = drupal8
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_force_framework_3.php
+++ b/tests/integration/ini/test_force_framework_3.php
@@ -11,6 +11,9 @@ map newrelic.framework names to enums.
 
 /*INI
 newrelic.framework = cakephp
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*XFAIL
@@ -26,6 +29,8 @@ which causes the metric to be generated.
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},            [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},               [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/ini/test_force_framework_5.php
+++ b/tests/integration/ini/test_force_framework_5.php
@@ -11,6 +11,9 @@ enable the Drupal tab in APM.
 
 /*INI
 newrelic.framework = drupal
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*XFAIL
@@ -23,6 +26,8 @@ The framework is being incorrectly reported as Drupal 8.
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/ini/test_force_framework_6.php
+++ b/tests/integration/ini/test_force_framework_6.php
@@ -10,6 +10,9 @@ Forcing the framework to 'none' should not generate a forced framework metric.
 
 /*INI
 newrelic.framework=none
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -18,6 +21,8 @@ newrelic.framework=none
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_ini_001.php
+++ b/tests/integration/ini/test_ini_001.php
@@ -10,6 +10,9 @@ Exercise the modify handler for the audit log.
 
 /*INI
 newrelic.daemon.auditlog = /dev/null
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -18,6 +21,8 @@ newrelic.daemon.auditlog = /dev/null
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_ini_002.php
+++ b/tests/integration/ini/test_ini_002.php
@@ -10,6 +10,9 @@ Exercise the modify handler for the newrelic.special ini setting.
 
 /*INI
 newrelic.special = flummoxed
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -18,6 +21,8 @@ newrelic.special = flummoxed
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_ini_003.php
+++ b/tests/integration/ini/test_ini_003.php
@@ -13,6 +13,9 @@ happens. For the list of files, we reference ourself with a pcre.
 /*INI
 newrelic.webtransaction.name.functions = f_0,f_1,bogus_f_0,,,
 newrelic.webtransaction.name.files = .*test_ini_003.php,**,[,bat/,baz,,,
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -33,6 +36,8 @@ f_3() called
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_ini_004.php
+++ b/tests/integration/ini/test_ini_004.php
@@ -13,6 +13,9 @@ happens. For the list of files, we reference ourself with a pcre.
 /*INI
 newrelic.webtransaction.name.functions = CLI/PHP_FLAGS_ARGS,Foobar::interesting_method,bar,baz,,,
 newrelic.webtransaction.name.files = .*exercise_ini_3.php,**,[,bat/,baz,,,
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -25,6 +28,8 @@ Foobar::interesting_method() called
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/ini/test_transaction_tracer_max_segments.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments.php
@@ -13,6 +13,9 @@ the agent limits the number of segments created to that value.
 newrelic.transaction_tracer.max_segments_cli=256
 newrelic.transaction_tracer.threshold=0
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_TXN_TRACES
@@ -63,6 +66,8 @@ newrelic.distributed_tracing_enabled=0
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/my_function"},                     [1000, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/my_function",
      "scope":"OtherTransaction/php__FILE__" },          [1000, "??", "??", "??", "??", "??"]],

--- a/tests/integration/ini/test_transaction_tracer_max_segments_nested.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_nested.php
@@ -13,6 +13,9 @@ the agent limits the number of segments created, even in a nested scenario.
 newrelic.transaction_tracer.max_segments_cli=10
 newrelic.transaction_tracer.threshold=0
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_TXN_TRACES
@@ -100,6 +103,8 @@ newrelic.distributed_tracing_enabled=0
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/great_grandmother"},               [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/great_grandmother",
      "scope":"OtherTransaction/php__FILE__" },          [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/ini/test_transaction_tracer_max_segments_no_cap.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_no_cap.php
@@ -13,6 +13,9 @@ value, the agent does not limit the number of segments created.
 newrelic.transaction_tracer.max_segments_cli=0
 newrelic.transaction_tracer.threshold=0
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_TXN_TRACES
@@ -63,6 +66,8 @@ newrelic.distributed_tracing_enabled=0
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/my_function"},                     [1000, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/my_function",
      "scope":"OtherTransaction/php__FILE__" },          [1000, "??", "??", "??", "??", "??"]],

--- a/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php
@@ -15,6 +15,9 @@ was called.
 newrelic.transaction_tracer.max_segments_cli=3
 newrelic.transaction_tracer.threshold=0
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_TXN_TRACES
@@ -82,6 +85,8 @@ newrelic.distributed_tracing_enabled=0
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/my_function"},                          [3, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/MySQL/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/MySQL/allOther"},                    [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/lang/test_generator_5.6-7.0.php
+++ b/tests/integration/lang/test_generator_5.6-7.0.php
@@ -20,6 +20,12 @@ if (version_compare(PHP_VERSION, '7.1', '>=')) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 1,2,3,4,5,6,7,8,9,10,
 */
@@ -30,6 +36,8 @@ if (version_compare(PHP_VERSION, '7.1', '>=')) {
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/lang/test_generator_7.1.php
+++ b/tests/integration/lang/test_generator_7.1.php
@@ -16,6 +16,12 @@ if (version_compare(PHP_VERSION, '7.1', '<')) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 1,2,3,4,5,6,7,8,9,10,
 */
@@ -26,6 +32,8 @@ if (version_compare(PHP_VERSION, '7.1', '<')) {
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/logging/monolog2/test_monolog_basic.php
+++ b/tests/integration/logging/monolog2/test_monolog_basic.php
@@ -55,7 +55,9 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_cat.php
+++ b/tests/integration/logging/monolog2/test_monolog_cat.php
@@ -55,7 +55,9 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_disable_forwarding.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_forwarding.php
@@ -56,7 +56,9 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_disable_logging.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_logging.php
@@ -46,8 +46,10 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/PHP/Monolog/disabled"},                     [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},                     [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_disable_logging.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_logging.php
@@ -46,7 +46,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/disabled"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/disabled"},                     [1, "??", "??", "??", "??", "??"]]

--- a/tests/integration/logging/monolog2/test_monolog_disable_metrics.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_metrics.php
@@ -50,7 +50,9 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},                     [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_drop_empty.php
+++ b/tests/integration/logging/monolog2/test_monolog_drop_empty.php
@@ -56,7 +56,9 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_hsm_disable_forwarding.php
+++ b/tests/integration/logging/monolog2/test_monolog_hsm_disable_forwarding.php
@@ -57,7 +57,9 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_large_message_limit.php
+++ b/tests/integration/logging/monolog2/test_monolog_large_message_limit.php
@@ -39,7 +39,9 @@ newrelic.application_logging.forwarding.max_samples_stored = 10000
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_large_message_limit_drops.php
+++ b/tests/integration/logging/monolog2/test_monolog_large_message_limit_drops.php
@@ -39,7 +39,9 @@ newrelic.application_logging.forwarding.max_samples_stored = 10000
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_limit_log_events.php
+++ b/tests/integration/logging/monolog2/test_monolog_limit_log_events.php
@@ -57,7 +57,9 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_limit_zero_events.php
+++ b/tests/integration/logging/monolog2/test_monolog_limit_zero_events.php
@@ -57,7 +57,9 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid1.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid1.php
@@ -40,6 +40,8 @@ newrelic.application_logging.forwarding.max_samples_stored = 0.4
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid2.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid2.php
@@ -40,6 +40,8 @@ newrelic.application_logging.forwarding.max_samples_stored = -1
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid3.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid3.php
@@ -40,6 +40,8 @@ newrelic.application_logging.forwarding.max_samples_stored = 100100
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid4.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid4.php
@@ -40,6 +40,8 @@ newrelic.application_logging.forwarding.max_samples_stored = butterflies
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog2/test_monolog_truncate_long_msgs.php
+++ b/tests/integration/logging/monolog2/test_monolog_truncate_long_msgs.php
@@ -42,7 +42,9 @@ monolog2.DEBUG: FDTZJACCUOBPXLNMOIRNOTGWNDYSIFHLRNXKIZHOIUSOGBZEBVLCOFJZYGJRVYAY
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_basic.php
+++ b/tests/integration/logging/monolog3/test_monolog_basic.php
@@ -55,7 +55,9 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_cat.php
+++ b/tests/integration/logging/monolog3/test_monolog_cat.php
@@ -55,7 +55,9 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_disable_forwarding.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_forwarding.php
@@ -56,7 +56,9 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_disable_logging.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_logging.php
@@ -46,7 +46,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/disabled"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/disabled"},                     [1, "??", "??", "??", "??", "??"]]

--- a/tests/integration/logging/monolog3/test_monolog_disable_logging.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_logging.php
@@ -46,8 +46,10 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/PHP/Monolog/disabled"},                     [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},                     [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_disable_metrics.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_metrics.php
@@ -50,7 +50,9 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},                     [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_drop_empty.php
+++ b/tests/integration/logging/monolog3/test_monolog_drop_empty.php
@@ -56,7 +56,9 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_hsm_disable_forwarding.php
+++ b/tests/integration/logging/monolog3/test_monolog_hsm_disable_forwarding.php
@@ -57,7 +57,9 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_large_message_limit.php
+++ b/tests/integration/logging/monolog3/test_monolog_large_message_limit.php
@@ -39,7 +39,9 @@ newrelic.application_logging.forwarding.max_samples_stored = 10000
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_large_message_limit_drops.php
+++ b/tests/integration/logging/monolog3/test_monolog_large_message_limit_drops.php
@@ -39,7 +39,9 @@ newrelic.application_logging.forwarding.max_samples_stored = 10000
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_limit_log_events.php
+++ b/tests/integration/logging/monolog3/test_monolog_limit_log_events.php
@@ -57,7 +57,9 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_limit_zero_events.php
+++ b/tests/integration/logging/monolog3/test_monolog_limit_zero_events.php
@@ -57,7 +57,9 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid1.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid1.php
@@ -40,6 +40,8 @@ newrelic.application_logging.forwarding.max_samples_stored = 0.4
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid2.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid2.php
@@ -40,6 +40,8 @@ newrelic.application_logging.forwarding.max_samples_stored = -1
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid3.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid3.php
@@ -40,6 +40,8 @@ newrelic.application_logging.forwarding.max_samples_stored = 100100
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid4.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid4.php
@@ -40,6 +40,8 @@ newrelic.application_logging.forwarding.max_samples_stored = butterflies
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog3/test_monolog_truncate_long_msgs.php
+++ b/tests/integration/logging/monolog3/test_monolog_truncate_long_msgs.php
@@ -42,7 +42,9 @@ monolog3.DEBUG: FDTZJACCUOBPXLNMOIRNOTGWNDYSIFHLRNXKIZHOIUSOGBZEBVLCOFJZYGJRVYAY
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/memcache/test_add.php
+++ b/tests/integration/memcache/test_add.php
@@ -12,6 +12,12 @@ The agent should report metrics for Memcache::add().
 <?php require('skipif.inc');
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - connect to server
 ok - add key 1
@@ -30,6 +36,8 @@ ok - delete key 3
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcache/test_incr_decr.php
+++ b/tests/integration/memcache/test_incr_decr.php
@@ -13,6 +13,12 @@ decremented.
 <?php require('skipif.inc');
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - connect to server
 ok - set key
@@ -28,6 +34,8 @@ ok - delete key
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcache/test_memcache_add.php
+++ b/tests/integration/memcache/test_memcache_add.php
@@ -13,6 +13,12 @@ procedural api.
 <?php require('skipif.inc');
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - connect to server
 ok - add key 1
@@ -31,6 +37,8 @@ ok - delete key 3
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcache/test_memcache_incr_decr.php
+++ b/tests/integration/memcache/test_memcache_incr_decr.php
@@ -13,6 +13,12 @@ decremented using the Memcache procedural api.
 <?php require('skipif.inc');
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - connect to server
 ok - set key
@@ -28,6 +34,8 @@ ok - delete key
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcache/test_memcache_replace.php
+++ b/tests/integration/memcache/test_memcache_replace.php
@@ -13,6 +13,12 @@ Memcache procedural api.
 <?php require('skipif.inc');
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - connect to server
 ok - add key 1
@@ -33,6 +39,8 @@ ok - delete key 3
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcache/test_memcache_set.php
+++ b/tests/integration/memcache/test_memcache_set.php
@@ -13,6 +13,12 @@ procedural api.
 <?php require('skipif.inc');
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - connect to server
 ok - set key 1 (2 args)
@@ -33,6 +39,8 @@ ok - delete key 3
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcache/test_replace.php
+++ b/tests/integration/memcache/test_replace.php
@@ -12,6 +12,12 @@ The agent should report metrics for Memcache::replace().
 <?php require('skipif.inc');
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - connect to server
 ok - add key 1
@@ -32,6 +38,8 @@ ok - delete key 3
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcache/test_set.php
+++ b/tests/integration/memcache/test_set.php
@@ -12,6 +12,12 @@ The agent should report metrics for Memcache::set().
 <?php require('skipif.inc');
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - connect to server
 ok - set key 1 (2 args)
@@ -32,6 +38,8 @@ ok - delete key 3
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_basic.php
+++ b/tests/integration/memcached/test_basic.php
@@ -13,6 +13,12 @@ increment, decrement, replace, and delete.
 <?php require('skipif.inc'); ?>
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - add
 ok - set
@@ -37,6 +43,8 @@ ok - delete
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_by_key.php
+++ b/tests/integration/memcached/test_by_key.php
@@ -15,6 +15,12 @@ NOTE: incrementByKey and decrementByKey are not instrumented by the agent.
 <?php require('skipif.inc'); ?>
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - addByKey
 ok - setByKey
@@ -39,6 +45,8 @@ ok - deleteByKey
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_cas.php5.php
+++ b/tests/integration/memcached/test_cas.php5.php
@@ -17,6 +17,12 @@ if (version_compare(PHP_VERSION, "7.0", ">=")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - set
 ok - get
@@ -31,6 +37,8 @@ ok - delete
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_cas.php7.php
+++ b/tests/integration/memcached/test_cas.php7.php
@@ -17,6 +17,12 @@ if (version_compare(PHP_VERSION, "7.0", "<")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - set
 ok - get
@@ -33,6 +39,8 @@ ok - delete
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_cas_by_key.php5.php
+++ b/tests/integration/memcached/test_cas_by_key.php5.php
@@ -17,6 +17,12 @@ if (version_compare(PHP_VERSION, "7.0", ">=")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - setByKey
 ok - getByKey
@@ -31,6 +37,8 @@ ok - deleteByKey
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_cas_by_key.php7.php
+++ b/tests/integration/memcached/test_cas_by_key.php7.php
@@ -17,6 +17,12 @@ if (version_compare(PHP_VERSION, "7.0", "<")) {
 }
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - setByKey
 ok - getByKey
@@ -33,6 +39,8 @@ ok - deleteByKey
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_concat.php
+++ b/tests/integration/memcached/test_concat.php
@@ -12,6 +12,12 @@ The agent should report metrics for Memcached string operations.
 <?php require('skipif.inc'); ?>
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - set
 ok - prepend
@@ -26,6 +32,8 @@ ok - delete
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_concat_by_key.php
+++ b/tests/integration/memcached/test_concat_by_key.php
@@ -12,6 +12,12 @@ The agent should report metrics for Memcached string operations.
 <?php require('skipif.inc'); ?>
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - setByKey
 ok - prependByKey
@@ -26,6 +32,8 @@ ok - deleteByKey
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_multi.php
+++ b/tests/integration/memcached/test_multi.php
@@ -15,6 +15,12 @@ NOTE: deleteMulti and fetchAll are not instrumented by the agent.
 <?php require('skipif.inc'); ?>
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - setMulti
 ok - assertEqual
@@ -33,6 +39,8 @@ ok - deleteMulti
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/memcached/test_multi_by_key.php
+++ b/tests/integration/memcached/test_multi_by_key.php
@@ -15,6 +15,12 @@ NOTE: deleteMultiByKey and fetchAll are not instrumented by the agent.
 <?php require('skipif.inc'); ?>
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - setMultiByKey
 ok - assertEqualByKey
@@ -33,6 +39,8 @@ ok - deleteMultiByKey
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mongo/test_execute.php
+++ b/tests/integration/mongo/test_execute.php
@@ -12,12 +12,20 @@ The agent should generate Datastore metrics for MongoDB::execute().
 <?php require('skipif.inc'); ?>
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mongo/test_find.php
+++ b/tests/integration/mongo/test_find.php
@@ -12,12 +12,20 @@ The agent should generate Datastore metrics for MongoCollection::find().
 <?php require('skipif.inc'); ?>
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                                [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysql/test_db_query.php
+++ b/tests/integration/mysql/test_db_query.php
@@ -20,6 +20,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
 error_reporting = E_ALL &~ E_DEPRECATED
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -35,6 +38,8 @@ array(1) {
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysql/test_db_query_error.php
+++ b/tests/integration/mysql/test_db_query_error.php
@@ -11,6 +11,9 @@ The agent should report Database metrics for mysql_query.
 /*INI
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 error_reporting = E_ALL & ~E_DEPRECATED
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*SKIPIF
@@ -24,6 +27,8 @@ require("skipif.inc");
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysql/test_query.php
+++ b/tests/integration/mysql/test_query.php
@@ -20,6 +20,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
 error_reporting = E_ALL &~ E_DEPRECATED
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -35,6 +38,8 @@ array(1) {
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysql/test_query_error.php
+++ b/tests/integration/mysql/test_query_error.php
@@ -16,6 +16,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 error_reporting = E_ALL & ~E_DEPRECATED
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -24,6 +27,8 @@ error_reporting = E_ALL & ~E_DEPRECATED
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysql/test_unbuffered_query.php
+++ b/tests/integration/mysql/test_unbuffered_query.php
@@ -20,6 +20,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
 error_reporting = E_ALL &~ E_DEPRECATED
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -35,6 +38,8 @@ array(1) {
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_bind_param_object_oo.php
+++ b/tests/integration/mysqli/test_bind_param_object_oo.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -39,6 +42,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_bind_param_oo.php
+++ b/tests/integration/mysqli/test_bind_param_oo.php
@@ -19,6 +19,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_bind_param_proc.php
+++ b/tests/integration/mysqli/test_bind_param_proc.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_connect.php
+++ b/tests/integration/mysqli/test_explain_connect.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_construct.php
+++ b/tests/integration/mysqli/test_explain_construct.php
@@ -19,6 +19,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_database_no_user.php
+++ b/tests/integration/mysqli/test_explain_database_no_user.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_init_oo.php
+++ b/tests/integration/mysqli/test_explain_init_oo.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_init_oo_persistent.php
+++ b/tests/integration/mysqli/test_explain_init_oo_persistent.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_init_proc.php
+++ b/tests/integration/mysqli/test_explain_init_proc.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_leading_whitespace.php
+++ b/tests/integration/mysqli/test_explain_leading_whitespace.php
@@ -17,6 +17,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -29,6 +32,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_options_garbage.php
+++ b/tests/integration/mysqli/test_explain_options_garbage.php
@@ -17,6 +17,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -25,6 +28,8 @@ newrelic.transaction_tracer.record_sql = obfuscated
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_real_connect_garbage.php
+++ b/tests/integration/mysqli/test_explain_real_connect_garbage.php
@@ -17,6 +17,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -25,6 +28,8 @@ newrelic.transaction_tracer.record_sql = obfuscated
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_reused_id.php
+++ b/tests/integration/mysqli/test_explain_reused_id.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_select_db_oo.php
+++ b/tests/integration/mysqli/test_explain_select_db_oo.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_explain_select_db_proc.php
+++ b/tests/integration/mysqli/test_explain_select_db_proc.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_multi_query_oo.php
+++ b/tests/integration/mysqli/test_multi_query_oo.php
@@ -16,6 +16,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.explain_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -35,6 +38,8 @@ array(1) {
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_multi_query_proc.php
+++ b/tests/integration/mysqli/test_multi_query_proc.php
@@ -16,6 +16,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.explain_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -35,6 +38,8 @@ array(1) {
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_mysqli_query_1.php
+++ b/tests/integration/mysqli/test_mysqli_query_1.php
@@ -20,6 +20,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = "obfuscated"
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -32,6 +35,8 @@ key=TABLE_NAME value=STATISTICS
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_prepare_oo.php
+++ b/tests/integration/mysqli/test_prepare_oo.php
@@ -14,6 +14,9 @@ The agent should report Datastore metrics for mysqli::prepare.
 
 /*INI
 newrelic.transaction_tracer.explain_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -105,6 +108,8 @@ ok - iteration 39
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_prepare_proc.php
+++ b/tests/integration/mysqli/test_prepare_proc.php
@@ -17,6 +17,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -29,6 +32,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_query_oo.php
+++ b/tests/integration/mysqli/test_query_oo.php
@@ -16,6 +16,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.explain_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ ok - test_query2 (fetch)
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_query_proc.php
+++ b/tests/integration/mysqli/test_query_proc.php
@@ -16,6 +16,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.explain_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ ok - test_mysqli_query3 (fetch)
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_real_query_oo.php
+++ b/tests/integration/mysqli/test_real_query_oo.php
@@ -20,6 +20,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -35,6 +38,8 @@ array(1) {
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_real_query_proc.php
+++ b/tests/integration/mysqli/test_real_query_proc.php
@@ -20,6 +20,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -37,6 +40,8 @@ array(2) {
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_stmt_prepare_oo.php
+++ b/tests/integration/mysqli/test_stmt_prepare_oo.php
@@ -17,6 +17,9 @@ require("skipif.inc");
 
 /*INI
 newrelic.transaction_tracer.explain_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_stmt_prepare_proc.php
+++ b/tests/integration/mysqli/test_stmt_prepare_proc.php
@@ -18,6 +18,9 @@ error_reporting = E_ALL & ~E_DEPRECATED
 newrelic.transaction_tracer.explain_enabled = true
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_subclassing.php
+++ b/tests/integration/mysqli/test_subclassing.php
@@ -19,6 +19,9 @@ if (version_compare(PHP_VERSION, "8.1", ">=")) {
 
 /*INI
 newrelic.transaction_tracer.explain_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/mysqli/test_subclassing.php81.php
+++ b/tests/integration/mysqli/test_subclassing.php81.php
@@ -19,6 +19,9 @@ if (version_compare(PHP_VERSION, "8.1", "<")) {
 
 /*INI
 newrelic.transaction_tracer.explain_enabled = false
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ STATISTICS
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pdo/test_bad_input_1.php
+++ b/tests/integration/pdo/test_bad_input_1.php
@@ -18,6 +18,9 @@ newrelic.datastore_tracer.instance_reporting.enabled = 0
 display_errors=1
 log_errors=0
 newrelic.distributed_tracing_enabled=0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -26,6 +29,8 @@ newrelic.distributed_tracing_enabled=0
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/pdo/test_query_1.php
+++ b/tests/integration/pdo/test_query_1.php
@@ -19,6 +19,9 @@ if (version_compare(PHP_VERSION, "8.1", ">=")) {
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -36,6 +39,8 @@ ok - drop table
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pdo/test_query_1.php81.php
+++ b/tests/integration/pdo/test_query_1.php81.php
@@ -19,6 +19,9 @@ if (version_compare(PHP_VERSION, "8.1", "<")) {
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -36,6 +39,8 @@ ok - drop table
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pdo/test_query_2.php
+++ b/tests/integration/pdo/test_query_2.php
@@ -16,6 +16,9 @@ PDO::query().
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -33,6 +36,8 @@ ok - drop table
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pdo/test_query_3.php
+++ b/tests/integration/pdo/test_query_3.php
@@ -16,6 +16,9 @@ PDO::query().
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ ok - drop table
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pdo/test_query_4.php
+++ b/tests/integration/pdo/test_query_4.php
@@ -16,6 +16,9 @@ PDO::query().
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -31,6 +34,8 @@ ok - drop table
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pgsql/test_pg_execute_mixed_use.php
+++ b/tests/integration/pgsql/test_pg_execute_mixed_use.php
@@ -22,6 +22,9 @@ newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -37,6 +40,8 @@ pg_stats
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                              [4, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                         [4, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/Postgres/all"},                     [4, "??", "??", "??", "??", "??"]],

--- a/tests/integration/pgsql/test_pg_execute_with_resource.php
+++ b/tests/integration/pgsql/test_pg_execute_with_resource.php
@@ -17,6 +17,9 @@ newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ pg_roles
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pgsql/test_pg_execute_without_resource.php
+++ b/tests/integration/pgsql/test_pg_execute_without_resource.php
@@ -19,6 +19,9 @@ newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = obfuscated
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -32,6 +35,8 @@ pg_roles
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                             [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pgsql/test_pg_query_error.php
+++ b/tests/integration/pgsql/test_pg_query_error.php
@@ -23,6 +23,9 @@ newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.stack_trace_threshold = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = raw
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -31,6 +34,8 @@ newrelic.transaction_tracer.record_sql = raw
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Postgres/other"},    [3, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Postgres/other",
       "scope":"OtherTransaction/php__FILE__"},         [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/pgsql/test_pg_query_params_error.php
+++ b/tests/integration/pgsql/test_pg_query_params_error.php
@@ -23,6 +23,9 @@ newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.stack_trace_threshold = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = raw
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT_METRICS
@@ -31,6 +34,8 @@ newrelic.transaction_tracer.record_sql = raw
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Postgres/other"},    [3, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Postgres/other",
       "scope":"OtherTransaction/php__FILE__"},         [3, "??", "??", "??", "??", "??"]],

--- a/tests/integration/pgsql/test_pg_query_params_with_resource.php
+++ b/tests/integration/pgsql/test_pg_query_params_with_resource.php
@@ -18,6 +18,9 @@ newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.stack_trace_threshold = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = raw
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ ok - pg_query_params successful
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                              [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pgsql/test_pg_query_params_without_resource.php
+++ b/tests/integration/pgsql/test_pg_query_params_without_resource.php
@@ -20,6 +20,9 @@ newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.stack_trace_threshold = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = raw
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -32,6 +35,8 @@ ok - pg_query_params successful
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                              [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pgsql/test_pg_query_with_resource.php
+++ b/tests/integration/pgsql/test_pg_query_with_resource.php
@@ -18,6 +18,9 @@ newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.stack_trace_threshold = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = raw
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -30,6 +33,8 @@ ok - pg_query successful
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                              [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/pgsql/test_pg_query_without_resource.php
+++ b/tests/integration/pgsql/test_pg_query_without_resource.php
@@ -20,6 +20,9 @@ newrelic.datastore_tracer.instance_reporting.enabled = 0
 newrelic.transaction_tracer.stack_trace_threshold = 0
 newrelic.transaction_tracer.explain_threshold = 0
 newrelic.transaction_tracer.record_sql = raw
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -32,6 +35,8 @@ ok - pg_query successful
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                              [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/predis/test_basic.php
+++ b/tests/integration/predis/test_basic.php
@@ -9,6 +9,12 @@ The agent SHALL report Datastore metrics for Redis basic operations.
 This Predis test is largely copied from the Redis version.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - set key
 ok - get key
@@ -25,6 +31,8 @@ ok - delete key
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},               [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                                                           [8, "??", "??", "??", "??", "??"]],

--- a/tests/integration/predis/test_cross_transaction.php
+++ b/tests/integration/predis/test_cross_transaction.php
@@ -9,6 +9,12 @@ The agent SHALL report Datastore metrics for Redis basic operations, even if the
 client initialization happens in a different transaction than the connection.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 ok - set key
 ok - get key
@@ -21,6 +27,8 @@ ok - delete key
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"/Datastore/all/"},                                                           [4, "??", "??", "??", "??", "??"]],

--- a/tests/integration/predis/test_pipeline.php
+++ b/tests/integration/predis/test_pipeline.php
@@ -9,12 +9,20 @@ Predis provides command pipelines. In these cases, we don't know what commands
 are being run, so they are instrumented as "pipeline".
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                                                            [12, "??", "??", "??", "??", "??"]],

--- a/tests/integration/predis/test_pipeline_atomic.php
+++ b/tests/integration/predis/test_pipeline_atomic.php
@@ -9,12 +9,20 @@ The "atomic" pipeline wraps commands in a Redis EXEC call, so they happen as
 an atomic operation.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                                                            [12, "??", "??", "??", "??", "??"]],

--- a/tests/integration/predis/test_pipeline_fire_and_forget.php
+++ b/tests/integration/predis/test_pipeline_fire_and_forget.php
@@ -9,12 +9,20 @@ Predis provides command pipelines. In these cases, we don't know what commands
 are being run, so they are instrumented as "pipeline".
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                                                            [12, "??", "??", "??", "??", "??"]],

--- a/tests/integration/queue/test_basic.php
+++ b/tests/integration/queue/test_basic.php
@@ -8,6 +8,12 @@
 The agent should obey the queue time header.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*HEADERS
 X_REQUEST_START=1368811467146000
 */
@@ -18,6 +24,8 @@ X_REQUEST_START=1368811467146000
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                      [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"},

--- a/tests/integration/queue/test_capitalized.php
+++ b/tests/integration/queue/test_capitalized.php
@@ -8,6 +8,12 @@
 The agent should obey the queue time header.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*HEADERS
 X_REQUEST_START=1368811467146000
 */
@@ -18,6 +24,8 @@ X_REQUEST_START=1368811467146000
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                      [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"},

--- a/tests/integration/queue/test_malformed.php
+++ b/tests/integration/queue/test_malformed.php
@@ -8,6 +8,12 @@
 The agent should obey the queue time header.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*HEADERS
 X_REQUEST_START=abc
 */
@@ -18,6 +24,8 @@ X_REQUEST_START=abc
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                      [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"},

--- a/tests/integration/queue/test_with_prefix.php
+++ b/tests/integration/queue/test_with_prefix.php
@@ -8,6 +8,12 @@
 The agent should obey the queue time header.
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*HEADERS
 X_REQUEST_START=t=1368811467146000
 */
@@ -18,6 +24,8 @@ X_REQUEST_START=t=1368811467146000
   "?? timeframe start",
   "?? timeframe stop",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                      [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"},

--- a/tests/integration/redis/test_basic.php
+++ b/tests/integration/redis/test_basic.php
@@ -19,6 +19,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -75,6 +78,8 @@ ok - verify reduced redis db key count
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_bitops.php
+++ b/tests/integration/redis/test_bitops.php
@@ -19,6 +19,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -43,6 +46,8 @@ ok - delete test keys
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_decr.php
+++ b/tests/integration/redis/test_decr.php
@@ -15,6 +15,9 @@ The agent should report Redis metrics for Redis decrement operations.
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -33,6 +36,8 @@ ok - delete key
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_geo.php
+++ b/tests/integration/redis/test_geo.php
@@ -19,6 +19,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -40,6 +43,8 @@ ok - query cities within 5000mi of seattle by member [readonly cmd]
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_hash.php
+++ b/tests/integration/redis/test_hash.php
@@ -15,6 +15,9 @@ The agent should report Redis metrics for Redis hash operations.
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -44,6 +47,8 @@ ok - delete hash
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_incr.php
+++ b/tests/integration/redis/test_incr.php
@@ -15,6 +15,9 @@ The agent should report Redis metrics for Redis increment operations.
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -33,6 +36,8 @@ ok - delete key
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_list.php
+++ b/tests/integration/redis/test_list.php
@@ -19,6 +19,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -64,6 +67,8 @@ ok - rpushx to a list that does not exist
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_set.php
+++ b/tests/integration/redis/test_set.php
@@ -19,6 +19,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -53,6 +56,8 @@ ok - remove destination key
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_set.redis6.php
+++ b/tests/integration/redis/test_set.redis6.php
@@ -21,6 +21,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -33,6 +36,8 @@ ok - check membership of multiple elements
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_setex.php
+++ b/tests/integration/redis/test_setex.php
@@ -15,6 +15,9 @@ The agent should report Redis metrics for Redis increment operations.
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -43,6 +46,8 @@ ok - delete key
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_stream.redis5.php
+++ b/tests/integration/redis/test_stream.redis5.php
@@ -20,6 +20,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -54,6 +57,8 @@ ok - delete our test keys
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_zset.php
+++ b/tests/integration/redis/test_zset.php
@@ -19,6 +19,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -54,6 +57,8 @@ ok - ensure all keys are cleaned up
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/redis/test_zset.redis5.php
+++ b/tests/integration/redis/test_zset.redis5.php
@@ -20,6 +20,9 @@ require("skipif.inc");
 /*INI
 newrelic.datastore_tracer.database_name_reporting.enabled = 0
 newrelic.datastore_tracer.instance_reporting.enabled = 0
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
 */
 
 /*EXPECT
@@ -35,6 +38,8 @@ ok - we deleted our test key
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite/test_bad_input_1.php
+++ b/tests/integration/sqlite/test_bad_input_1.php
@@ -13,12 +13,20 @@ arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_bad_input_2.php
+++ b/tests/integration/sqlite/test_bad_input_2.php
@@ -13,12 +13,20 @@ arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_bad_input_3.php
+++ b/tests/integration/sqlite/test_bad_input_3.php
@@ -13,12 +13,20 @@ with the wrong arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_bad_input_4.php
+++ b/tests/integration/sqlite/test_bad_input_4.php
@@ -13,12 +13,20 @@ with the wrong arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_bad_input_5.php
+++ b/tests/integration/sqlite/test_bad_input_5.php
@@ -13,12 +13,20 @@ with the wrong argument types.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_exec.php
+++ b/tests/integration/sqlite/test_exec.php
@@ -13,12 +13,20 @@ gracefully handle the first two parameters occuring in either order.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                          [5, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                     [5, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                   [5, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_query_1.php
+++ b/tests/integration/sqlite/test_query_1.php
@@ -12,6 +12,12 @@ The agent should report Datastore metrics for sqlite_query() and sqlite_exec().
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 Array
 (
@@ -42,6 +48,8 @@ Array
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                          [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                     [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                   [6, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_query_2.php
+++ b/tests/integration/sqlite/test_query_2.php
@@ -12,6 +12,12 @@ The agent should report Datastore metrics for sqlite_query() and sqlite_exec().
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 Array
 (
@@ -42,6 +48,8 @@ Array
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                          [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                     [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                   [6, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_unbuffered_1.php
+++ b/tests/integration/sqlite/test_unbuffered_1.php
@@ -12,6 +12,12 @@ The agent should report Datastore metrics for sqlite_unbuffered_query().
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 Array
 (
@@ -42,6 +48,8 @@ Array
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                          [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                     [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                   [6, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite/test_unbuffered_2.php
+++ b/tests/integration/sqlite/test_unbuffered_2.php
@@ -12,6 +12,12 @@ The agent should report Datastore metrics for sqlite_unbuffered_query().
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 Array
 (
@@ -42,6 +48,8 @@ Array
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                          [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                     [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                   [6, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlite3/test_bad_input_1.php
+++ b/tests/integration/sqlite3/test_bad_input_1.php
@@ -13,12 +13,20 @@ arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_bad_input_2.php
+++ b/tests/integration/sqlite3/test_bad_input_2.php
@@ -13,12 +13,20 @@ arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_bad_input_3.php
+++ b/tests/integration/sqlite3/test_bad_input_3.php
@@ -13,12 +13,20 @@ arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_bad_input_4.php
+++ b/tests/integration/sqlite3/test_bad_input_4.php
@@ -13,12 +13,20 @@ arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_bad_input_5.php
+++ b/tests/integration/sqlite3/test_bad_input_5.php
@@ -13,12 +13,20 @@ arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_bad_sql_1.php
+++ b/tests/integration/sqlite3/test_bad_sql_1.php
@@ -12,12 +12,20 @@ The agent should record an error when a query fails.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_bad_sql_2.php
+++ b/tests/integration/sqlite3/test_bad_sql_2.php
@@ -12,12 +12,20 @@ The agent should record an error when a SQLite3::querysingle() fails.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_query.php
+++ b/tests/integration/sqlite3/test_query.php
@@ -12,6 +12,12 @@ The agent should report database metrics for SQLite3.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 Array
 (
@@ -36,6 +42,8 @@ Array
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_querysingle_1.php
+++ b/tests/integration/sqlite3/test_querysingle_1.php
@@ -12,6 +12,12 @@ The agent should generate Database metrics for SQLite3::querysingle().
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 1
 */
@@ -22,6 +28,8 @@ The agent should generate Database metrics for SQLite3::querysingle().
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlite3/test_querysingle_2.php
+++ b/tests/integration/sqlite3/test_querysingle_2.php
@@ -12,6 +12,12 @@ The agent should generate Database metrics for SQLite3::querysingle().
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 Array
 (
@@ -26,6 +32,8 @@ Array
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
                                                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},

--- a/tests/integration/sqlitedatabase/test_bad_input_1.php
+++ b/tests/integration/sqlitedatabase/test_bad_input_1.php
@@ -13,12 +13,20 @@ receiving the wrong arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlitedatabase/test_bad_input_2.php
+++ b/tests/integration/sqlitedatabase/test_bad_input_2.php
@@ -13,12 +13,20 @@ wrong arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlitedatabase/test_bad_input_3.php
+++ b/tests/integration/sqlitedatabase/test_bad_input_3.php
@@ -13,12 +13,20 @@ the wrong arguments.
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT_METRICS
 [
   "?? agent run id",
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlitedatabase/test_query.php
+++ b/tests/integration/sqlitedatabase/test_query.php
@@ -13,6 +13,12 @@ SQLDatabase::queryExec().
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 Array
 (
@@ -43,6 +49,8 @@ Array
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                          [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                     [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                   [6, "??", "??", "??", "??", "??"]],

--- a/tests/integration/sqlitedatabase/test_unbuffered.php
+++ b/tests/integration/sqlitedatabase/test_unbuffered.php
@@ -12,6 +12,12 @@ The agent should report Datastore metrics for SQLiteDatabase::unbufferedQuery().
 <?php require("skipif.inc");
 */
 
+/*INI
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
 /*EXPECT
 Array
 (
@@ -42,6 +48,8 @@ Array
   "?? start time",
   "?? stop time",
   [
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/all"},                          [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/allOther"},                     [6, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/SQLite/all"},                   [6, "??", "??", "??", "??", "??"]],


### PR DESCRIPTION
Send `Supportability/Logging/Metrics/PHP/{enabled|disabled}` and
`Supportability/Logging/Forwarding/PHP/{enabled|disabled}` with
value for {enabled|disabled} based on the INI settings. Metrics
will only be sent once.