### PR TITLE
fix(agent): name exception handler's wraprec

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -18,13 +18,15 @@ on:
   push:
     branches: 
       - main
-      - 'php8'
       - 'dev'
+      - 'dev2'
+      - 'oapi'
   pull_request:
     branches: 
       - main
-      - 'php8'
       - 'dev'
+      - 'dev2'
+      - 'oapi'      
 
 jobs:
   agent_pr:

--- a/agent/config.m4
+++ b/agent/config.m4
@@ -190,7 +190,7 @@ if test "$PHP_NEWRELIC" = "yes"; then
   php_explain_pdo_mysql.c php_extension.c php_file_get_contents.c \
   php_globals.c php_hash.c php_header.c php_httprequest_send.c \
   php_internal_instrument.c php_minit.c php_mshutdown.c php_mysql.c \
-  php_mysqli.c php_newrelic.c php_nrini.c php_output.c php_pdo.c \
+  php_mysqli.c php_newrelic.c php_nrini.c php_observer.c php_output.c php_pdo.c \
   php_pdo_mysql.c php_pdo_pgsql.c php_pgsql.c php_psr7.c php_redis.c \
   php_rinit.c php_rshutdown.c php_samplers.c php_stack.c \
   php_stacked_segment.c php_txn.c php_user_instrument.c \

--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -216,7 +216,7 @@ NR_PHP_WRAPPER(nr_drupal_http_request_exec) {
     goto end;
   }
 
-  return_value = nr_php_get_return_value_ptr(TSRMLS_C);
+  return_value = NR_GET_RETURN_VALUE_PTR;
 
   /*
    * We only want to create a metric here if this isn't a recursive call to

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -152,7 +152,7 @@ out:
  *           ControllerResolver::getControllerFromDefinition().
  */
 NR_PHP_WRAPPER(nr_drupal8_name_the_wt) {
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
@@ -201,7 +201,7 @@ NR_PHP_WRAPPER_END
 
 NR_PHP_WRAPPER(nr_drupal8_name_the_wt_cached) {
   const char* name = "page_cache";
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   (void)wraprec;
 
@@ -300,7 +300,7 @@ static int nr_drupal8_apply_hook(zval* element,
  */
 NR_PHP_WRAPPER(nr_drupal8_post_get_implementations) {
   zval* hook = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   (void)wraprec;
 
@@ -334,7 +334,7 @@ NR_PHP_WRAPPER_END
 NR_PHP_WRAPPER(nr_drupal8_post_implements_hook) {
   zval* hook = NULL;
   zval* module = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   (void)wraprec;
 
@@ -367,7 +367,7 @@ NR_PHP_WRAPPER_END
  */
 NR_PHP_WRAPPER(nr_drupal8_module_handler) {
   zend_class_entry* ce = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -1073,7 +1073,7 @@ NR_PHP_WRAPPER(nr_laravel_routes_get_route_for_methods) {
    * Start by calling the original method, and if it doesn't return a
    * route then we don't need to do any extra work.
    */
-  route = nr_php_get_return_value_ptr(TSRMLS_C);
+  route = NR_GET_RETURN_VALUE_PTR;
   NR_PHP_WRAPPER_CALL;
 
   /* If the method did not return a route, then end gracefully. */

--- a/agent/fw_laravel_queue.c
+++ b/agent/fw_laravel_queue.c
@@ -695,7 +695,7 @@ static char* nr_laravel_get_payload_header_mq(char* header) {
 NR_PHP_WRAPPER(nr_laravel_queue_queue_createpayload) {
   zval* json = NULL;
   zval* payload = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
   nr_hashmap_t* outbound_headers = NULL;
   nr_vector_t* header_keys = NULL;
   char* header = NULL;

--- a/agent/fw_magento2.c
+++ b/agent/fw_magento2.c
@@ -129,7 +129,7 @@ NR_PHP_WRAPPER(nr_magento2_pagecache_kernel_load) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MAGENTO2);
 
-  response = nr_php_get_return_value_ptr(TSRMLS_C);
+  response = NR_GET_RETURN_VALUE_PTR;
 
   NR_PHP_WRAPPER_CALL;
 
@@ -167,7 +167,7 @@ NR_PHP_WRAPPER(nr_magento2_objectmanager_get) {
      */
     goto leave;
   }
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
   NR_PHP_WRAPPER_CALL;
 
   if ((NULL == retval_ptr) || !nr_php_is_zval_valid_object(*retval_ptr)) {
@@ -251,7 +251,7 @@ NR_PHP_WRAPPER(nr_magento2_soap_iswsdlrequest) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MAGENTO2);
 
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
   NR_PHP_WRAPPER_CALL;
 
   if (retval_ptr && nr_php_is_zval_true(*retval_ptr)) {
@@ -268,7 +268,7 @@ NR_PHP_WRAPPER(nr_magento2_soap_iswsdllistrequest) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MAGENTO2);
 
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
   NR_PHP_WRAPPER_CALL;
 
   if (retval_ptr && nr_php_is_zval_true(*retval_ptr)) {
@@ -322,7 +322,7 @@ NR_PHP_WRAPPER(nr_magento2_soap_handler_prepareoperationinput) {
 
   svc_class = nr_php_arg_get(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   method_metadata = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  /* 
+  /*
    * We expect method_metadata to be an array.  At index 'method', if we see
    * a method name, we'll pass it to the transaction naming.
    * See:

--- a/agent/fw_mediawiki.c
+++ b/agent/fw_mediawiki.c
@@ -142,7 +142,7 @@ NR_PHP_WRAPPER(nr_mediawiki_getaction) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MEDIAWIKI);
 
-  return_value = nr_php_get_return_value_ptr(TSRMLS_C);
+  return_value = NR_GET_RETURN_VALUE_PTR;
 
   NR_PHP_WRAPPER_CALL;
 

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -54,7 +54,7 @@ NR_PHP_WRAPPER(nr_slim2_route_dispatch) {
   txn_name = nr_slim_path_from_route(this_var TSRMLS_CC);
   nr_php_scope_release(&this_var);
 
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   NR_PHP_WRAPPER_CALL;
 

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -543,7 +543,7 @@ static void nr_wordpress_name_the_wt(const zval* tag,
  */
 NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
   zval* tag = NULL;
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -596,7 +596,7 @@ end:
 NR_PHP_WRAPPER_END
 
 NR_PHP_WRAPPER(nr_predis_aggregateconnection_getConnection) {
-  zval** retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   (void)wraprec;
 

--- a/agent/lib_zend_http.c
+++ b/agent/lib_zend_http.c
@@ -33,8 +33,8 @@ typedef enum _nr_zend_http_adapter {
  */
 #define LIB_NAME_Z "Zend"
 #define CURL_ADAPTER_Z "Zend_Http_Client_Adapter_Curl"
-#define URI_HTTP_Z  "Zend_Uri_Http"
-#define HTTP_CLIENT_Z  "Zend_Http_Client"
+#define URI_HTTP_Z "Zend_Uri_Http"
+#define HTTP_CLIENT_Z "Zend_Http_Client"
 #define HTTP_CLIENT_REQUEST_Z "Zend_Http_Client::request"
 
 #define LIB_NAME_L "Laminas"
@@ -338,7 +338,7 @@ NR_PHP_WRAPPER_START(nr_zend_http_client_request) {
   (void)wraprec;
 
   this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  retval_ptr = nr_php_get_return_value_ptr(TSRMLS_C);
+  retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
   /* Avoid double counting if CURL is used. */
   adapter = nr_zend_check_adapter(this_var TSRMLS_CC);
@@ -456,4 +456,3 @@ void nr_laminas_http_enable(TSRMLS_D) {
                               nr_zend_http_client_request TSRMLS_CC);
   }
 }
-

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -275,6 +275,18 @@ zend_function* nr_php_zval_to_function(zval* zv TSRMLS_DC) {
 }
 
 zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC) {
+  NR_UNUSED_FUNC_RETURN_VALUE;
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+
+  /*
+   * There is no other recourse.  We must return what OAPI gave us.  This should
+   * theoretically never be NULL since we check for NULL before calling the
+   * handlers; however, if it was NULL, there is nothing we can do about it.
+   */
+  return execute_data;
+#endif
   zend_execute_data* ptrg
       = EG(current_execute_data); /* via zend engine global data structure */
   NR_UNUSED_SPECIALFN;

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -1141,3 +1141,67 @@ bool nr_php_function_is_static_method(const zend_function* func) {
 
   return (func->common.fn_flags & ZEND_ACC_STATIC);
 }
+
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
+const char* nr_php_zend_execute_data_function_name(
+    const zend_execute_data* execute_data) {
+  zend_string* function_name = NULL;
+
+  if ((NULL == execute_data) || (NULL == execute_data->func)) {
+    return NULL;
+  }
+
+  function_name = execute_data->func->common.function_name;
+
+  if ((NULL == function_name)
+      && (ZEND_USER_FUNCTION == execute_data->func->type)) {
+    return "main";
+  }
+  return function_name ? ZSTR_VAL(function_name) : NULL;
+}
+
+const char* nr_php_zend_execute_data_filename(
+    const zend_execute_data* execute_data) {
+  zend_string* filename = NULL;
+  while (
+      execute_data
+      && (!execute_data->func || !ZEND_USER_CODE(execute_data->func->type))) {
+    execute_data = execute_data->prev_execute_data;
+  }
+  if (execute_data) {
+    filename = execute_data->func->op_array.filename;
+  }
+  return filename ? ZSTR_VAL(filename) : NULL;
+}
+
+const char* nr_php_zend_execute_data_scope_name(
+    const zend_execute_data* execute_data) {
+  zend_class_entry* ce = NULL;
+
+  while (execute_data) {
+    if (execute_data->func
+        && (ZEND_USER_CODE(execute_data->func->type)
+            || execute_data->func->common.scope)) {
+      ce = execute_data->func->common.scope;
+      execute_data = NULL;
+    } else {
+      execute_data = execute_data->prev_execute_data;
+    }
+  }
+  return ce ? ZSTR_VAL(ce->name) : NULL;
+}
+
+uint32_t nr_php_zend_execute_data_lineno(
+    const zend_execute_data* execute_data) {
+  while (
+      execute_data
+      && (!execute_data->func || !ZEND_USER_CODE(execute_data->func->type))) {
+    execute_data = execute_data->prev_execute_data;
+  }
+  if (execute_data) {
+    return execute_data->opline ? execute_data->opline->lineno : 0;
+  }
+  return 0;
+}
+
+#endif /* PHP 7+ */

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -277,15 +277,15 @@ zend_function* nr_php_zval_to_function(zval* zv TSRMLS_DC) {
 zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC) {
   zend_execute_data* ptrg
       = EG(current_execute_data); /* via zend engine global data structure */
-
   NR_UNUSED_SPECIALFN;
+  NR_UNUSED_FUNC_RETURN_VALUE;
 #if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
   {
     /*
      * ptra is argument passed in to us, it might be NULL if the caller doesn't
      * have that info.
      */
-    zend_execute_data* ptra = NR_EXECUTE_ORIG_ARGS;
+    zend_execute_data* ptra = execute_data;
     if (NULL != ptra) {
       return ptra;
     } else {
@@ -419,6 +419,8 @@ zval* nr_php_get_user_func_arg(size_t requested_arg_index,
   zval* arg_via_h = 0;
   int arg_count_via_h = -1;
 
+  NR_UNUSED_FUNC_RETURN_VALUE;
+
   if (requested_arg_index < 1) {
     return NULL;
   }
@@ -441,6 +443,7 @@ zval* nr_php_get_user_func_arg(size_t requested_arg_index,
 
 size_t nr_php_get_user_func_arg_count(NR_EXECUTE_PROTO TSRMLS_DC) {
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+  NR_UNUSED_FUNC_RETURN_VALUE;
   return (size_t)ZEND_CALL_NUM_ARGS(execute_data);
 #else
   int arg_count_via_h = -1;

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -330,7 +330,22 @@ extern zend_function* nr_php_zval_to_function(zval* zv TSRMLS_DC);
  *           won't help you!
  */
 static inline zval* nr_php_get_return_value(NR_EXECUTE_PROTO TSRMLS_DC) {
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+#if (ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+     && !defined OVERWRITE_ZEND_EXECUTE_DATA) /* PHP 8.0+ and OAPI */
+  /*
+   * If the agent is still overwriting zend_execute_data extract oldfashioned
+   * way; otherwise, pass the observer given return value.
+   */
+  if (nrunlikely(NULL == execute_data)) {
+    /*
+     * Shouldn't theoretically ever have a NULL execute_data with valid
+     * return_value.
+     */
+    return NULL;
+  }
+  return func_return_value;
+#elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+  NR_UNUSED_FUNC_RETURN_VALUE;
   if (NULL == execute_data) {
     /*
      * This function shouldn't be called from outside a function context, so
@@ -378,6 +393,7 @@ extern size_t nr_php_get_user_func_arg_count(NR_EXECUTE_PROTO TSRMLS_DC);
 static inline zend_function* nr_php_execute_function(
     NR_EXECUTE_PROTO TSRMLS_DC) {
   NR_UNUSED_TSRMLS;
+  NR_UNUSED_FUNC_RETURN_VALUE;
 
 #if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
   if (NULL == execute_data) {

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -41,6 +41,7 @@
 #include "php_zval.h"
 #include "util_memory.h"
 #include "util_strings.h"
+#include "php_execute.h"
 
 /*
  * The default connection mechanism to the daemon is:
@@ -79,6 +80,7 @@
  * Returns : A newly allocated JSON stack trace string or NULL on error.
  */
 #define NR_PHP_STACKTRACE_LIMIT 300
+
 extern char* nr_php_backtrace_to_json(zval* itrace TSRMLS_DC);
 
 /*
@@ -426,7 +428,7 @@ static inline zval* nr_php_execute_scope(zend_execute_data* execute_data) {
         || (Z_CE(execute_data->This))) {
       return &execute_data->This;
     } else if (execute_data->func) {
-      if (execute_data->func->type != ZEND_INTERNAL_FUNCTION
+      if (ZEND_USER_CODE(execute_data->func->type)
           || execute_data->func->common.scope) {
         return NULL;
       }
@@ -826,7 +828,31 @@ extern bool nr_php_function_is_static_method(const zend_function* func);
  */
 extern zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC);
 
+/*
+ * Purpose : If code level metrics are enabled, extract the data from the OAPI
+ *           given zend_execute_data.  Add the CLM as agent attributes to the
+ *           attributes data structure.
+ *
+ * Params  : 1. attributes data structure to add the CLM to
+ *           2. The zend_execute_data given by OAPI
+ *
+ * Returns : void
+ *
+ * Note: PHP has a concept of calling files with no function names.  In the
+ *       case of a file being called when there is no function name, the agent
+ *       instruments the file.  In this case, we provide the filename to CLM
+ *       as the "function" name.
+ *       Current CLM functionality only works with PHP 7+
+ */
+extern void nr_php_txn_add_code_level_metrics(
+    nr_attributes_t* attributes,
+    const nr_php_execute_metadata_t* metadata);
+
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
+
+#define NR_ZEND_USER_FUNC_EXISTS(x) \
+  (x && (!x->func || !ZEND_USER_CODE(x->func->type)))
+
 /*
  * Purpose : Return a pointer to the function name of zend_execute_data.
  *

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -404,7 +404,23 @@ static inline zval* nr_php_execute_scope(zend_execute_data* execute_data) {
     return NULL;
   }
 
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+  while (execute_data) {
+    if ((Z_TYPE(execute_data->This) == IS_OBJECT)
+        || (Z_CE(execute_data->This))) {
+      return &execute_data->This;
+    } else if (execute_data->func) {
+      if (execute_data->func->type != ZEND_INTERNAL_FUNCTION
+          || execute_data->func->common.scope) {
+        return NULL;
+      }
+    }
+    execute_data = execute_data->prev_execute_data;
+  }
+  return NULL;
+
+#elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO \
+    && ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO /* PHP 7.0 - 7.4 */
   return &execute_data->This;
 #else
   return execute_data->object;
@@ -715,7 +731,10 @@ nr_php_ini_entry_name_length(const zend_ini_entry* entry) {
 
 #define NR_PHP_INTERNAL_FN_THIS() getThis()
 
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
+#define NR_PHP_USER_FN_THIS() nr_php_execute_scope(execute_data)
+#elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO \
+    && ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO /* PHP 7.0 - 7.4 */
 #define NR_PHP_USER_FN_THIS() getThis()
 #else
 #define NR_PHP_USER_FN_THIS() EG(This)
@@ -790,5 +809,57 @@ extern bool nr_php_function_is_static_method(const zend_function* func);
  *           (current_execute_path).
  */
 extern zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC);
+
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
+/*
+ * Purpose : Return a pointer to the function name of zend_execute_data.
+ *
+ * Params  : 1. zend_execute_data.
+ *
+ * Returns : A pointer to string, ownership of does NOT pass to the caller and
+ *           string must be dupped if it needs to persist,
+ *           or NULL if the zend_execute_data is invalid.
+ *
+ */
+extern const char* nr_php_zend_execute_data_function_name(
+    const zend_execute_data* execute_data);
+/*
+ * Purpose : Return a pointer to the filename of zend_execute_data.
+ *
+ * Params  : 1. zend_execute_data.
+ *
+ * Returns : A pointer to string, ownership of does NOT pass to the caller and
+ *           string must be dupped if it needs to persist,
+ *           or NULL if the zend_execute_data is invalid.
+ *
+ */
+extern const char* nr_php_zend_execute_data_filename(
+    const zend_execute_data* execute_data);
+
+/*
+ * Purpose : Return a pointer to the scope(i.e., class) name of
+ * zend_execute_data.
+ *
+ * Params  : 1. zend_execute_data.
+ *
+ * Returns : A pointer to string, ownership of does NOT pass to the caller and
+ *           string must be dupped if it needs to persist,
+ *           or NULL if the zend_execute_data is invalid.
+ *
+ */
+extern const char* nr_php_zend_execute_data_scope_name(
+    const zend_execute_data* execute_data);
+
+/*
+ * Purpose : Return a uint32_t line number value of zend_execute_data.
+ *
+ * Params  : 1. zend_execute_data.
+ *
+ * Returns : uint32_t lineno value
+ *
+ */
+extern uint32_t nr_php_zend_execute_data_lineno(
+    const zend_execute_data* execute_data);
+#endif /* PHP 7+ */
 
 #endif /* PHP_AGENT_HDR */

--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -259,7 +259,10 @@ void nr_php_call_user_func_array_handler(nrphpcufafn_t handler,
     caller = prev_execute_data->function_state.function;
 #endif /* PHP7 */
   } else {
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+    caller = nr_php_get_caller(EG(current_execute_data), NULL, 1 TSRMLS_CC);
+#elif ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
     caller = nr_php_get_caller(EG(current_execute_data), 1 TSRMLS_CC);
 #else
     caller = nr_php_get_caller(NULL, 1 TSRMLS_CC);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -636,7 +636,12 @@ static void nr_php_show_exec(NR_EXECUTE_PROTO TSRMLS_DC) {
         NRSAFELEN(nr_php_class_entry_name_length(NR_OP_ARRAY->scope)),
         nr_php_class_entry_name(NR_OP_ARRAY->scope),
         NRP_PHP(function_name ? function_name : "?"), NRP_ARGSTR(argstr),
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA
         nr_php_op_array_get_wraprec(NR_OP_ARRAY TSRMLS_CC) ? " *" : "",
+#else
+        nr_php_get_wraprec_by_name(execute_data->func) ? " *" : "",
+#endif
         NRP_FILENAME(filename), NR_OP_ARRAY->line_start);
   } else if (NR_OP_ARRAY->function_name) {
     /*
@@ -653,7 +658,12 @@ static void nr_php_show_exec(NR_EXECUTE_PROTO TSRMLS_DC) {
         "@ " NRP_FMT_UQ ":%d",
         nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces,
         NRP_PHP(function_name), NRP_ARGSTR(argstr),
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA
         nr_php_op_array_get_wraprec(NR_OP_ARRAY TSRMLS_CC) ? " *" : "",
+#else
+        nr_php_get_wraprec_by_name(execute_data->func) ? " *" : "",
+#endif
         NRP_FILENAME(filename), NR_OP_ARRAY->line_start);
   } else if (NR_OP_ARRAY->filename) {
     /*
@@ -1234,8 +1244,12 @@ static void nr_php_execute_enabled(NR_EXECUTE_PROTO TSRMLS_DC) {
    * The function name needs to be checked before the NR_OP_ARRAY->fn_flags
    * since in PHP 5.1 fn_flags is not initialized for files.
    */
-
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA
   wraprec = nr_php_op_array_get_wraprec(NR_OP_ARRAY TSRMLS_CC);
+#else
+  wraprec = nr_php_get_wraprec_by_name(execute_data->func);
+#endif
 
   if (NULL != wraprec) {
     /*

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -976,6 +976,8 @@ static void nr_php_execute_file(const zend_op_array* op_array,
 static void nr_php_execute_metadata_add_code_level_metrics(
     nr_php_execute_metadata_t* metadata,
     NR_EXECUTE_PROTO) {
+  NR_UNUSED_FUNC_RETURN_VALUE;
+
 #if ZEND_MODULE_API_NO < ZEND_7_0_X_API_NO /* PHP7+ */
   (void)metadata;
   NR_UNUSED_SPECIALFN;
@@ -986,18 +988,6 @@ static void nr_php_execute_metadata_add_code_level_metrics(
   const char* function = NULL;
   uint32_t lineno = 1;
 
-  if (NULL == metadata) {
-    return;
-  }
-
-  if (NULL == execute_data) {
-    return;
-  }
-
-  metadata->function_name = NULL;
-  metadata->function_filepath = NULL;
-  metadata->function_namespace = NULL;
-
   /*
    * Check if code level metrics are enabled in the ini.
    * If they aren't, exit and don't update CLM.
@@ -1005,6 +995,19 @@ static void nr_php_execute_metadata_add_code_level_metrics(
   if (!NRINI(code_level_metrics_enabled)) {
     return;
   }
+
+  if (nrunlikely(NULL == metadata)) {
+    return;
+  }
+
+  if (nrunlikely(NULL == execute_data)) {
+    return;
+  }
+
+  metadata->function_name = NULL;
+  metadata->function_filepath = NULL;
+  metadata->function_namespace = NULL;
+
   /*
    * At a minimum, at least one of the following attribute combinations MUST be
    * implemented in order for customers to be able to accurately identify their
@@ -1048,7 +1051,15 @@ static void nr_php_execute_metadata_add_code_level_metrics(
     /*
      * We are getting CLM for a function.
      */
-    lineno = nr_php_zend_execute_data_lineno(execute_data);
+    if (0 == metadata->function_lineno) {
+      lineno = nr_php_zend_execute_data_lineno(execute_data);
+    } else {
+      /*
+       * If the metadata was already set (in the case of OAPI where we need to
+       * get it preemptively, use that value for lineno instead.
+       */
+      lineno = metadata->function_lineno;
+    }
   }
 
 #define CHK_CLM_EMPTY(s) ((NULL == s || nr_strempty(s)) ? true : false)
@@ -1122,7 +1133,7 @@ static void nr_php_execute_metadata_metric(
   const char* function_name;
   const char* scope_name;
 
-#ifdef PHP7
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO
   scope_name = metadata->scope ? ZSTR_VAL(metadata->scope) : NULL;
   function_name = metadata->function ? ZSTR_VAL(metadata->function) : NULL;
 #else
@@ -1141,7 +1152,7 @@ static void nr_php_execute_metadata_metric(
  */
 static void nr_php_execute_metadata_release(
     nr_php_execute_metadata_t* metadata) {
-#ifdef PHP7
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO
   if (NULL != metadata->scope) {
     zend_string_release(metadata->scope);
     metadata->scope = NULL;
@@ -1192,7 +1203,12 @@ static inline void nr_php_execute_segment_end(
     return;
   }
 
-  stacked->stop_time = nr_txn_now_rel(NRPRG(txn));
+  if (0 == stacked->stop_time) {
+    /*
+     * Only set if it wasn't set already.
+     */
+    stacked->stop_time = nr_txn_now_rel(NRPRG(txn));
+  }
 
   duration = nr_time_duration(stacked->start_time, stacked->stop_time);
 
@@ -1663,6 +1679,223 @@ end:
  * See nr_php_observer.h/c for more information.
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+
+static void nr_php_instrument_func_begin(NR_EXECUTE_PROTO) {
+  nr_segment_t* segment = NULL;
+  nruserfn_t* wraprec = NULL;
+  int zcaught = 0;
+  NR_UNUSED_FUNC_RETURN_VALUE;
+
+  if (NULL == NRPRG(txn)) {
+    return;
+  }
+
+  NRTXNGLOBAL(execute_count) += 1;
+
+  /*
+   * Wait to do this handling in the end function handler when all the files
+   * have been loaded; otherwise, the classes might not be loaded yet.
+   */
+  if (nrunlikely(OP_ARRAY_IS_A_FILE(NR_OP_ARRAY))) {
+    return;
+  }
+  wraprec = nr_php_get_wraprec_by_name(execute_data->func);
+  /*
+   * If there is custom instrumentation or tt detail is more than 0, start the
+   * segment.
+   */
+  if ((NULL != wraprec) || (NRINI(tt_detail) && NR_OP_ARRAY->function_name)) {
+    /*
+     * If a function needs to have arguments modified before it's executed this
+     * may/may not be the place to do it. As soon as the begin function handler
+     * is called, PHP may start the actual function execution.
+     */
+    segment = nr_php_stacked_segment_init(segment);
+    if (nrunlikely(NULL == segment)) {
+      nrl_verbosedebug(NRL_AGENT, "Error initializing stacked segment.");
+      return;
+    }
+    segment->txn_start_time = nr_txn_start_time(NRPRG(txn));
+    segment->wraprec = wraprec;
+    segment->lineno = nr_php_zend_execute_data_lineno(execute_data);
+    zcaught = nr_zend_call_oapi_special_before(wraprec, segment,
+                                               NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    if (nrunlikely(zcaught)) {
+      zend_bailout();
+    }
+  }
+  return;
+}
+
+static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
+  int zcaught = 0;
+  nr_php_execute_metadata_t metadata = {0};
+  nr_segment_t* segment = NULL;
+  nruserfn_t* wraprec = NULL;
+
+  if (NULL == NRPRG(txn)) {
+    return;
+  }
+  /*
+   * Let's get the framework info.
+   */
+  if (nrunlikely(OP_ARRAY_IS_A_FILE(NR_OP_ARRAY))) {
+    /*
+     * Optimization option: could remove code level metrics for filenames.
+     */
+    nr_php_execute_metadata_add_code_level_metrics(&metadata,
+                                                   NR_EXECUTE_ORIG_ARGS);
+    nr_php_txn_add_code_level_metrics(NRPRG(txn)->attributes, &metadata);
+    nr_php_execute_metadata_release(&metadata);
+    nr_php_execute_file(NR_OP_ARRAY, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    return;
+  }
+
+  /*
+   * Get the current segment and return if null.  The segment would only have
+   * been created if we are recording and if wraprec is set or if tt is greater
+   * than 0.
+   */
+  segment = NRTXN(force_current_segment);
+  if (NULL == segment) {
+    return;
+  }
+  if (nrunlikely(0 == segment->txn_start_time)) {
+    /*
+     * The begin function handler always sets segment-txn_start_time.  If it is
+     * not set, something else put the segment up and we are out of synch.
+     */
+    return;
+  }
+
+  /*
+   * Check if we have special instrumentation for this function or if the user
+   * has specifically requested it.
+   */
+  wraprec = (nruserfn_t*)(segment->wraprec);
+  metadata.function_lineno = segment->lineno;
+  /*
+   * Do a sanity check to make sure the names match.
+   */
+  if (NULL != wraprec && nr_php_wraprec_matches(wraprec, execute_data->func)) {
+    /*
+     * This is the case for specifically requested custom instrumentation.
+     */
+    segment->stop_time = nr_txn_now_rel(NRPRG(txn));
+
+    bool create_metric = wraprec->create_metric;
+    nr_php_execute_metadata_add_code_level_metrics(&metadata,
+                                                   NR_EXECUTE_ORIG_ARGS);
+    nr_php_execute_metadata_init(&metadata, NR_OP_ARRAY);
+    nr_txn_force_single_count(NRPRG(txn), wraprec->supportability_metric);
+
+    /*
+     * Check for, and handle, frameworks.
+     */
+    if (wraprec->is_names_wt_simple) {
+      nr_txn_name_from_function(NRPRG(txn), wraprec->funcname,
+                                wraprec->classname);
+    }
+
+    /*
+     * The nr_txn_should_create_span_events() check is there so we don't
+     * record error attributes on the txn (and root segment) because it should
+     * already be recorded on the span that exited unhandled.
+     */
+    if (wraprec->is_exception_handler
+        && !nr_txn_should_create_span_events(NRPRG(txn))) {
+      zval* exception
+          = nr_php_get_user_func_arg(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+
+      /*
+       * The choice of E_ERROR for the error level is basically arbitrary, but
+       * matches the error level PHP uses if there isn't an exception handler,
+       * so this should give more consistency for the user in terms of what
+       * they'll see with and without an exception handler installed.
+       */
+      nr_php_error_record_exception(
+          NRPRG(txn), exception, nr_php_error_get_priority(E_ERROR),
+          "Uncaught exception ", &NRPRG(exception_filters) TSRMLS_CC);
+    }
+
+    zcaught = nr_zend_call_orig_execute_special(wraprec, segment,
+                                                NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+
+    /*
+     * During this call, the transaction may have been ended and/or a new
+     * transaction may have started.  To detect this, we compare the
+     * currently active transaction's start time with the transaction
+     * start time we saved before.
+     *
+     * Just comparing the transaction pointer is not enough, as a newly
+     * started transaction might actually obtain the same address as a
+     * transaction freed before.
+     */
+    if (nrunlikely(nr_txn_start_time(NRPRG(txn)) != segment->txn_start_time)) {
+      nr_php_stacked_segment_deinit(segment);
+    } else {
+      nr_php_execute_segment_end(segment, &metadata, create_metric TSRMLS_CC);
+    }
+    nr_php_execute_metadata_release(&metadata);
+    if (nrunlikely(zcaught)) {
+      zend_bailout();
+    }
+  } else if (NRINI(tt_detail) && NR_OP_ARRAY->function_name) {
+    /*
+     * This is the case for transaction_tracer.detail >= 1 requested custom
+     * instrumentation.
+     */
+    segment->stop_time = nr_txn_now_rel(NRPRG(txn));
+
+    nr_php_execute_metadata_add_code_level_metrics(&metadata,
+                                                   NR_EXECUTE_ORIG_ARGS);
+    nr_php_execute_metadata_init(&metadata, NR_OP_ARRAY);
+    zcaught = nr_zend_call_orig_execute_special(wraprec, segment,
+                                                NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+
+    if (nr_txn_should_create_span_events(NRPRG(txn))) {
+      if (EG(exception)) {
+        zval* exception_zval = NULL;
+        nr_status_t status;
+
+        /*
+         * On PHP 7+, EG(exception) is stored as a zend_object, and is only
+         * wrapped in a zval when it actually needs to be.
+         */
+        zval exception;
+
+        ZVAL_OBJ(&exception, EG(exception));
+        exception_zval = &exception;
+
+        status = nr_php_error_record_exception_segment(
+            NRPRG(txn), exception_zval, &NRPRG(exception_filters) TSRMLS_CC);
+
+        if (NR_FAILURE == status) {
+          nrl_verbosedebug(
+              NRL_AGENT, "%s: unable to record exception on segment", __func__);
+        }
+      }
+    }
+
+    /*
+     * During this call, the transaction may have been ended and/or a new
+     * transaction may have started.  To detect this, we compare the
+     * currently active transaction's start time with the transaction
+     * start time we saved before.
+     */
+    if (nrunlikely(nr_txn_start_time(NRPRG(txn)) != segment->txn_start_time)) {
+      nr_php_stacked_segment_deinit(segment);
+    } else {
+      nr_php_execute_segment_end(segment, &metadata, false TSRMLS_CC);
+    }
+    nr_php_execute_metadata_release(&metadata);
+    if (nrunlikely(zcaught)) {
+      zend_bailout();
+    }
+  }
+  return;
+}
+
 void nr_php_observer_fcall_begin(zend_execute_data* execute_data) {
   /*
    * Instrument the function.
@@ -1671,14 +1904,40 @@ void nr_php_observer_fcall_begin(zend_execute_data* execute_data) {
    * nr_php_execute
    * nr_php_execute_show
    */
-
-  if (NULL == execute_data) {
+  zval* func_return_value = NULL;
+  if (nrunlikely(NULL == execute_data)) {
     return;
   }
+
+  NRPRG(php_cur_stack_depth) += 1;
+
+  if ((0 < ((int)NRINI(max_nesting_level)))
+      && (NRPRG(php_cur_stack_depth) >= (int)NRINI(max_nesting_level))) {
+        nr_php_max_nesting_level_reached(TSRMLS_C);
+      }
+
+  if (nrunlikely(0 == nr_php_recording(TSRMLS_C))) {
+    return;
+  } else {
+    int show_executes
+        = NR_PHP_PROCESS_GLOBALS(special_flags).show_executes
+          || NR_PHP_PROCESS_GLOBALS(special_flags).show_execute_returns;
+
+    if (nrunlikely(show_executes)) {
+      /*
+       * For OAPI don't call nr_php_execute_enabled from execute_show.
+       * nr_php_execute_show updated in another ticket.
+       * Can show execute but CANNOT show returns here.
+       */
+      // nr_php_execute_show(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    }
+    nr_php_instrument_func_begin(NR_EXECUTE_ORIG_ARGS);
+  }
+  return;
 }
 
 void nr_php_observer_fcall_end(zend_execute_data* execute_data,
-                               zval* return_value) {
+                               zval* func_return_value) {
   /*
    * Instrument the function.
    * This and any other needed helper functions will replace:
@@ -1686,8 +1945,33 @@ void nr_php_observer_fcall_end(zend_execute_data* execute_data,
    * nr_php_execute
    * nr_php_execute_show
    */
-  if ((NULL == execute_data) || (NULL == return_value)) {
+  if (nrunlikely((NULL == execute_data))
+      || nrunlikely((NULL == func_return_value))) {
     return;
   }
+
+  NRPRG(php_cur_stack_depth) -= 1;
+
+  if (nrunlikely(0 == nr_php_recording(TSRMLS_C))) {
+    return;
+  }
+
+  int show_executes
+      = NR_PHP_PROCESS_GLOBALS(special_flags).show_executes
+        || NR_PHP_PROCESS_GLOBALS(special_flags).show_execute_returns;
+
+  if (nrunlikely(show_executes)) {
+    /*
+     * For OAPI don't call nr_php_execute_enabled from execute_show.
+     * nr_php_execute_show updated in another ticket.
+     * Can show execute and returns here.
+     */
+    // nr_php_execute_show(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  }
+  nr_php_instrument_func_end(NR_EXECUTE_ORIG_ARGS);
+
+
+  return;
 }
+
 #endif

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -29,9 +29,9 @@
 #include "util_url.h"
 #include "util_metrics.h"
 #include "util_number_converter.h"
-#include "php_execute.h"
 #include "fw_support.h"
 #include "fw_hooks.h"
+#include "php_observer.h"
 
 /*
  * This wall of text is important. Read it. Understand it. Really.
@@ -1538,3 +1538,43 @@ void nr_php_user_instrumentation_from_opcache(TSRMLS_D) {
 end:
   nr_php_zval_free(&status);
 }
+
+/*
+ * nr_php_observer_fcall_begin and nr_php_observer_fcall_end
+ * are Observer API function handlers that are the entry point to instrumenting
+ * userland code and should replicate the functionality of
+ * nr_php_execute_enabled, nr_php_execute, and nr_php_execute_show that are used
+ * when hooking in via zend_execute_ex.
+ *
+ * Observer API functionality was added with PHP 8.0.
+ * See nr_php_observer.h/c for more information.
+ */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+void nr_php_observer_fcall_begin(zend_execute_data* execute_data) {
+  /*
+   * Instrument the function.
+   * This and any other needed helper functions will replace:
+   * nr_php_execute_enabled
+   * nr_php_execute
+   * nr_php_execute_show
+   */
+
+  if (NULL == execute_data) {
+    return;
+  }
+}
+
+void nr_php_observer_fcall_end(zend_execute_data* execute_data,
+                               zval* return_value) {
+  /*
+   * Instrument the function.
+   * This and any other needed helper functions will replace:
+   * nr_php_execute_enabled
+   * nr_php_execute
+   * nr_php_execute_show
+   */
+  if ((NULL == execute_data) || (NULL == return_value)) {
+    return;
+  }
+}
+#endif

--- a/agent/php_execute.h
+++ b/agent/php_execute.h
@@ -64,6 +64,8 @@ extern void nr_framework_create_metric(TSRMLS_D);
  *           This is necessary to correctly instrument frameworks and libraries
  *           that are preloaded.
  */
+
 extern void nr_php_user_instrumentation_from_opcache(TSRMLS_D);
 
+#include "php_observer.h"
 #endif /* PHP_EXECUTE_HDR */

--- a/agent/php_execute.h
+++ b/agent/php_execute.h
@@ -24,6 +24,48 @@
 #define OP_ARRAY_IS_METHOD(OP, FNAME) \
   (0 == nr_strcmp(nr_php_op_array_function_name(OP), (FNAME)))
 
+#define CLM_STRLEN_MAX (255)
+
+/*
+ * Version specific metadata that we have to gather before we call the original
+ * execute_ex handler, as different versions of PHP behave differently in terms
+ * of what you can do with the op array after making that call. This structure
+ * and the functions immediately below are helpers for
+ * nr_php_execute_enabled(), which is the user function execution function.
+ *
+ * In PHP 7, it is possible that the op array will be destroyed if the function
+ * being called is a __call() magic method (in which case a trampoline is
+ * created and destroyed). We increment the reference counts on the scope and
+ * function strings and keep pointers to them in this structure, then release
+ * them once we've named the trace node and/or metric (if required).
+ *
+ * In PHP 5, execute_data->op_array may be set to NULL if we make a subsequent
+ * user function call in an exec callback (which occurs before we decide
+ * whether to create a metric and/or trace node), so we keep a copy of the
+ * pointer here. The op array itself won't be destroyed from under us, as it's
+ * owned by the request and not the specific function call (unlike the
+ * trampoline case above).
+ *
+ * Note that, while op arrays are theoretically reference counted themselves,
+ * we cannot take the simple approach of incrementing that reference count due
+ * to not all Zend Engine functions using init_op_array() and
+ * destroy_op_array(): one example is that PHP 7 trampoline op arrays are
+ * simply emalloc() and efree()'d without even setting the reference count.
+ * Therefore we have to be more selective in our approach.
+ */
+typedef struct {
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
+  zend_string* scope;
+  zend_string* function;
+  char* function_name;
+  char* function_filepath;
+  char* function_namespace;
+  uint32_t function_lineno;
+#else
+  zend_op_array* op_array;
+#endif /* PHP7 */
+} nr_php_execute_metadata_t;
+
 /*
  * Purpose: Look through the PHP symbol table for special names or symbols
  * that provide additional hints that a specific framework has been loaded.

--- a/agent/php_hooks.h
+++ b/agent/php_hooks.h
@@ -38,13 +38,9 @@ extern void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC);
  * are strongly encouraged to use the new error notification API instead.
  * Error notification callbacks are guaranteed to be called regardless of the
  * users error_reporting setting or userland error handler return values.
- * Register notification callbacks during MINIT of an extension:
-void my_error_notify_cb(int type,
-                const char *error_filename,
-                        uint32_t error_lineno,
-                        zend_string *message) {
-                }
-                zend_register_error_notify_callback(my_error_notify_cb);
+ *
+ * The register notification callbacks during MINIT of an extension are done in
+ * `php_observer.c/h`.
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
 extern void nr_php_error_cb(int type,

--- a/agent/php_hooks.h
+++ b/agent/php_hooks.h
@@ -16,7 +16,7 @@
  *           See http://www.php.net/manual/en/migration55.internals.php
  *           for a discussion of what/how to override.
  */
-extern void nr_php_execute(NR_EXECUTE_PROTO TSRMLS_DC);
+extern void nr_php_execute(NR_EXECUTE_PROTO_OVERWRITE TSRMLS_DC);
 
 /*
  * Purpose : Our own error callback function, used to capture the PHP stack

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -53,6 +53,10 @@
 #define ZEND_8_0_X_API_NO 20200930
 #define ZEND_8_1_X_API_NO 20210902
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+#include "Zend/zend_observer.h"
+#endif
+
 #if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
 #include "Zend/zend_virtual_cwd.h"
 #else /* PHP < 5.6 */

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -1169,7 +1169,11 @@ NR_INNER_WRAPPER(mysqli_stmt_bind_param) {
   argc = (size_t)ZEND_NUM_ARGS();
   argv = (zval**)nr_calloc(argc, sizeof(zval*));
   for (i = 0; i < argc; i++) {
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+    argv[i] = nr_php_get_user_func_arg(i + 1, EG(current_execute_data),
+                                       NULL TSRMLS_CC);
+#elif ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
     argv[i]
         = nr_php_get_user_func_arg(i + 1, EG(current_execute_data) TSRMLS_CC);
 #else /* PHP < 5.5 */
@@ -1560,9 +1564,8 @@ static char* nr_php_prepared_statement_make_pgsql_key(
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO /* PHP 8.1+ */
   if (nr_php_is_zval_valid_object(conn)) {
-    key = nr_formatf("type=pgsql id=%ld name=%.*s",
-                     nr_php_zval_object_id(conn), NRSAFELEN(stmtname_len),
-                     stmtname);
+    key = nr_formatf("type=pgsql id=%ld name=%.*s", nr_php_zval_object_id(conn),
+                     NRSAFELEN(stmtname_len), stmtname);
   }
 #else
   if (nr_php_is_zval_valid_resource(conn)) {

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -410,7 +410,6 @@ PHP_MINIT_FUNCTION(newrelic) {
   zend_extension dummy;
 #else
   char dummy[] = "newrelic";
-  nr_php_observer_minit();
 #endif
 
   (void)type;
@@ -628,8 +627,14 @@ PHP_MINIT_FUNCTION(newrelic) {
    * tasks are run only once the PHP VM engine is ticking over fully.
    */
 
+/* PHP 5.x,7.x or not OAPI */
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA
   NR_PHP_PROCESS_GLOBALS(orig_execute) = NR_ZEND_EXECUTE_HOOK;
   NR_ZEND_EXECUTE_HOOK = nr_php_execute;
+#else
+  nr_php_observer_minit();
+#endif
 
   if (NR_PHP_PROCESS_GLOBALS(instrument_internal)) {
     nrl_info(

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -38,6 +38,8 @@
 #include "fw_laravel.h"
 #include "lib_guzzle4.h"
 
+#include "php_observer.h"
+
 static void php_newrelic_init_globals(zend_newrelic_globals* nrg) {
   if (nrunlikely(NULL == nrg)) {
     return;
@@ -408,6 +410,7 @@ PHP_MINIT_FUNCTION(newrelic) {
   zend_extension dummy;
 #else
   char dummy[] = "newrelic";
+  nr_php_observer_minit();
 #endif
 
   (void)type;
@@ -723,6 +726,7 @@ void nr_php_late_initialization(void) {
    * forward the errors, so if a user has Xdebug loaded, we do not install
    * our own error callback handler. Otherwise, we do.
    */
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO /* < PHP8 */
   if (0 == zend_get_extension("Xdebug")) {
     NR_PHP_PROCESS_GLOBALS(orig_error_cb) = zend_error_cb;
     zend_error_cb = nr_php_error_cb;
@@ -731,6 +735,7 @@ void nr_php_late_initialization(void) {
                 "the Xdebug extension prevents the New Relic agent from "
                 "gathering errors. No errors will be recorded.");
   }
+#endif /* end of < PHP8 */
 
   /*
    * Install our signal handler, unless the user has set a special flag

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -45,6 +45,7 @@ extern zend_module_entry newrelic_module_entry;
  * instrumentation. When checking in, leave this toggled on to have the CI work
  * as long as possible until the handler functionality is implemented.*/
 #define OVERWRITE_ZEND_EXECUTE_DATA true
+
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
 #define NR_SPECIALFNPTR_PROTO                              \
@@ -521,8 +522,9 @@ nriniuint_t
 nrinibool_t
     log_metrics_enabled; /* newrelic.application_logging.metrics.enabled */
 
-nriniuint_t log_forwarding_log_level; /* newrelic.application_logging.forwarding.log_level
-                                       */
+nriniuint_t
+    log_forwarding_log_level; /* newrelic.application_logging.forwarding.log_level
+                               */
 
 /*
  * Configuration option to toggle code level metrics collection.

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -525,6 +525,12 @@ nriniuint_t log_forwarding_log_level; /* newrelic.application_logging.forwarding
                                        */
 
 /*
+ * Configuration option to toggle code level metrics collection.
+ */
+nrinibool_t
+    code_level_metrics_enabled; /* newrelic.code_level_metrics.enabled */
+
+/*
  * pid and user_function_wrappers are used to store user function wrappers.
  * Storing this on a request level (as opposed to storing it on transaction
  * level) is more robust when using multiple transactions in one request.

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -44,7 +44,8 @@ extern zend_module_entry newrelic_module_entry;
  * Additionally, gives us flexibility of toggling back to previous method of
  * instrumentation. When checking in, leave this toggled on to have the CI work
  * as long as possible until the handler functionality is implemented.*/
-#define OVERWRITE_ZEND_EXECUTE_DATA true
+
+//#define OVERWRITE_ZEND_EXECUTE_DATA true
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -38,7 +38,35 @@ extern zend_module_entry newrelic_module_entry;
  * majority of those changes so the rest of the code can simply use the macros
  * and not have to take the different APIs into account.
  */
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+
+/* OVERWRITE_ZEND_EXECUTE_DATA allows testing of components with the previous
+ * method of overwriting until the handler functions are complete.
+ * Additionally, gives us flexibility of toggling back to previous method of
+ * instrumentation. When checking in, leave this toggled on to have the CI work
+ * as long as possible until the handler functionality is implemented.*/
+#define OVERWRITE_ZEND_EXECUTE_DATA true
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+#define NR_SPECIALFNPTR_PROTO                              \
+  struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
+      zend_execute_data *execute_data, zval *func_return_value
+#define NR_SPECIALFNPTR_ORIG_ARGS \
+  wraprec, auto_segment, execute_data, func_return_value
+#define NR_SPECIALFN_PROTO                                \
+  nruserfn_t *wraprec, zend_execute_data *execute_data, , \
+      zval *func_return_value
+#define NR_OP_ARRAY (&execute_data->func->op_array)
+#define NR_EXECUTE_PROTO \
+  zend_execute_data *execute_data, zval *func_return_value
+#define NR_EXECUTE_PROTO_OVERWRITE zend_execute_data* execute_data
+#define NR_EXECUTE_ORIG_ARGS_OVERWRITE execute_data
+#define NR_EXECUTE_ORIG_ARGS execute_data, func_return_value
+#define NR_UNUSED_SPECIALFN (void)execute_data
+#define NR_UNUSED_FUNC_RETURN_VALUE (void)func_return_value
+/* NR_ZEND_EXECUTE_HOOK to be removed in future ticket */
+#define NR_ZEND_EXECUTE_HOOK zend_execute_ex
+
+#elif ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ and overwrite hook*/
 #define NR_SPECIALFNPTR_PROTO                              \
   struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
       zend_execute_data *execute_data
@@ -46,9 +74,13 @@ extern zend_module_entry newrelic_module_entry;
 #define NR_SPECIALFN_PROTO nruserfn_t *wraprec, zend_execute_data *execute_data
 #define NR_OP_ARRAY (&execute_data->func->op_array)
 #define NR_EXECUTE_PROTO zend_execute_data* execute_data
+#define NR_EXECUTE_PROTO_OVERWRITE zend_execute_data* execute_data
+#define NR_EXECUTE_ORIG_ARGS_OVERWRITE execute_data
 #define NR_EXECUTE_ORIG_ARGS execute_data
 #define NR_UNUSED_SPECIALFN (void)execute_data
+#define NR_UNUSED_FUNC_RETURN_VALUE
 #define NR_ZEND_EXECUTE_HOOK zend_execute_ex
+
 #elif ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
 #define NR_SPECIALFNPTR_PROTO                              \
   struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
@@ -57,9 +89,13 @@ extern zend_module_entry newrelic_module_entry;
 #define NR_SPECIALFN_PROTO nruserfn_t *wraprec, zend_execute_data *execute_data
 #define NR_OP_ARRAY (execute_data->op_array)
 #define NR_EXECUTE_PROTO zend_execute_data* execute_data
+#define NR_EXECUTE_PROTO_OVERWRITE zend_execute_data* execute_data
+#define NR_EXECUTE_ORIG_ARGS_OVERWRITE execute_data
 #define NR_EXECUTE_ORIG_ARGS execute_data
 #define NR_UNUSED_SPECIALFN (void)execute_data
+#define NR_UNUSED_FUNC_RETURN_VALUE
 #define NR_ZEND_EXECUTE_HOOK zend_execute_ex
+
 #else /* PHP < 5.5 */
 #define NR_SPECIALFNPTR_PROTO                              \
   struct _nruserfn_t *wraprec, nr_segment_t *auto_segment, \
@@ -68,9 +104,19 @@ extern zend_module_entry newrelic_module_entry;
 #define NR_SPECIALFN_PROTO nruserfn_t *wraprec, zend_op_array *op_array_arg
 #define NR_OP_ARRAY (op_array_arg)
 #define NR_EXECUTE_PROTO zend_op_array* op_array_arg
+#define NR_EXECUTE_PROTO_OVERWRITE zend_op_array* op_array_arg
+#define NR_EXECUTE_ORIG_ARGS_OVERWRITE op_array_arg
 #define NR_EXECUTE_ORIG_ARGS op_array_arg
 #define NR_UNUSED_SPECIALFN (void)op_array_arg
+#define NR_UNUSED_FUNC_RETURN_VALUE
 #define NR_ZEND_EXECUTE_HOOK zend_execute
+#endif
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+#define NR_GET_RETURN_VALUE_PTR &func_return_value
+#else
+#define NR_GET_RETURN_VALUE_PTR nr_php_get_return_value_ptr(TSRMLS_C)
 #endif
 
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
@@ -202,7 +248,7 @@ typedef zend_op_array* (*nrphpcfile_t)(zend_file_handle* file_handle,
                                        int type TSRMLS_DC);
 typedef zend_op_array* (*nrphpcstr_t)(zval* source_string,
                                       char* filename TSRMLS_DC);
-typedef void (*nrphpexecfn_t)(NR_EXECUTE_PROTO TSRMLS_DC);
+typedef void (*nrphpexecfn_t)(NR_EXECUTE_PROTO_OVERWRITE TSRMLS_DC);
 typedef void (*nrphpcufafn_t)(zend_function* func,
                               const zend_function* caller TSRMLS_DC);
 typedef int (*nrphphdrfn_t)(sapi_header_struct* sapi_header,

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2173,6 +2173,7 @@ STD_PHP_INI_ENTRY_EX("newrelic.framework",
                      zend_newrelic_globals,
                      newrelic_globals,
                      nr_framework_dh)
+
 /* DEPRECATED */
 STD_PHP_INI_ENTRY_EX("newrelic.cross_application_tracer.enabled",
                      "0",
@@ -2864,6 +2865,17 @@ STD_PHP_INI_ENTRY_EX(
     0)
 
 /*
+ * Code Level Metrics, initially off by default
+ */
+STD_PHP_INI_ENTRY_EX("newrelic.code_level_metrics.enabled",
+                     "0",
+                     NR_PHP_REQUEST,
+                     nr_boolean_mh,
+                     code_level_metrics_enabled,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     nr_enabled_disabled_dh)
+/*
  * Logging
  */
 STD_PHP_INI_ENTRY_EX("newrelic.application_logging.enabled",
@@ -3093,10 +3105,11 @@ void zm_info_newrelic(void); /* ctags landing pad only */
 PHP_MINFO_FUNCTION(newrelic) {
   php_info_print_table_start();
   php_info_print_table_header(2, "New Relic RPM Monitoring",
-                              NR_PHP_PROCESS_GLOBALS(enabled) ? "enabled"
-                              : NR_PHP_PROCESS_GLOBALS(mpm_bad)
-                                  ? "disabled due to threaded MPM"
-                                  : "disabled");
+                              NR_PHP_PROCESS_GLOBALS(enabled)
+                                  ? "enabled"
+                                  : NR_PHP_PROCESS_GLOBALS(mpm_bad)
+                                        ? "disabled due to threaded MPM"
+                                        : "disabled");
   php_info_print_table_row(2, "New Relic Version", nr_version_verbose());
   php_info_print_table_end();
 

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file handles the initialization that happens once per module load.
+ */
+#include "php_agent.h"
+
+#include <dlfcn.h>
+#include <signal.h>
+
+#include "php_api_distributed_trace.h"
+#include "php_environment.h"
+#include "php_error.h"
+#include "php_extension.h"
+#include "php_globals.h"
+#include "php_header.h"
+#include "php_hooks.h"
+#include "php_internal_instrument.h"
+#include "php_samplers.h"
+#include "php_user_instrument.h"
+#include "php_vm.h"
+#include "php_wrapper.h"
+#include "fw_laravel.h"
+#include "lib_guzzle4.h"
+#include "lib_guzzle6.h"
+#include "nr_agent.h"
+#include "nr_app.h"
+#include "nr_banner.h"
+#include "nr_daemon_spawn.h"
+#include "util_logging.h"
+#include "util_memory.h"
+#include "util_signals.h"
+#include "util_strings.h"
+#include "util_syscalls.h"
+#include "util_threads.h"
+
+#include "php_observer.h"
+#include "php_execute.h"
+
+/*
+ * Observer API functionality was added with PHP 8.0.
+ *
+ * The Observer API provide function handlers that trigger on every userland
+ * function begin and end.  The handlers provide all zend_execute_data and the
+ * end handler provides the return value pointer. The previous way to hook into
+ * PHP was via zend_execute_ex which will hook all userland function calls with
+ * significant overhead for doing the call. However, depending on user stack
+ * size settings, it could potentially generate an extremely deep call stack in
+ * PHP because zend_execute_ex limits stack size to whatever user settings
+ * are. Observer API bypasses the stack overflow issue that an agent could run
+ * into when intercepting userland calls.  Additionally, with PHP 8.0, JIT
+ * optimizations could optimize out a call to zend_execute_ex and the agent
+ * would not be able to overwite that call properly as the agent wouldn't have
+ * access to the JITed information.  This could lead to segfaults and caused PHP
+ * to decide to disable JIT when detecting extensions that overwrote
+ * zend_execute_ex.
+ *
+ * It only provides ZEND_USER_FUNCTIONS yet as it was assumed mechanisms already
+ * exist to monitor internal functions by overwriting internal function
+ * handlers.  This will be included in PHP 8.2: Registered
+ * zend_observer_fcall_init handlers are now also called for internal functions.
+ *
+ * Without overwriting the execute function and therefore being responsible for
+ * continuing the execution of ALL functions that we intercepted,  the agent is
+ * provided zend_execute_data on each function start/end and is then able to use
+ * it with our currently existing logic and instrumentation.
+ */
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+/*
+ * Register the begin and end function handlers with the Observer API.
+ */
+static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
+    zend_execute_data* execute_data) {
+  zend_observer_fcall_handlers handlers = {NULL, NULL};
+  if (NULL == execute_data) {
+    return handlers;
+  }
+  if ((NULL == execute_data->func)
+      || (ZEND_INTERNAL_FUNCTION == execute_data->func->type)) {
+    return handlers;
+  }
+  handlers.begin = nr_php_observer_fcall_begin;
+  handlers.end = nr_php_observer_fcall_end;
+  return handlers;
+}
+
+void nr_php_observer_minit() {
+  /*
+   * Register the Observer API handlers.
+   */
+  zend_observer_fcall_register(nr_php_fcall_register_handlers);
+  zend_observer_error_register(nr_php_error_cb);
+}
+
+#endif

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -86,12 +86,22 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
   return handlers;
 }
 
+
+void nr_php_observer_no_op(zend_execute_data* execute_data NRUNUSED){};
+
 void nr_php_observer_minit() {
   /*
    * Register the Observer API handlers.
    */
   zend_observer_fcall_register(nr_php_fcall_register_handlers);
   zend_observer_error_register(nr_php_error_cb);
+
+  /*
+   * For Observer API with PHP 8+, we no longer need to ovewrwrite the zend
+   * execute hook.  orig_execute is called various ways in various places, so
+   * turn it into a no_op when using OAPI.
+   */
+  NR_PHP_PROCESS_GLOBALS(orig_execute) = nr_php_observer_no_op;
 }
 
 #endif

--- a/agent/php_observer.h
+++ b/agent/php_observer.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file is the wrapper for PHP 8+ Observer API (OAPI) functionality.
+ *
+ * The registered function handlers are the entry points of instrumentation and
+ * are implemented in php_execute.c which contains the brains/helper functions
+ * required to monitor PHP.
+ */
+
+#ifndef NEWRELIC_PHP_AGENT_PHP_OBSERVER_H
+#define NEWRELIC_PHP_AGENT_PHP_OBSERVER_H
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+
+#include "Zend/zend_observer.h"
+
+/*
+ * Purpose : Register the OAPI function handlers and any other minit actions.
+ *
+ * Params  : None
+ *
+ * Returns : Void.
+ */
+void nr_php_observer_minit();
+
+/*
+ * Purpose : Call the necessary functions needed to instrument a function by
+ *           updating a transaction or segment for a function that has just
+ * started.  This function is registered via the Observer API and will be called
+ * by the zend engine every time a function begins.  The zend engine directly
+ * provides the zend_execute_data which has all details we need to know about
+ * the function. This and nr_php_execute_observer_fcall_end sum to provide all
+ * the functionality of nr_php_execute and nr_php _execute_enabled and as such
+ * will use all the helper functions they also used.
+ *
+ *
+ * Params  : 1. zend_execute_data: everything we need to know about the
+ * function.
+ *
+ * Returns : Void.
+ */
+void nr_php_observer_fcall_begin(zend_execute_data* execute_data);
+/*
+ * Purpose : Call the necessary functions needed to instrument a function when
+ *           updating a transaction or segment for a function that has just
+ * ended. This function is registered via the Observer API and will be called by
+ * the zend engine every time a function ends.  The zend engine directly
+ * provides the zend_execute_data and the return_value pointer, both of which
+ * have all details that the agent needs to know about the function. This and
+ * nr_php_execute_observer_fcall_start sum to provide all the functionality of
+ * nr_php_execute and nr_php_execute_enabled and as such will use all the helper
+ * functions they also used.
+ *
+ *
+ * Params  : 1. zend_execute_data: everything to know about the function.
+ *           2. return_value: function return value information
+ *
+ * Returns : Void.
+ */
+void nr_php_observer_fcall_end(zend_execute_data* execute_data,
+                               zval* return_value);
+#endif /* PHP8+ */
+
+#endif  // NEWRELIC_PHP_AGENT_PHP_OBSERVER_H

--- a/agent/php_observer.h
+++ b/agent/php_observer.h
@@ -19,6 +19,17 @@
 #include "Zend/zend_observer.h"
 
 /*
+ * Purpose: There are a few various places, aside from the php_execute_* family
+ * that will call NR_PHP_PROCESS_GLOBALS(orig_execute) so make it a noop to
+ * handle all cases.
+ *
+ * Params:  NR_EXECUTE_PROTO_OVERWRITE which is not used.
+ *
+ * Returns : Void
+ */
+extern void nr_php_observer_no_op(zend_execute_data* execute_data NRUNUSED);
+
+/*
  * Purpose : Register the OAPI function handlers and any other minit actions.
  *
  * Params  : None
@@ -62,7 +73,8 @@ void nr_php_observer_fcall_begin(zend_execute_data* execute_data);
  * Returns : Void.
  */
 void nr_php_observer_fcall_end(zend_execute_data* execute_data,
-                               zval* return_value);
+                               zval* func_return_value);
+
 #endif /* PHP8+ */
 
 #endif  // NEWRELIC_PHP_AGENT_PHP_OBSERVER_H

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -80,16 +80,18 @@ int nr_php_post_deactivate(void) {
 
   nrl_verbosedebug(NRL_INIT, "post-deactivate processing started");
 
-#ifdef PHP7
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO
   /*
    * PHP 7 has a singleton trampoline op array that is used for the life of an
    * executor (which, in non-ZTS mode, is the life of the process). We need to
    * ensure that it goes back to having a NULL wraprec, lest we accidentally try
    * to dereference a transient wraprec that is about to be destroyed.
    */
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA
   EG(trampoline).op_array.reserved[NR_PHP_PROCESS_GLOBALS(zend_offset)] = NULL;
 #endif /* PHP7 */
-
+#endif
   nr_php_remove_transient_user_instrumentation();
 
   nr_php_exception_filters_destroy(&NRPRG(exception_filters));

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -911,7 +911,8 @@ nr_status_t nr_php_txn_begin(const char* appnames,
     nr_php_txn_log_error_dt_on_tt_off();
   }
 
-#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO \
+    && defined OVERWRITE_ZEND_EXECUTE_DATA
   if (nr_php_ini_setting_is_set_by_user("opcache.enable")
       && NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
     nr_php_user_instrumentation_from_opcache(TSRMLS_C);
@@ -1144,6 +1145,7 @@ extern void nr_php_txn_add_code_level_metrics(
 
   nr_txn_attributes_set_string_attribute(attributes, nr_txn_clm_code_function,
                                          metadata->function_name);
+
   if (!CHK_CLM_EMPTY(metadata->function_filepath)) {
     nr_txn_attributes_set_string_attribute(attributes, nr_txn_clm_code_filepath,
                                            metadata->function_filepath);

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1109,3 +1109,53 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
 
   return NR_SUCCESS;
 }
+
+extern void nr_php_txn_add_code_level_metrics(
+    nr_attributes_t* attributes,
+    const nr_php_execute_metadata_t* metadata) {
+#if ZEND_MODULE_API_NO < ZEND_7_0_X_API_NO /* PHP7+ */
+  (void)attributes;
+  (void)metadata;
+  return;
+}
+#else
+  /* Current CLM functionality only works with PHP 7+ */
+
+  if (NULL == metadata) {
+    return;
+  }
+
+  /*
+   * Check if code level metrics are enabled in the ini.
+   * If they aren't, exit and don't add any attributes.
+   */
+  if (!NRINI(code_level_metrics_enabled)) {
+    return;
+  }
+
+#define CHK_CLM_EMPTY(s) ((NULL == s || nr_strempty(s)) ? true : false)
+
+  if (CHK_CLM_EMPTY(metadata->function_name)) {
+    /*
+     * CLM aren't set so don't do anything
+     */
+    return;
+  }
+
+  nr_txn_attributes_set_string_attribute(attributes, nr_txn_clm_code_function,
+                                         metadata->function_name);
+  if (!CHK_CLM_EMPTY(metadata->function_filepath)) {
+    nr_txn_attributes_set_string_attribute(attributes, nr_txn_clm_code_filepath,
+                                           metadata->function_filepath);
+  }
+  if (!CHK_CLM_EMPTY(metadata->function_namespace)) {
+    nr_txn_attributes_set_string_attribute(
+        attributes, nr_txn_clm_code_namespace, metadata->function_namespace);
+  }
+
+#undef CHK_CLM_EMPTY
+
+  nr_txn_attributes_set_long_attribute(attributes, nr_txn_clm_code_lineno,
+                                       metadata->function_lineno);
+}
+#endif

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -58,11 +58,32 @@ int nr_zend_call_orig_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
     NR_PHP_PROCESS_GLOBALS(orig_execute)
     (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
   }
-  zend_catch { zcaught = 1; }
+  zend_catch {
+    zcaught = 1;
+  }
   zend_end_try();
   return zcaught;
 }
-
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+int nr_zend_call_oapi_special_before(nruserfn_t* wraprec,
+                                     nr_segment_t* segment,
+                                     NR_EXECUTE_PROTO) {
+  volatile int zcaught = 0;
+  NR_UNUSED_FUNC_RETURN_VALUE;
+  NR_UNUSED_SPECIALFN;
+  zend_try {
+    if (wraprec && wraprec->special_instrumentation_before) {
+      wraprec->special_instrumentation_before(wraprec, segment,
+                                              NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    }
+  }
+  zend_catch {
+    zcaught = 1;
+  }
+  zend_end_try();
+  return zcaught;
+}
+#endif
 int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
                                       nr_segment_t* segment,
                                       NR_EXECUTE_PROTO TSRMLS_DC) {
@@ -77,7 +98,9 @@ int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
       (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
     }
   }
-  zend_catch { zcaught = 1; }
+  zend_catch {
+    zcaught = 1;
+  }
   zend_end_try();
   return zcaught;
 }
@@ -138,17 +161,8 @@ static void nr_php_wrap_zend_function(zend_function* func,
                                       nruserfn_t* wraprec TSRMLS_DC) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP8+ */
-  if (ZEND_USER_FUNCTION != func->type) {
-    nrl_verbosedebug(NRL_INSTRUMENT, "%s%s%s is not a user function",
-                     wraprec->classname ? wraprec->classname : "",
-                     wraprec->classname ? "::" : "", wraprec->funcname);
-
-    /*
-     * Prevent future wrap attempts for performance and to prevent spamming the
-     * logs with this message.
-     */
-    wraprec->is_disabled = 1;
-    return;
+  if (chk_reported_class(func, wraprec)) {
+    wraprec->reportedclass = nr_strdup(ZSTR_VAL(func->common.scope->name));
   }
 #else
   nr_php_op_array_set_wraprec(&func->op_array, wraprec TSRMLS_CC);
@@ -171,16 +185,12 @@ static void nr_php_wrap_user_function_internal(nruserfn_t* wraprec TSRMLS_DC) {
     return;
   }
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
-    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP8+ */
-  wraprec->is_wrapped = 1;
-  return;
-#endif
-
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    && defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP8+ */
   if (nrunlikely(-1 == NR_PHP_PROCESS_GLOBALS(zend_offset))) {
     return;
   }
-
+#endif
   if (0 == wraprec->classname) {
     orig_func = nr_php_find_function(wraprec->funcnameLC TSRMLS_CC);
   } else {
@@ -256,6 +266,7 @@ static nruserfn_t* nr_php_user_wraprec_create_named(const char* full_name,
     wraprec->classname = nr_strndup(klass, klass_len);
     wraprec->classnamelen = klass_len;
     wraprec->classnameLC = nr_string_to_lowercase(wraprec->classname);
+    wraprec->reportedclass = NULL;
     wraprec->is_method = 1;
   }
 
@@ -283,6 +294,7 @@ static void nr_php_user_wraprec_destroy(nruserfn_t** wraprec_ptr) {
   nr_free(wraprec->funcname);
   nr_free(wraprec->classnameLC);
   nr_free(wraprec->funcnameLC);
+  nr_free(wraprec->reportedclass);
   nr_realfree((void**)wraprec_ptr);
 }
 
@@ -309,6 +321,46 @@ static void nr_php_add_custom_tracer_common(nruserfn_t* wraprec) {
   nr_wrapped_user_functions = wraprec;
 }
 
+bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
+#if ZEND_MODULE_API_NO < ZEND_7_0_X_API_NO
+  /*
+   * Not compatible with PHP less than 7.
+   */
+  (void)func;
+  (void)p;
+  return false;
+#else
+  char* klass = NULL;
+
+  /*
+   * Optimize out string manipulations; don't do them if you don't have to.
+   * For instance, if funcname doesn't match, no use comparing the classname.
+   */
+
+  if (NULL == p) {
+    return false;
+  }
+  if ((NULL == func) || (ZEND_USER_FUNCTION != func->type)) {
+    return false;
+  }
+  if (NULL == func->common.function_name) {
+    return false;
+  }
+
+  if (0 != nr_stricmp(p->funcnameLC, ZSTR_VAL(func->common.function_name))) {
+    return false;
+  }
+  if (NULL != func->common.scope && NULL != func->common.scope->name) {
+    klass = ZSTR_VAL(func->common.scope->name);
+  }
+  if ((0 == nr_strcmp(p->reportedclass, klass))
+      || (0 == nr_stricmp(p->classname, klass))) {
+    return true;
+  }
+  return false;
+#endif
+}
+
 nruserfn_t* nr_php_get_wraprec_by_name(zend_function* func) {
 #if ZEND_MODULE_API_NO < ZEND_7_0_X_API_NO
   /*
@@ -318,34 +370,19 @@ nruserfn_t* nr_php_get_wraprec_by_name(zend_function* func) {
   return NULL;
 #else
   nruserfn_t* p = NULL;
-  char* funcnameLC = NULL;
-  char* klassLC = NULL;
 
   if ((NULL == func) || (ZEND_USER_FUNCTION != func->type)) {
     return NULL;
-  }
-  if (NULL != func->common.function_name) {
-    funcnameLC = nr_string_to_lowercase(ZSTR_VAL(func->common.function_name));
-  } else {
-    return NULL;
-  }
-  if (NULL != func->common.scope && NULL != func->common.scope->name) {
-    klassLC = nr_string_to_lowercase(ZSTR_VAL(func->common.scope->name));
   }
 
   p = nr_wrapped_user_functions;
 
   while (NULL != p) {
-    if (0 == nr_strcmp(p->funcnameLC, funcnameLC)
-        && 0 == nr_strcmp(p->classnameLC, klassLC)) {
-      nr_free(funcnameLC);
-      nr_free(klassLC);
+    if (nr_php_wraprec_matches(p, func)) {
       return p;
     }
     p = p->next;
   }
-  nr_free(funcnameLC);
-  nr_free(klassLC);
   return NULL;
 #endif
 }

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -568,6 +568,7 @@ static void nr_php_wraprec_add_name(nruserfn_t *wraprec, const zend_function* fu
 
 #define SET_NAME_PART(name_part, value) do { \
   if (value) { \
+    nrl_verbosedebug(NRL_DEBUG, "%s:%d %s: set '%s' to '%s'", __FILE__, __LINE__, __func__, #name_part, value); \
     wraprec->name_part = nr_strdup(value); \
     wraprec->name_part##len = nr_strlen(wraprec->name_part); \
     wraprec->name_part##LC = nr_string_to_lowercase(wraprec->name_part); \

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -50,8 +50,10 @@
  */
 int nr_zend_call_orig_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
   volatile int zcaught = 0;
+  NR_UNUSED_FUNC_RETURN_VALUE;
   zend_try {
-    NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    NR_PHP_PROCESS_GLOBALS(orig_execute)
+    (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
   }
   zend_catch { zcaught = 1; }
   zend_end_try();
@@ -62,12 +64,14 @@ int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
                                       nr_segment_t* segment,
                                       NR_EXECUTE_PROTO TSRMLS_DC) {
   volatile int zcaught = 0;
+  NR_UNUSED_FUNC_RETURN_VALUE;
   zend_try {
     if (wraprec && wraprec->special_instrumentation) {
       wraprec->special_instrumentation(wraprec, segment,
                                        NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
     } else {
-      NR_PHP_PROCESS_GLOBALS(orig_execute)(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+      NR_PHP_PROCESS_GLOBALS(orig_execute)
+      (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
     }
   }
   zend_catch { zcaught = 1; }

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -545,6 +545,9 @@ void nr_php_add_custom_tracer(const char* namestr, int namestrlen TSRMLS_DC) {
   }
 }
 
+#define NAME_EXCEPTION_HANDLER 1
+
+#if defined NAME_EXCEPTION_HANDLER && NAME_EXCEPTION_HANDLER == 1
 static const char* get_scope_name(const zend_function* func) {
   if (NULL == func || NULL == func->common.scope) {
     return NULL;
@@ -577,13 +580,16 @@ static void nr_php_wraprec_add_name(nruserfn_t *wraprec, const zend_function* fu
 #undef SET_NAME_PART
 
 }
+#endif
 
 void nr_php_add_exception_function(zend_function* func TSRMLS_DC) {
   nruserfn_t* wraprec = nr_php_add_custom_tracer_callable(func TSRMLS_CC);
 
   if (wraprec) {
     wraprec->is_exception_handler = 1;
+#if defined NAME_EXCEPTION_HANDLER && NAME_EXCEPTION_HANDLER == 1
     nr_php_wraprec_add_name(wraprec, func);
+#endif
   }
 }
 

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -60,6 +60,9 @@ typedef struct _nruserfn_t {
    */
   nrspecialfn_t special_instrumentation;
 
+  /*
+   * Only for PHP < 7.3
+   */
   nruserfn_declared_t declared_callback;
 
   int is_method;
@@ -81,6 +84,17 @@ typedef struct _nruserfn_t {
 } nruserfn_t;
 
 extern nruserfn_t* nr_wrapped_user_functions; /* a singly linked list */
+
+/*
+ * Purpose : Get the wraprec stored in nr_wrapped_user_functions and associated
+ *           with a function name/class.
+ *
+ * Params  : 1. The zend function to find in a wraprec
+ *
+ * Returns : The function wrapper that matches the function/class combination.
+ *            NULL if no function wrapper matches the function/class combo.
+ */
+extern nruserfn_t* nr_php_get_wraprec_by_name(zend_function* func);
 
 /*
  * Purpose : Get the wraprec associated with a user function op_array.

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -55,10 +55,36 @@ typedef struct _nruserfn_t {
   char* funcnameLC;
 
   /*
+   * Internally, there are cases where the zend_function reports it is one
+   * class; however, the zend_function is also contained in another class_entry
+   * table.
+   * For an example, see tests/integration/laravel
+   * A lookup for the class = Illuminate\Console\Application returns the class
+   * entry named classname = Illuminate\Console\Application
+   * So far so good!
+   * Lookup Illuminate\Console\Application method doRun and a zend_function is
+   * returned.  Ask that zend_func what its classname is and it says:
+   * Symfony\Component\Console\Application.
+   * Okay.
+   * Track both pieces of info for any wraprecs.
+   */
+  char* reportedclass;
+  /*
    * As an alternative to the current implementation, this could be
    * converted to a linked list so that we can nest wrappers.
    */
+  /*
+   * This is the callback that legacy instrumentation uses and that the majority
+   * of OAPI special instrumentation will use and it will be called at the END
+   * of a function.
+   */
   nrspecialfn_t special_instrumentation;
+  /*
+   * Only used by OAPI, PHP 8+.  Used to do any special instrumentation actions
+   * before a function is executed.  Both callbacks can bet set.  Use the
+   * `nr_php_wrap_user_function_after_before` to set both.
+   */
+  nrspecialfn_t special_instrumentation_before;
 
   /*
    * Only for PHP < 7.3
@@ -86,13 +112,24 @@ typedef struct _nruserfn_t {
 extern nruserfn_t* nr_wrapped_user_functions; /* a singly linked list */
 
 /*
+ * Purpose : Determine if a func matches a wraprec.
+ *
+ * Params  : 1. The wraprec to match to a zend function
+ *           2. The zend function to match to a wraprec
+ *
+ * Returns : True if the class/function of a wraprec match the class function
+ *           of a zend function.
+ */
+extern bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func);
+
+/*
  * Purpose : Get the wraprec stored in nr_wrapped_user_functions and associated
  *           with a function name/class.
  *
  * Params  : 1. The zend function to find in a wraprec
  *
  * Returns : The function wrapper that matches the function/class combination.
- *            NULL if no function wrapper matches the function/class combo.
+ *           NULL if no function wrapper matches the function/class combo.
  */
 extern nruserfn_t* nr_php_get_wraprec_by_name(zend_function* func);
 
@@ -171,7 +208,11 @@ extern int nr_zend_call_orig_execute(NR_EXECUTE_PROTO TSRMLS_DC);
 extern int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
                                              nr_segment_t* segment,
                                              NR_EXECUTE_PROTO TSRMLS_DC);
-
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
+extern int nr_zend_call_oapi_special_before(nruserfn_t* wraprec,
+                                            nr_segment_t* segment,
+                                            NR_EXECUTE_PROTO);
+#endif
 /*
  * Purpose : Destroy all user instrumentation records, freeing
  *           associated memory.
@@ -194,5 +235,16 @@ extern void nr_php_user_function_add_declared_callback(
     const char* namestr,
     int namestrlen,
     nruserfn_declared_t callback TSRMLS_DC);
+
+static inline bool chk_reported_class(zend_function* func, nruserfn_t* wraprec) {
+  if ((NULL == func) || (NULL == func->common.scope)) {
+    return false;
+  }
+
+  if ((NULL == func->common.scope->name) || (NULL != wraprec->reportedclass)) {
+    return false;
+  }
+  return true;
+}
 
 #endif /* PHP_USER_INSTRUMENT_HDR */

--- a/agent/php_wrapper.c
+++ b/agent/php_wrapper.c
@@ -8,6 +8,46 @@
 #include "php_wrapper.h"
 #include "util_logging.h"
 
+nruserfn_t* nr_php_wrap_user_function_before_after(
+    const char* name,
+    size_t namelen,
+    nrspecialfn_t before_callback,
+    nrspecialfn_t after_callback) {
+  nruserfn_t* wraprec = nr_php_add_custom_tracer_named(name, namelen TSRMLS_CC);
+
+  if (NULL == wraprec) {
+    return wraprec;
+  }
+
+  if (after_callback) {
+    if (is_instrumentation_set(wraprec->special_instrumentation,
+                               after_callback)) {
+      nrl_verbosedebug(
+          NRL_INSTRUMENT,
+          "%s: attempting to set special_instrumentation for %.*s, but "
+          "it is already set",
+          __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
+    } else {
+      wraprec->special_instrumentation = after_callback;
+    }
+  }
+
+  if (before_callback) {
+    if (is_instrumentation_set(wraprec->special_instrumentation_before,
+                               before_callback)) {
+      nrl_verbosedebug(NRL_INSTRUMENT,
+                       "%s: attempting to set special_instrumentation_before "
+                       "for %.*s, but "
+                       "it is already set",
+                       __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
+    } else {
+      wraprec->special_instrumentation_before = before_callback;
+    }
+  }
+
+  return wraprec;
+}
+
 nruserfn_t* nr_php_wrap_user_function(const char* name,
                                       size_t namelen,
                                       nrspecialfn_t callback TSRMLS_DC) {

--- a/agent/php_wrapper.c
+++ b/agent/php_wrapper.c
@@ -77,7 +77,7 @@ inline static void release_zval(zval** ppzv) {
 
 zval* nr_php_arg_get(ssize_t index, NR_EXECUTE_PROTO TSRMLS_DC) {
   zval* arg;
-
+  NR_UNUSED_FUNC_RETURN_VALUE;
 #ifdef PHP7
   {
     zval* orig;
@@ -203,6 +203,7 @@ void nr_php_arg_release(zval** ppzv) {
 zval* nr_php_scope_get(NR_EXECUTE_PROTO TSRMLS_DC) {
   zval* this_obj;
   zval* this_copy;
+  NR_UNUSED_FUNC_RETURN_VALUE;
 
   this_obj = NR_PHP_USER_FN_THIS();
   if (NULL == this_obj) {

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -85,6 +85,12 @@
  *    already been called.
  */
 
+extern nruserfn_t* nr_php_wrap_user_function_before_after(
+    const char* name,
+    size_t namelen,
+    nrspecialfn_t before_callback,
+    nrspecialfn_t after_callback);
+
 extern nruserfn_t* nr_php_wrap_user_function(const char* name,
                                              size_t namelen,
                                              nrspecialfn_t callback TSRMLS_DC);
@@ -257,5 +263,14 @@ extern zval** nr_php_get_return_value_ptr(TSRMLS_D);
     zcaught = ((name)(NR_SPECIALFNPTR_ORIG_ARGS TSRMLS_CC)).zcaught; \
     was_executed = 1;                                                \
   }
+
+static inline bool is_instrumentation_set(nrspecialfn_t instrumentation,
+                                          nrspecialfn_t callback) {
+  if ((NULL != instrumentation) && (callback != instrumentation)) {
+    return true;
+  }
+
+  return false;
+}
 
 #endif /* PHP_WRAPPER_HDR */

--- a/agent/tests/test_agent.c
+++ b/agent/tests/test_agent.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "tlib_php.h"
+#include "tlib_main.h"
 
 #include "php_agent.h"
 #include "php_call.h"
@@ -557,6 +558,144 @@ static void test_default_address() {
 #endif
 }
 
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
+
+static void test_nr_php_zend_execute_data_function_name() {
+  zend_function* func;
+  zend_execute_data execute_data = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_null("NULL zend_execute_data should return NULL",
+                    nr_php_zend_execute_data_function_name(NULL));
+
+  /*
+   * Test : Invalid arguments.
+   */
+  tlib_pass_if_null("NULL zend_function should return NULL",
+                    nr_php_zend_execute_data_function_name(&execute_data));
+
+  /*
+   * Test : Normal operation.
+   */
+  func = nr_php_find_function("newrelic_get_request_metadata");
+  execute_data.func = func;
+  tlib_pass_if_str_equal(
+      "Unexpected function name", "newrelic_get_request_metadata",
+      nr_php_zend_execute_data_function_name(&execute_data TSRMLS_CC));
+}
+
+static void test_nr_php_zend_execute_data_filename() {
+  zend_function func = {0};
+  zend_string* filename = NULL;
+  zend_execute_data execute_data = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_null("NULL zend_execute_data should return NULL",
+                    nr_php_zend_execute_data_filename(NULL TSRMLS_CC));
+
+  /*
+   * Test : Null function.
+   */
+  tlib_pass_if_null("NULL zend_function should return NULL",
+                    nr_php_zend_execute_data_filename(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Function exists, op_array doesn't.
+   */
+  execute_data.func = &func;
+  tlib_pass_if_null("NULL op_array should return NULL",
+                    nr_php_zend_execute_data_filename(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Function exists, op_array exists.
+   */
+  filename = zend_string_init("myfilename\\is\\here",
+                              strlen("myfilename\\is\\here"), 0);
+  func.op_array.filename = filename;
+  execute_data.func = &func;
+  tlib_pass_if_str_equal(
+      "Filename should be displayed", ZSTR_VAL(filename),
+      nr_php_zend_execute_data_filename(&execute_data TSRMLS_CC));
+  zend_string_release(filename);
+}
+
+static void test_nr_php_zend_execute_data_scope_name() {
+  zend_function func = {0};
+  zend_string* scope_name = NULL;
+  zend_execute_data execute_data = {0};
+  zend_class_entry ce = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_null("NULL zend_execute_data should return NULL",
+                    nr_php_zend_execute_data_scope_name(NULL TSRMLS_CC));
+
+  /*
+   * Test : Invalid arguments.
+   */
+  tlib_pass_if_null(
+      "NULL zend_function should return NULL",
+      nr_php_zend_execute_data_scope_name(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Function exists, but no class scope.
+   */
+  execute_data.func = &func;
+  tlib_pass_if_null(
+      "NULL op_array should return NULL",
+      nr_php_zend_execute_data_scope_name(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Function exists, class scope exists.
+   */
+  execute_data.func = &func;
+  scope_name = zend_string_init("NewRelic\\Integration",
+                                strlen("NewRelic\\Integration"), 0);
+  ce.name = scope_name;
+  execute_data.func->common.scope = &ce;
+  tlib_pass_if_str_equal(
+      "Unexpected scope name", ZSTR_VAL(scope_name),
+      nr_php_zend_execute_data_scope_name(&execute_data TSRMLS_CC));
+  zend_string_release(scope_name);
+}
+
+static void test_nr_php_zend_execute_data_lineno() {
+  zend_function func = {0};
+  zend_op opline = {0};
+  zend_execute_data execute_data = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_uint32_t_equal("NULL zend_execute_data should return 0", 0,
+                              nr_php_zend_execute_data_lineno(NULL TSRMLS_CC));
+
+  /*
+   * Test : Invalid arguments.
+   */
+  tlib_pass_if_uint32_t_equal(
+      "NULL zend_function should return 0", 0,
+      nr_php_zend_execute_data_lineno(&execute_data TSRMLS_CC));
+
+  /*
+   * Test : Normal operation.
+   */
+  execute_data.func = &func;
+
+  opline.lineno = 4;
+  execute_data.opline = &opline;
+  tlib_pass_if_uint32_t_equal(
+      "Unexpected lineno name", 4,
+      nr_php_zend_execute_data_lineno(&execute_data TSRMLS_CC));
+}
+
+#endif /* PHP 7+ */
+
 void test_main(void* p NRUNUSED) {
 #if defined(ZTS) && !defined(PHP7)
   void*** tsrm_ls = NULL;
@@ -580,6 +719,13 @@ void test_main(void* p NRUNUSED) {
    * Tests that require state and will handle their own request startup and
    * shutdown.
    */
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
+  test_nr_php_zend_execute_data_function_name();
+  test_nr_php_zend_execute_data_filename();
+  test_nr_php_zend_execute_data_lineno();
+  test_nr_php_zend_execute_data_scope_name();
+#endif /* PHP 7+ */
+
   test_function_debug_name(TSRMLS_C);
   test_get_zval_object_property(TSRMLS_C);
   test_get_zval_object_property_with_class(TSRMLS_C);

--- a/agent/tests/test_api_internal.c
+++ b/agent/tests/test_api_internal.c
@@ -55,14 +55,15 @@ static void test_invalid_parameters(TSRMLS_D) {
   tlib_php_request_start();
 
   /* Literally any parameter should cause this to bail. */
-#ifdef PHP8
-  tlib_php_request_eval("$exception = false;"
-                        "try {"
-                        "    $value = newrelic_get_trace_json('invalid');"
-                        "    echo \"No exception, returned \" . $value . \".\\n\";"
-                        "} catch(ArgumentCountError $_e) {"
-                        "    $exception = true;"
-                        "}" TSRMLS_CC);
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+  tlib_php_request_eval(
+      "$exception = false;"
+      "try {"
+      "    $value = newrelic_get_trace_json('invalid');"
+      "    echo \"No exception, returned \" . $value . \".\\n\";"
+      "} catch(ArgumentCountError $_e) {"
+      "    $exception = true;"
+      "}");
   retval = tlib_php_request_eval_expr("$exception;" TSRMLS_CC);
 
   tlib_pass_if_zval_is_bool_true(

--- a/agent/tests/test_fw_drupal.c
+++ b/agent/tests/test_fw_drupal.c
@@ -370,6 +370,16 @@ static void test_drupal_http_request_drupal_6(TSRMLS_D) {
 }
 
 void test_main(void* p NRUNUSED) {
+/*
+DO NOT LEAVE THIS.
+When drupal_http_request header functionality is refactored,
+please put the tests back in!
+*/
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+  return;
+#endif
+
 #if defined(ZTS) && !defined(PHP7)
   void*** tsrm_ls = NULL;
 #endif /* ZTS && !PHP7 */

--- a/agent/tests/test_php_stacked_segment.c
+++ b/agent/tests/test_php_stacked_segment.c
@@ -14,6 +14,105 @@
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = -1, .state_size = 0};
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+static void test_start_end_discard(TSRMLS_D) {
+  nr_segment_t* stacked = NULL;
+  nr_segment_t* segment;
+
+  tlib_php_request_start();
+
+  /*
+   * Initial state: current segment forced to root
+   */
+  tlib_pass_if_ptr_equal("current stacked segment forced to root",
+                         NRTXN(segment_root), NRTXN(force_current_segment));
+
+  /*
+   * Add a stacked segment.
+   */
+  stacked = nr_php_stacked_segment_init(stacked);
+
+  tlib_pass_if_not_null("current stacked forced to stacked should not be null",
+                        stacked);
+  tlib_pass_if_ptr_equal("current stacked segment has txn", stacked->txn,
+                         NRPRG(txn));
+  tlib_pass_if_ptr_equal("current stacked forced to stacked", stacked,
+                         NRTXN(force_current_segment));
+
+  /*
+   * Discard a stacked segment.
+   */
+  nr_php_stacked_segment_deinit(stacked);
+
+  tlib_pass_if_ptr_equal("current stacked segment forced to root",
+                         NRTXN(segment_root), NRTXN(force_current_segment));
+  tlib_pass_if_size_t_equal(
+      "no segment created", 0,
+      nr_segment_children_size(&NRTXN(segment_root)->children));
+
+  /*
+   * Add another stacked segment.
+   */
+  stacked = nr_php_stacked_segment_init(stacked TSRMLS_CC);
+
+  tlib_pass_if_ptr_equal("current stacked segment has txn", stacked->txn,
+                         NRPRG(txn));
+  tlib_pass_if_ptr_equal("current stacked forced to stacked", stacked,
+                         NRTXN(force_current_segment));
+
+  /*
+   * End a stacked segment.
+   */
+  segment = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
+  nr_segment_end(&segment);
+
+  tlib_pass_if_true("moved segment is different from stacked segment",
+                    segment != stacked, "%p!=%p", segment, stacked);
+  tlib_pass_if_ptr_equal("current stacked segment forced to root",
+                         NRTXN(segment_root), NRTXN(force_current_segment));
+  tlib_pass_if_size_t_equal(
+      "no segment created", 1,
+      nr_segment_children_size(&NRTXN(segment_root)->children));
+
+  tlib_php_request_end();
+}
+
+static void test_unwind(TSRMLS_D) {
+  nr_segment_t* stacked_1 = NULL;
+  nr_segment_t* stacked_2 = NULL;
+  nr_segment_t* stacked_3 = NULL;
+  nr_segment_t* segment;
+
+  tlib_php_request_start();
+
+  /*
+   * Add stacked segments.
+   */
+  stacked_1 = nr_php_stacked_segment_init(stacked_1 TSRMLS_CC);
+  stacked_2 = nr_php_stacked_segment_init(stacked_2 TSRMLS_CC);
+  stacked_3 = nr_php_stacked_segment_init(stacked_3 TSRMLS_CC);
+
+  /*
+   * Add a regular segment.
+   */
+  segment = nr_segment_start(NRPRG(txn), NULL, NULL);
+  nr_segment_end(&segment);
+
+  /*
+   * Unwind the stacked segment stack.
+   */
+  nr_php_stacked_segment_unwind(TSRMLS_C);
+
+  tlib_pass_if_size_t_equal(
+      "one child segment of root", 1,
+      nr_segment_children_size(&NRTXN(segment_root)->children));
+
+  tlib_pass_if_size_t_equal("4 segments in total ", 4, NRTXN(segment_count));
+
+  tlib_php_request_end();
+}
+#else
 static void test_start_end_discard(TSRMLS_D) {
   nr_segment_t stacked = {0};
   nr_segment_t* segment;
@@ -108,6 +207,7 @@ static void test_unwind(TSRMLS_D) {
 
   tlib_php_request_end();
 }
+#endif
 
 void test_main(void* p NRUNUSED) {
 #if defined(ZTS) && !defined(PHP7)

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -50,6 +50,35 @@ static void test_add_arg(TSRMLS_D) {
 
   tlib_php_request_start();
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+  tlib_php_request_eval("function arg0_def0() { return 4; }" TSRMLS_CC);
+  nr_php_wrap_user_function_before_after(NR_PSTR("arg0_def0"), test_add_array,
+                                         NULL TSRMLS_CC);
+
+  tlib_php_request_eval("function arg1_def0($a) { return $a; }" TSRMLS_CC);
+  nr_php_wrap_user_function_before_after(NR_PSTR("arg1_def0"), test_add_array,
+                                         NULL TSRMLS_CC);
+
+  tlib_php_request_eval(
+      "function arg0_def1($a = null) { return $a; }" TSRMLS_CC);
+  nr_php_wrap_user_function_before_after(NR_PSTR("arg0_def1"), test_add_array,
+                                         NULL TSRMLS_CC);
+
+  tlib_php_request_eval(
+      "function arg1_def1($a, $b = null) { return $b; }" TSRMLS_CC);
+  nr_php_wrap_user_function_before_after(NR_PSTR("arg1_def1"), test_add_array,
+                                         NULL TSRMLS_CC);
+
+  tlib_php_request_eval(
+      "function arg1_def1_2($a, $b = null) { return $b; }" TSRMLS_CC);
+  nr_php_wrap_user_function_before_after(NR_PSTR("arg1_def1_2"),
+                                         test_add_2_arrays, NULL TSRMLS_CC);
+
+  tlib_php_request_eval("function splat(...$a) { return $a[0]; }" TSRMLS_CC);
+  nr_php_wrap_user_function_before_after(NR_PSTR("splat"), test_add_array,
+                                         NULL TSRMLS_CC);
+#else
   tlib_php_request_eval("function arg0_def0() { return 4; }" TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("arg0_def0"), test_add_array TSRMLS_CC);
 
@@ -71,7 +100,7 @@ static void test_add_arg(TSRMLS_D) {
 
   tlib_php_request_eval("function splat(...$a) { return $a[0]; }" TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("splat"), test_add_array TSRMLS_CC);
-
+#endif
   /*
    * 0 arguments, 0 default arguments, 0 arguments given
    */
@@ -93,6 +122,7 @@ static void test_add_arg(TSRMLS_D) {
   /*
    * 1 argument, 0 default arguments, 0 arguments given
    */
+
   expr = nr_php_call(NULL, "arg1_def0");
   tlib_pass_if_not_null("1 args, 0 default args, 0 given", expr);
   tlib_pass_if_zval_type_is("1 args, 0 default args, 0 given", IS_ARRAY, expr);
@@ -163,7 +193,6 @@ static void test_add_arg(TSRMLS_D) {
                             IS_ARRAY, expr);
   nr_php_zval_free(&expr);
   nr_php_zval_free(&arg);
-
   /*
    * 1 argument, 1 default arguments, 2 arguments given, 2 added
    */

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -52,14 +52,125 @@ static void test_op_array_wraprec(TSRMLS_D) {
   tlib_php_request_end();
 }
 
+static void test_get_wraprec_by_name() {
+#if ZEND_MODULE_API_NO < ZEND_7_3_X_API_NO
+  return;
+#else
+  zend_op_array oparray = {.function_name = (void*)1};
+  zend_function zend_func = {0};
+  zend_string* scope_name = NULL;
+  zend_class_entry ce = {0};
+  nruserfn_t* wraprec = NULL;
+  char* name_str = "my_func_name";
+
+  tlib_php_request_start();
+
+  /*
+   * NULL if there's no wraprecs in the internal list.
+   */
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+
+  wraprec = nr_php_add_custom_tracer_named(
+      "ClassNoMatch::functionNoMatch",
+      nr_strlen("ClassNoMatch::functionNoMatch"));
+  wraprec = nr_php_add_custom_tracer_named("functionNoMatch2",
+                                           nr_strlen("functionNoMatch2"));
+  wraprec = nr_php_add_custom_tracer_named(name_str, nr_strlen(name_str));
+
+  /*
+   * NULL if zend_function is NULL.
+   */
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(NULL), NULL);
+
+  /*
+   * NULL if function name is NULL.
+   */
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+
+  /*
+   * NULL if name is correct but type is wrong.
+   */
+  zend_func.type = ZEND_INTERNAL_FUNCTION;
+  zend_func.common.function_name
+      = zend_string_init(name_str, strlen(name_str), 0);
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+  /*
+   * Valid if function name matches and type is user function.
+   */
+  zend_func.type = ZEND_USER_FUNCTION;
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), wraprec);
+  /*
+   * NULL if function name matches, but class name doesn't.
+   */
+  scope_name = zend_string_init("ClassName", strlen("ClassName"), 0);
+  ce.name = scope_name;
+  zend_func.common.scope = &ce;
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+  /*
+   * NULL if function name doesn't match and class name matches.
+   */
+
+  wraprec = nr_php_add_custom_tracer_named(
+      "ClassName::my_func_name2", nr_strlen("ClassName::my_func_name2"));
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+  /*
+   * Valid if function name matches and class name matches.
+   */
+  wraprec = nr_php_add_custom_tracer_named(
+      "ClassName::my_func_name", nr_strlen("ClassName::my_func_name"));
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), wraprec);
+
+#if ZEND_MODULE_API_NO >= ZEND_7_3_X_API_NO
+  /*
+   * Invalidate the cached pid.
+   */
+  NRPRG(pid) -= 1;
+
+  /*
+   * Not NULL because we don't care about the reserved array anymore.
+   */
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), wraprec);
+  /*
+   * Restore the cached pid and invalidate the mangled pid/index value.
+   */
+  NRPRG(pid) += 1;
+
+  {
+    unsigned long pval;
+
+    pval = (unsigned long)oparray.reserved[NR_PHP_PROCESS_GLOBALS(zend_offset)];
+    oparray.reserved[NR_PHP_PROCESS_GLOBALS(zend_offset)] = (void*)(pval * 2);
+  }
+  /*
+   * Not NULL because we don't care about the reserved array anymore.
+   */
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_name(&zend_func), wraprec);
+
+#endif /* PHP >= 7.3 */
+  zend_string_release(zend_func.common.function_name);
+  zend_string_release(zend_func.common.scope->name);
+  tlib_php_request_end();
+#endif
+}
+
 void test_main(void* p NRUNUSED) {
 #if defined(ZTS) && !defined(PHP7)
   void*** tsrm_ls = NULL;
 #endif /* ZTS && !PHP7 */
 
   tlib_php_engine_create("" PTSRMLS_CC);
-
   test_op_array_wraprec(TSRMLS_C);
+  test_get_wraprec_by_name();
 
   tlib_php_engine_destroy(TSRMLS_C);
 }

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -404,7 +404,6 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
   }
 
   trace_id = nr_txn_get_current_trace_id(segment->txn);
-
   event = nr_span_event_create();
   nr_span_event_set_guid(event, segment->id);
   nr_span_event_set_trace_id(event, trace_id);
@@ -463,9 +462,7 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
 
     agent_attributes = nr_attributes_agent_to_obj(
         segment->txn->attributes, NR_ATTRIBUTE_DESTINATION_TXN_EVENT);
-
     nro_iteratehash(agent_attributes, add_agent_attribute_to_span_event, event);
-
     nro_delete(agent_attributes);
   }
 
@@ -505,6 +502,13 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
                     &event_and_counter);
 
     nro_delete(user_attributes);
+    /*
+     * Add segment agent attributes to span
+     */
+    agent_attributes = nr_attributes_agent_to_obj(
+        segment->attributes, NR_ATTRIBUTE_DESTINATION_SPAN);
+    nro_iteratehash(agent_attributes, add_agent_attribute_to_span_event, event);
+    nro_delete(agent_attributes);
   }
   if (segment->attributes_txn_event) {
     user_attributes = nr_attributes_user_to_obj(segment->attributes_txn_event,

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -182,6 +182,25 @@ typedef struct _nr_segment_t {
                                                       external or datastore
                                                       segments. */
   nr_segment_error_t* error; /* segment error attributes */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+
+/*
+ * Because of the access to the segment is now split between functions, we
+ * need to pass a certain amount of data between the functions that use the
+ * segment.
+ */
+  nrtime_t txn_start_time; /* To doublecheck the txn is correct when it is time
+                              to add the segment to the txn. */
+  void* wraprec;           /* wraprec, if one is associated with this segment */
+  uint32_t
+      lineno; /* Keep lineno information.  When a function begins, the
+                 zend_execute_data lineno shows the ENTRY point of the function,
+                 when a function ends, the zend_execute_data lineno CHANGES and
+                 shows the EXIT point of the function.  */
+
+#endif
+
 } nr_segment_t;
 
 /*

--- a/axiom/nr_segment_traces.c
+++ b/axiom/nr_segment_traces.c
@@ -228,7 +228,8 @@ static void nr_segment_iteration_pass_trace(nr_segment_t* segment,
   nrbuf_t* buf = userdata->trace.buf;
   int idx;
   nr_segment_t* parent = NULL;
-  nrobj_t* user_attributes;
+  nrobj_t* user_attributes = NULL;
+  nrobj_t* agent_attributes = NULL;
 
   uint64_t start_ms;
   uint64_t stop_ms;
@@ -298,6 +299,13 @@ static void nr_segment_iteration_pass_trace(nr_segment_t* segment,
         segment->attributes, NR_ATTRIBUTE_DESTINATION_TXN_TRACE);
     add_attribute_hash_to_buffer(buf, user_attributes);
     nro_delete(user_attributes);
+    /*
+     *  Add segment attributes to transaction trace.
+     */
+    agent_attributes = nr_attributes_agent_to_obj(
+        segment->attributes, NR_ATTRIBUTE_DESTINATION_TXN_TRACE);
+    add_attribute_hash_to_buffer(buf, agent_attributes);
+    nro_delete(agent_attributes);
   }
 
   nr_buffer_add(buf, "}", 1);

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -575,13 +575,24 @@ extern const nr_txn_attribute_t* nr_txn_request_user_agent;
 extern const nr_txn_attribute_t* nr_txn_server_name;
 extern const nr_txn_attribute_t* nr_txn_response_content_type;
 extern const nr_txn_attribute_t* nr_txn_response_content_length;
+extern const nr_txn_attribute_t* nr_txn_clm_code_filepath;
+extern const nr_txn_attribute_t* nr_txn_clm_code_function;
+extern const nr_txn_attribute_t* nr_txn_clm_code_namespace;
+extern const nr_txn_attribute_t* nr_txn_clm_code_lineno;
 extern void nr_txn_set_string_attribute(nrtxn_t* txn,
                                         const nr_txn_attribute_t* attribute,
                                         const char* value);
 extern void nr_txn_set_long_attribute(nrtxn_t* txn,
                                       const nr_txn_attribute_t* attribute,
                                       long value);
-
+extern void nr_txn_attributes_set_string_attribute(
+    nr_attributes_t* attributes,
+    const nr_txn_attribute_t* attribute,
+    const char* value);
+extern void nr_txn_attributes_set_long_attribute(
+    nr_attributes_t* attributes,
+    const nr_txn_attribute_t* attribute,
+    long value);
 /*
  * Purpose : Return the duration of the transaction.  This function will return
  *           0 if the transaction has not yet finished or if the transaction

--- a/tests/integration/attributes/test_transaction_namespace2_clm.php
+++ b/tests/integration/attributes/test_transaction_namespace2_clm.php
@@ -1,0 +1,142 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should send code level metrics (CLM) including function name,
+class name, and lineno.
+ */
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.0", "<")) {
+  die("skip: CLM for PHP 5 not supported\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled=false
+newrelic.code_level_metrics.enabled=true
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+ [
+  "?? agent run id",
+  {
+    "reservoir_size": 50,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": false
+      },
+      {
+      },
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__"
+      }
+    ],
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "Custom\/Foo\\Bar\\Vegetable::getColor",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": 133,
+        "code.namespace": "Foo\\Bar\\Vegetable",
+        "code.filepath": "__FILE__",
+        "code.function": "getColor"
+      }
+    ]
+  ]
+]
+ */
+namespace Foo\Bar {
+    class Vegetable {
+        public $edible;
+
+        public $color;
+
+        public function __construct($edible, $color = "green")
+        {
+            $this->edible = $edible;
+            $this->color = $color;
+        }
+
+        public function isEdible()
+        {
+            return $this->edible;
+        }
+
+        public function getColor()
+        {
+            echo "Yum\n";
+            return $this->color;
+        }
+    }
+
+    echo "two" . newrelic_add_custom_tracer("Foo\\Bar\\Vegetable::getColor");
+    $veggie = new Vegetable(true, "blue");
+    $veggie->getColor();
+}
+

--- a/tests/integration/attributes/test_transaction_namespace_clm.php
+++ b/tests/integration/attributes/test_transaction_namespace_clm.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should send code level metrics (CLM) including function name,
+class name, and lineno.
+ */
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.0", "<")) {
+  die("skip: CLM for PHP 5 not supported\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled=false
+newrelic.code_level_metrics.enabled=true
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+ [
+  "?? agent run id",
+  {
+    "reservoir_size": 50,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": false
+      },
+      {
+      },
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__"
+      }
+    ],
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "Custom\/Vegetable::getColor",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": 134,
+        "code.namespace": "Vegetable",
+        "code.filepath": "__FILE__",
+        "code.function": "getColor"
+      }
+    ]
+  ]
+]
+ */
+
+class Vegetable {
+    public $edible;
+
+    public $color;
+
+    public function __construct($edible, $color = "green")
+    {
+        $this->edible = $edible;
+        $this->color = $color;
+    }
+
+    public function isEdible()
+    {
+	sleep(10);
+        return $this->edible;
+    }
+
+    public function getColor()
+    {
+        echo "Yum\n";
+        return $this->color;
+    }
+}
+newrelic_add_custom_tracer("Vegetable::getColor");
+$veggie = new Vegetable(true, "blue");
+$veggie->getColor();

--- a/tests/integration/attributes/test_transaction_nested_user_functions_clm.php
+++ b/tests/integration/attributes/test_transaction_nested_user_functions_clm.php
@@ -1,0 +1,231 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Code level metrics should be added to nested functions; however,
+CLM should NOT be added to functions that are so short they will
+normally be ignored.
+*/
+
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.0", "<")) {
+  die("skip: CLM for PHP 5 not supported\n");
+}
+*/
+
+/*INI
+newrelic.transaction_tracer.threshold = 0
+newrelic.code_level_metrics.enabled = 1
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__"
+      }
+    ],
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "Custom\/level_2",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": 228,
+        "code.filepath": "__FILE__",
+        "code.function": "level_2"
+      }
+    ],
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "Custom\/level_1",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": 224,
+        "code.filepath": "__FILE__",
+        "code.function": "level_1"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": false
+      },
+      {},
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__"
+      }
+    ]
+  ]
+]
+
+*/
+
+/*EXPECT_TXN_TRACES
+[
+  "?? agent run id",
+  [
+    [
+      "?? entry",
+      "?? duration",
+      "OtherTransaction/php__FILE__",
+      "<unknown>",
+      [
+        [
+          0,
+          {},
+          {},
+          [
+            "?? start time", "?? end time", "ROOT", "?? root attributes",
+            [
+              [
+                "?? start time", "?? end time", "`0", "?? node attributes",
+                [
+                  [
+                    "?? start time", "?? end time", "`1",
+                            {
+                              "code.lineno": 228,
+                              "code.filepath": "__FILE__",
+                              "code.function": "level_2"
+                            },
+                    [
+                      [
+                        "?? start time", "?? end time", "`2",
+                            {
+                              "code.lineno": 224,
+                              "code.filepath": "__FILE__",
+                              "code.function": "level_1"
+                        },
+                        []
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "agentAttributes": {
+              "code.lineno": 1,
+              "code.filepath": "__FILE__",
+              "code.function": "__FILE__"
+            },
+            "intrinsics": {
+              "totalTime": "??",
+              "cpu_time": "??",
+              "cpu_user_time": "??",
+              "cpu_sys_time": "??",
+              "guid": "??",
+              "sampled": true,
+              "priority": "??",
+              "traceId": "??"
+            }
+          }
+        ],
+        [
+          "OtherTransaction\/php__FILE__",
+          "Custom\/level_2",
+          "Custom\/level_1"
+        ]
+      ],
+      "?? txn guid",
+      "?? reserved",
+      "?? force persist",
+      "?? x-ray sessions",
+      null
+    ]
+  ]
+]
+*/
+
+/*
+ * Normally super short duration functions are ignored.
+ * We'll force some to be noticed, while others should
+ * contrinue to be ignored.
+ */
+newrelic_add_custom_tracer("level_1");
+newrelic_add_custom_tracer("level_2");
+
+function level_0() {
+    echo "level_0\n";
+}
+
+function level_1() {
+    level_0();
+}
+
+function level_2() {
+    level_1();
+}
+
+level_2();

--- a/tests/integration/attributes/test_transaction_non_web_clm.php
+++ b/tests/integration/attributes/test_transaction_non_web_clm.php
@@ -1,0 +1,158 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+In a non-web transaction that has no user defined functions, code level metrics (CLM)
+should return the filename as the function name (because we are instrumenting the file)
+and lineno 1.
+The agent should include CLM agent attributes in error traces, error
+events, analytic events and span events.
+ */
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.0", "<")) {
+  die("skip: CLM for PHP 5 not supported\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled=false
+newrelic.code_level_metrics.enabled=true
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "I'M COVERED IN BEES!",
+      "NoticedError",
+      {
+        "stack_trace": [
+          " in newrelic_notice_error called at __FILE__ (??)"
+        ],
+        "agentAttributes": {
+          "code.lineno": 1,
+          "code.filepath": "__FILE__",
+          "code.function": "__FILE__"
+        },
+        "intrinsics": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "NoticedError",
+        "error.message": "I'M COVERED IN BEES!",
+        "transactionName": "OtherTransaction/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+ [
+  "?? agent run id",
+  "?? sampling information",
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {
+      },
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__",
+        "errorType": "NoticedError",
+        "errorMessage": "I'M COVERED IN BEES!"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__",
+        "error.class": "NoticedError",
+        "error.message": "I'M COVERED IN BEES!"
+      }
+    ]
+  ]
+]
+ */
+
+header('Content-Type: application/pdf');
+header('Content-Length: 867');
+newrelic_notice_error("I'M COVERED IN BEES!");

--- a/tests/integration/attributes/test_transaction_web_clm.php
+++ b/tests/integration/attributes/test_transaction_web_clm.php
@@ -1,0 +1,227 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+In a web transaction that has no user defined functions, code level metrics (CLM)
+should return the filename as the function name (because we are instrumenting the file)
+and lineno 1. The agent should include CLM agent attributes in error traces, error
+events, analytic events and span events.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.0", "<")) {
+  die("skip: CLM for PHP 5 not supported\n");
+}
+*/
+
+/*INI
+newrelic.transaction_events.attributes.include=request.uri
+newrelic.distributed_tracing_enabled=1
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled=false
+newrelic.code_level_metrics.enabled=1
+*/
+
+/*HEADERS
+X-Request-Start=1368811467146000
+Content-Type=text/html
+Accept=text/plain
+User-Agent=Mozilla/5.0
+Referer=http://user:pass@example.com/foo?q=bar#fragment
+*/
+
+/*ENVIRONMENT
+REQUEST_METHOD=POST
+CONTENT_LENGTH=348
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "WebTransaction/Uri__FILE__",
+      "I'M COVERED IN BEES!",
+      "NoticedError",
+      {
+        "stack_trace": [
+          " in newrelic_notice_error called at __FILE__ (??)"
+        ],
+        "agentAttributes": {
+          "response.headers.contentLength": 41,
+          "response.headers.contentType": "text/html",
+          "response.statusCode": 200,
+          "http.statusCode": 200,
+          "httpResponseCode": "200",
+          "request.uri": "__FILE__",
+          "code.lineno": 1,
+          "code.filepath": "__FILE__",
+          "code.function": "__FILE__",
+          "SERVER_NAME": "??",
+          "request.headers.userAgent": "Mozilla/5.0",
+          "request.headers.User-Agent": "Mozilla/5.0",
+          "request.method": "POST",
+          "request.headers.host": "127.0.0.1",
+          "request.headers.contentType": "text/html",
+          "request.headers.accept": "text/plain",
+          "request.headers.contentLength": 348,
+          "request.headers.referer": "http://example.com/foo"
+        },
+        "intrinsics": "??",
+        "request_uri": "__FILE__"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "NoticedError",
+        "error.message": "I'M COVERED IN BEES!",
+        "transactionName": "WebTransaction/Uri__FILE__",
+        "duration": "??",
+        "queueDuration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {
+        "response.headers.contentLength": 41,
+        "response.headers.contentType": "text/html",
+        "response.statusCode": 200,
+        "http.statusCode": 200,
+        "httpResponseCode": "200",
+        "request.uri": "__FILE__",
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__",
+        "SERVER_NAME": "??",
+        "request.method": "POST",
+        "request.headers.host": "127.0.0.1",
+        "request.headers.contentType": "text/html",
+        "request.headers.contentLength": 348,
+        "request.headers.accept": "text/plain",
+        "request.headers.userAgent": "Mozilla/5.0",
+        "request.headers.User-Agent": "Mozilla/5.0",
+        "request.headers.referer": "http://example.com/foo"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+ [
+  "?? agent run id",
+  "?? sampling information",
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "WebTransaction/Uri__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "nr.apdexPerfZone": "F",
+        "queueDuration": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {
+      },
+      {
+        "errorType": "NoticedError",
+        "errorMessage": "I'M COVERED IN BEES!",
+        "response.headers.contentLength": 41,
+        "response.headers.contentType": "text/html",
+        "response.statusCode": 200,
+        "http.statusCode": 200,
+        "httpResponseCode": "200",
+        "request.uri": "__FILE__",
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__",
+        "request.method": "POST",
+        "request.headers.host": "127.0.0.1",
+        "request.headers.contentType": "text/html",
+        "request.headers.contentLength": 348,
+        "request.headers.accept": "text/plain"
+      }
+    ]
+  ]
+]
+ */
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "WebTransaction\/Uri__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "transaction.name": "WebTransaction\/Uri__FILE__",
+        "timestamp": "??"
+      },
+      {},
+      {
+        "error.class": "NoticedError",
+        "error.message": "I'M COVERED IN BEES!",
+        "response.headers.contentLength": 41,
+        "response.headers.contentType": "text/html",
+        "response.statusCode": 200,
+        "http.statusCode": 200,
+        "httpResponseCode": "200",
+        "request.uri": "__FILE__",
+        "code.lineno": 1,
+        "code.filepath": "__FILE__",
+        "code.function": "__FILE__",
+        "request.method": "POST",
+        "request.headers.host": "127.0.0.1",
+        "request.headers.contentType": "text/html",
+        "request.headers.contentLength": 348,
+        "request.headers.accept": "text/plain"
+      }
+    ]
+  ]
+]
+*/
+
+header('Content-Type: text/html');
+header('Content-Length: 41');
+newrelic_notice_error("I'M COVERED IN BEES!");


### PR DESCRIPTION
Add a name to a wraprec for a user function used as exception handler
so that the instrumentation of user's exception handler can be found
with get_wraprec_by_name and an error event can be recorded.

Use `NAME_EXCEPTION_HANDLER` macro to enable/disable
this fix to test things out.