### PR TITLE
docs(agent): clean up `newrelic.framework` INI info

### DIFF
--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -638,10 +638,11 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;          Must be one of the following values:
 ;          cakephp, codeigniter, drupal, drupal8, joomla, kohana, laravel,
-;          magento, magento2, mediawiki, silex, slim, symfony1, symfony2,
+;          magento, magento2, mediawiki, slim, symfony2, symfony4,
 ;          wordpress, yii, zend, zend2, no_framework
 ;
-;          Note that "drupal" covers only Drupal 6 and 7.
+;          Note that "drupal" covers only Drupal 6 and 7 and "symfony2"
+;          now only supports Symfony 3.x.
 ;
 ;newrelic.framework = ""
 


### PR DESCRIPTION
Update comment in template newrelic.ini to reflect supported frameworks.