### PR TITLE
fix(agent, daemon): Bump max log samples to 20k

### DIFF
--- a/axiom/nr_limits.h
+++ b/axiom/nr_limits.h
@@ -55,6 +55,6 @@
 /*
  * The maximum number of log events in a transaction.
  */
-#define NR_MAX_LOG_EVENTS_MAX_SAMPLES_STORED 10000
+#define NR_MAX_LOG_EVENTS_MAX_SAMPLES_STORED 20000
 
 #endif /* NR_LIMITS_HDR */

--- a/src/newrelic/collector/client.go
+++ b/src/newrelic/collector/client.go
@@ -430,7 +430,8 @@ func (c *clientImpl) Execute(cmd RpmCmd, cs RpmControls) RPMResponse {
 			cmd.Name, err.Error(), cleanURL)
 	}
 
-	log.Audit("command='%s' url='%s', response={%s}", cmd.Name, url, string(resp.Body))
-	log.Debugf("command='%s' url='%s', response={%s}", cmd.Name, cleanURL, string(resp.Body))
+	log.Audit("command='%s' url='%s', status=%d, response={%s}", cmd.Name, url, resp.StatusCode, string(resp.Body))
+	log.Debugf("command='%s' url='%s', status=%d, response={%s}", cmd.Name, cleanURL, resp.StatusCode, string(resp.Body))
+
 	return resp
 }

--- a/src/newrelic/limits/limits.go
+++ b/src/newrelic/limits/limits.go
@@ -31,7 +31,7 @@ const (
 	MaxCustomEvents              = 10 * 1000
 	MaxErrorEvents               = 100
 	MaxSpanMaxEvents             = 10000
-	MaxLogMaxEvents              = 10 * 1000
+	MaxLogMaxEvents              = 20 * 1000
 	MaxErrors                    = 20
 	MaxSlowSQLs                  = 10
 	MaxRegularTraces             = 1

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid1.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid1.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 When the log events max_samples_stored limit is set to any integer 
-less than 1 or greater than 10000 (max value)
+less than 1 or greater than 20000 (max value)
 the max_samples_stored value should be treated as the default (10000) value.
 Setting a invalid value should result in the default value of 10000 being seen.
 */

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid2.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid2.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 When the log events max_samples_stored limit is set to any integer 
-less than 1 or greater than 10000 (max value)
+less than 1 or greater than 20000 (max value)
 the max_samples_stored value should be treated as the default (10000) value.
 Setting a invalid value should result in the default value of 10000 being seen.
 */

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid3.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid3.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 When the log events max_samples_stored limit is set to any integer 
-less than 1 or greater than 10000 (max value)
+less than 1 or greater than 20000 (max value)
 the max_samples_stored value should be treated as the default (10000) value.
 Setting a invalid value should result in the default value of 10000 being seen.
 */

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid4.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid4.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 When the log events max_samples_stored limit is set to any integer 
-less than 1 or greater than 10000 (max value)
+less than 1 or greater than 20000 (max value)
 the max_samples_stored value should be treated as the default (10000) value.
 Setting a invalid value should result in the default value of 10000 being seen.
 */

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid1.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid1.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 When the log events max_samples_stored limit is set to any integer 
-less than 1 or greater than 10000 (max value)
+less than 1 or greater than 20000 (max value)
 the max_samples_stored value should be treated as the default (10000) value.
 Setting a invalid value should result in the default value of 10000 being seen.
 */

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid2.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid2.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 When the log events max_samples_stored limit is set to any integer 
-less than 1 or greater than 10000 (max value)
+less than 1 or greater than 20000 (max value)
 the max_samples_stored value should be treated as the default (10000) value.
 Setting a invalid value should result in the default value of 10000 being seen.
 */

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid3.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid3.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 When the log events max_samples_stored limit is set to any integer 
-less than 1 or greater than 10000 (max value)
+less than 1 or greater than 20000 (max value)
 the max_samples_stored value should be treated as the default (10000) value.
 Setting a invalid value should result in the default value of 10000 being seen.
 */

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid4.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid4.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 When the log events max_samples_stored limit is set to any integer 
-less than 1 or greater than 10000 (max value)
+less than 1 or greater than 20000 (max value)
 the max_samples_stored value should be treated as the default (10000) value.
 Setting a invalid value should result in the default value of 10000 being seen.
 */


### PR DESCRIPTION
This PR bumps the max log samples to 20000 per minute or 1666 per 5 second fast harvest.
The previous max was 10000 and based on OATS results the new value was selected.
The default value remains 10000.

The new maximum was verified by sending 1666 log events to the collector in a single harvest cycle and confirming this many event were recorded.

Several logging integration tests were updated in accordance with the new max value.

This PR also adds the HTTP response status to the debugging output as newer communications rely on a response code and not the response body to indicate status and errors.  This will help troubleshooting issues.