### PR TITLE
chore(agent): Reduce severity of log message for env vars

### DIFF
--- a/agent/php_environment.c
+++ b/agent/php_environment.c
@@ -479,8 +479,8 @@ static void nr_php_get_environment_variables(TSRMLS_D) {
    * it.
    */
   if (NULL == environ) {
-    nrl_warning(NRL_AGENT, "%s: Unable to access environmental variables.",
-                __func__);
+    nrl_verbosedebug(NRL_AGENT, "%s: Unable to access environmental variables.",
+                     __func__);
     return;
   }
 


### PR DESCRIPTION
Previously when parsing the process environment for variables if it was not accessible this generated a warning log message. This commit changes it to a verbosedebug message.