### PR TITLE
feat(agent): add log level config option

### DIFF
--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -465,13 +465,18 @@ nrinitime_t
  * configuration options for handling application logging
  */
 
-nrinibool_t logging_enabled;        /* newrelic.application_logging.enabled */
-nrinibool_t log_forwarding_enabled; /* newrelic.application_logging.forwarding.enabled
-                                     */
-nriniuint_t log_events_max_samples_stored; /* newrelic.application_logging.forwarding.max_samples_stored
-                                            */
+nrinibool_t logging_enabled; /* newrelic.application_logging.enabled */
+nrinibool_t
+    log_forwarding_enabled; /* newrelic.application_logging.forwarding.enabled
+                             */
+nriniuint_t
+    log_events_max_samples_stored; /* newrelic.application_logging.forwarding.max_samples_stored
+                                    */
 nrinibool_t
     log_metrics_enabled; /* newrelic.application_logging.metrics.enabled */
+
+nriniuint_t log_forwarding_log_level; /* newrelic.application_logging.forwarding.log_level
+                                       */
 
 /*
  * pid and user_function_wrappers are used to store user function wrappers.

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1805,6 +1805,7 @@ static PHP_INI_MH(nr_log_events_max_samples_stored_mh) {
 
 static PHP_INI_MH(nr_log_forwarding_log_level_mh) {
   nriniuint_t* p;
+  int log_level = LOG_LEVEL_DEFAULT;
 
 #ifndef ZTS
   char* base = (char*)mh_arg2;
@@ -1823,11 +1824,17 @@ static PHP_INI_MH(nr_log_forwarding_log_level_mh) {
   if (NEW_VALUE_LEN > 0) {
     nrl_debug(NRL_INIT, "Log Level (PSR-3): %s", NEW_VALUE);
 
-    p->value = nr_log_level_str_to_int(NEW_VALUE);
+    log_level = nr_log_level_str_to_int(NEW_VALUE);
+    if (LOG_LEVEL_UNKNOWN ==  log_level) {
+      log_level = LOG_LEVEL_DEFAULT;
+      nrl_warning(NRL_INIT, "Unknown log forwarding level %s, using %s instead.",
+      NEW_VALUE, nr_log_level_rfc_to_psr(log_level));
+    }
+    p->value = log_level;
     p->where = stage;
 
-    nrl_debug(NRL_INIT, "Log Forwarding Log Level (RFC5424) set to: %d",
-              p->value);
+    nrl_debug(NRL_INIT, "Log Forwarding Log Level (RFC5424) set to: %d (%s)",
+              p->value, nr_log_level_rfc_to_psr(p->value));
     return SUCCESS;
   }
 

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1826,7 +1826,8 @@ static PHP_INI_MH(nr_log_forwarding_log_level_mh) {
     p->value = nr_log_level_str_to_int(NEW_VALUE);
     p->where = stage;
 
-    nrl_debug(NRL_INIT, "Log Level (RFC5424): %d", p->value);
+    nrl_debug(NRL_INIT, "Log Forwarding Log Level (RFC5424) set to: %d",
+              p->value);
     return SUCCESS;
   }
 

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2883,7 +2883,7 @@ STD_PHP_INI_ENTRY_EX(
     zend_newrelic_globals,
     newrelic_globals,
     0)
-STD_PHP_INI_ENTRY_EX("newerlic.application_logging.forwarding.log_level",
+STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.log_level",
                      "WARNING",
                      NR_PHP_REQUEST,
                      nr_log_forwarding_log_level_mh,

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -737,6 +737,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   opts.span_queue_batch_timeout = NRINI(agent_span_queue_timeout);
   opts.logging_enabled = NRINI(logging_enabled);
   opts.log_forwarding_enabled = NRINI(log_forwarding_enabled);
+  opts.log_forwarding_log_level = NRINI(log_forwarding_log_level);
   opts.log_events_max_samples_stored = NRINI(log_events_max_samples_stored);
   opts.log_metrics_enabled = NRINI(log_metrics_enabled);
 

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1174,6 +1174,29 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;newrelic.application_logging.forwarding.max_samples_stored = 10000
 
+; Setting: newrelic.application_logging.forwarding.log_level
+; Type   : string
+; Scope  : per-directory
+; Default: "WARNING"
+; Info   : Sets the minimum log level to be collected when log forwarding
+;          is enabled. 
+;
+;          Based on
+;           https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel
+;           https://datatracker.ietf.org/doc/html/rfc5424
+;
+;          Valid settings (ordered highest to lowest):
+;           "EMERGENCY"
+;           "ALERT"
+;           "CRITICAL"
+;           "ERROR"
+;           "WARNING"
+;           "NOTICE"
+;           "INFO"
+;           "DEBUG"
+;          
+;newrelic.application_logging.forwarding.log_level = "WARNING"
+
 ; Setting: newrelic.application_logging.metrics.enabled
 ; Type   : boolean
 ; Scope  : per-directory

--- a/axiom/Makefile
+++ b/axiom/Makefile
@@ -104,6 +104,7 @@ OBJS := \
 	nr_header.o \
 	nr_log_event.o \
 	nr_log_events.o \
+	nr_log_level.o \
 	nr_mysqli_metadata.o \
 	nr_postgres.o \
 	nr_rules.o \

--- a/axiom/nr_log_level.c
+++ b/axiom/nr_log_level.c
@@ -14,6 +14,11 @@
 
 int nr_log_level_str_to_int(const char* str) {
   int level;
+  bool err = false;
+
+  if (NULL == str) {
+    err = true;
+  }
 
 #define LEVELCMP(x) (0 == nr_stricmp(str, x))
 
@@ -34,14 +39,18 @@ int nr_log_level_str_to_int(const char* str) {
   } else if (LEVELCMP(LL_DEBU_STR)) {
     level = LOG_LEVEL_DEBUG;
   } else {
+    err = true;
+  }
+
+#undef LEVELCMP
+
+  if (err) {
     nrl_warning(
         NRL_INIT,
         "Unknown Log Forwarding Log Level Specified; Defaulting to \"%s\"",
         nr_log_level_rfc_to_psr(LOG_LEVEL_UNKNOWN));
     level = LOG_LEVEL_UNKNOWN;
   }
-
-#undef LEVELCMP
 
   return level;
 }

--- a/axiom/nr_log_level.c
+++ b/axiom/nr_log_level.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nr_axiom.h"
+
+#include <stddef.h>
+
+#include "nr_log_level.h"
+#include "util_strings.h"
+#include "util_logging.h"
+#include "util_memory.h"
+
+int nr_log_level_str_to_int(const char* str) {
+  int level;
+
+#define LEVELCMP(x) (0 == nr_stricmp(str, x))
+
+  if (LEVELCMP(LL_EMER_STR)) {
+    level = LOG_LEVEL_EMERGENCY;
+  } else if (LEVELCMP(LL_ALER_STR)) {
+    level = LOG_LEVEL_ALERT;
+  } else if (LEVELCMP(LL_CRIT_STR)) {
+    level = LOG_LEVEL_CRITICAL;
+  } else if (LEVELCMP(LL_ERRO_STR)) {
+    level = LOG_LEVEL_ERROR;
+  } else if (LEVELCMP(LL_WARN_STR)) {
+    level = LOG_LEVEL_WARNING;
+  } else if (LEVELCMP(LL_NOTI_STR)) {
+    level = LOG_LEVEL_NOTICE;
+  } else if (LEVELCMP(LL_INFO_STR)) {
+    level = LOG_LEVEL_INFO;
+  } else if (LEVELCMP(LL_DEBU_STR)) {
+    level = LOG_LEVEL_DEBUG;
+  } else {
+    nrl_warning(
+        NRL_INIT,
+        "Unknown Log Forwarding Log Level Specified; Defaulting to \"%s\"",
+        nr_log_level_rfc_to_psr(LOG_LEVEL_UNKNOWN));
+    level = LOG_LEVEL_UNKNOWN;
+  }
+
+#undef LEVELCMP
+
+  return level;
+}
+
+char* nr_log_level_rfc_to_psr(int level) {
+  char* psr = NULL;
+
+#define COPY(s) (psr = nr_strdup(s));
+
+  switch (level) {
+    case LOG_LEVEL_EMERGENCY:
+      COPY(LL_EMER_STR)
+      break;
+    case LOG_LEVEL_ALERT:
+      COPY(LL_ALER_STR)
+      break;
+    case LOG_LEVEL_CRITICAL:
+      COPY(LL_CRIT_STR)
+      break;
+    case LOG_LEVEL_ERROR:
+      COPY(LL_ERRO_STR)
+      break;
+    case LOG_LEVEL_WARNING:
+      COPY(LL_WARN_STR)
+      break;
+    case LOG_LEVEL_NOTICE:
+      COPY(LL_NOTI_STR)
+      break;
+    case LOG_LEVEL_INFO:
+      COPY(LL_INFO_STR)
+      break;
+    case LOG_LEVEL_DEBUG:
+      COPY(LL_DEBU_STR)
+      break;
+    default:
+      nrl_warning(NRL_INIT,
+                  "ERROR converting Log Level rfc to psr; Defaulting to \"%s\"",
+                  LL_UNKN_STR);
+      COPY(LL_UNKN_STR)
+      break;
+  }
+
+#undef COPY
+
+  return psr;
+}

--- a/axiom/nr_log_level.c
+++ b/axiom/nr_log_level.c
@@ -57,45 +57,38 @@ int nr_log_level_str_to_int(const char* str) {
   return level;
 }
 
-char* nr_log_level_rfc_to_psr(int level) {
-  char* psr = NULL;
-
-#define COPY(s) (psr = nr_strdup(s));
+const char* nr_log_level_rfc_to_psr(int level) {
+  const char* psr = NULL;
 
   switch (level) {
     case LOG_LEVEL_EMERGENCY:
-      COPY(LL_EMER_STR)
+      psr = LL_EMER_STR;
       break;
     case LOG_LEVEL_ALERT:
-      COPY(LL_ALER_STR)
+      psr = LL_ALER_STR;
       break;
     case LOG_LEVEL_CRITICAL:
-      COPY(LL_CRIT_STR)
+      psr = LL_CRIT_STR;
       break;
     case LOG_LEVEL_ERROR:
-      COPY(LL_ERRO_STR)
+      psr = LL_ERRO_STR;
       break;
     case LOG_LEVEL_WARNING:
-      COPY(LL_WARN_STR)
+      psr = LL_WARN_STR;
       break;
     case LOG_LEVEL_NOTICE:
-      COPY(LL_NOTI_STR)
+      psr = LL_NOTI_STR;
       break;
     case LOG_LEVEL_INFO:
-      COPY(LL_INFO_STR)
+      psr = LL_INFO_STR;
       break;
     case LOG_LEVEL_DEBUG:
-      COPY(LL_DEBU_STR)
+      psr = LL_DEBU_STR;
       break;
     default:
-      nrl_warning(NRL_INIT,
-                  "ERROR converting Log Level rfc to psr; Defaulting to \"%s\"",
-                  LL_UNKN_STR);
-      COPY(LL_UNKN_STR)
+      psr = LL_UNKN_STR;
       break;
   }
-
-#undef COPY
 
   return psr;
 }

--- a/axiom/nr_log_level.c
+++ b/axiom/nr_log_level.c
@@ -22,24 +22,26 @@ int nr_log_level_str_to_int(const char* str) {
 
 #define LEVELCMP(x) (0 == nr_stricmp(str, x))
 
-  if (LEVELCMP(LL_EMER_STR)) {
-    level = LOG_LEVEL_EMERGENCY;
-  } else if (LEVELCMP(LL_ALER_STR)) {
-    level = LOG_LEVEL_ALERT;
-  } else if (LEVELCMP(LL_CRIT_STR)) {
-    level = LOG_LEVEL_CRITICAL;
-  } else if (LEVELCMP(LL_ERRO_STR)) {
-    level = LOG_LEVEL_ERROR;
-  } else if (LEVELCMP(LL_WARN_STR)) {
-    level = LOG_LEVEL_WARNING;
-  } else if (LEVELCMP(LL_NOTI_STR)) {
-    level = LOG_LEVEL_NOTICE;
-  } else if (LEVELCMP(LL_INFO_STR)) {
-    level = LOG_LEVEL_INFO;
-  } else if (LEVELCMP(LL_DEBU_STR)) {
-    level = LOG_LEVEL_DEBUG;
-  } else {
-    err = true;
+  if (!err) {
+    if (LEVELCMP(LL_EMER_STR)) {
+      level = LOG_LEVEL_EMERGENCY;
+    } else if (LEVELCMP(LL_ALER_STR)) {
+      level = LOG_LEVEL_ALERT;
+    } else if (LEVELCMP(LL_CRIT_STR)) {
+      level = LOG_LEVEL_CRITICAL;
+    } else if (LEVELCMP(LL_ERRO_STR)) {
+      level = LOG_LEVEL_ERROR;
+    } else if (LEVELCMP(LL_WARN_STR)) {
+      level = LOG_LEVEL_WARNING;
+    } else if (LEVELCMP(LL_NOTI_STR)) {
+      level = LOG_LEVEL_NOTICE;
+    } else if (LEVELCMP(LL_INFO_STR)) {
+      level = LOG_LEVEL_INFO;
+    } else if (LEVELCMP(LL_DEBU_STR)) {
+      level = LOG_LEVEL_DEBUG;
+    } else {
+      err = true;
+    }
   }
 
 #undef LEVELCMP

--- a/axiom/nr_log_level.h
+++ b/axiom/nr_log_level.h
@@ -36,19 +36,22 @@
 #define LL_UNKN_STR "UNKNOWN"
 
 /*
- * @brief       Convert PSR-3 string log level to RFC5424 represenation.
+ * Purpose : Convert PSR-3 string log level to RFC5424 represenation.
  *
- * @param       str     String Log Level
- * @return      int     RFC5424 Log Level numerical code
+ * Params  : 1.  str     String Log Level
+ *
+ * Returns : Integer RFC5424 Log Level numerical code
  */
 extern int nr_log_level_str_to_int(const char* str);
 
 /*
- * @brief       Convert RFC5424 log level to PSR-3 string represenation.
+ * Purpose : Convert RFC5424 log level to PSR-3 string represenation.
  *
- * @param       level   RFC5424 Log Level
- * @return      char*   PSR-3 String Log Level
+ * Params  : 1. level   RFC5424 Log Level
+ *
+ * Returns : PSR-3 String Log Level as a const char *
+ *
  */
-extern char* nr_log_level_rfc_to_psr(int level);
+extern const char* nr_log_level_rfc_to_psr(int level);
 
 #endif /* NR_LOG_LEVEL_HDR */

--- a/axiom/nr_log_level.h
+++ b/axiom/nr_log_level.h
@@ -6,6 +6,8 @@
 #ifndef NR_LOG_LEVEL_HDR
 #define NR_LOG_LEVEL_HDR
 
+#include <stdbool.h>
+
 /*
  *  Implementation Based on:
  *      https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel

--- a/axiom/nr_log_level.h
+++ b/axiom/nr_log_level.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NR_LOG_LEVEL_HDR
+#define NR_LOG_LEVEL_HDR
+
+/*
+ *  Implementation Based on:
+ *      https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel
+ *      https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
+ */
+
+#define LOG_LEVEL_EMERGENCY (0)  // system is unusable
+#define LOG_LEVEL_ALERT (1)      // action must be taken immediately
+#define LOG_LEVEL_CRITICAL (2)   // critical conditions
+#define LOG_LEVEL_ERROR (3)      // error conditions
+#define LOG_LEVEL_WARNING (4)    // warning conditions
+#define LOG_LEVEL_NOTICE (5)     // normal but significant conditions
+#define LOG_LEVEL_INFO (6)       // informational messages
+#define LOG_LEVEL_DEBUG (7)      // debug-level messages
+#define LOG_LEVEL_UNKNOWN (8)    // NON PSR- Unknown/Undefined log level
+#define LOG_LEVEL_DEFAULT (LOG_LEVEL_WARNING)
+
+#define LL_EMER_STR ("EMERGENCY")
+#define LL_ALER_STR ("ALERT")
+#define LL_CRIT_STR ("CRITICAL")
+#define LL_ERRO_STR ("ERROR")
+#define LL_WARN_STR ("WARNING")
+#define LL_NOTI_STR ("NOTICE")
+#define LL_INFO_STR ("INFO")
+#define LL_DEBU_STR ("DEBUG")
+#define LL_UNKN_STR ("UNKNOWN")
+
+/*
+ * @brief       Convert PSR-3 string log level to RFC5424 represenation.
+ *
+ * @param       str     String Log Level
+ * @return      int     RFC5424 Log Level numerical code
+ */
+extern int nr_log_level_str_to_int(const char* str);
+
+/*
+ * @brief       Convert RFC5424 log level to PSR-3 string represenation.
+ *
+ * @param       level   RFC5424 Log Level
+ * @return      char*   PSR-3 String Log Level
+ */
+extern char* nr_log_level_rfc_to_psr(int level);
+
+#endif /* NR_LOG_LEVEL_HDR */

--- a/axiom/nr_log_level.h
+++ b/axiom/nr_log_level.h
@@ -25,15 +25,15 @@
 #define LOG_LEVEL_UNKNOWN (8)    // NON PSR- Unknown/Undefined log level
 #define LOG_LEVEL_DEFAULT (LOG_LEVEL_WARNING)
 
-#define LL_EMER_STR ("EMERGENCY")
-#define LL_ALER_STR ("ALERT")
-#define LL_CRIT_STR ("CRITICAL")
-#define LL_ERRO_STR ("ERROR")
-#define LL_WARN_STR ("WARNING")
-#define LL_NOTI_STR ("NOTICE")
-#define LL_INFO_STR ("INFO")
-#define LL_DEBU_STR ("DEBUG")
-#define LL_UNKN_STR ("UNKNOWN")
+#define LL_EMER_STR "EMERGENCY"
+#define LL_ALER_STR "ALERT"
+#define LL_CRIT_STR "CRITICAL"
+#define LL_ERRO_STR "ERROR"
+#define LL_WARN_STR "WARNING"
+#define LL_NOTI_STR "NOTICE"
+#define LL_INFO_STR "INFO"
+#define LL_DEBU_STR "DEBUG"
+#define LL_UNKN_STR "UNKNOWN"
 
 /*
  * @brief       Convert PSR-3 string log level to RFC5424 represenation.

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -18,6 +18,7 @@
 #include "nr_header.h"
 #include "nr_limits.h"
 #include "nr_log_events.h"
+#include "nr_log_level.h"
 #include "nr_segment.h"
 #include "nr_segment_private.h"
 #include "nr_segment_traces.h"
@@ -3269,6 +3270,37 @@ bool nr_txn_log_forwarding_enabled(nrtxn_t* txn) {
   return true;
 }
 
+bool nr_txn_log_forwarding_log_level_verify(nrtxn_t* txn,
+                                            const char* log_level_name) {
+  int log_level;
+
+  if (NULL == txn) { /* more like an assert */
+    return false;
+  }
+
+  if (!txn->options.logging_enabled || !txn->options.log_forwarding_enabled) {
+    return false;
+  }
+
+  if (txn->high_security) {
+    return false;
+  }
+
+  log_level = nr_log_level_str_to_int(log_level_name);
+
+  // pass through UNKNOWN by default
+  if (LOG_LEVEL_UNKNOWN == log_level) {
+    return true;
+  }
+
+  // log levels are organized 0 -> 7 in decreasing severity
+  if (log_level > txn->options.log_forwarding_log_level) {
+    return false;
+  }
+
+  return true;
+}
+
 bool nr_txn_log_metrics_enabled(nrtxn_t* txn) {
   if (NULL == txn) { /* more like an assert */
     return false;
@@ -3374,6 +3406,10 @@ static void nr_txn_add_log_event(nrtxn_t* txn,
   }
 
   if (nr_strempty(log_message)) {
+    return;
+  }
+
+  if (!nr_txn_log_forwarding_log_level_verify(txn, log_level_name)) {
     return;
   }
 

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3413,7 +3413,6 @@ static void nr_txn_add_log_event(nrtxn_t* txn,
     } else {
       event_dropped = nr_log_events_add_event(txn->log_events, e);
     }
-    nr_log_event_destroy(&e);
   }
 
   if (event_dropped) {

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -23,6 +23,7 @@
 #include "nr_errors.h"
 #include "nr_file_naming.h"
 #include "nr_log_events.h"
+#include "nr_log_level.h"
 #include "nr_segment.h"
 #include "nr_slowsqls.h"
 #include "nr_span_queue.h"
@@ -117,7 +118,9 @@ typedef struct _nrtxnopt_t {
   nrtime_t span_queue_batch_timeout; /* Span queue batch timeout in us. */
   bool logging_enabled; /* An overall configuration for enabling/disabling all
                            application logging features */
-  bool log_forwarding_enabled;          /* Whether log forwarding is enabled */
+  bool log_forwarding_enabled;  /* Whether log forwarding is enabled */
+  int log_forwarding_log_level; /* minimum log level to forward to the collector
+                                 */
   size_t log_events_max_samples_stored; /* The maximum number of log events per
                                            transaction */
   bool log_metrics_enabled;             /* Whether log metrics are enabled */
@@ -616,6 +619,12 @@ extern void nr_txn_record_custom_event(nrtxn_t* txn,
  * Purpose : Check log forwarding configuration
  */
 extern bool nr_txn_log_forwarding_enabled(nrtxn_t* txn);
+
+/*
+ * Purpose : Check log forwarding log level configuration
+ */
+extern bool nr_txn_log_forwarding_log_level_verify(nrtxn_t* txn,
+                                                   const char* log_level_name);
 
 /*
  * Purpose : Check logging metrics configuration

--- a/axiom/tests/.gitignore
+++ b/axiom/tests/.gitignore
@@ -68,6 +68,7 @@ test_json
 test_labels
 test_log_event
 test_log_events
+test_log_level
 test_logging
 test_logging_parallel
 test_math

--- a/axiom/tests/Makefile
+++ b/axiom/tests/Makefile
@@ -149,6 +149,7 @@ TESTS := \
   test_labels \
   test_log_event \
   test_log_events \
+  test_log_level \
   test_logging \
   test_math \
   test_memory \

--- a/axiom/tests/test_log_level.c
+++ b/axiom/tests/test_log_level.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <limits.h>
+
+#include "tlib_main.h"
+#include "nr_log_level.h"
+
+static void test_log_level_rfc_to_psr(void) {
+  /* Test with invalid values */
+  tlib_pass_if_str_equal("invalid rfc value -1", LL_UNKN_STR,
+                         nr_log_level_rfc_to_psr(-1));
+
+  tlib_pass_if_str_equal("invalid rfc value INT_MAX", LL_UNKN_STR,
+                         nr_log_level_rfc_to_psr(INT_MAX));
+
+  tlib_pass_if_str_equal("invalid rfc value INT_MIN", LL_UNKN_STR,
+                         nr_log_level_rfc_to_psr(INT_MIN));
+
+  /* Test known values */
+  tlib_pass_if_str_equal("rfc value 0", LL_EMER_STR,
+                         nr_log_level_rfc_to_psr(0));
+  tlib_pass_if_str_equal("rfc value 1", LL_ALER_STR,
+                         nr_log_level_rfc_to_psr(1));
+  tlib_pass_if_str_equal("rfc value 2", LL_CRIT_STR,
+                         nr_log_level_rfc_to_psr(2));
+  tlib_pass_if_str_equal("rfc value 3", LL_ERRO_STR,
+                         nr_log_level_rfc_to_psr(3));
+  tlib_pass_if_str_equal("rfc value 4", LL_WARN_STR,
+                         nr_log_level_rfc_to_psr(4));
+  tlib_pass_if_str_equal("rfc value 5", LL_NOTI_STR,
+                         nr_log_level_rfc_to_psr(5));
+  tlib_pass_if_str_equal("rfc value 6", LL_INFO_STR,
+                         nr_log_level_rfc_to_psr(6));
+  tlib_pass_if_str_equal("rfc value 7", LL_DEBU_STR,
+                         nr_log_level_rfc_to_psr(7));
+
+  /* Test unknown value */
+  tlib_pass_if_str_equal("rfc value 8", LL_UNKN_STR,
+                         nr_log_level_rfc_to_psr(8));
+}
+
+static void test_log_level_str_to_int(void) {
+  /* Test NULL value */
+  tlib_pass_if_int_equal("NULL str to rfc", LOG_LEVEL_UNKNOWN,
+                         nr_log_level_str_to_int(NULL));
+
+  /* custom level name */
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_UNKNOWN,
+                         nr_log_level_str_to_int("GOSSIP"));
+
+  /* defined level names */
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_EMERGENCY,
+                         nr_log_level_str_to_int("EMERGENCY"));
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_ALERT,
+                         nr_log_level_str_to_int("ALERT"));
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_CRITICAL,
+                         nr_log_level_str_to_int("CRITICAL"));
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_ERROR,
+                         nr_log_level_str_to_int("ERROR"));
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_WARNING,
+                         nr_log_level_str_to_int("WARNING"));
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_NOTICE,
+                         nr_log_level_str_to_int("NOTICE"));
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_INFO,
+                         nr_log_level_str_to_int("INFO"));
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_DEBUG,
+                         nr_log_level_str_to_int("DEBUG"));
+  tlib_pass_if_int_equal("Unknown str to rfc", LOG_LEVEL_UNKNOWN,
+                         nr_log_level_str_to_int("UNKNOWN"));
+}
+
+tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};
+
+void test_main(void* p NRUNUSED) {
+  test_log_level_str_to_int();
+  test_log_level_rfc_to_psr();
+}

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8101,6 +8101,7 @@ static nrtxn_t* new_txn_for_record_log_event_test(char* entity_name) {
   nr_memset(&opts, 0, sizeof(opts));
   opts.logging_enabled = true;
   opts.log_forwarding_enabled = true;
+  opts.log_forwarding_log_level = LOG_LEVEL_WARNING;
   opts.log_events_max_samples_stored = 10;
   opts.log_metrics_enabled = true;
 
@@ -8118,7 +8119,7 @@ static nrtxn_t* new_txn_for_record_log_event_test(char* entity_name) {
 }
 
 static void test_record_log_event(void) {
-#define LOG_LEVEL "INFO"
+#define LOG_LEVEL LL_WARN_STR
 #define LOG_MESSAGE "Sample log message"
 #define LOG_TIMESTAMP 1234
 #define LOG_EVENT_PARAMS \
@@ -8191,7 +8192,9 @@ static void test_record_log_event(void) {
       = "{"
         "\"message\":\"" LOG_MESSAGE
         "\","
-        "\"level\":\"UNKNOWN\","
+        "\"log.level\":\"" LL_UNKN_STR
+        "\","
+        "\"timestamp\":0,"
         "\"trace.id\":\"0000000000000000\","
         "\"span.id\":\"0000000000000000\","
         "\"entity.name\":\"" APP_ENTITY_NAME

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8230,9 +8230,8 @@ static void test_record_log_event(void) {
       = "{"
         "\"message\":\"" LOG_MESSAGE
         "\","
-        "\"log.level\":\"" LL_UNKN_STR
+        "\"level\":\"" LL_UNKN_STR
         "\","
-        "\"timestamp\":0,"
         "\"trace.id\":\"0000000000000000\","
         "\"span.id\":\"0000000000000000\","
         "\"entity.name\":\"" APP_ENTITY_NAME

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8118,6 +8118,44 @@ static nrtxn_t* new_txn_for_record_log_event_test(char* entity_name) {
   return txn;
 }
 
+static void test_log_level_verify(void) {
+  nrtxn_t* txn = NULL;
+  txn = new_txn_for_record_log_event_test("test_log_level_verify");
+
+  /* Test NULL values */
+  tlib_pass_if_false("NULL txn ok",
+                     nr_txn_log_forwarding_log_level_verify(NULL, LL_NOTI_STR),
+                     "expected false");
+  tlib_pass_if_true("NULL log level ok",
+                    nr_txn_log_forwarding_log_level_verify(txn, NULL),
+                    "expected true");
+
+  /* Test known values */
+  txn->options.log_forwarding_log_level = LOG_LEVEL_WARNING;
+  tlib_pass_if_false("INFO not passed for log level = WARNING",
+                     nr_txn_log_forwarding_log_level_verify(txn, LL_INFO_STR),
+                     "expected false");
+  tlib_pass_if_false("DEBUG not passed for log level = WARNING",
+                     nr_txn_log_forwarding_log_level_verify(txn, LL_INFO_STR),
+                     "expected false");
+  txn->options.log_forwarding_log_level = LOG_LEVEL_WARNING;
+  tlib_pass_if_true("ALERT  passed for log level = WARNING",
+                    nr_txn_log_forwarding_log_level_verify(txn, LL_ALER_STR),
+                    "expected true");
+  txn->options.log_forwarding_log_level = LOG_LEVEL_WARNING;
+  tlib_pass_if_true("EMERGENCY  passed for log level = WARNING",
+                    nr_txn_log_forwarding_log_level_verify(txn, LL_EMER_STR),
+                    "expected true");
+
+  /* Test unknown level passed even if threshold set to EMERGENCY */
+  txn->options.log_forwarding_log_level = LOG_LEVEL_EMERGENCY;
+  tlib_pass_if_true("Unknown log level passed for log level = EMERGENCY",
+                    nr_txn_log_forwarding_log_level_verify(txn, "APPLES"),
+                    "expected true");
+
+  nr_txn_destroy(&txn);
+}
+
 static void test_record_log_event(void) {
 #define LOG_LEVEL LL_WARN_STR
 #define LOG_MESSAGE "Sample log message"
@@ -8310,6 +8348,45 @@ static void test_record_log_event(void) {
   tlib_pass_if_int_equal("happy path, hsm, 0 len vector", 0,
                          nr_vector_size(vector));
   nr_vector_destroy(&vector);
+  nr_txn_destroy(&txn);
+
+  /* Happy path but log level causes some message to be ignored */
+  txn = new_txn_for_record_log_event_test(APP_ENTITY_NAME);
+
+  /* default filter log level is LOG_LEVEL_WARNING */
+  /* these messages should be accepted */
+  nr_txn_record_log_event(txn, LL_ALER_STR, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, LL_CRIT_STR, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, LL_WARN_STR, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, LL_EMER_STR, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, LL_UNKN_STR, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, "APPLES", LOG_MESSAGE, 0, NULL);
+
+  /* these messages will be dropped */
+  nr_txn_record_log_event(txn, LL_INFO_STR, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, LL_DEBU_STR, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, LL_NOTI_STR, LOG_MESSAGE, 0, NULL);
+
+  /* events seen and saved are both 6 because the filtering occurs before
+   * log forwarding handles the messages.
+   */
+  tlib_pass_if_int_equal(
+      "happy path with WARNING log level threshold, events seen", 6,
+      nr_log_events_number_seen(txn->log_events));
+  tlib_pass_if_int_equal(
+      "happy path with WARNING log level threshold, events saved", 6,
+      nr_log_events_number_saved(txn->log_events));
+
+  /* should see 9 messages in Logging/lines metric */
+  test_txn_metric_is(
+      "happy path with WARNING log level threshold, events total",
+      txn->unscoped_metrics, MET_FORCED, "Logging/lines", 9, 0, 0, 0, 0, 0);
+
+  /* Dropped metric should show all the 3 messages were not considered */
+  test_txn_metric_is(
+      "happy path with WARNING log level threshold, events dropped",
+      txn->unscoped_metrics, MET_FORCED, "Logging/Forwarding/Dropped", 3, 0, 0,
+      0, 0, 0);
   nr_txn_destroy(&txn);
 }
 
@@ -8518,6 +8595,7 @@ void test_main(void* p NRUNUSED) {
   test_txn_accept_distributed_trace_payload_w3c_and_nr();
   test_span_queue();
   test_segment_record_error();
+  test_log_level_verify();
   test_record_log_event();
   test_txn_log_configuration();
 }

--- a/tests/integration/logging/monolog2/test_monolog_basic.php
+++ b/tests/integration/logging/monolog2/test_monolog_basic.php
@@ -16,10 +16,12 @@ require('skipif.inc');
 */
 
 /*INI
+newrelic.loglevel = verbosedebug
 newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog2/test_monolog_cat.php
+++ b/tests/integration/logging/monolog2/test_monolog_cat.php
@@ -20,6 +20,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
 */

--- a/tests/integration/logging/monolog2/test_monolog_disable_forwarding.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_forwarding.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = false
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog2/test_monolog_disable_logging.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_logging.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = false
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog2/test_monolog_disable_metrics.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_metrics.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = false
 newrelic.application_logging.forwarding.max_samples_stored = 5
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog2/test_monolog_drop_empty.php
+++ b/tests/integration/logging/monolog2/test_monolog_drop_empty.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog2/test_monolog_hsm_disable_forwarding.php
+++ b/tests/integration/logging/monolog2/test_monolog_hsm_disable_forwarding.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 newrelic.high_security=true
 */
 

--- a/tests/integration/logging/monolog2/test_monolog_large_message_limit.php
+++ b/tests/integration/logging/monolog2/test_monolog_large_message_limit.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10000
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog2/test_monolog_large_message_limit_drops.php
+++ b/tests/integration/logging/monolog2/test_monolog_large_message_limit_drops.php
@@ -20,6 +20,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10000
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog2/test_monolog_limit_log_events.php
+++ b/tests/integration/logging/monolog2/test_monolog_limit_log_events.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 4
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog2/test_monolog_limit_zero_events.php
+++ b/tests/integration/logging/monolog2/test_monolog_limit_zero_events.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 0
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid1.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid1.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 0.4
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid2.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid2.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = -1
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid3.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid3.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 100100
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid4.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid4.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = butterflies
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog2/test_monolog_log_level_filter.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_level_filter.php
@@ -56,6 +56,8 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog2/test_monolog_log_level_filter.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_level_filter.php
@@ -1,0 +1,167 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters by log level
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = WARNING
+*/
+
+/*EXPECT
+monolog2.DEBUG: debug []
+monolog2.INFO: info []
+monolog2.NOTICE: notice []
+monolog2.WARNING: warning []
+monolog2.ERROR: error []
+monolog2.CRITICAL: critical []
+monolog2.ALERT: alert []
+monolog2.EMERGENCY: emergency []
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/forwarding/Dropped"},                                      [3, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/CRITICAL"},                                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/EMERGENCY"},                                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ERROR"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/WARNING"},                                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "error",
+          "level": "ERROR",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        },
+        {
+          "message": "critical",
+          "level": "CRITICAL",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        },        
+        {
+          "message": "warning",
+          "level": "WARNING",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        },
+        {
+          "message": "alert",
+          "level": "ALERT",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        },  
+        {
+          "message": "emergency",
+          "level": "EMERGENCY",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+    
+    // insert delays between log messages to allow priority sampling
+    // to resolve that later messages have higher precedence
+    // since timestamps are only millisecond resolution
+    // without delays sometimes order in output will reflect
+    // all having the same timestamp.
+    $logger->debug("debug");
+    usleep(10000);
+    $logger->info("info");
+    usleep(10000);
+    $logger->notice("notice");
+    usleep(10000);
+    $logger->warning("warning");
+    usleep(10000);
+    $logger->error("error");
+    usleep(10000);
+    $logger->critical("critical");
+    usleep(10000);
+    $logger->alert("alert");
+    usleep(10000);
+    $logger->emergency("emergency");
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_log_level_filter.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_level_filter.php
@@ -42,12 +42,15 @@ monolog2.EMERGENCY: emergency []
   [
     [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
     [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Logging/forwarding/Dropped"},                                      [3, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/Forwarding/Dropped"},                                      [3, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines"},                                                   [8, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/CRITICAL"},                                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/EMERGENCY"},                                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/ERROR"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/INFO"},                                              [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/NOTICE"},                                            [1, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/WARNING"},                                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
@@ -68,6 +71,16 @@ monolog2.EMERGENCY: emergency []
       },
       "logs": [
         {
+          "message": "alert",
+          "level": "ALERT",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        },
+        {
           "message": "error",
           "level": "ERROR",
           "timestamp": "??",
@@ -86,30 +99,20 @@ monolog2.EMERGENCY: emergency []
           "entity.guid": "??",
           "entity.name": "tests/integration/logging/monolog2__FILE__",
           "hostname": "__HOST__"
+        }, 
+        {
+          "message": "emergency",
+          "level": "EMERGENCY",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
         },        
         {
           "message": "warning",
           "level": "WARNING",
-          "timestamp": "??",
-          "trace.id": "??",
-          "span.id": "??",
-          "entity.guid": "??",
-          "entity.name": "tests/integration/logging/monolog2__FILE__",
-          "hostname": "__HOST__"
-        },
-        {
-          "message": "alert",
-          "level": "ALERT",
-          "timestamp": "??",
-          "trace.id": "??",
-          "span.id": "??",
-          "entity.guid": "??",
-          "entity.name": "tests/integration/logging/monolog2__FILE__",
-          "hostname": "__HOST__"
-        },  
-        {
-          "message": "emergency",
-          "level": "EMERGENCY",
           "timestamp": "??",
           "trace.id": "??",
           "span.id": "??",

--- a/tests/integration/logging/monolog2/test_monolog_log_level_filter_invalid.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_level_filter_invalid.php
@@ -5,8 +5,8 @@
  */
 
 /*DESCRIPTION
-Test that Monolog3 instrumentation does not forward log events
-if the max log samples is set to 0.
+Test that Monolog2 instrumentation uses default log level filter
+if an invalid log level is passed to config option.
 */
 
 /*SKIPIF
@@ -20,19 +20,19 @@ require('skipif.inc');
 newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
-newrelic.application_logging.forwarding.max_samples_stored = 0
-newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = INVALID
 */
 
 /*EXPECT
-monolog3.DEBUG: debug []
-monolog3.INFO: info []
-monolog3.NOTICE: notice []
-monolog3.WARNING: warning []
-monolog3.ERROR: error []
-monolog3.CRITICAL: critical []
-monolog3.ALERT: alert []
-monolog3.EMERGENCY: emergency []
+monolog2.DEBUG: debug []
+monolog2.INFO: info []
+monolog2.NOTICE: notice []
+monolog2.WARNING: warning []
+monolog2.ERROR: error []
+monolog2.CRITICAL: critical []
+monolog2.ALERT: alert []
+monolog2.EMERGENCY: emergency []
 */
 
 /*EXPECT_METRICS
@@ -43,7 +43,7 @@ monolog3.EMERGENCY: emergency []
   [
     [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
     [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Logging/Forwarding/Dropped"},                                      [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/Forwarding/Dropped"},                                      [3, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines"},                                                   [8, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/CRITICAL"},                                          [1, "??", "??", "??", "??", "??"]],
@@ -58,20 +58,77 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */
 
+
 /*EXPECT_LOG_EVENTS
-null
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "alert",
+          "level": "ALERT",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        },
+        {
+          "message": "error",
+          "level": "ERROR",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        },
+        {
+          "message": "critical",
+          "level": "CRITICAL",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        }, 
+        {
+          "message": "emergency",
+          "level": "EMERGENCY",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        },        
+        {
+          "message": "warning",
+          "level": "WARNING",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__"
+        }
+      ]
+    }
+  ]
  */
 
 require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
-require_monolog(3);
+require_monolog(2);
 
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
@@ -79,7 +136,7 @@ use Monolog\Formatter\LineFormatter;
 
 
 function test_logging() {
-    $logger = new Logger('monolog3');
+    $logger = new Logger('monolog2');
 
     $logfmt = "%channel%.%level_name%: %message% %context%\n";
     $formatter = new LineFormatter($logfmt);
@@ -89,13 +146,25 @@ function test_logging() {
 
     $logger->pushHandler($stdoutHandler);
     
+    // insert delays between log messages to allow priority sampling
+    // to resolve that later messages have higher precedence
+    // since timestamps are only millisecond resolution
+    // without delays sometimes order in output will reflect
+    // all having the same timestamp.
     $logger->debug("debug");
+    usleep(10000);
     $logger->info("info");
+    usleep(10000);
     $logger->notice("notice");
+    usleep(10000);
     $logger->warning("warning");
+    usleep(10000);
     $logger->error("error");
+    usleep(10000);
     $logger->critical("critical");
+    usleep(10000);
     $logger->alert("alert");
+    usleep(10000);
     $logger->emergency("emergency");
 }
 

--- a/tests/integration/logging/monolog2/test_monolog_log_level_filter_invalid.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_level_filter_invalid.php
@@ -57,6 +57,8 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog2/test_monolog_truncate_long_msgs.php
+++ b/tests/integration/logging/monolog2/test_monolog_truncate_long_msgs.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_basic.php
+++ b/tests/integration/logging/monolog3/test_monolog_basic.php
@@ -20,6 +20,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_cat.php
+++ b/tests/integration/logging/monolog3/test_monolog_cat.php
@@ -22,6 +22,7 @@ newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
 newrelic.distributed_tracing_enabled=0
 newrelic.cross_application_tracer.enabled = true
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_disable_forwarding.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_forwarding.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = false
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_disable_logging.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_logging.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = false
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_disable_metrics.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_metrics.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = false
 newrelic.application_logging.forwarding.max_samples_stored = 5
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_drop_empty.php
+++ b/tests/integration/logging/monolog3/test_monolog_drop_empty.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_hsm_disable_forwarding.php
+++ b/tests/integration/logging/monolog3/test_monolog_hsm_disable_forwarding.php
@@ -22,6 +22,7 @@ newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
 newrelic.high_security = true
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_large_message_limit.php
+++ b/tests/integration/logging/monolog3/test_monolog_large_message_limit.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10000
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog3/test_monolog_large_message_limit_drops.php
+++ b/tests/integration/logging/monolog3/test_monolog_large_message_limit_drops.php
@@ -20,6 +20,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10000
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog3/test_monolog_limit_log_events.php
+++ b/tests/integration/logging/monolog3/test_monolog_limit_log_events.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 4
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid1.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid1.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 0.4
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid2.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid2.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = -1
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid3.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid3.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 100100
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid4.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid4.php
@@ -23,6 +23,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = butterflies
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 

--- a/tests/integration/logging/monolog3/test_monolog_log_level_filter.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_level_filter.php
@@ -56,6 +56,8 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog3/test_monolog_log_level_filter.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_level_filter.php
@@ -5,8 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that Monolog3 instrumentation does not forward log events
-if the max log samples is set to 0.
+Test that monolog3 instrumentation filters by log level
 */
 
 /*SKIPIF
@@ -20,8 +19,8 @@ require('skipif.inc');
 newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
-newrelic.application_logging.forwarding.max_samples_stored = 0
-newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = WARNING
 */
 
 /*EXPECT
@@ -43,7 +42,7 @@ monolog3.EMERGENCY: emergency []
   [
     [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
     [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Logging/Forwarding/Dropped"},                                      [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/Forwarding/Dropped"},                                      [3, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines"},                                                   [8, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Logging/lines/CRITICAL"},                                          [1, "??", "??", "??", "??", "??"]],
@@ -58,15 +57,72 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */
 
+
 /*EXPECT_LOG_EVENTS
-null
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "alert",
+          "level": "ALERT",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__"
+        },
+        {
+          "message": "error",
+          "level": "ERROR",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__"
+        },
+        {
+          "message": "critical",
+          "level": "CRITICAL",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__"
+        }, 
+        {
+          "message": "emergency",
+          "level": "EMERGENCY",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__"
+        },        
+        {
+          "message": "warning",
+          "level": "WARNING",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__"
+        }
+      ]
+    }
+  ]
  */
 
 require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
@@ -89,13 +145,25 @@ function test_logging() {
 
     $logger->pushHandler($stdoutHandler);
     
+    // insert delays between log messages to allow priority sampling
+    // to resolve that later messages have higher precedence
+    // since timestamps are only millisecond resolution
+    // without delays sometimes order in output will reflect
+    // all having the same timestamp.
     $logger->debug("debug");
+    usleep(10000);
     $logger->info("info");
+    usleep(10000);
     $logger->notice("notice");
+    usleep(10000);
     $logger->warning("warning");
+    usleep(10000);
     $logger->error("error");
+    usleep(10000);
     $logger->critical("critical");
+    usleep(10000);
     $logger->alert("alert");
+    usleep(10000);
     $logger->emergency("emergency");
 }
 

--- a/tests/integration/logging/monolog3/test_monolog_log_level_filter_invalid.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_level_filter_invalid.php
@@ -57,6 +57,8 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/logging/monolog3/test_monolog_truncate_long_msgs.php
+++ b/tests/integration/logging/monolog3/test_monolog_truncate_long_msgs.php
@@ -21,6 +21,7 @@ newrelic.application_logging.enabled = true
 newrelic.application_logging.forwarding.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
 */
 
 /*EXPECT


### PR DESCRIPTION
NOTE: This is a reposting of an existing PR which "bduranleau-nr" created the vast majority of the work.    I did some work to tweak it and add tests and when I needed to rebase the branch it seemed better to make a new PR than to overwrite his original work/branch with a force push so we could have it as a reference

This PR addresses adding the ability for a user to configure a "minimum" log level to forward to the collector, based on the following PHP Log Level standards:
- https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
- https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel
