### PR TITLE
feat(agent): Remove function hooks that overwrite zend_execute_ex for USER functions.

### DIFF
--- a/agent/nr_php_observer.c
+++ b/agent/nr_php_observer.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file handles the initialization that happens once per module load.
+ */
+#include "php_agent.h"
+
+#include <dlfcn.h>
+#include <signal.h>
+
+#include "php_api_distributed_trace.h"
+#include "php_environment.h"
+#include "php_error.h"
+#include "php_extension.h"
+#include "php_globals.h"
+#include "php_header.h"
+#include "php_hooks.h"
+#include "php_internal_instrument.h"
+#include "php_samplers.h"
+#include "php_user_instrument.h"
+#include "php_vm.h"
+#include "php_wrapper.h"
+#include "fw_laravel.h"
+#include "lib_guzzle4.h"
+#include "lib_guzzle6.h"
+#include "nr_agent.h"
+#include "nr_app.h"
+#include "nr_banner.h"
+#include "nr_daemon_spawn.h"
+#include "util_logging.h"
+#include "util_memory.h"
+#include "util_signals.h"
+#include "util_strings.h"
+#include "util_syscalls.h"
+#include "util_threads.h"
+
+#include "nr_php_observer.h"
+#include "php_execute.h"
+
+/*
+ * Observer API functionality was added with PHP 8.0.
+ *
+ * The Observer API provide function handlers that trigger on every userland
+ * function begin and end.  The handlers provide all zend_execute_data and the
+ * end handler provides the return value pointer. The previous way to hook into
+ * PHP was via zend_execute_ex which will hook all userland function calls with
+ * significant overhead for doing the call . However, depending on your stack
+ * size settings, it could potentially generate an extremely deep call stack in
+ * PH because  zend_execute_ex limits your stack size to whatever your settings
+ * are. Observer API bypasses the stack overflow issue that you can run into
+ * when intercepting userland calls.  Additionally, with PHP 8.0, JIT
+ * optimizations could optimize out a call to zend_execute_ex and the agent
+ * would not be able to overwite that call properly as the agent wouldn't have
+ * access to the JITed information.  This could lead to segfaults and caused PHP
+ * to decide to disable JIT when detecting extensions that overwrote
+ * zend_execute_ex.
+ *
+ * It only provides ZEND_USER_FUNCTIONS yet as it was assumed mechanisms already
+ * exist to monitor internal functions by overwriting internal function
+ * handlers.  This will be included in PHP 8.2: Registered
+ * zend_observer_fcall_init handlers are now also called for internal functions.
+ *
+ * Without overwriting the execute function and therefore being responsible for
+ * continuing the execution of ALL functions that we intercepted,  the agent is
+ * provided zend_execute_data on each function start/end and is then able to use
+ * it with our currently existing logic and instrumentation.
+ */
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+/*
+ * Register the begin and end function handlers with the Observer API.
+ */
+static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
+    zend_execute_data* execute_data) {
+  zend_observer_fcall_handlers handlers = {NULL, NULL};
+  if (NULL == execute_data) {
+    return handlers;
+  }
+  if (NULL == execute_data->func) {
+    return handlers;
+  }
+  handlers.begin = nr_php_observer_fcall_begin;
+  handlers.end = nr_php_observer_fcall_end;
+  return handlers;
+}
+
+extern void nr_php_observer_no_op(zend_execute_data* execute_data NRUNUSED){};
+
+void nr_php_observer_minit() {
+  /*
+   * Register the Observer API handlers.
+   */
+  /*
+   * For Observer API with PHP 8+, we no longer need to ovewrwrite the zend
+   * execute hook.  orig_execute is called various ways in various places, so
+   * turn it into a no_op when using OAPI.
+   */
+  NR_PHP_PROCESS_GLOBALS(orig_execute) = nr_php_observer_no_op;
+
+  zend_observer_fcall_register(nr_php_fcall_register_handlers);
+  zend_observer_error_register(nr_php_error_cb);
+}
+
+#endif

--- a/agent/nr_php_observer.h
+++ b/agent/nr_php_observer.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file is the wrapper for PHP 8+ Observer API (OAPI) functionality.
+ *
+ * The registered function handlers are the entry points of instrumentation and
+ * are implemented in php_execute.c which contains the brains/helper functions
+ * required to monitor PHP.
+ */
+
+//#include "php_newrelic.h"
+
+#ifndef NEWRELIC_PHP_AGENT_PHP_OBSERVER_H
+#define NEWRELIC_PHP_AGENT_PHP_OBSERVER_H
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+
+/*
+ * Purpose: There are a few various places, aside from the php_execute_* family
+ * that will call NR_PHP_PROCESS_GLOBALS(orig_execute) so make it a noop to
+ * handle all cases.
+ *
+ * Params:  NR_EXECUTE_PROTO_OVERWRITE which is not used.
+ *
+ * Returns : Void
+ */
+extern void nr_php_observer_no_op(zend_execute_data* execute_data NRUNUSED);
+
+/*
+ * Purpose : Register the OAPI function handlers and any other minit actions.
+ *
+ * Params  : None
+ *
+ * Returns : Void
+ */
+void nr_php_observer_minit();
+
+/*
+ * Purpose : Call the necessary functions needed to instrument a function by
+ *           updating a transaction or segment for a function that has just
+ * started.  This function is registered via the Observer API and will be called
+ * by the zend engine every time a function begins.  The zend engine directly
+ * provides the zend_execute_data which has all details we need to know about
+ * the function. This and nr_php_execute_observer_fcall_end sum to provide all
+ * the functionality of nr_php_execute and nr_php _execute_enabled and as such
+ * will use all the helper functions they also used.
+ *
+ *
+ * Params  : 1. zend_execute_data: everything we need to know about the
+ * function.
+ *
+ * Returns : Void.
+ */
+void nr_php_observer_fcall_begin(zend_execute_data* execute_data);
+/*
+ * Purpose : Call the necessary functions needed to instrument a function when
+ *           updating a transaction or segment for a function that has just
+ * ended. This function is registered via the Observer API and will be called by
+ * the zend engine every time a function ends.  The zend engine directly
+ * provides the zend_execute_data and the return_value pointer, both of which
+ * have all details that the agent needs to know about the function. This and
+ * nr_php_execute_observer_fcall_start sum to provide all the functionality of
+ * nr_php_execute and nr_php_execute_enabled and as such will use all the helper
+ * functions they also used.
+ *
+ *
+ * Params  : 1. zend_execute_data: everything to know about the function.
+ *           2. return_value: function return value information
+ *
+ * Returns : Void.
+ */
+void nr_php_observer_fcall_end(zend_execute_data* execute_data,
+                               zval* return_value);
+#endif /* PHP8+ */
+
+#endif /* NEWRELIC_PHP_AGENT_PHP_OBSERVER_H */

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -38,6 +38,8 @@
 #include "fw_laravel.h"
 #include "lib_guzzle4.h"
 
+#include "nr_php_observer.h"
+
 static void php_newrelic_init_globals(zend_newrelic_globals* nrg) {
   if (nrunlikely(NULL == nrg)) {
     return;
@@ -408,6 +410,7 @@ PHP_MINIT_FUNCTION(newrelic) {
   zend_extension dummy;
 #else
   char dummy[] = "newrelic";
+  nr_php_observer_minit();
 #endif
 
   (void)type;
@@ -625,8 +628,13 @@ PHP_MINIT_FUNCTION(newrelic) {
    * tasks are run only once the PHP VM engine is ticking over fully.
    */
 
+/* PHP 5.x,7.x or not OAPI */
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA
   NR_PHP_PROCESS_GLOBALS(orig_execute) = NR_ZEND_EXECUTE_HOOK;
   NR_ZEND_EXECUTE_HOOK = nr_php_execute;
+
+#endif
 
   if (NR_PHP_PROCESS_GLOBALS(instrument_internal)) {
     nrl_info(
@@ -723,6 +731,7 @@ void nr_php_late_initialization(void) {
    * forward the errors, so if a user has Xdebug loaded, we do not install
    * our own error callback handler. Otherwise, we do.
    */
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO /* < PHP8 */
   if (0 == zend_get_extension("Xdebug")) {
     NR_PHP_PROCESS_GLOBALS(orig_error_cb) = zend_error_cb;
     zend_error_cb = nr_php_error_cb;
@@ -731,6 +740,7 @@ void nr_php_late_initialization(void) {
                 "the Xdebug extension prevents the New Relic agent from "
                 "gathering errors. No errors will be recorded.");
   }
+#endif /* end of < PHP8 */
 
   /*
    * Install our signal handler, unless the user has set a special flag

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -38,6 +38,15 @@ extern zend_module_entry newrelic_module_entry;
  * majority of those changes so the rest of the code can simply use the macros
  * and not have to take the different APIs into account.
  */
+/* 
+ * OVERWRITE_ZEND_EXECUTE_DATA allows testing of components with the previous
+ * method of overwriting until the handler functions are complete.
+ * Additionally, gives us flexibility of toggling back to previous method of
+ * instrumentation. When checking in, leave this toggled on to have the CI work
+ * as long as possible until the handler functionality is implemented. 
+ */
+#define OVERWRITE_ZEND_EXECUTE_DATA true
+
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
 #define NR_SPECIALFNPTR_PROTO                              \
   struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
@@ -465,11 +474,13 @@ nrinitime_t
  * configuration options for handling application logging
  */
 
-nrinibool_t logging_enabled;        /* newrelic.application_logging.enabled */
-nrinibool_t log_forwarding_enabled; /* newrelic.application_logging.forwarding.enabled
-                                     */
-nriniuint_t log_events_max_samples_stored; /* newrelic.application_logging.forwarding.max_samples_stored
-                                            */
+nrinibool_t logging_enabled; /* newrelic.application_logging.enabled */
+nrinibool_t
+    log_forwarding_enabled; /* newrelic.application_logging.forwarding.enabled
+                             */
+nriniuint_t
+    log_events_max_samples_stored; /* newrelic.application_logging.forwarding.max_samples_stored
+                                    */
 nrinibool_t
     log_metrics_enabled; /* newrelic.application_logging.metrics.enabled */
 


### PR DESCRIPTION
1) Remove the function hooks from php_minit when we are using OAPI.
2) Made orig_func a no_op when we are using OAPI.
3) Made nr_zend_call_orig_execute_* functions no_op when using OAPI.
4) Updated the nr_php_observer module.

Testing: Utilized the OVERWRITE_ZEND_EXECUTE_DATA setting to toggle between current and new mode. With the overwrite setting all valgrind/integration tests passed. Without the setting, 121 tests fail (374 pass) since we aren't doing USER instrumentation anymore, but the internal instrumentation still functioned.