### PR TITLE
fix(agent): fix nr_drupal_http_request_exec

### DIFF
--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -230,20 +230,6 @@ NR_PHP_WRAPPER(nr_drupal_http_request_exec) {
         = {.library = "Drupal",
            .uri = nr_strndup(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1))};
 
-    segment = nr_segment_start(NRPRG(txn), NULL, NULL);
-
-    /*
-     * Our wrapper for drupal_http_request (which we installed in
-     * nr_drupal_replace_http_request()) will take care of adding the request
-     * headers, so let's just go ahead and call the function.
-     */
-    NR_PHP_WRAPPER_CALL;
-
-    external_params.encoded_response_header
-        = nr_drupal_http_request_get_response_header(return_value TSRMLS_CC);
-
-    external_params.status
-        = nr_drupal_http_request_get_response_code(return_value TSRMLS_CC);
     /*
      * Drupal 6 will have a third argument with the method, Drupal 7 will not
      * have a third argument it must be parsed from the second.
@@ -269,6 +255,20 @@ NR_PHP_WRAPPER(nr_drupal_http_request_exec) {
       external_params.procedure = nr_strdup("GET");
     }
 
+    segment = nr_segment_start(NRPRG(txn), NULL, NULL);
+
+    /*
+     * Our wrapper for drupal_http_request (which we installed in
+     * nr_drupal_replace_http_request()) will take care of adding the request
+     * headers, so let's just go ahead and call the function.
+     */
+    NR_PHP_WRAPPER_CALL;
+
+    external_params.encoded_response_header
+        = nr_drupal_http_request_get_response_header(return_value TSRMLS_CC);
+
+    external_params.status
+        = nr_drupal_http_request_get_response_code(return_value TSRMLS_CC);
     if (NRPRG(txn) && NRTXN(special_flags.debug_cat)) {
       nrl_verbosedebug(
           NRL_CAT, "CAT: outbound response: transport='Drupal 6-7' %s=" NRP_FMT,


### PR DESCRIPTION
Fix memory corruption leading to seg fault caused by retrieving the name
of HTTP request method from execute_data after the call to drupal_http_request.

Accessing execute_data after NR_PHP_WRAPPER_CALL leads to memory 
corruption, because execute_data (which can be thought of as a function 
call stack frame) is destroyed after returning from function call and 
therefore it no longer holds a valid information about function args.

This change makes `drupal_http_request` instrumentation compliant with
[Checklist for writing a user function wrapper](https://github.com/newrelic/newrelic-php-agent/blob/main/agent/php_wrapper.h#L64):
> 1. Any call to nr_php_arg_get, nr_php_scope_get, or
>    nr_php_get_return_value_ptr follows any NR_PHP_WRAPPER_REQUIRE_FRAMEWORK_*
>    calls and precedes any NR_PHP_WRAPPER_CALL.

More information can be found [here](https://github.com/newrelic/newrelic-php-agent/blob/main/agent/php_wrapper.h#L48).