### PR TITLE
feat(agent): detect more logging frameworks

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -572,6 +572,14 @@ static size_t num_libraries = sizeof(libraries) / sizeof(nr_library_table_t);
 static nr_library_table_t logging_frameworks[] = {
     /* Monolog - Logging for PHP */
     {"Monolog", "monolog/logger.php", nr_monolog_enable},
+    /* Consolidation/Log - Logging for PHP */
+    {"Consolidation/Log", "consolidation/log/src/logger.php", NULL},
+    /* laminas-log - Logging for PHP */
+    {"laminas-log", "laminas-log/src/logger.php", NULL},
+    /* cakephp-log - Logging for PHP */
+    {"cakephp-log", "cakephp/log/log.php", NULL},
+    /* Analog - Logging for PHP */
+    {"Analog", "analog/analog.php", NULL},
 };
 
 static size_t num_logging_frameworks

--- a/tests/integration/logging/analog/test_supportability_metric.php
+++ b/tests/integration/logging/analog/test_supportability_metric.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Supportability metrics: library/Analog/detected and 
+Logging/PHP/Analog/disabled metrics are created when analog 
+library is detected.
+This test is a mock composer project that uses a logging library as if it
+were installed by composer. The library itself is a mock.
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Analog/disabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Analog/detected"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/vendor/analog/analog/lib/Analog/Analog.php');

--- a/tests/integration/logging/analog/vendor/analog/analog/lib/Analog/Analog.php
+++ b/tests/integration/logging/analog/vendor/analog/analog/lib/Analog/Analog.php
@@ -1,0 +1,3 @@
+<?php
+
+/* This is a mock of Analog library as it would have been installed by a composer */

--- a/tests/integration/logging/cakephp-log/test_supportability_metric.php
+++ b/tests/integration/logging/cakephp-log/test_supportability_metric.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Supportability metrics: library/cakephp-log/detected and 
+Logging/PHP/cakephp-log/disabled metrics are created when cakephp-log 
+library is detected.
+This test is a mock composer project that uses a logging library as if it
+were installed by composer. The library itself is a mock.
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/cakephp-log/disabled"},                 [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/cakephp-log/detected"},                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/vendor/cakephp/log/Log.php');

--- a/tests/integration/logging/cakephp-log/vendor/cakephp/log/Log.php
+++ b/tests/integration/logging/cakephp-log/vendor/cakephp/log/Log.php
@@ -1,0 +1,3 @@
+<?php
+
+/* This is a mock of cakephp-log library as it would have been installed by a composer */

--- a/tests/integration/logging/consolidation-log/test_supportability_metric.php
+++ b/tests/integration/logging/consolidation-log/test_supportability_metric.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Supportability metrics: library/Consolidation/Log/detected and 
+Logging/PHP/Consolidation/Log/disabled metrics are created when consolidation-log 
+library is detected.
+This test is a mock composer project that uses a logging library as if it
+were installed by composer. The library itself is a mock.
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Consolidation/Log/disabled"},           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Consolidation/Log/detected"},               [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/vendor/consolidation/log/src/Logger.php');

--- a/tests/integration/logging/consolidation-log/vendor/consolidation/log/src/Logger.php
+++ b/tests/integration/logging/consolidation-log/vendor/consolidation/log/src/Logger.php
@@ -1,0 +1,3 @@
+<?php
+
+/* This is a mock of consolidation-log library as it would have been installed by a composer */

--- a/tests/integration/logging/laminas-log/test_supportability_metric.php
+++ b/tests/integration/logging/laminas-log/test_supportability_metric.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Supportability metrics: library/laminas-log/detected and 
+Logging/PHP/laminas-log/disabled metrics are created when laminas-log 
+library is detected.
+This test is a mock composer project that uses a logging library as if it
+were installed by composer. The library itself is a mock.
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/laminas-log/disabled"},                 [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/laminas-log/detected"},                     [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/vendor/laminas/laminas-log/src/Logger.php');

--- a/tests/integration/logging/laminas-log/vendor/laminas/laminas-log/src/Logger.php
+++ b/tests/integration/logging/laminas-log/vendor/laminas/laminas-log/src/Logger.php
@@ -1,0 +1,3 @@
+<?php
+
+/* This is a mock of laminas-log library as it would have been installed by a composer */


### PR DESCRIPTION
Send `Supportability/Logging/PHP/{framework}/disabled` metric for a few more logging frameworks:

* [Consolidation\Log](https://packagist.org/packages/consolidation/log)
* [laminas-log](https://packagist.org/packages/laminas/laminas-log)
* [CakePHP Logging Library](https://packagist.org/packages/cakephp/log)
* [Analog](https://packagist.org/packages/analog/analog)

The frameworks were selected based on number of downloads on https://packagist.org/. All frameworks exceed 1M downloads.