### PR TITLE
chore(docker): Install composer in dev env

### DIFF
--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -166,6 +166,11 @@ RUN php composer.phar require "predis/predis"
 RUN php composer.phar update
 
 #
+# install composer and make executable so it can be used in dev env
+#
+RUN cp composer.phar /usr/local/bin/composer && chmod +x /usr/local/bin/composer
+
+#
 # These args need to be repeated so we can propagate the VARS within this build context.
 #
 ARG PHP_VER


### PR DESCRIPTION
This PR makes the 'composer' tool available in the agent container created by the docker-compose.yaml.  Useful for adding additional PHP frameworks after building the container.