### PR TITLE
test: set LogEventConfig in integration_runner

### DIFF
--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -139,6 +139,11 @@ var (
 		// Ensure that we get Javascript agent code in the reply
 		map[string]interface{}{"newrelic.browser_monitoring.debug": false, "newrelic.browser_monitoring.loader": "rum"},
 		SecurityPolicyToken: "",
+		AgentEventLimits: collector.EventConfigs{
+			LogEventConfig: collector.Event{
+				Limit: 10000,
+			},
+		},
 	}
 
 	// Integration tests have this mock cross process id hard coded into


### PR DESCRIPTION
Hardcode 10000 as the integration_runner's daemon default log event harvest limit that is to be used when connecting to collector.

integration_runner does not use agent settings from integration tests for values in pre-connect/connect payload. It is using pre-cooked app info structure, and any uninitialized fields in that structure, like AgentEventLimits.LogEventConfig.Limit, which is sent in connect payload as the value for event_harvest_config.harvest_limits.log_event_data, gets the default value of 0. Collector accepts and honors this value, which results in integration_runner's daemon and agent to be configured not to collect any log events. This breaks logging integration tests.