### PR TITLE
feat(agent): OAPI exception handling

### DIFF
--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -39,6 +39,7 @@
 #include "php_compat.h"
 #include "php_newrelic.h"
 #include "php_zval.h"
+#include "util_logging.h"
 #include "util_memory.h"
 #include "util_strings.h"
 #include "php_execute.h"
@@ -766,6 +767,42 @@ nr_php_ini_entry_name_length(const zend_ini_entry* entry) {
 #endif /* PHP8+ */
 
 /*
+ * Purpose : Ensure all dangling segments caused by an OAPI exception are closed
+ * before having an API act on the calling segment.
+ *
+ * Params  :
+ *
+ * Returns :
+ */
+static inline void nr_php_api_ensure_current_segment() {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  /*
+   * Before we call an API that depends on current segment, we need to ensure
+   * there isn't an outstanding uncaught exception that needs to be applied to
+   * dangling segments. If so, we need to apply the exception and close the
+   * stacked segments until we get to the segment that called the API.  To do
+   * this, we detect the execute_data that called the API which is guaranteed to
+   * be what the current segment should be (otherwise, fcall_end would have
+   * closed normal segments and we would have taken care of any dangling
+   * segments already) and any segments stacked above it need to be closed due
+   * to an exception.
+   */
+
+  /*
+   * Get the function that called the API.  prev_execute_data
+   * should never be null, but doublecheck for it anyway.
+   */
+  if (NULL != EG(current_execute_data)->prev_execute_data) {
+    zval* exception_this = &EG(current_execute_data)->prev_execute_data->This;
+
+    nr_php_observer_handle_uncaught_exception(exception_this);
+  }
+
+#endif
+}
+
+/*
  * Purpose : Wrap the native PHP json_decode function for those times when we
  *           need a more robust JSON decoder than nro_create_from_json.
  *
@@ -847,7 +884,6 @@ extern zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC);
 extern void nr_php_txn_add_code_level_metrics(
     nr_attributes_t* attributes,
     const nr_php_execute_metadata_t* metadata);
-
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
 
 #define NR_ZEND_USER_FUNC_EXISTS(x) \
@@ -902,6 +938,22 @@ extern const char* nr_php_zend_execute_data_scope_name(
  */
 extern uint32_t nr_php_zend_execute_data_lineno(
     const zend_execute_data* execute_data);
+
+/*
+ * Purpose : Return a uint32_t (zend_uint) line number value of zend_function.
+ *
+ * Params  : 1. zend_function.
+ *
+ * Returns : uint32_t lineno value
+ *
+ */
+static inline uint32_t nr_php_zend_function_lineno(const zend_function* func) {
+  if (NULL != func) {
+    return func->op_array.line_start;
+  }
+  return 0;
+}
+
 #endif /* PHP 7+ */
 
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -956,23 +956,4 @@ static inline uint32_t nr_php_zend_function_lineno(const zend_function* func) {
 
 #endif /* PHP 7+ */
 
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP7+ */
-
-/*
- * Purpose : Return a uint32_t (zend_uint) line number value of zend_function.
- *
- * Params  : 1. zend_function.
- *
- * Returns : uint32_t lineno value
- *
- */
-static inline uint32_t nr_php_zend_function_lineno(const zend_function* func) {
-  if (NULL != func) {
-    return func->op_array.line_start;
-  }
-  return 0;
-}
-
-#endif /* PHP 7+ */
-
 #endif /* PHP_AGENT_HDR */

--- a/agent/php_api.c
+++ b/agent/php_api.c
@@ -97,6 +97,8 @@ PHP_FUNCTION(newrelic_notice_error) {
     priority = nr_php_error_get_priority(E_ERROR);
   }
 
+  nr_php_api_ensure_current_segment();
+
   if (NR_SUCCESS != nr_txn_record_error_worthy(NRPRG(txn), priority)) {
     nrl_debug(NRL_API,
               "newrelic_notice_error: a higher severity error has already been "
@@ -303,6 +305,8 @@ PHP_FUNCTION(newrelic_end_transaction) {
       RETURN_FALSE;
     }
   }
+
+  nr_php_api_ensure_current_segment();
 
   ret = nr_php_txn_end((0 != ignore), 0 TSRMLS_CC);
   if (NR_SUCCESS == ret) {
@@ -740,6 +744,7 @@ PHP_FUNCTION(newrelic_add_custom_parameter) {
   obj = nr_php_api_zval_to_attribute_obj(zzvalue TSRMLS_CC);
 
   if (obj) {
+    nr_php_api_ensure_current_segment();
     rv = nr_txn_add_user_custom_parameter(NRPRG(txn), key, obj);
   }
 
@@ -1233,6 +1238,7 @@ PHP_FUNCTION(newrelic_set_user_attributes) {
     RETURN_FALSE;
   }
 
+  nr_php_api_ensure_current_segment();
   rv = nr_php_api_add_custom_parameter_string(NRPRG(txn), "user", userstr,
                                               userlen);
   if (NR_FAILURE == rv) {
@@ -1260,6 +1266,7 @@ static nr_status_t nr_php_api_add_custom_span_attribute(const char* keystr,
   char* key = NULL;
   nr_segment_t* current;
 
+  nr_php_api_ensure_current_segment();
   current = nr_txn_get_current_segment(NRPRG(txn), NULL);
   if (!current) {
     return NR_FAILURE;
@@ -1523,6 +1530,7 @@ PHP_FUNCTION(newrelic_get_linking_metadata) {
   }
 
   if (nrlikely(NRPRG(txn))) {
+    nr_php_api_ensure_current_segment();
     trace_id = nr_txn_get_current_trace_id(NRPRG(txn));
     span_id = nr_txn_get_current_span_id(NRPRG(txn));
 
@@ -1565,6 +1573,7 @@ PHP_FUNCTION(newrelic_get_trace_metadata) {
   }
 
   if (nrlikely(NRPRG(txn))) {
+    nr_php_api_ensure_current_segment();
     trace_id = nr_txn_get_current_trace_id(NRPRG(txn));
     if (trace_id) {
       nr_php_add_assoc_string(return_value, "trace_id", trace_id);

--- a/agent/php_api_internal.c
+++ b/agent/php_api_internal.c
@@ -49,7 +49,7 @@ PHP_FUNCTION(newrelic_get_request_metadata) {
   }
 
   array_init(return_value);
-
+  nr_php_api_ensure_current_segment();
   outbound_headers = nr_header_outbound_request_create(
       NRPRG(txn), nr_txn_get_current_segment(NRPRG(txn), NULL));
 

--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -53,7 +53,8 @@ zval* nr_php_call_user_func(zval* object_ptr,
   /*
    * With PHP8, `call_user_function_ex` was removed and `call_user_function`
    * became the recommended function.  This does't return a FAILURE for
-   * exceptions and needs to be in a try/catch block.
+   * exceptions and needs to be in a try/catch block in order to clean up
+   * properly.
    */
   zend_try {
     zend_result = call_user_function(EG(function_table), object_ptr, fname,

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1704,8 +1704,12 @@ void nr_php_observer_segment_end(zval* exception) {
   }
   segment = NRTXN(force_current_segment);
   if (NULL != segment) {
+    bool create_metric = false;
     wraprec = (nruserfn_t*)(segment->wraprec);
-    bool create_metric = (wraprec ? wraprec->create_metric : false);
+    if (NULL != wraprec) {
+      create_metric = wraprec->create_metric;
+      nr_zend_call_oapi_special_clean(wraprec, segment, NULL, NULL);
+    }
     nr_php_execute_segment_end(segment, segment->metadata, create_metric);
   }
   return;

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -731,7 +731,9 @@ void nr_php_late_initialization(void) {
    * forward the errors, so if a user has Xdebug loaded, we do not install
    * our own error callback handler. Otherwise, we do.
    */
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO /* < PHP8 */
+
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA /* < PHP8 */
   if (0 == zend_get_extension("Xdebug")) {
     NR_PHP_PROCESS_GLOBALS(orig_error_cb) = zend_error_cb;
     zend_error_cb = nr_php_error_cb;
@@ -740,7 +742,7 @@ void nr_php_late_initialization(void) {
                 "the Xdebug extension prevents the New Relic agent from "
                 "gathering errors. No errors will be recorded.");
   }
-#endif /* end of < PHP8 */
+#endif /* end of < PHP8 or not using OAPI*/
 
   /*
    * Install our signal handler, unless the user has set a special flag

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -436,6 +436,16 @@ nrphpcufafn_t
     cufa_callback; /* The current call_user_func_array callback, if any */
 
 /*
+ * The exception happens whether the exception was caught or not.  Keep track of
+ * the execute_data frame to determine if it was uncaught and so we can compare
+ * to determine if we need to propagate the exception or not. */
+zval* uncaught_exception; /* The last exception that occurred. Does need to be
+                             freed. */
+zval* uncaught_exeption_execute_data_this; /* Keep track of the execute data
+                                              that the last exception occurred
+                                              on. Does not need to be freed. */
+
+/*
  * We instrument database connection constructors and store the instance
  * information in a hash keyed by a string containing the connection resource
  * id.

--- a/agent/php_observer.h
+++ b/agent/php_observer.h
@@ -75,6 +75,32 @@ void nr_php_observer_fcall_begin(zend_execute_data* execute_data);
 void nr_php_observer_fcall_end(zend_execute_data* execute_data,
                                zval* func_return_value);
 
+/*
+ * Purpose : Overwrite the php exception hook.
+ *
+ * Params  : zend_object* exception : The exception to monitor.
+ */
+void nr_throw_exception_hook(zend_object* exception);
+
+/*
+ * Purpose : Monitor the exception to take care of dangling segments, if needed.
+ *
+ * Params  : 1) zval* exception : The exception to monitor.
+ * 	     2) zval* execute_data_this: The pointer to the unique execute data
+ * that the exception was thrown from.
+ */
+void php_observer_handle_exception_hook(zval* exception_zval,
+                                        zval* execute_data_this);
+
+/*
+ * Purpose : End a stacked segment.  If an exception is provided, add it before
+ * exiting.
+ *
+ * Params  : zval* exception : The exception to add to the segment.  If NULL, no
+ * exception is recorded on the segment.
+ */
+extern void nr_php_observer_segment_end(zval* exception);
+
 #endif /* PHP8+ */
 
 #endif  // NEWRELIC_PHP_AGENT_PHP_OBSERVER_H

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -40,6 +40,7 @@ PHP_RINIT_FUNCTION(newrelic) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
   NRPRG(drupal_http_request_segment) = NULL;
+  NRPRG(drupal_http_request_depth) = 0;
 #endif
 
   if ((0 == NR_PHP_PROCESS_GLOBALS(enabled)) || (0 == NRINI(enabled))) {

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -122,6 +122,8 @@ int nr_php_post_deactivate(void) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
   NRPRG(drupal_http_request_segment) = NULL;
+  NRPRG(drupal_http_request_depth) = 0;
+
 #endif
 
   nrl_verbosedebug(NRL_INIT, "post-deactivate processing done");

--- a/agent/php_stacked_segment.c
+++ b/agent/php_stacked_segment.c
@@ -2,10 +2,11 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "php_error.h"
-#include "php_execute.h"
+
 #include "php_stacked_segment.h"
 #include "util_logging.h"
+#include "php_execute.h"
+#include "php_error.h"
 
 /*
  * Purpose : Add a stacked segment to the stacked segment stack. The top
@@ -85,14 +86,14 @@ void nr_php_stacked_segment_unwind(TSRMLS_D) {
      * their naming contexts.
      */
     nr_php_observer_segment_end(NRPRG(uncaught_exception));
-  }
+
 #else
     stacked = NRTXN(force_current_segment);
     segment = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
     nr_segment_end(&segment);
-  }
-#endif
 
+#endif
+  }
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
   /*

--- a/agent/php_stacked_segment.c
+++ b/agent/php_stacked_segment.c
@@ -2,8 +2,10 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
+#include "php_error.h"
+#include "php_execute.h"
 #include "php_stacked_segment.h"
+#include "util_logging.h"
 
 /*
  * Purpose : Add a stacked segment to the stacked segment stack. The top
@@ -32,6 +34,12 @@ nr_segment_t* nr_php_stacked_segment_init(nr_segment_t* stacked TSRMLS_DC) {
     return NULL;
   }
 
+  stacked->metadata = nr_calloc(1, sizeof(nr_php_execute_metadata_t));
+  if (NULL == stacked->metadata) {
+    nr_free(stacked);
+    return NULL;
+  }
+
 #endif
 
   stacked->txn = NRPRG(txn);
@@ -57,23 +65,49 @@ void nr_php_stacked_segment_deinit(nr_segment_t* stacked TSRMLS_DC) {
   /*
    * This is allocated differently for OAPI and hence needs to be freed.
    */
+  nr_php_execute_metadata_release(stacked->metadata);
+  nr_free(stacked->metadata);
   nr_free(stacked);
 #endif
 }
 
 void nr_php_stacked_segment_unwind(TSRMLS_D) {
-  nr_segment_t* stacked;
-  nr_segment_t* segment;
-
   if (NULL == NRPRG(txn)) {
     return;
   }
+
   while (NRTXN(force_current_segment)
          && (NRTXN(segment_root) != NRTXN(force_current_segment))) {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+    /*
+     * With OAPI, we need to gracefully close off the stacked segments with
+     * their naming contexts.
+     */
+    nr_php_observer_segment_end(NRPRG(uncaught_exception));
+  }
+#else
     stacked = NRTXN(force_current_segment);
     segment = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
     nr_segment_end(&segment);
   }
+#endif
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  /*
+   * If OAPI we need to record the uncaught exception (if it exists) on the root
+   * segment as well.
+   */
+  if (NULL != NRPRG(uncaught_exception)) {
+    if (NRTXN(segment_root) == NRTXN(force_current_segment)) {
+      nr_php_error_record_exception_segment(
+          NRPRG(txn), NRPRG(uncaught_exception),
+          &NRPRG(exception_filters) TSRMLS_CC);
+    }
+  }
+  php_observer_clear_uncaught_exception_globals();
+#endif
 }
 
 nr_segment_t* nr_php_stacked_segment_move_to_heap(
@@ -105,6 +139,8 @@ nr_segment_t* nr_php_stacked_segment_move_to_heap(
   /*
    * This is allocated differently for OAPI and hence needs to be freed.
    */
+  nr_php_execute_metadata_release(stacked->metadata);
+  nr_free(stacked->metadata);
   nr_free(stacked);
 #endif
 

--- a/agent/php_stacked_segment.c
+++ b/agent/php_stacked_segment.c
@@ -88,8 +88,9 @@ void nr_php_stacked_segment_unwind(TSRMLS_D) {
     nr_php_observer_segment_end(NRPRG(uncaught_exception));
 
 #else
-    stacked = NRTXN(force_current_segment);
-    segment = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
+    nr_segment_t* stacked = NRTXN(force_current_segment);
+    nr_segment_t* segment
+        = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
     nr_segment_end(&segment);
 
 #endif

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1169,15 +1169,13 @@ extern void nr_php_txn_add_code_level_metrics(
     function = filepath;
   }
 
-#define CHK_CLM_EMPTY(s) (nr_strempty(s)) ? true : false)
-
-  if (CHK_CLM_EMPTY(function)) {
+  if (nr_strempty(function)) {
     /*
      * Name isn't set so don't do anything
      */
     return;
   }
-  if (CHK_CLM_EMPTY(namespace) && CHK_CLM_EMPTY(filepath)) {
+  if (nr_strempty(namespace) && nr_strempty(filepath)) {
     /*
      * CLM MUST have either function+namespace or function+filepath.
      */
@@ -1187,16 +1185,14 @@ extern void nr_php_txn_add_code_level_metrics(
   nr_txn_attributes_set_string_attribute(attributes, nr_txn_clm_code_function,
                                          function);
 
-  if (!CHK_CLM_EMPTY(metadata->function_filepath)) {
+  if (!nr_strempty(metadata->function_filepath)) {
     nr_txn_attributes_set_string_attribute(attributes, nr_txn_clm_code_filepath,
                                            filepath);
   }
-  if (!CHK_CLM_EMPTY(metadata->function_namespace)) {
+  if (!nr_strempty(metadata->function_namespace)) {
     nr_txn_attributes_set_string_attribute(
         attributes, nr_txn_clm_code_namespace, namespace);
   }
-
-#undef CHK_CLM_EMPTY
 
   nr_txn_attributes_set_long_attribute(attributes, nr_txn_clm_code_lineno,
                                        metadata->function_lineno);

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1169,7 +1169,7 @@ extern void nr_php_txn_add_code_level_metrics(
     function = filepath;
   }
 
-#define CHK_CLM_EMPTY(s) ((NULL == s || nr_strempty(s)) ? true : false)
+#define CHK_CLM_EMPTY(s) (nr_strempty(s)) ? true : false)
 
   if (CHK_CLM_EMPTY(function)) {
     /*

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -56,9 +56,7 @@ int nr_zend_call_orig_execute(NR_EXECUTE_PROTO TSRMLS_DC) {
     NR_PHP_PROCESS_GLOBALS(orig_execute)
     (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
   }
-  zend_catch {
-    zcaught = 1;
-  }
+  zend_catch { zcaught = 1; }
   zend_end_try();
   return zcaught;
 }
@@ -75,9 +73,25 @@ int nr_zend_call_oapi_special_before(nruserfn_t* wraprec,
                                               NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
     }
   }
-  zend_catch {
-    zcaught = 1;
+  zend_catch { zcaught = 1; }
+  zend_end_try();
+  return zcaught;
+}
+
+int nr_zend_call_oapi_special_clean(nruserfn_t* wraprec,
+                                    nr_segment_t* segment,
+                                    NR_EXECUTE_PROTO) {
+  volatile int zcaught = 0;
+  NR_UNUSED_FUNC_RETURN_VALUE;
+  NR_UNUSED_SPECIALFN;
+
+  zend_try {
+    if (wraprec && wraprec->special_instrumentation_clean) {
+      wraprec->special_instrumentation_clean(wraprec, segment,
+                                             NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    }
   }
+  zend_catch { zcaught = 1; }
   zend_end_try();
   return zcaught;
 }
@@ -96,9 +110,7 @@ int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
       (NR_EXECUTE_ORIG_ARGS_OVERWRITE TSRMLS_CC);
     }
   }
-  zend_catch {
-    zcaught = 1;
-  }
+  zend_catch { zcaught = 1; }
   zend_end_try();
   return zcaught;
 }

--- a/agent/php_wrapper.c
+++ b/agent/php_wrapper.c
@@ -8,12 +8,13 @@
 #include "php_wrapper.h"
 #include "util_logging.h"
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
 nruserfn_t* nr_php_wrap_user_function_before_after(
     const char* name,
     size_t namelen,
     nrspecialfn_t before_callback,
     nrspecialfn_t after_callback) {
-  nruserfn_t* wraprec = nr_php_add_custom_tracer_named(name, namelen TSRMLS_CC);
+  nruserfn_t* wraprec = nr_php_add_custom_tracer_named(name, namelen);
 
   if (NULL == wraprec) {
     return wraprec;
@@ -47,7 +48,7 @@ nruserfn_t* nr_php_wrap_user_function_before_after(
 
   return wraprec;
 }
-
+#endif
 nruserfn_t* nr_php_wrap_user_function(const char* name,
                                       size_t namelen,
                                       nrspecialfn_t callback TSRMLS_DC) {

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -84,13 +84,13 @@
  *    NR_PHP_WRAPPER_DELEGATE (foo), provided the original function hasn't
  *    already been called.
  */
-
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
 extern nruserfn_t* nr_php_wrap_user_function_before_after(
     const char* name,
     size_t namelen,
     nrspecialfn_t before_callback,
     nrspecialfn_t after_callback);
-
+#endif
 extern nruserfn_t* nr_php_wrap_user_function(const char* name,
                                              size_t namelen,
                                              nrspecialfn_t callback TSRMLS_DC);

--- a/agent/tests/test_php_execute.c
+++ b/agent/tests/test_php_execute.c
@@ -123,6 +123,6 @@ void test_main(void* p NRUNUSED) {
   tlib_php_engine_create("" PTSRMLS_CC);
   test_add_segment_metric(TSRMLS_C);
   test_txn_restart_in_callstack(TSRMLS_C);
-  test_php_cur_stack_depth();
+  test_php_cur_stack_depth(TSRMLS_C);
   tlib_php_engine_destroy(TSRMLS_C);
 }

--- a/agent/tests/test_php_stacked_segment.c
+++ b/agent/tests/test_php_stacked_segment.c
@@ -10,6 +10,7 @@
 #include "php_stacked_segment.h"
 #include "php_globals.h"
 #include "php_wrapper.h"
+#include "util_sleep.h"
 
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = -1, .state_size = 0};
@@ -98,6 +99,11 @@ static void test_unwind(TSRMLS_D) {
    */
   segment = nr_segment_start(NRPRG(txn), NULL, NULL);
   nr_segment_end(&segment);
+
+  /*
+   * Sleep; otherwise, unwind will dump the short segments and fail.
+   */
+  nr_msleep(500);
 
   /*
    * Unwind the stacked segment stack.
@@ -193,6 +199,11 @@ static void test_unwind(TSRMLS_D) {
    */
   segment = nr_segment_start(NRPRG(txn), NULL, NULL);
   nr_segment_end(&segment);
+
+  /*
+   * Sleep; otherwise, unwind will dump the short segments and fail.
+   */
+  nr_msleep(500);
 
   /*
    * Unwind the stacked segment stack.

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -185,19 +185,18 @@ typedef struct _nr_segment_t {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
 
-/*
- * Because of the access to the segment is now split between functions, we
- * need to pass a certain amount of data between the functions that use the
- * segment.
- */
+  /*
+   * Because of the access to the segment is now split between functions, we
+   * need to pass a certain amount of data between the functions that use the
+   * segment.
+   */
   nrtime_t txn_start_time; /* To doublecheck the txn is correct when it is time
                               to add the segment to the txn. */
-  void* wraprec;           /* wraprec, if one is associated with this segment */
-  uint32_t
-      lineno; /* Keep lineno information.  When a function begins, the
-                 zend_execute_data lineno shows the ENTRY point of the function,
-                 when a function ends, the zend_execute_data lineno CHANGES and
-                 shows the EXIT point of the function.  */
+  void* wraprec; /* wraprec, if one is associated with this segment, to reduce
+                    wraprec lookups */
+
+  void* metadata; /* Persist data for OAPI for when exceptions prevent fcall_end
+                     from being called */
 
 #endif
 

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -190,8 +190,6 @@ typedef struct _nr_segment_t {
    * need to pass a certain amount of data between the functions that use the
    * segment.
    */
-  nrtime_t txn_start_time; /* To doublecheck the txn is correct when it is time
-                              to add the segment to the txn. */
   void* wraprec; /* wraprec, if one is associated with this segment, to reduce
                     wraprec lookups */
 

--- a/tests/integration/api/add_custom_parameter/test_add_custom_parameter_nested_caught_exception.php
+++ b/tests/integration/api/add_custom_parameter/test_add_custom_parameter_nested_caught_exception.php
@@ -1,0 +1,198 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_add_custom_parameter() on a nested path that includes a caught exception.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "a_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "b_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+Caught exception: Division by zero
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_add_custom_parameter("string", "b_str");
+    newrelic_add_custom_parameter("int", 7);
+    newrelic_add_custom_parameter("bool", false);
+    newrelic_add_custom_parameter("double", 1.5);
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_add_custom_parameter("string", "a_str");
+    newrelic_add_custom_parameter("int", 7);
+    newrelic_add_custom_parameter("bool", false);
+    newrelic_add_custom_parameter("double", 1.5);
+};
+
+a();
+b();

--- a/tests/integration/api/add_custom_parameter/test_add_custom_parameter_nested_happy.php
+++ b/tests/integration/api/add_custom_parameter/test_add_custom_parameter_nested_happy.php
@@ -1,0 +1,192 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_add_span_parameter() on a nested, happy path.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "a_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "b_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+0
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_add_custom_parameter("string", "b_str");
+    newrelic_add_custom_parameter("int", 7);
+    newrelic_add_custom_parameter("bool", false);
+    newrelic_add_custom_parameter("double", 1.5);
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+	return 0;
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_add_custom_parameter("string", "a_str");
+    newrelic_add_custom_parameter("int", 7);
+    newrelic_add_custom_parameter("bool", false);
+    newrelic_add_custom_parameter("double", 1.5);
+};
+
+a();
+b();

--- a/tests/integration/api/add_custom_parameter/test_add_custom_parameter_nested_uncaught_exception.php
+++ b/tests/integration/api/add_custom_parameter/test_add_custom_parameter_nested_uncaught_exception.php
@@ -1,0 +1,225 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_add_custom_parameter() on a nested path that includes a caught exception.  Any txn custom parameters get rolled up, so the parameters for `a` should get rolled up to the error event.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "a_str"
+      },
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "a_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }     
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT_REGEX
+.*(PHP )?Fatal error: Uncaught.*RuntimeException.*zero.*
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    c();
+    newrelic_add_custom_parameter("string", "b_str");
+    newrelic_add_custom_parameter("int", 7);
+    newrelic_add_custom_parameter("bool", false);
+    newrelic_add_custom_parameter("double", 1.5);
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_add_custom_parameter("string", "a_str");
+    newrelic_add_custom_parameter("int", 7);
+    newrelic_add_custom_parameter("bool", false);
+    newrelic_add_custom_parameter("double", 1.5);
+};
+
+a();
+b();

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_nested_caught_exception.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_nested_caught_exception.php
@@ -1,0 +1,198 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_add_custom_span_parameter() on a nested path that includes a caught exception.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "a_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "b_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+Caught exception: Division by zero
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_add_custom_span_parameter("string", "b_str");
+    newrelic_add_custom_span_parameter("int", 7);
+    newrelic_add_custom_span_parameter("bool", false);
+    newrelic_add_custom_span_parameter("double", 1.5);
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_add_custom_span_parameter("string", "a_str");
+    newrelic_add_custom_span_parameter("int", 7);
+    newrelic_add_custom_span_parameter("bool", false);
+    newrelic_add_custom_span_parameter("double", 1.5);
+};
+
+a();
+b();

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_nested_happy.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_nested_happy.php
@@ -1,0 +1,192 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_add_custom_span_parameter() on a happy, nested path.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "a_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "b_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+0
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_add_custom_span_parameter("string", "b_str");
+    newrelic_add_custom_span_parameter("int", 7);
+    newrelic_add_custom_span_parameter("bool", false);
+    newrelic_add_custom_span_parameter("double", 1.5);
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+	return 0;
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_add_custom_span_parameter("string", "a_str");
+    newrelic_add_custom_span_parameter("int", 7);
+    newrelic_add_custom_span_parameter("bool", false);
+    newrelic_add_custom_span_parameter("double", 1.5);
+};
+
+a();
+b();

--- a/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_nested_uncaught_exception.php
+++ b/tests/integration/api/add_custom_span_parameter/test_span_event_parameter_nested_uncaught_exception.php
@@ -1,0 +1,221 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_add_custom_span_parameter() on a nested path that includes an uncaught exception.
+The custom span parameters for `a` should not show up on the span error event associated with for `b`.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "double": 1.50000,
+        "bool": false,
+        "int": 7,
+        "string": "a_str"
+      },
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }     
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT_REGEX
+.*(PHP )?Fatal error: Uncaught.*RuntimeException.*zero.*
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    c();
+    newrelic_add_custom_span_parameter("string", "b_str");
+    newrelic_add_custom_span_parameter("int", 7);
+    newrelic_add_custom_span_parameter("bool", false);
+    newrelic_add_custom_span_parameter("double", 1.5);
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_add_custom_span_parameter("string", "a_str");
+    newrelic_add_custom_span_parameter("int", 7);
+    newrelic_add_custom_span_parameter("bool", false);
+    newrelic_add_custom_span_parameter("double", 1.5);
+};
+
+a();
+b();

--- a/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_caught_exception.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_caught_exception.php
@@ -1,0 +1,151 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_create_distributed_trace_payload() on a caught exception, nested path. 
+We can ensure the payloads were associated with the correct segment by using the INI settings to limit the spans it saves to only those with payloads or exceptions (and the root).
+*/
+
+/*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.detail = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.max_segments_cli = 4
+newrelic.special.expensive_node_min = 0
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_RESPONSE_HEADERS
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 4
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+Caught exception: Division by zero
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_create_distributed_trace_payload();
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+	throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_create_distributed_trace_payload();
+};
+
+a();
+b();

--- a/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_caught_exception.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_caught_exception.php
@@ -8,6 +8,13 @@ Tests newrelic_create_distributed_trace_payload() on a caught exception, nested 
 We can ensure the payloads were associated with the correct segment by using the INI settings to limit the spans it saves to only those with payloads or exceptions (and the root).
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
+}
+*/
+
 /*INI
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true

--- a/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_happy.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_happy.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_create_distributed_trace_payload() on a happy, nested path. We can ensure the payloads were associated with the correct segment by using the INI settings to limit the spans it saves to only those with payloads (and the root).
+*/
+
+/*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.detail = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.max_segments_cli = 3
+newrelic.special.expensive_node_min = 0
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_RESPONSE_HEADERS
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+0
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_create_distributed_trace_payload();
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+	return 0;
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_create_distributed_trace_payload();
+};
+
+a();
+b();

--- a/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_uncaught_exception.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_uncaught_exception.php
@@ -9,6 +9,13 @@ Tests newrelic_create_distributed_trace_payload() on an uncaught exception,  nes
 We can ensure the payloads were associated with the correct segment by using the INI settings to limit the spans it saves to only those with payloads (and the root).  Because the payload call isn't made in `b` we don't expect to see `b` with the other error spans to grab.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
+}
+*/
+
 /*INI
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 newrelic.distributed_tracing_enabled = true

--- a/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_uncaught_exception.php
+++ b/tests/integration/api/distributed_trace/newrelic/test_create_payload_nested_uncaught_exception.php
@@ -1,0 +1,156 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Tests newrelic_create_distributed_trace_payload() on an uncaught exception,  nested path. 
+We can ensure the payloads were associated with the correct segment by using the INI settings to limit the spans it saves to only those with payloads (and the root).  Because the payload call isn't made in `b` we don't expect to see `b` with the other error spans to grab.
+*/
+
+/*INI
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.detail = 1
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.max_segments_cli = 3
+newrelic.special.expensive_node_min = 0
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT_REGEX
+.*(PHP )?Fatal error: Uncaught.*RuntimeException.*zero.*
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    c();
+    newrelic_create_distributed_trace_payload();
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_create_distributed_trace_payload();
+};
+
+a();
+b();

--- a/tests/integration/api/notice_error/test_notice_error_nested_caught_exception.php
+++ b/tests/integration/api/notice_error/test_notice_error_nested_caught_exception.php
@@ -1,0 +1,214 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_notice_error() on a nested path with a caught exception.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "Exception",
+        "error.message": "Noticed exception 'Exception' with message 'Sample Exception b' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Noticed exception 'Exception' with message 'Sample Exception a' in __FILE__:??",
+        "error.class": "Exception"
+      }      
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Noticed exception 'Exception' with message 'Sample Exception b' in __FILE__:??",
+        "error.class": "Exception"
+      }      
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+Caught exception: Division by zero
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+newrelic_notice_error(new Exception('Sample Exception b'));
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_notice_error(new Exception('Sample Exception a'));
+};
+
+a();
+b();

--- a/tests/integration/api/notice_error/test_notice_error_nested_happy.php
+++ b/tests/integration/api/notice_error/test_notice_error_nested_happy.php
@@ -1,0 +1,208 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_notice_error on a happy, nested path.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "Exception",
+        "error.message": "Noticed exception 'Exception' with message 'Sample Exception b' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {
+        "error.message": "Noticed exception 'Exception' with message 'Sample Exception a' in __FILE__:??",
+        "error.class": "Exception"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {
+        "error.message": "Noticed exception 'Exception' with message 'Sample Exception b' in __FILE__:??",
+        "error.class": "Exception"
+      }     
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+0
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_notice_error(new Exception('Sample Exception b'));
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+	return 0;
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_notice_error(new Exception('Sample Exception a'));
+};
+
+a();
+b();

--- a/tests/integration/api/notice_error/test_notice_error_nested_uncaught_exception.php
+++ b/tests/integration/api/notice_error/test_notice_error_nested_uncaught_exception.php
@@ -1,0 +1,212 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_set_notice_error() on a nested path with a caught exception.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {
+        "error.message": "Noticed exception 'Exception' with message 'Sample Exception a' in __FILE__:??",
+        "error.class": "Exception"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }     
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT_REGEX
+.*(PHP )?Fatal error: Uncaught.*RuntimeException.*zero.*
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    c();
+    newrelic_notice_error(new Exception('Sample Exception b'));
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_notice_error(new Exception('Sample Exception a'));
+};
+
+a();
+b();

--- a/tests/integration/api/other/test_end_transaction_nested.php8.php
+++ b/tests/integration/api/other/test_end_transaction_nested.php8.php
@@ -5,16 +5,19 @@
  */
 /*DESCRIPTION
 Test that newrelic_end_transaction() ends all unended segments in the stack.
+Additionally, unlike previously, we can gracefully close the segments with 
+their proper names and parenting.
 */
 
 /*SKIPIF
 <?php
-if (version_compare(PHP_VERSION, "8.0", ">=")) {
-  die("skip: PHP >= 8.0.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0.0 not supported\n");
 }
 */
 
 /*INI
+newrelic.special.expensive_node_min = 0
 newrelic.transaction_tracer.threshold = 0
 */
 
@@ -40,10 +43,10 @@ newrelic.transaction_tracer.threshold = 0
                     "?? start time", "?? end time", "`1", "?? node attributes",
                     [
                       [
-                        "?? start time", "?? end time", "`1", "?? node attributes",
+                        "?? start time", "?? end time", "`2", "?? node attributes",
                         [ 
                           [
-                            "?? start time", "?? end time", "`2", "?? node attributes",
+                            "?? start time", "?? end time", "`3", "?? node attributes",
                             []
                           ]
                         ]
@@ -68,9 +71,10 @@ newrelic.transaction_tracer.threshold = 0
           }
         ],
         [
-          "OtherTransaction/php__FILE__",
-          "<unknown>",
-          "Custom/level_0"
+          "OtherTransaction\/php__FILE__",
+          "Custom\/level_2",
+          "Custom\/level_1",
+          "Custom\/level_0"
         ]
       ],
       "?? txn guid",

--- a/tests/integration/api/other/test_set_user_attributes_nested_caught_exception.php
+++ b/tests/integration/api/other/test_set_user_attributes_nested_caught_exception.php
@@ -1,0 +1,190 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_set_user_attributes() on a nested path with a caught exception.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "product": "a_product",
+        "account": "a_account",
+        "user": "a_user"
+      },      
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "product": "b_product",
+        "account": "b_account",
+        "user": "b_user"
+      },      
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+Caught exception: Division by zero
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_set_user_attributes("b_user", "b_account", "b_product");
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_set_user_attributes("a_user", "a_account", "a_product");
+};
+
+a();
+b();

--- a/tests/integration/api/other/test_set_user_attributes_nested_happy.php
+++ b/tests/integration/api/other/test_set_user_attributes_nested_happy.php
@@ -1,0 +1,184 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_set_user_attributes() on a happy, nested path.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "product": "a_product",
+        "account": "a_account",
+        "user": "a_user"
+      },      
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "product": "b_product",
+        "account": "b_account",
+        "user": "b_user"
+      },      
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+0
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_set_user_attributes("b_user", "b_account", "b_product");
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+	return 0;
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_set_user_attributes("a_user", "a_account", "a_product");
+};
+
+a();
+b();

--- a/tests/integration/api/other/test_set_user_attributes_nested_uncaught_exception.php
+++ b/tests/integration/api/other/test_set_user_attributes_nested_uncaught_exception.php
@@ -1,0 +1,217 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Tests newrelic_set_user_attributes() on a nested path with an ucaught exception.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {
+        "product": "a_product",
+        "account": "a_account",
+        "user": "a_user"
+      },
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {
+        "product": "a_product",
+        "account": "a_account",
+        "user": "a_user"
+      },      
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},      
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }     
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT_REGEX
+.*(PHP )?Fatal error: Uncaught.*RuntimeException.*zero.*
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    c();
+    newrelic_set_user_attributes("b_user", "b_account", "b_product");
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+    newrelic_set_user_attributes("a_user", "a_account", "a_product");
+};
+
+a();
+b();

--- a/tests/integration/attributes/test_transaction_namespace2_clm.php
+++ b/tests/integration/attributes/test_transaction_namespace2_clm.php
@@ -102,7 +102,7 @@ newrelic.code_level_metrics.enabled=true
       },
       {},
       {
-        "code.lineno": 133,
+        "code.lineno": 131,
         "code.namespace": "Foo\\Bar\\Vegetable",
         "code.filepath": "__FILE__",
         "code.function": "getColor"

--- a/tests/integration/attributes/test_transaction_namespace_clm.php
+++ b/tests/integration/attributes/test_transaction_namespace_clm.php
@@ -102,7 +102,7 @@ newrelic.code_level_metrics.enabled=true
       },
       {},
       {
-        "code.lineno": 134,
+        "code.lineno": 132,
         "code.namespace": "Vegetable",
         "code.filepath": "__FILE__",
         "code.function": "getColor"

--- a/tests/integration/attributes/test_transaction_namespace_len_clm.php
+++ b/tests/integration/attributes/test_transaction_namespace_len_clm.php
@@ -102,7 +102,7 @@ newrelic.code_level_metrics.enabled=true
       },
       {},
       {
-        "code.lineno": 127,
+        "code.lineno": 125,
         "code.filepath":  "__FILE__",
         "code.function":  "getLap"
       }

--- a/tests/integration/attributes/test_transaction_nested_user_functions_clm.php
+++ b/tests/integration/attributes/test_transaction_nested_user_functions_clm.php
@@ -68,7 +68,7 @@ newrelic.code_level_metrics.enabled = 1
       },
       {},
       {
-        "code.lineno": 228,
+        "code.lineno": 227,
         "code.filepath": "__FILE__",
         "code.function": "level_2"
       }
@@ -89,7 +89,7 @@ newrelic.code_level_metrics.enabled = 1
       },
       {},
       {
-        "code.lineno": 224,
+        "code.lineno": 223,
         "code.filepath": "__FILE__",
         "code.function": "level_1"
       }
@@ -154,7 +154,7 @@ newrelic.code_level_metrics.enabled = 1
                   [
                     "?? start time", "?? end time", "`1",
                             {
-                              "code.lineno": 228,
+                              "code.lineno": 227,
                               "code.filepath": "__FILE__",
                               "code.function": "level_2"
                             },
@@ -162,7 +162,7 @@ newrelic.code_level_metrics.enabled = 1
                       [
                         "?? start time", "?? end time", "`2",
                             {
-                              "code.lineno": 224,
+                              "code.lineno": 223,
                               "code.filepath": "__FILE__",
                               "code.function": "level_1"
                         },


### PR DESCRIPTION
1. Renamed nr_php_execute_metadata_add_code_level_metrics to  nr_php_observer_metadata_init as this will be the way we populate the metadata.  We don't need to do duplicate effort with `nr_php_execute_metadata_init` anymore.
2. Since nr_php_execute_metadata_init is now for populating metadata, moved all CLM checks out nr_php_observer_metadata_init and into nr_php_txn_add_code_level_metrics where it is more appropriate.
3. Modified stacked segments to have a pointer to the metadata so if they are closed off by an exception, they will properly propogate the information.  Added initializations/deninitializations.
4. For php_execute_enabled, only call nr_php_observer_metadata_init if we need to.
5. Added nr_php_observer_exception_segment_end
 To handled closing off observer segments if an exception occurs.
6. Now use zend_throw_exception_hook (more info:
https://www.phpinternalsbook.com/php7/extensions_design/hooks.html
Note: This ONLY notifies when an exception is thrown.  It gives no indication if that exception was subsequently caught or not.
8. OAPI leaves dangling segments in the case of exceptions.  These need to be cleaned up for functions that rely on the current segment (includes begin/end functions, stacked segment unwinding, and API calls) 
9. New inline function re`nr_php_api_ensure_current_segment` to account for dangling segments when calling our API.
10. TXN globals to keep track of the exception
11. Change in php_txn turn off recording after unwind the segments to give timer to attach exception to dangling segment(s).
12. Modify stacked segments init/denit to handle additional segment metadata variable.
13. Functions to clear/set TXN uncaught_exception variables.
14. Update metadata struct to retain more context of the segment.
15. Removed legacy exception code that wasn't getting called anymore.
16. Added tests.