### PR TITLE
fix(agent): instrument `drupal_http_request`

### DIFF
--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -127,7 +127,7 @@ static char* nr_drupal_http_request_get_method(NR_EXECUTE_PROTO TSRMLS_DC) {
    */
   arg3 = nr_php_arg_get(3, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   // There is no third arg, this is drupal 7
-  if (0 == arg3) {
+  if (NULL == arg3) {
     arg2 = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
     if (NULL != arg2) {
       method = nr_php_zend_hash_find(Z_ARRVAL_P(arg2), "method");

--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -129,6 +129,156 @@ static char* nr_drupal_http_request_get_response_header(
   return NULL;
 }
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+
+NR_PHP_WRAPPER(nr_drupal_http_request_before) {
+  (void)wraprec;
+  /*
+   * For PHP 7.3 and newer, New Relic headers are added here.
+   * For older versions, New Relic headers are added via the proxy function
+   * nr_drupal_replace_http_request.
+   *
+   * Reason: using the proxy function involves swizzling
+   * (nr_php_swap_user_functions), which breaks as since PHP 7.3 user
+   * functions are stored in shared memory.
+   */
+  bool is_drupal_7;
+  zval* arg = NULL;
+  zend_execute_data* ex = nr_get_zend_execute_data(NR_EXECUTE_ORIG_ARGS);
+
+  if (NULL == ex) {
+    NR_PHP_WRAPPER_LEAVE
+  }
+
+  is_drupal_7 = (ex->func->common.num_args == 2);
+
+  /*
+   * If only one argument is given, an empty list is inserted as second
+   * argument. NR headers are added during a later step.
+   */
+  if (ZEND_NUM_ARGS() == 1) {
+    arg = nr_php_zval_alloc();
+    array_init(arg);
+
+    nr_php_arg_add(NR_EXECUTE_ORIG_ARGS, arg);
+
+    nr_php_zval_free(&arg);
+  }
+
+  /*
+   * nr_php_get_user_func_arg is used, as nr_php_arg_get calls ZVAL_DUP
+   * on the argument zval and thus doesn't allow us to change the
+   * original argument.
+   */
+  arg = nr_php_get_user_func_arg(2, NR_EXECUTE_ORIG_ARGS);
+
+  /*
+   * Add NR headers.
+   */
+  nr_drupal_headers_add(arg, is_drupal_7 TSRMLS_CC);
+
+  NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_DRUPAL);
+
+  NRPRG(drupal_http_request_depth) += 1;
+
+  /*
+   * We only want to create a metric here if this isn't a recursive call to
+   * drupal_http_request() caused by the original call returning a redirect.
+   * We can check how many drupal_http_request() calls are on the stack by
+   * checking a counter.
+   */
+  if (1 == NRPRG(drupal_http_request_depth)) {
+    NRPRG(drupal_http_request_segment)
+        = nr_segment_start(NRPRG(txn), NULL, NULL);
+  }
+}
+NR_PHP_WRAPPER_END
+
+NR_PHP_WRAPPER(nr_drupal_http_request_after) {
+  zval* arg1 = NULL;
+  zval* arg2 = NULL;
+  zval* arg3 = NULL;
+  zval* method = NULL;
+
+  (void)wraprec;
+
+  NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_DRUPAL);
+
+  /*
+   * Grab the URL for the external metric, which is the first parameter in all
+   * versions of Drupal.
+   */
+  arg1 = nr_php_arg_get(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  if (0 == nr_php_is_zval_non_empty_string(arg1)) {
+    goto end;
+  }
+
+  /*
+   * We only want to create a metric here if this isn't a recursive call to
+   * drupal_http_request() caused by the original call returning a redirect.
+   * We can check how many drupal_http_request() calls are on the stack by
+   * checking a counter.
+   */
+  if (1 == NRPRG(drupal_http_request_depth)) {
+    nr_segment_external_params_t external_params
+        = {.library = "Drupal",
+           .uri = nr_strndup(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1))};
+
+    /*
+     * Drupal 6 will have a third argument with the method, Drupal 7 will not
+     * have a third argument it must be parsed from the second.
+     */
+    arg3 = nr_php_arg_get(3, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    // There is no third arg, this is drupal 7
+    if (0 == arg3) {
+      arg2 = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+      if (NULL != arg2) {
+        method = nr_php_zend_hash_find(Z_ARRVAL_P(arg2), "method");
+        if (nr_php_is_zval_valid_string(method)) {
+          external_params.procedure
+              = nr_strndup(Z_STRVAL_P(method), Z_STRLEN_P(method));
+        }
+      }
+    } else if (nr_php_is_zval_valid_string(arg3)) {
+      // This is drupal 6, the method is the third arg.
+      external_params.procedure
+          = nr_strndup(Z_STRVAL_P(arg3), Z_STRLEN_P(arg3));
+    }
+    // If the method is not set, Drupal will default to GET
+    if (NULL == external_params.procedure) {
+      external_params.procedure = nr_strdup("GET");
+    }
+    external_params.encoded_response_header
+        = nr_drupal_http_request_get_response_header(&func_return_value);
+
+    external_params.status
+        = nr_drupal_http_request_get_response_code(&func_return_value);
+    if (NRPRG(txn) && NRTXN(special_flags.debug_cat)) {
+      nrl_verbosedebug(
+          NRL_CAT, "CAT: outbound response: transport='Drupal 6-7' %s=" NRP_FMT,
+          X_NEWRELIC_APP_DATA,
+          NRP_CAT(external_params.encoded_response_header));
+    }
+
+    nr_segment_external_end(&NRPRG(drupal_http_request_segment),
+                            &external_params);
+
+    nr_free(external_params.encoded_response_header);
+    nr_free(external_params.procedure);
+    nr_free(external_params.uri);
+  }
+
+end:
+  nr_php_arg_release(&arg1);
+  nr_php_arg_release(&arg2);
+  nr_php_arg_release(&arg3);
+  NRPRG(drupal_http_request_depth) -= 1;
+}
+NR_PHP_WRAPPER_END
+
+#else
+
 /*
  * Drupal 6:
  *   drupal_http_request ($url, $headers = array(), $method = 'GET',
@@ -292,6 +442,8 @@ end:
   NRPRG(drupal_http_request_depth) -= 1;
 }
 NR_PHP_WRAPPER_END
+
+#endif
 
 static void nr_drupal_name_the_wt(const zend_function* func TSRMLS_DC) {
   char* action = NULL;
@@ -632,8 +784,15 @@ void nr_drupal_enable(TSRMLS_D) {
                             nr_drupal_name_wt_as_cached_page TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("drupal_cron_run"),
                             nr_drupal_cron_run TSRMLS_CC);
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_php_wrap_user_function_before_after(
+      NR_PSTR("drupal_http_request"), nr_drupal_http_request_before,
+      nr_drupal_http_request_after TSRMLS_CC);
+#else
   nr_php_wrap_user_function(NR_PSTR("drupal_http_request"),
                             nr_drupal_http_request_exec TSRMLS_CC);
+#endif
 
   /*
    * The drupal_modules config setting controls instrumentation of modules,

--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -290,6 +290,7 @@ NR_PHP_WRAPPER(nr_drupal_http_request_after) {
 
     nr_segment_external_end(&NRPRG(drupal_http_request_segment),
                             &external_params);
+    NRPRG(drupal_http_request_segment) = NULL;
 
     nr_free(external_params.encoded_response_header);
     nr_free(external_params.procedure);

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -409,7 +409,10 @@ size_t drupal_module_invoke_all_hook_len; /* The length of the current Drupal
                                              hook */
 size_t drupal_http_request_depth; /* The current depth of drupal_http_request()
                                      calls */
-
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+nr_segment_t* drupal_http_request_segment;
+#endif
 int symfony1_in_dispatch; /* Whether we are currently within a
                              sfFrontWebController::dispatch() frame */
 int symfony1_in_error404; /* Whether we are currently within a

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -37,7 +37,10 @@ PHP_RINIT_FUNCTION(newrelic) {
   NRPRG(sapi_headers) = NULL;
   NRPRG(pid) = getpid();
   NRPRG(user_function_wrappers) = nr_vector_create(64, NULL, NULL);
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
   NRPRG(drupal_http_request_segment) = NULL;
+#endif
 
   if ((0 == NR_PHP_PROCESS_GLOBALS(enabled)) || (0 == NRINI(enabled))) {
     return SUCCESS;

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -37,6 +37,7 @@ PHP_RINIT_FUNCTION(newrelic) {
   NRPRG(sapi_headers) = NULL;
   NRPRG(pid) = getpid();
   NRPRG(user_function_wrappers) = nr_vector_create(64, NULL, NULL);
+  NRPRG(drupal_http_request_segment) = NULL;
 
   if ((0 == NR_PHP_PROCESS_GLOBALS(enabled)) || (0 == NRINI(enabled))) {
     return SUCCESS;

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -118,6 +118,7 @@ int nr_php_post_deactivate(void) {
 
   NRPRG(current_framework) = NR_FW_UNSET;
   NRPRG(framework_version) = 0;
+  NRPRG(drupal_http_request_segment) = NULL;
 
   nrl_verbosedebug(NRL_INIT, "post-deactivate processing done");
   return SUCCESS;

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -118,7 +118,10 @@ int nr_php_post_deactivate(void) {
 
   NRPRG(current_framework) = NR_FW_UNSET;
   NRPRG(framework_version) = 0;
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
   NRPRG(drupal_http_request_segment) = NULL;
+#endif
 
   nrl_verbosedebug(NRL_INIT, "post-deactivate processing done");
   return SUCCESS;

--- a/agent/tests/test_fw_drupal.c
+++ b/agent/tests/test_fw_drupal.c
@@ -370,15 +370,6 @@ static void test_drupal_http_request_drupal_6(TSRMLS_D) {
 }
 
 void test_main(void* p NRUNUSED) {
-/*
-DO NOT LEAVE THIS.
-When drupal_http_request header functionality is refactored,
-please put the tests back in!
-*/
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
-    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
-  return;
-#endif
 
 #if defined(ZTS) && !defined(PHP7)
   void*** tsrm_ls = NULL;


### PR DESCRIPTION
Fix `drupal_http_request` instrumentation for PHP 8.0+ by using Observer
APIs `before` callback to add New Relic headers and `after` callback
to finalize external segment with metrics. Observer API instrumentation
requires the external request segment to be created in `before` callback
but be available in `after` callback. Therefore it is made a NRPRG global.