### PR TITLE
fix(installer): Remove dupe exit msg

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -253,7 +253,6 @@ An unsupported architecture detected.
 Please visit:
   https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/
 to view compatibilty requirements for the the New Relic PHP agent.
-The install will now exit.
 EOF
 )
 


### PR DESCRIPTION
Ended up with duplicate exit messages if an unsupported arch was detected.