### PR TITLE
Fix creating some logging metrics

### DIFF
--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -635,7 +635,6 @@ static void nr_php_txn_send_metrics_once(nrtxn_t* txn TSRMLS_DC) {
     return;
   }
 
-  nrl_verbosedebug(NRL_TXN, "creating one time logging metrics");
 #define FMT_BOOL(v) (v) ? "enabled" : "disabled"
 
   metname = nr_formatf("Supportability/Logging/Forwarding/PHP/%s",
@@ -648,7 +647,7 @@ static void nr_php_txn_send_metrics_once(nrtxn_t* txn TSRMLS_DC) {
   nrm_force_add(NRTXN(unscoped_metrics), metname, 0);
   nr_free(metname);
 
-  txn->created_logging_onetime_metrics = 1;
+  txn->created_logging_onetime_metrics = true;
 
 #undef FMT_BOOL
 }

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -625,17 +625,17 @@ static void nr_php_txn_log_error_dt_on_tt_off(void) {
 }
 
 static void nr_php_txn_send_metrics_once(nrtxn_t* txn TSRMLS_DC) {
-  static unsigned int sent = 0;
   char* metname = NULL;
 
   if (nrunlikely(NULL == NRPRG(txn))) {
     return;
   }
 
-  if (nrlikely(0 != sent)) {
+  if (nrlikely(0 != txn->created_logging_onetime_metrics)) {
     return;
   }
 
+  nrl_verbosedebug(NRL_TXN, "creating one time logging metrics");
 #define FMT_BOOL(v) (v) ? "enabled" : "disabled"
 
   metname = nr_formatf("Supportability/Logging/Forwarding/PHP/%s",
@@ -648,7 +648,7 @@ static void nr_php_txn_send_metrics_once(nrtxn_t* txn TSRMLS_DC) {
   nrm_force_add(NRTXN(unscoped_metrics), metname, 0);
   nr_free(metname);
 
-  sent = 1;
+  txn->created_logging_onetime_metrics = 1;
 
 #undef FMT_BOOL
 }

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -447,7 +447,7 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nr_sampling_priority_t priority;
   nr_slab_t* segment_slab;
 
-  if (0 == app) {
+  if (NULL == app) {
     return 0;
   }
 
@@ -536,6 +536,11 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
 
   nt->custom_events = nr_analytics_events_create(app->limits.custom_events);
   nt->log_events = nr_log_events_create(app->limits.log_events);
+
+  /*
+   * reset flag for creation of one-time logging metrics
+   */
+  nt->created_logging_onetime_metrics = false;
 
   /*
    * Set the status fields to their defaults.

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -295,6 +295,12 @@ typedef struct _nrtxn_t {
   nr_span_queue_t* span_queue; /* span queue when 8T is enabled */
 
   /*
+   * flag to indicate if one time (per transaction) logging metrics
+   * have been created
+   */
+  bool created_logging_onetime_metrics;
+
+  /*
    * Special control variables derived from named bits in
    * nrphpglobals_t.special_flags These are used to debug the agent, possibly in
    * the field.

--- a/tests/integration/api/set_appname/test_already_ended.php
+++ b/tests/integration/api/set_appname/test_already_ended.php
@@ -29,7 +29,9 @@ ok - newrelic_set_appname no transaction
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
     [{"name":"see_me"},                                 [1, 1, 1, 1, 1, 1]],
     [{"name":"Supportability/api/custom_metric"},       [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/api/set_appname/after"},   [1, 0, 0, 0, 0, 0]]
+    [{"name":"Supportability/api/set_appname/after"},   [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/api/set_appname/test_appname_license.php
+++ b/tests/integration/api/set_appname/test_appname_license.php
@@ -29,7 +29,9 @@ ok - newrelic_set_appname appname and license
     [{"name":"see_me"},                                     [1, 1, 1, 1, 1, 1]],
     [{"name":"Supportability/api/custom_metric"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/after"},       [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/api/set_appname/with_license"},[1, 0, 0, 0, 0, 0]]
+    [{"name":"Supportability/api/set_appname/with_license"},[1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/api/set_appname/test_appname_switch_license.php
+++ b/tests/integration/api/set_appname/test_appname_switch_license.php
@@ -32,7 +32,9 @@ ok - newrelic_set_appname appname and license
     [{"name":"Supportability/api/set_appname/before"},              [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/after"},               [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/switched_license"},    [2, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/api/set_appname/with_license"},        [2, 0, 0, 0, 0, 0]]
+    [{"name":"Supportability/api/set_appname/with_license"},        [2, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [2, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [2, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/api/set_appname/test_appname_switch_license_lasp.php
+++ b/tests/integration/api/set_appname/test_appname_switch_license_lasp.php
@@ -34,7 +34,9 @@ newrelic.security_policies_token = 00000000
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/custom_metric"},                   [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/start_transaction"},               [1, 0, 0, 0, 0, 0]],
-    [{"name":"see_me"},                                             [1, 1, 1, 1, 1, 1]]
+    [{"name":"see_me"},                                             [1, 1, 1, 1, 1, 1]],
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/api/set_appname/test_no_license.php
+++ b/tests/integration/api/set_appname/test_no_license.php
@@ -28,7 +28,9 @@ ok - newrelic_set_appname just appname
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
     [{"name":"see_me"},                                 [1, 1, 1, 1, 1, 1]],
     [{"name":"Supportability/api/custom_metric"},       [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/api/set_appname/after"},   [1, 0, 0, 0, 0, 0]]
+    [{"name":"Supportability/api/set_appname/after"},   [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/api/set_appname/test_transmit_false.php
+++ b/tests/integration/api/set_appname/test_transmit_false.php
@@ -30,7 +30,9 @@ ok - newrelic_set_appname transmit=false
     [{"name":"see_me"},                                     [1, 1, 1, 1, 1, 1]],
     [{"name":"Supportability/api/custom_metric"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/after"},       [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/api/set_appname/with_license"},[1, 0, 0, 0, 0, 0]]
+    [{"name":"Supportability/api/set_appname/with_license"},[1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]]
 
   ]
 ]

--- a/tests/integration/api/set_appname/test_transmit_int.php
+++ b/tests/integration/api/set_appname/test_transmit_int.php
@@ -31,8 +31,8 @@ ok - newrelic_set_appname transmit=1
     [{"name":"OtherTransactionTotalTime/php__FILE__"},                [3, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/api/set_appname/after"},                 [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/before"},                [2, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]]
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [3, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [3, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/api/set_appname/test_transmit_true.php
+++ b/tests/integration/api/set_appname/test_transmit_true.php
@@ -32,8 +32,8 @@ ok - newrelic_set_appname transmit=1
     [{"name":"Supportability/api/set_appname/after"},                 [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/before"},                [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/api/set_appname/with_license"},          [2, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]]
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [3, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [3, "??", "??", "??", "??", "??"]]
   ]
 ]
 */

--- a/tests/integration/external/curl_multi_exec/test_txn_restart.php
+++ b/tests/integration/external/curl_multi_exec/test_txn_restart.php
@@ -51,7 +51,9 @@ ok - end of function reached without crash
     [{"name":"OtherTransaction/php__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},       [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/api/start_transaction"},        [1, "??", "??", "??", "??", "??"]]
+    [{"name":"Supportability/api/start_transaction"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]]
   ]
 ]
 */


### PR DESCRIPTION
The logging metrics "Supportability/Logging/Forwarding/PHP/<state>" and "Supportability/Logging/Metrics/PHP/<state>"} are supposed to be created once per request.  The previous mechanism did not properly create these metrics if a transaction was started and restarted during a request, or if newrelic_set_appname() was called.

This fix uses a flag within the transaction structure to track if the metrics have been created for the transaction which fixes the previous issue.

Affected integration tests were updated to reflect the metrics are now being created properly.