### PR TITLE
feat(daemon): Add notification on # of apps

### DIFF
--- a/src/newrelic/limits/limits.go
+++ b/src/newrelic/limits/limits.go
@@ -16,7 +16,13 @@ import (
 const (
 	// AppLimit is the maximum number of applications that the daemon will
 	// support.  The agent's limit is in nr_app.h.
+	// AppLimitNotifyHigh is the limit at which a notification will be output that
+	// the number of applications connected has reached this value from below.
+	// AppLimitNotifyLow is the lower limit at which a notification will be
+	// output that the number of applications has dropped to this point.
 	AppLimit                 = 250
+	AppLimitNotifyHigh       = 200
+	AppLimitNotifyLow        = 25
 	AppConnectAttemptBackoff = 30 * time.Second
 
 	// DefaultAppTimeout specifies the elapsed time after which an application

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -366,7 +366,6 @@ func (p *Processor) processAppInfo(m AppInfoMessage) {
 	}
 
 	numapps := len(p.apps)
-	log.Debugf("number of apps is %d", numapps)
 	if numapps > limits.AppLimit {
 		log.Errorf("unable to add app '%s', limit of %d applications reached",
 			m.Info, limits.AppLimit)
@@ -713,7 +712,6 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 	if p.cfg.AppTimeout > 0 && app.Inactive(p.cfg.AppTimeout) {
 		log.Infof("removing %q with run id %q for lack of activity within %v",
 			app, id, p.cfg.AppTimeout)
-		log.Debugf("number of apps is %d", len(p.apps))
 		if len(p.apps) == limits.AppLimitNotifyLow {
 			log.Infof("current number of apps is %d",
 				limits.AppLimitNotifyLow)

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -365,10 +365,15 @@ func (p *Processor) processAppInfo(m AppInfoMessage) {
 		return
 	}
 
-	if len(p.apps) > limits.AppLimit {
+	numapps := len(p.apps)
+	log.Debugf("number of apps is %d", numapps)
+	if numapps > limits.AppLimit {
 		log.Errorf("unable to add app '%s', limit of %d applications reached",
 			m.Info, limits.AppLimit)
 		return
+	} else if numapps == limits.AppLimitNotifyHigh {
+		log.Infof("approaching app limit of %d, current number of apps is %d",
+			limits.AppLimit, limits.AppLimitNotifyHigh)
 	}
 
 	app = NewApp(m.Info)
@@ -697,7 +702,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		logEvents := harvest.LogEvents
 		harvest.LogEvents = NewLogEvents(eventConfigs.LogEventConfig.Limit)
 		considerHarvestPayload(logEvents, args)
-
 	}
 }
 
@@ -709,6 +713,11 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 	if p.cfg.AppTimeout > 0 && app.Inactive(p.cfg.AppTimeout) {
 		log.Infof("removing %q with run id %q for lack of activity within %v",
 			app, id, p.cfg.AppTimeout)
+		log.Debugf("number of apps is %d", len(p.apps))
+		if len(p.apps) == limits.AppLimitNotifyLow {
+			log.Infof("current number of apps is %d",
+				limits.AppLimitNotifyLow)
+		}
 		p.shutdownAppHarvest(id)
 		delete(p.apps, app.Key())
 


### PR DESCRIPTION
Simple addition to the daemon to output a notification when the number of applications is approaching the maximum limit.  Also another notification when the number of apps has dropped to a low value.

The intention is to allow for detecting when a new daemon container needs to be spun up to service more applications and also when the number of applications on that daemon container has dropped to a lower threshold.

Also added a debug only message that outputs the current number of applications which might be useful for troubleshooting .