### PR TITLE
fix(agent): move globals that utilized the call stack into a global stack

### DIFF
--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -51,19 +51,27 @@ NR_PHP_WRAPPER(nr_doctrine2_cache_dql) {
 
 /* If not using OAPI, we can simply free the value after the NR_PHP_WRAPPER_CALL.
  * Otherwise, we need an "after function" to do the freeing */
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_free(NRPRG(doctrine_dql));
+#endif /* not OAPI */
+}
+NR_PHP_WRAPPER_END
+
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
+NR_PHP_WRAPPER(nr_doctrine2_cache_dql_clean) {
+  (void)wraprec;
+  nr_free(NRPRG(doctrine_dql));
 }
 NR_PHP_WRAPPER_END
 
 NR_PHP_WRAPPER(nr_doctrine2_cache_dql_after) {
   (void)wraprec;
   nr_free(NRPRG(doctrine_dql));
-#else
-  nr_free(NRPRG(doctrine_dql));
-#endif /* OAPI */
 }
 NR_PHP_WRAPPER_END
+#endif /* OAPI */
 
 
 nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
@@ -92,7 +100,7 @@ void nr_doctrine2_enable(TSRMLS_D) {
   nr_php_wrap_user_function_before_after_clean(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                                          nr_doctrine2_cache_dql,
                                          nr_doctrine2_cache_dql_after,
-                                         nr_doctrine2_cache_dql_after);
+                                         nr_doctrine2_cache_dql_clean);
 #else
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -49,6 +49,8 @@ NR_PHP_WRAPPER(nr_doctrine2_cache_dql) {
 
   NR_PHP_WRAPPER_CALL;
 
+/* If not using OAPI, we can simply free the value after the NR_PHP_WRAPPER_CALL.
+ * Otherwise, we need an "after function" to do the freeing */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
 }
@@ -87,8 +89,9 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 void nr_doctrine2_enable(TSRMLS_D) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
+  nr_php_wrap_user_function_before_after_clean(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                                          nr_doctrine2_cache_dql,
+                                         nr_doctrine2_cache_dql_after,
                                          nr_doctrine2_cache_dql_after);
 #else
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -49,9 +49,20 @@ NR_PHP_WRAPPER(nr_doctrine2_cache_dql) {
 
   NR_PHP_WRAPPER_CALL;
 
-  nr_free(NRPRG(doctrine_dql));
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
 }
 NR_PHP_WRAPPER_END
+
+NR_PHP_WRAPPER(nr_doctrine2_cache_dql_after) {
+  (void)wraprec;
+  nr_free(NRPRG(doctrine_dql));
+#else
+  nr_free(NRPRG(doctrine_dql));
+#endif /* OAPI */
+}
+NR_PHP_WRAPPER_END
+
 
 nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
   nr_slowsqls_labelled_query_t* query = NULL;
@@ -74,6 +85,13 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 }
 
 void nr_doctrine2_enable(TSRMLS_D) {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_php_wrap_user_function_before_after(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
+                                         nr_doctrine2_cache_dql,
+                                         nr_doctrine2_cache_dql_after);
+#else
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);
+#endif /* OAPI */
 }

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -544,13 +544,19 @@ NR_PHP_WRAPPER(nr_predis_connection_readResponse) {
    * have set predis_ctx to a non-NULL async context, so we use that to add an
    * async context to the datastore node.
    */
-  if (NRPRG(predis_ctx)) {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  char* ctx = (char *)nr_stack_pop(&NRPRG(predis_ctxs));
+#else
+  char* ctx = NRPRG(predis_ctx);
+#endif /* OAPI */
+  if (ctx) {
     /*
      * Since we need a unique async context for each element within the
      * pipeline, we'll concatenate the object ID onto the base context name
      * generated in the executePipeline() instrumentation.
      */
-    async_context = nr_formatf("%s." NR_UINT64_FMT, NRPRG(predis_ctx), index);
+    async_context = nr_formatf("%s." NR_UINT64_FMT, ctx, index);
   }
 
   segment = nr_segment_start(NRPRG(txn), NULL, async_context);
@@ -684,7 +690,6 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
 NR_PHP_WRAPPER_END
 
 NR_PHP_WRAPPER(nr_predis_pipeline_executePipeline) {
-  char* prev_predis_ctx;
 
   (void)wraprec;
 
@@ -698,16 +703,33 @@ NR_PHP_WRAPPER(nr_predis_pipeline_executePipeline) {
    * We'll save any existing context just in case this is a nested pipeline.
    */
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_stack_push(&NRPRG(predis_ctxs), nr_formatf("Predis #" NR_TIME_FMT, nr_get_time()));
+#else
+  char* prev_predis_ctx;
   prev_predis_ctx = NRPRG(predis_ctx);
   NRPRG(predis_ctx) = nr_formatf("Predis #" NR_TIME_FMT, nr_get_time());
+#endif /* OAPI */
 
   NR_PHP_WRAPPER_CALL;
 
   /*
    * Restore any previous context on the way out.
    */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+}
+NR_PHP_WRAPPER_END
+
+NR_PHP_WRAPPER(nr_predis_pipeline_executePipeline_after) {
+  (void)wraprec;
+  char* predis_ctx = (char *)nr_stack_pop(&NRPRG(predis_ctxs));
+  nr_free(predis_ctx);
+#else
   nr_free(NRPRG(predis_ctx));
   NRPRG(predis_ctx) = prev_predis_ctx;
+#endif /* OAPI */
 }
 NR_PHP_WRAPPER_END
 
@@ -755,6 +777,25 @@ void nr_predis_enable(TSRMLS_D) {
    * Instrument the pipeline classes that are bundled with Predis so that we
    * correctly set up async contexts.
    */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_php_wrap_user_function_before_after(
+      NR_PSTR("Predis\\Pipeline\\Pipeline::executePipeline"),
+      nr_predis_pipeline_executePipeline,
+      nr_predis_pipeline_executePipeline_after);
+  nr_php_wrap_user_function_before_after(
+      NR_PSTR("Predis\\Pipeline\\Atomic::executePipeline"),
+      nr_predis_pipeline_executePipeline,
+      nr_predis_pipeline_executePipeline_after);
+  nr_php_wrap_user_function_before_after(
+      NR_PSTR("Predis\\Pipeline\\ConnectionErrorProof::executePipeline"),
+      nr_predis_pipeline_executePipeline,
+      nr_predis_pipeline_executePipeline_after);
+  nr_php_wrap_user_function_before_after(
+      NR_PSTR("Predis\\Pipeline\\FireAndForget::executePipeline"),
+      nr_predis_pipeline_executePipeline,
+      nr_predis_pipeline_executePipeline_after);
+#else
   nr_php_wrap_user_function(
       NR_PSTR("Predis\\Pipeline\\Pipeline::executePipeline"),
       nr_predis_pipeline_executePipeline TSRMLS_CC);
@@ -767,6 +808,7 @@ void nr_predis_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Predis\\Pipeline\\FireAndForget::executePipeline"),
       nr_predis_pipeline_executePipeline TSRMLS_CC);
+#endif /* OAPI */
 
   /*
    * Instrument Webdis connections, since they don't use the same

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -546,7 +546,7 @@ NR_PHP_WRAPPER(nr_predis_connection_readResponse) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  char* ctx = (char *)nr_stack_pop(&NRPRG(predis_ctxs));
+  char* ctx = (char *)nr_stack_get_top(&NRPRG(predis_ctxs));
 #else
   char* ctx = NRPRG(predis_ctx);
 #endif /* OAPI */
@@ -716,6 +716,9 @@ NR_PHP_WRAPPER(nr_predis_pipeline_executePipeline) {
 
   /*
    * Restore any previous context on the way out.
+   *
+   * If not using OAPI, we can simply free the value after the NR_PHP_WRAPPER_CALL.
+   * Otherwise, we need an "after function" to do the freeing
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
@@ -779,21 +782,25 @@ void nr_predis_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\Pipeline::executePipeline"),
       nr_predis_pipeline_executePipeline,
+      nr_predis_pipeline_executePipeline_after.
       nr_predis_pipeline_executePipeline_after);
-  nr_php_wrap_user_function_before_after(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\Atomic::executePipeline"),
       nr_predis_pipeline_executePipeline,
+      nr_predis_pipeline_executePipeline_after.
       nr_predis_pipeline_executePipeline_after);
-  nr_php_wrap_user_function_before_after(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\ConnectionErrorProof::executePipeline"),
       nr_predis_pipeline_executePipeline,
+      nr_predis_pipeline_executePipeline_after.
       nr_predis_pipeline_executePipeline_after);
-  nr_php_wrap_user_function_before_after(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\FireAndForget::executePipeline"),
       nr_predis_pipeline_executePipeline,
+      nr_predis_pipeline_executePipeline_after.
       nr_predis_pipeline_executePipeline_after);
 #else
   nr_php_wrap_user_function(

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -785,22 +785,22 @@ void nr_predis_enable(TSRMLS_D) {
   nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\Pipeline::executePipeline"),
       nr_predis_pipeline_executePipeline,
-      nr_predis_pipeline_executePipeline_after.
+      nr_predis_pipeline_executePipeline_after,
       nr_predis_pipeline_executePipeline_after);
   nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\Atomic::executePipeline"),
       nr_predis_pipeline_executePipeline,
-      nr_predis_pipeline_executePipeline_after.
+      nr_predis_pipeline_executePipeline_after,
       nr_predis_pipeline_executePipeline_after);
   nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\ConnectionErrorProof::executePipeline"),
       nr_predis_pipeline_executePipeline,
-      nr_predis_pipeline_executePipeline_after.
+      nr_predis_pipeline_executePipeline_after,
       nr_predis_pipeline_executePipeline_after);
   nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\FireAndForget::executePipeline"),
       nr_predis_pipeline_executePipeline,
-      nr_predis_pipeline_executePipeline_after.
+      nr_predis_pipeline_executePipeline_after,
       nr_predis_pipeline_executePipeline_after);
 #else
   nr_php_wrap_user_function(

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -561,7 +561,14 @@ nrapp_t* app; /* The application used in the last attempt to initialize a
 
 nrtxn_t* txn; /* The all-important transaction pointer */
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+nr_stack_t predis_ctxs; /* Without OAPI, we are able to utilize the call
+                           stack to keep track of the current predis_ctx.
+                           WIth OAPI, we must track this manually */
+#else
 char* predis_ctx; /* The current Predis pipeline context name, if any */
+#endif
 nr_hashmap_t* predis_commands;
 
 /*

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -101,6 +101,17 @@ PHP_RINIT_FUNCTION(newrelic) {
       "(^([a-z_-]+[_-])([0-9a-f_.]+[0-9][0-9a-f.]+)(_{0,1}.*)$|(.*))",
       NR_REGEX_CASELESS, 0);
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  /* Stack needs to have a dtor set so that when we free it
+   * during rshutdown, all elements are properly freed */
+  void stack_dtor(void* e, NRUNUSED void* d) {
+    char* str = (char*)e;
+    nr_free(str);
+  }
+  nr_stack_init(&NRPRG(predis_ctxs), NR_STACK_DEFAULT_CAPACITY);
+  NRPRG(predis_ctxs).dtor = stack_dtor;
+#endif
   NRPRG(mysql_last_conn) = NULL;
   NRPRG(pgsql_last_conn) = NULL;
   NRPRG(datastore_connections) = nr_hashmap_create(

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -105,12 +105,12 @@ PHP_RINIT_FUNCTION(newrelic) {
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
   /* Stack needs to have a dtor set so that when we free it
    * during rshutdown, all elements are properly freed */
-  void stack_dtor(void* e, NRUNUSED void* d) {
+  void str_stack_dtor(void* e, NRUNUSED void* d) {
     char* str = (char*)e;
     nr_free(str);
   }
   nr_stack_init(&NRPRG(predis_ctxs), NR_STACK_DEFAULT_CAPACITY);
-  NRPRG(predis_ctxs).dtor = stack_dtor;
+  NRPRG(predis_ctxs).dtor = str_stack_dtor;
 #endif
   NRPRG(mysql_last_conn) = NULL;
   NRPRG(pgsql_last_conn) = NULL;

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -29,7 +29,7 @@ static void nr_php_datastore_instance_destroy(
 /* OAPI global stacks (as opposed to call stack used previously) 
  * need to have a dtor set so that when we free it
  * during rshutdown, all elements are properly freed */
-void str_stack_dtor(void* e, NRUNUSED void* d) {
+static void str_stack_dtor(void* e, NRUNUSED void* d) {
   char* str = (char*)e;
   nr_free(str);
 }

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -113,7 +113,12 @@ int nr_php_post_deactivate(void) {
   nr_free(NRPRG(pgsql_last_conn));
   nr_hashmap_destroy(&NRPRG(datastore_connections));
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_stack_destroy_fields(&NRPRG(predis_ctxs));
+#else
   nr_free(NRPRG(predis_ctx));
+#endif /* OAPI */
   nr_hashmap_destroy(&NRPRG(predis_commands));
 
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO

--- a/tests/integration/predis/test_pipeline.php
+++ b/tests/integration/predis/test_pipeline.php
@@ -20,11 +20,11 @@ are being run, so they are instrumented as "pipeline".
   [
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/all"},                                      [12, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/allOther"},                                 [12, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/Redis/all"},                                [12, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/Redis/allOther"},                           [12, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/instance/Redis/__HOST__/6379"},             [12, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/all"},                                      [13, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/allOther"},                                 [13, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/Redis/all"},                                [13, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/Redis/allOther"},                           [13, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/instance/Redis/__HOST__/6379"},             [13, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/del"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/del",
       "scope":"OtherTransaction/php__FILE__"},                      [1, "??", "??", "??", "??", "??"]],
@@ -40,9 +40,9 @@ are being run, so they are instrumented as "pipeline".
     [{"name":"Datastore/operation/Redis/mget"},                     [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/mget",
       "scope":"OtherTransaction/php__FILE__"},                      [2, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/ping"},                     [2, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/operation/Redis/ping"},                     [3, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/ping",
-      "scope":"OtherTransaction/php__FILE__"},                      [2, "??", "??", "??", "??", "??"]],
+      "scope":"OtherTransaction/php__FILE__"},                      [3, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                               [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
@@ -101,6 +101,15 @@ function test_pipeline() {
   $pipe->exists($key);
   $pipe->mget('does_not_exist', $key);
   $replies = $pipe->execute();
+
+  /* method 3 (exception) */
+  $replies = $client->pipeline(function($pipe) {
+    try {
+      $pipe->execute();
+    } catch (Exception $e) {
+      $pipe->ping();
+    }
+  });
 
   $client->del($key);
   $client->quit();


### PR DESCRIPTION
Symfony1 instrumentation utilizes the call stack, but should never be run with PHP8+.

Repeat of https://github.com/newrelic/newrelic-php-agent/pull/576 based on a non-forked branch so other PR's can be based on this one.