### PR TITLE
refactor(agent): Wraprec refactoring to take advantage of lineno.

### DIFF
--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -912,7 +912,7 @@ extern uint32_t nr_php_zend_execute_data_lineno(
  *
  */
 static inline uint32_t nr_php_zend_function_lineno(const zend_function* func) {
-  if (NULL != func) {
+  if ((NULL != func) && (func->type == ZEND_USER_FUNCTION)) {
     return func->op_array.line_start;
   }
   return 0;

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -902,6 +902,22 @@ extern const char* nr_php_zend_execute_data_scope_name(
  */
 extern uint32_t nr_php_zend_execute_data_lineno(
     const zend_execute_data* execute_data);
+
+/*
+ * Purpose : Return a uint32_t (zend_uint) line number value of zend_function.
+ *
+ * Params  : 1. zend_function.
+ *
+ * Returns : uint32_t lineno value
+ *
+ */
+static inline uint32_t nr_php_zend_function_lineno(const zend_function* func) {
+  if (NULL != func) {
+    return func->op_array.line_start;
+  }
+  return 0;
+}
+
 #endif /* PHP 7+ */
 
 #endif /* PHP_AGENT_HDR */

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1035,7 +1035,6 @@ static void nr_php_execute_metadata_add_code_level_metrics(
 
 #undef CHK_CLM_STRLEN
 
-  // lineno = nr_php_zend_execute_data_lineno(execute_data);
   lineno = nr_php_zend_function_lineno(execute_data->func);
 
   /*

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -366,8 +366,12 @@ bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
 
   if (0 != p->lineno) {
     /*
-     * We have lineno/filename pair.  If this doesn't match, we can exit without
+     * Lineno is set in the wraprec.  If lineno doesn't match, we can exit without
      * going on to the funcname/classname pair comparison.
+     * If lineno matches, but the wraprec filename is NULL, it is inconclusive and we
+     * we must do the funcname/classname compare.
+     * If lineno matches, wraprec filename is not NULL, and it matches/doesn't match,
+     * we can exit without doing the funcname/classname compare.
      */
     if (p->lineno != nr_php_zend_function_lineno(func)) {
       return false;

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -405,27 +405,27 @@ bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
     klass = ZSTR_VAL(func->common.scope->name);
   }
 
-  if ((0 == nr_strcmp(p->reportedclass, klass))
-      || (0 == nr_stricmp(p->classname, klass))) {
-    /*
-     * If we get here it means lineno/filename weren't initially set.
-     * Set it now so we can do the optimized compare next time.
-     * lineno/filename is usually not set if the func wasn't loaded when we
-     * created the initial wraprec and we had to use the more difficult way to
-     * set, update it with lineno/filename now.
-     */
-    if (NULL == p->filename) {
-      filename = nr_php_function_filename(func);
-      if ((NULL != filename) && (0 != nr_strcmp("-", filename))) {
-        p->filename = nr_strdup(filename);
-      }
-    }
-    if (0 == p->lineno) {
-      p->lineno = nr_php_zend_function_lineno(func);
-    }
-    return true;
+  if ((0 != nr_strcmp(p->reportedclass, klass))
+      && (0 != nr_stricmp(p->classname, klass))) {
+        return false;
   }
-  return false;
+  /*
+   * If we get here it means lineno/filename weren't initially set.
+   * Set it now so we can do the optimized compare next time.
+   * lineno/filename is usually not set if the func wasn't loaded when we
+   * created the initial wraprec and we had to use the more difficult way to
+   * set, update it with lineno/filename now.
+   */
+  if (NULL == p->filename) {
+    filename = nr_php_function_filename(func);
+    if ((NULL != filename) && (0 != nr_strcmp("-", filename))) {
+      p->filename = nr_strdup(filename);
+    }
+  }
+  if (0 == p->lineno) {
+    p->lineno = nr_php_zend_function_lineno(func);
+  }
+  return true;
 #endif
 }
 

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -375,23 +375,22 @@ bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
      */
     if (p->lineno != nr_php_zend_function_lineno(func)) {
       return false;
-    } else {
-      /*
-       * lineno matched, let's check the filename
-       */
-      filename = nr_php_function_filename(func);
+    } 
+    /*
+     * lineno matched, let's check the filename
+     */
+    filename = nr_php_function_filename(func);
 
-      /*
-       * If p->filename isn't NULL, we know the comparison is accurate;
-       * otherwise, it's inconclusive even if we have a lineno because it
-       * could be a cli call or evaluated expression that has no filename.
-       */
-      if (NULL != p->filename) {
-        if (0 == nr_strcmp(p->filename, filename)) {
-          return true;
-        }
-        return false;
+    /*
+     * If p->filename isn't NULL, we know the comparison is accurate;
+     * otherwise, it's inconclusive even if we have a lineno because it
+     * could be a cli call or evaluated expression that has no filename.
+     */
+    if (NULL != p->filename) {
+      if (0 == nr_strcmp(p->filename, filename)) {
+        return true;
       }
+      return false;
     }
   }
 

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -58,9 +58,7 @@ int nr_zend_call_orig_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
     NR_PHP_PROCESS_GLOBALS(orig_execute)
     (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
   }
-  zend_catch {
-    zcaught = 1;
-  }
+  zend_catch { zcaught = 1; }
   zend_end_try();
   return zcaught;
 }
@@ -77,9 +75,7 @@ int nr_zend_call_oapi_special_before(nruserfn_t* wraprec,
                                               NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
     }
   }
-  zend_catch {
-    zcaught = 1;
-  }
+  zend_catch { zcaught = 1; }
   zend_end_try();
   return zcaught;
 }
@@ -98,9 +94,7 @@ int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
       (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
     }
   }
-  zend_catch {
-    zcaught = 1;
-  }
+  zend_catch { zcaught = 1; }
   zend_end_try();
   return zcaught;
 }
@@ -161,6 +155,22 @@ static void nr_php_wrap_zend_function(zend_function* func,
                                       nruserfn_t* wraprec TSRMLS_DC) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP8+ */
+
+  const char* filename = nr_php_function_filename(func);
+  /*
+   * Before setting a filename, ensure it is not NULL and it doesn't equal the
+   * "special" designation given to funcs without filenames. If the function is
+   * an evaluated expression or called directly from the CLI there is no
+   * filename, but the function says the filename is "-". Avoid setting in this
+   * case; otherwise, all the evaluated/cli calls would match.
+   */
+  if ((NULL == wraprec->filename) && (NULL != filename)
+      && (0 != nr_strcmp("-", filename))) {
+    wraprec->filename = nr_strdup(filename);
+  }
+
+  wraprec->lineno = nr_php_zend_function_lineno(func);
+
   if (chk_reported_class(func, wraprec)) {
     wraprec->reportedclass = nr_strdup(ZSTR_VAL(func->common.scope->name));
   }
@@ -270,6 +280,9 @@ static nruserfn_t* nr_php_user_wraprec_create_named(const char* full_name,
     wraprec->is_method = 1;
   }
 
+  wraprec->lineno = 0;
+  wraprec->filename = NULL;
+
   wraprec->supportability_metric = nr_txn_create_fn_supportability_metric(
       wraprec->funcname, wraprec->classname);
 
@@ -295,6 +308,7 @@ static void nr_php_user_wraprec_destroy(nruserfn_t** wraprec_ptr) {
   nr_free(wraprec->classnameLC);
   nr_free(wraprec->funcnameLC);
   nr_free(wraprec->reportedclass);
+  nr_free(wraprec->filename);
   nr_realfree((void**)wraprec_ptr);
 }
 
@@ -331,6 +345,12 @@ bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
   return false;
 #else
   char* klass = NULL;
+  const char* filename = NULL;
+
+  /*
+   * We are able to match either by lineno/filename pair or funcname/classname
+   * pair.
+   */
 
   /*
    * Optimize out string manipulations; don't do them if you don't have to.
@@ -343,6 +363,34 @@ bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
   if ((NULL == func) || (ZEND_USER_FUNCTION != func->type)) {
     return false;
   }
+
+  if (0 != p->lineno) {
+    /*
+     * We have lineno/filename pair.  If this doesn't match, we can exit without
+     * going on to the funcname/classname pair comparison.
+     */
+    if (p->lineno != nr_php_zend_function_lineno(func)) {
+      return false;
+    } else {
+      /*
+       * lineno matched, let's check the filename
+       */
+      filename = nr_php_function_filename(func);
+
+      /*
+       * If p->filename isn't NULL, we know the comparison is accurate;
+       * otherwise, it's inconclusive even if we have a lineno because it
+       * could be a cli call or evaluated expression that has no filename.
+       */
+      if (NULL != p->filename) {
+        if (0 == nr_strcmp(p->filename, filename)) {
+          return true;
+        }
+        return false;
+      }
+    }
+  }
+
   if (NULL == func->common.function_name) {
     return false;
   }
@@ -353,15 +401,32 @@ bool nr_php_wraprec_matches(nruserfn_t* p, zend_function* func) {
   if (NULL != func->common.scope && NULL != func->common.scope->name) {
     klass = ZSTR_VAL(func->common.scope->name);
   }
+
   if ((0 == nr_strcmp(p->reportedclass, klass))
       || (0 == nr_stricmp(p->classname, klass))) {
+    /*
+     * If we get here it means lineno/filename weren't initially set.
+     * Set it now so we can do the optimized compare next time.
+     * lineno/filename is usually not set if the func wasn't loaded when we
+     * created the initial wraprec and we had to use the more difficult way to
+     * set, update it with lineno/filename now.
+     */
+    if (NULL == p->filename) {
+      filename = nr_php_function_filename(func);
+      if ((NULL != filename) && (0 != nr_strcmp("-", filename))) {
+        p->filename = nr_strdup(filename);
+      }
+    }
+    if (0 == p->lineno) {
+      p->lineno = nr_php_zend_function_lineno(func);
+    }
     return true;
   }
   return false;
 #endif
 }
 
-nruserfn_t* nr_php_get_wraprec_by_name(zend_function* func) {
+nruserfn_t* nr_php_get_wraprec_by_func(zend_function* func) {
 #if ZEND_MODULE_API_NO < ZEND_7_0_X_API_NO
   /*
    * Not compatible with PHP less than 7.
@@ -411,7 +476,7 @@ nruserfn_t* nr_php_add_custom_tracer_callable(zend_function* func TSRMLS_DC) {
     || defined OVERWRITE_ZEND_EXECUTE_DATA
   wraprec = nr_php_op_array_get_wraprec(&func->op_array TSRMLS_CC);
 #else
-  wraprec = nr_php_get_wraprec_by_name(func);
+  wraprec = nr_php_get_wraprec_by_func(func);
 #endif
 
   if (wraprec) {
@@ -564,7 +629,7 @@ void nr_php_remove_exception_function(zend_function* func TSRMLS_DC) {
     || defined OVERWRITE_ZEND_EXECUTE_DATA
   wraprec = nr_php_op_array_get_wraprec(&func->op_array TSRMLS_CC);
 #else
-  wraprec = nr_php_get_wraprec_by_name(func);
+  wraprec = nr_php_get_wraprec_by_func(func);
 #endif
   if (wraprec) {
     wraprec->is_exception_handler = 0;

--- a/agent/tests/test_agent.c
+++ b/agent/tests/test_agent.c
@@ -694,6 +694,30 @@ static void test_nr_php_zend_execute_data_lineno() {
       nr_php_zend_execute_data_lineno(&execute_data TSRMLS_CC));
 }
 
+static void test_nr_php_zend_function_lineno() {
+  zend_function func = {0};
+
+  /*
+   * Test : Invalid arguments, NULL zend_execute_data
+   */
+  tlib_pass_if_uint32_t_equal("NULL zend_execute_data should return 0", 0,
+                              nr_php_zend_function_lineno(NULL));
+
+  /*
+   * Test : Invalid arguments.
+   */
+  tlib_pass_if_uint32_t_equal("uninitialized zend_function should return 0", 0,
+                              nr_php_zend_function_lineno(&func));
+
+  /*
+   * Test : Normal operation.
+   */
+
+  func.op_array.line_start = 4;
+  tlib_pass_if_uint32_t_equal("Unexpected lineno name", 4,
+                              nr_php_zend_function_lineno(&func));
+}
+
 #endif /* PHP 7+ */
 
 void test_main(void* p NRUNUSED) {
@@ -724,6 +748,7 @@ void test_main(void* p NRUNUSED) {
   test_nr_php_zend_execute_data_filename();
   test_nr_php_zend_execute_data_lineno();
   test_nr_php_zend_execute_data_scope_name();
+  test_nr_php_zend_function_lineno();
 #endif /* PHP 7+ */
 
   test_function_debug_name(TSRMLS_C);

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -52,7 +52,7 @@ static void test_op_array_wraprec(TSRMLS_D) {
   tlib_php_request_end();
 }
 
-static void test_get_wraprec_by_name() {
+static void test_get_wraprec_by_func() {
 #if ZEND_MODULE_API_NO < ZEND_7_3_X_API_NO
   return;
 #else
@@ -62,6 +62,7 @@ static void test_get_wraprec_by_name() {
   zend_class_entry ce = {0};
   nruserfn_t* wraprec = NULL;
   char* name_str = "my_func_name";
+  char* file_str = "my_file_name";
 
   tlib_php_request_start();
 
@@ -69,7 +70,7 @@ static void test_get_wraprec_by_name() {
    * NULL if there's no wraprecs in the internal list.
    */
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+                         nr_php_get_wraprec_by_func(&zend_func), NULL);
 
   wraprec = nr_php_add_custom_tracer_named(
       "ClassNoMatch::functionNoMatch",
@@ -82,13 +83,13 @@ static void test_get_wraprec_by_name() {
    * NULL if zend_function is NULL.
    */
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(NULL), NULL);
+                         nr_php_get_wraprec_by_func(NULL), NULL);
 
   /*
    * NULL if function name is NULL.
    */
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+                         nr_php_get_wraprec_by_func(&zend_func), NULL);
 
   /*
    * NULL if name is correct but type is wrong.
@@ -97,13 +98,13 @@ static void test_get_wraprec_by_name() {
   zend_func.common.function_name
       = zend_string_init(name_str, strlen(name_str), 0);
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+                         nr_php_get_wraprec_by_func(&zend_func), NULL);
   /*
    * Valid if function name matches and type is user function.
    */
   zend_func.type = ZEND_USER_FUNCTION;
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), wraprec);
+                         nr_php_get_wraprec_by_func(&zend_func), wraprec);
   /*
    * NULL if function name matches, but class name doesn't.
    */
@@ -111,7 +112,7 @@ static void test_get_wraprec_by_name() {
   ce.name = scope_name;
   zend_func.common.scope = &ce;
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+                         nr_php_get_wraprec_by_func(&zend_func), NULL);
   /*
    * NULL if function name doesn't match and class name matches.
    */
@@ -119,14 +120,14 @@ static void test_get_wraprec_by_name() {
   wraprec = nr_php_add_custom_tracer_named(
       "ClassName::my_func_name2", nr_strlen("ClassName::my_func_name2"));
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), NULL);
+                         nr_php_get_wraprec_by_func(&zend_func), NULL);
   /*
    * Valid if function name matches and class name matches.
    */
   wraprec = nr_php_add_custom_tracer_named(
       "ClassName::my_func_name", nr_strlen("ClassName::my_func_name"));
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), wraprec);
+                         nr_php_get_wraprec_by_func(&zend_func), wraprec);
 
 #if ZEND_MODULE_API_NO >= ZEND_7_3_X_API_NO
   /*
@@ -138,7 +139,7 @@ static void test_get_wraprec_by_name() {
    * Not NULL because we don't care about the reserved array anymore.
    */
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), wraprec);
+                         nr_php_get_wraprec_by_func(&zend_func), wraprec);
   /*
    * Restore the cached pid and invalidate the mangled pid/index value.
    */
@@ -154,11 +155,62 @@ static void test_get_wraprec_by_name() {
    * Not NULL because we don't care about the reserved array anymore.
    */
   tlib_pass_if_ptr_equal("obtain instrumented function",
-                         nr_php_get_wraprec_by_name(&zend_func), wraprec);
+                         nr_php_get_wraprec_by_func(&zend_func), wraprec);
 
 #endif /* PHP >= 7.3 */
+  /*
+   * Valid if lineno/filename match.
+   */
+
+  /*
+   * Because no lineno/filename are set yet, this wraprec matches using
+   * funcname/classname.
+   */
+  wraprec = nr_php_get_wraprec_by_func(&zend_func);
+  /*
+   * Let's add filename/lineno to func.  Because it doesn't exist in wraprec, it
+   * should match with funcname/classname, but should then ADD the
+   * filename/lineno to the wraprec.
+   */
+  zend_func.op_array.filename = zend_string_init(file_str, strlen(file_str), 0);
+  zend_func.op_array.line_start = 4;
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_func(&zend_func), wraprec);
+  tlib_pass_if_ptr_equal(
+      "obtain instrumented function filename added after wraprec is created",
+      nr_php_get_wraprec_by_func(&zend_func), wraprec);
+  tlib_pass_if_int_equal(
+      "obtain instrumented function lineno added after wraprec is created", 4,
+      wraprec->lineno);
+  /*
+   * Now if we remove funcname and klassname, should still match by
+   * lineno/filename that was added in previous test.
+   */
+
   zend_string_release(zend_func.common.function_name);
+  zend_func.common.function_name = NULL;
   zend_string_release(zend_func.common.scope->name);
+  zend_func.common.scope->name = NULL;
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_func(&zend_func), wraprec);
+
+  /*
+   * NULL if filename matches but lineno doesn't.
+   */
+  zend_func.op_array.line_start = 41;
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_func(&zend_func), NULL);
+
+  /*
+   * NULL if lineno matches but filename doesn't.
+   */
+  zend_func.op_array.line_start = 4;
+  zend_string_release(zend_func.op_array.filename);
+  zend_func.op_array.filename = NULL;
+
+  tlib_pass_if_ptr_equal("obtain instrumented function",
+                         nr_php_get_wraprec_by_func(&zend_func), NULL);
+
   tlib_php_request_end();
 #endif
 }
@@ -170,7 +222,7 @@ void test_main(void* p NRUNUSED) {
 
   tlib_php_engine_create("" PTSRMLS_CC);
   test_op_array_wraprec(TSRMLS_C);
-  test_get_wraprec_by_name();
+  test_get_wraprec_by_func();
 
   tlib_php_engine_destroy(TSRMLS_C);
 }

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -185,19 +185,15 @@ typedef struct _nr_segment_t {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
 
-/*
- * Because of the access to the segment is now split between functions, we
- * need to pass a certain amount of data between the functions that use the
- * segment.
- */
+  /*
+   * Because of the access to the segment is now split between functions, we
+   * need to pass a certain amount of data between the functions that use the
+   * segment.
+   */
   nrtime_t txn_start_time; /* To doublecheck the txn is correct when it is time
                               to add the segment to the txn. */
-  void* wraprec;           /* wraprec, if one is associated with this segment */
-  uint32_t
-      lineno; /* Keep lineno information.  When a function begins, the
-                 zend_execute_data lineno shows the ENTRY point of the function,
-                 when a function ends, the zend_execute_data lineno CHANGES and
-                 shows the EXIT point of the function.  */
+  void* wraprec; /* wraprec, if one is associated with this segment, to reduce
+                    wraprec lookups */
 
 #endif
 

--- a/tests/integration/attributes/test_transaction_namespace2_clm.php
+++ b/tests/integration/attributes/test_transaction_namespace2_clm.php
@@ -102,7 +102,7 @@ newrelic.code_level_metrics.enabled=true
       },
       {},
       {
-        "code.lineno": 133,
+        "code.lineno": 131,
         "code.namespace": "Foo\\Bar\\Vegetable",
         "code.filepath": "__FILE__",
         "code.function": "getColor"

--- a/tests/integration/attributes/test_transaction_namespace_clm.php
+++ b/tests/integration/attributes/test_transaction_namespace_clm.php
@@ -102,7 +102,7 @@ newrelic.code_level_metrics.enabled=true
       },
       {},
       {
-        "code.lineno": 134,
+        "code.lineno": 132,
         "code.namespace": "Vegetable",
         "code.filepath": "__FILE__",
         "code.function": "getColor"

--- a/tests/integration/attributes/test_transaction_nested_user_functions_clm.php
+++ b/tests/integration/attributes/test_transaction_nested_user_functions_clm.php
@@ -68,7 +68,7 @@ newrelic.code_level_metrics.enabled = 1
       },
       {},
       {
-        "code.lineno": 228,
+        "code.lineno": 227,
         "code.filepath": "__FILE__",
         "code.function": "level_2"
       }
@@ -89,7 +89,7 @@ newrelic.code_level_metrics.enabled = 1
       },
       {},
       {
-        "code.lineno": 224,
+        "code.lineno": 223,
         "code.filepath": "__FILE__",
         "code.function": "level_1"
       }
@@ -154,7 +154,7 @@ newrelic.code_level_metrics.enabled = 1
                   [
                     "?? start time", "?? end time", "`1",
                             {
-                              "code.lineno": 228,
+                              "code.lineno": 227,
                               "code.filepath": "__FILE__",
                               "code.function": "level_2"
                             },
@@ -162,7 +162,7 @@ newrelic.code_level_metrics.enabled = 1
                       [
                         "?? start time", "?? end time", "`2",
                             {
-                              "code.lineno": 224,
+                              "code.lineno": 223,
                               "code.filepath": "__FILE__",
                               "code.function": "level_1"
                         },


### PR DESCRIPTION
1) Added nr_php_zend_function_lineno(zend_function func); 
2) removed lineno from segment (not needed anymore since nr_php_zend_function_lineno(execute_data->func); gives the same lineno whether entering or exiting function 
3) added filename, lineno to wraprec
4) updated/added test cases
5) renamed get_wraprec_by_name to get_wraprec_by_func 6) updated  nr_php_wraprec_matches
 To first check for lineno/filename match.  If lineno/filename are not set (this happens when we are wrapping before all funcs are loaded), defaults to original check, but adds lineno/filename as soon as they are known so we can pop back into the optimized comparison.