### PR TITLE
fix(agent): detect framework in oapi's fcall_begin

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1692,11 +1692,10 @@ static void nr_php_instrument_func_begin(NR_EXECUTE_PROTO) {
 
   NRTXNGLOBAL(execute_count) += 1;
 
-  /*
-   * Wait to do this handling in the end function handler when all the files
-   * have been loaded; otherwise, the classes might not be loaded yet.
-   */
   if (nrunlikely(OP_ARRAY_IS_A_FILE(NR_OP_ARRAY))) {
+    const char* filename = nr_php_op_array_file_name(NR_OP_ARRAY);
+    nr_execute_handle_framework(all_frameworks, num_all_frameworks,
+                              filename TSRMLS_CC);
     return;
   }
   wraprec = nr_php_get_wraprec_by_name(execute_data->func);


### PR DESCRIPTION
Framework detection (`nr_execute_handle_framework`) not only adds `wraprecs`
but also sets `NRPRG(current_framework)`. It is important to set it before
function is called, because its value affects other instrumentation, e.g.
when datastore segment for SQL operation is ended, a table name modify
function (`nr_php_modify_table_name_fn`) to shorten table name is selected
based on `NRPRG(current_framework)`.

This fixes `frameworks/magento/test_temp_tables.php` and
`frameworks/wordpress/test_site_specific_tables.php` integration tests.