### PR TITLE
refactor(agent): user instrumentation lookup

### DIFF
--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -106,6 +106,7 @@ TEST_BINARIES = \
 	tests/test_txn \
 	tests/test_txn_private \
 	tests/test_user_instrument \
+	tests/test_user_instrument_hashmap \
 	tests/test_zval
 
 .PHONY: unit-tests

--- a/agent/config.m4
+++ b/agent/config.m4
@@ -194,7 +194,7 @@ if test "$PHP_NEWRELIC" = "yes"; then
   php_pdo_mysql.c php_pdo_pgsql.c php_pgsql.c php_psr7.c php_redis.c \
   php_rinit.c php_rshutdown.c php_samplers.c php_stack.c \
   php_stacked_segment.c php_txn.c php_user_instrument.c \
-  php_vm.c php_wrapper.c"
+  php_user_instrument_hashmap.c php_vm.c php_wrapper.c"
   FRAMEWORKS="fw_cakephp.c fw_codeigniter.c fw_drupal8.c \
   fw_drupal.c fw_drupal_common.c fw_joomla.c fw_kohana.c \
   fw_laminas3.c fw_laravel.c fw_laravel_queue.c fw_lumen.c \

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -57,7 +57,7 @@ static void nr_drupal8_add_method_callback(const zend_class_entry* ce,
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
   if (NULL == nr_php_op_array_get_wraprec(&function->op_array TSRMLS_CC)) {
 #else
-  if (NULL == nr_php_get_wraprec_by_func(function)) {
+  if (NULL == nr_php_get_wraprec(function)) {
 #endif
     char* class_method = nr_formatf(
         "%.*s::%.*s", NRSAFELEN(nr_php_class_entry_name_length(ce)),

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -647,7 +647,7 @@ static void nr_php_show_exec(NR_EXECUTE_PROTO TSRMLS_DC) {
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
         nr_php_op_array_get_wraprec(NR_OP_ARRAY TSRMLS_CC) ? " *" : "",
 #else
-        nr_php_get_wraprec_by_func(execute_data->func) ? " *" : "",
+        nr_php_get_wraprec(execute_data->func) ? " *" : "",
 #endif
         NRP_FILENAME(filename), NR_OP_ARRAY->line_start);
   } else if (NR_OP_ARRAY->function_name) {
@@ -668,7 +668,7 @@ static void nr_php_show_exec(NR_EXECUTE_PROTO TSRMLS_DC) {
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
         nr_php_op_array_get_wraprec(NR_OP_ARRAY TSRMLS_CC) ? " *" : "",
 #else
-        nr_php_get_wraprec_by_func(execute_data->func) ? " *" : "",
+        nr_php_get_wraprec(execute_data->func) ? " *" : "",
 #endif
         NRP_FILENAME(filename), NR_OP_ARRAY->line_start);
   } else if (NR_OP_ARRAY->filename) {
@@ -1334,7 +1334,7 @@ static void nr_php_execute_enabled(NR_EXECUTE_PROTO TSRMLS_DC) {
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
   wraprec = nr_php_op_array_get_wraprec(NR_OP_ARRAY TSRMLS_CC);
 #else
-  wraprec = nr_php_get_wraprec_by_func(execute_data->func);
+  wraprec = nr_php_get_wraprec(execute_data->func);
 #endif
 
   if (NULL != wraprec) {

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -485,6 +485,7 @@ nriniuint_t log_forwarding_log_level; /* newrelic.application_logging.forwarding
 nrinibool_t
     code_level_metrics_enabled; /* newrelic.code_level_metrics.enabled */
 
+#if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
 /*
  * pid and user_function_wrappers are used to store user function wrappers.
  * Storing this on a request level (as opposed to storing it on transaction
@@ -492,6 +493,7 @@ nrinibool_t
  */
 uint64_t pid;
 nr_vector_t* user_function_wrappers;
+#endif
 
 nrapp_t* app; /* The application used in the last attempt to initialize a
                  transaction */

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -36,9 +36,7 @@ PHP_RINIT_FUNCTION(newrelic) {
   NRPRG(php_cur_stack_depth) = 0;
   NRPRG(deprecated_capture_request_parameters) = NRINI(capture_params);
   NRPRG(sapi_headers) = NULL;
-#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-  nr_php_init_transient_user_instrumentation();
-#else
+#if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
   NRPRG(pid) = getpid();
   NRPRG(user_function_wrappers) = nr_vector_create(64, NULL, NULL);
 #endif

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -36,7 +36,9 @@ PHP_RINIT_FUNCTION(newrelic) {
   NRPRG(php_cur_stack_depth) = 0;
   NRPRG(deprecated_capture_request_parameters) = NRINI(capture_params);
   NRPRG(sapi_headers) = NULL;
-#if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+  nr_php_init_user_instrumentation();
+#else
   NRPRG(pid) = getpid();
   NRPRG(user_function_wrappers) = nr_vector_create(64, NULL, NULL);
 #endif

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -11,6 +11,7 @@
 #include "php_error.h"
 #include "php_globals.h"
 #include "php_header.h"
+#include "php_user_instrument.h"
 #include "nr_datastore_instance.h"
 #include "nr_txn.h"
 #include "nr_rum.h"
@@ -35,8 +36,12 @@ PHP_RINIT_FUNCTION(newrelic) {
   NRPRG(php_cur_stack_depth) = 0;
   NRPRG(deprecated_capture_request_parameters) = NRINI(capture_params);
   NRPRG(sapi_headers) = NULL;
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+  nr_php_init_transient_user_instrumentation();
+#else
   NRPRG(pid) = getpid();
   NRPRG(user_function_wrappers) = nr_vector_create(64, NULL, NULL);
+#endif
 
   if ((0 == NR_PHP_PROCESS_GLOBALS(enabled)) || (0 == NRINI(enabled))) {
     return SUCCESS;

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -109,7 +109,9 @@ int nr_php_post_deactivate(void) {
   nr_free(NRPRG(predis_ctx));
   nr_hashmap_destroy(&NRPRG(predis_commands));
 
+#if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
   nr_vector_destroy(&NRPRG(user_function_wrappers));
+#endif
 
   NRPRG(cufa_callback) = NULL;
 

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -109,7 +109,9 @@ int nr_php_post_deactivate(void) {
   nr_free(NRPRG(predis_ctx));
   nr_hashmap_destroy(&NRPRG(predis_commands));
 
-#if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+  nr_php_reset_user_instrumentation();
+#else
   nr_vector_destroy(&NRPRG(user_function_wrappers));
 #endif
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -679,7 +679,10 @@ nr_status_t nr_php_txn_begin(const char* appnames,
    */
   pfd = nr_get_daemon_fd();
 
+#if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
+  /* For PHP 7.4+ user instrumentation is reset at rshutdown. */
   nr_php_reset_user_instrumentation();
+#endif
 
   if (pfd < 0) {
     nrl_debug(NRL_INIT, "unable to begin transaction: no daemon connection");

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -439,6 +439,7 @@ void nr_php_reset_user_instrumentation(void) {
   }
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
   if (NULL != user_function_wrappers) {
+    // send a metric with the number of transient wrappers
     nr_hashmap_destroy(&user_function_wrappers);
   }
   /* wraprecs are re-usable and stored in linked list - no destructor */
@@ -451,6 +452,7 @@ void nr_php_reset_user_instrumentation(void) {
  */
 void nr_php_remove_transient_user_instrumentation(void) {
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+  // send a metric with the number of transient wrappers
   nr_hashmap_destroy(&transient_wrappers);
 #else
   nruserfn_t* p = nr_wrapped_user_functions;

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -416,7 +416,7 @@ void nr_php_reset_user_instrumentation(void) {
     nr_hashmap_destroy(&user_function_wrappers);
   }
   // send a metric with the number of transient wrappers
-  user_function_wrappers = nr_hashmap_create_buckets(10, reset_wraprec);
+  user_function_wrappers = nr_hashmap_create_buckets(1024, reset_wraprec);
 #else
   nruserfn_t* p = nr_wrapped_user_functions;
   while (0 != p) {

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -416,7 +416,7 @@ void nr_php_reset_user_instrumentation(void) {
     nr_hashmap_destroy(&user_function_wrappers);
   }
   // send a metric with the number of transient wrappers
-  user_function_wrappers = nr_hashmap_create(reset_wraprec);
+  user_function_wrappers = nr_hashmap_create_buckets(10, reset_wraprec);
 #else
   nruserfn_t* p = nr_wrapped_user_functions;
   while (0 != p) {

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -444,7 +444,10 @@ void nr_php_reset_user_instrumentation(void) {
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
    // send a metric with the number of transient wrappers
   if (NULL != user_function_wrappers) {
-    nr_php_wraprec_hashmap_destroy(&user_function_wrappers);
+    nr_php_wraprec_hashmap_stats_t stats = nr_php_wraprec_hashmap_destroy(&user_function_wrappers);
+
+    nrl_debug(NRL_INSTRUMENT, "# elements: %lu, # buckets used: %lu", stats.elements, stats.buckets_used);
+    nrl_debug(NRL_INSTRUMENT, "collisions - min: %lu, max: %lu, avg: %lu", stats.collisions_min, stats.collisions_max, stats.collisions_mean);
   }
 #else
   nruserfn_t* p = nr_wrapped_user_functions;

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -412,7 +412,7 @@ static void destroy_transient_wrapper(void* wraprec) {
 
 void nr_php_init_transient_user_instrumentation(void) {
   /* wraprecs are not re-usable and destroyed together with hashmap */
-  transient_wrappers = nr_hashmap_create(destroy_transient_wrapper);
+  transient_wrappers = nr_hashmap_create_buckets(10, destroy_transient_wrapper);
 }
 #endif
 
@@ -433,7 +433,7 @@ void nr_php_reset_user_instrumentation(void) {
     nr_hashmap_destroy(&user_function_wrappers);
   }
   /* wraprecs are re-usable and stored in linked list - no destructor */
-  user_function_wrappers = nr_hashmap_create(NULL);
+  user_function_wrappers = nr_hashmap_create_buckets(6, NULL);
 #endif
 }
 

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -89,8 +89,8 @@ static nr_hashmap_t* user_function_wrappers;
  * together with all wraprecs in it at the end of the request. */
 static nr_hashmap_t* transient_wrappers;
 
-static inline void nr_php_wraprec_hashmap_set(nr_hashmap_t* h, nruserfn_t* wr) {
-  nr_hashmap_update(h, (const char *)&wr->zf, sizeof(zend_function*), wr);
+static inline void nr_php_wraprec_hashmap_set(nr_hashmap_t* h, zend_function* zf, nruserfn_t* wr) {
+  nr_hashmap_update(h, (const char *)&zf, sizeof(zend_function*), wr);
 }
 static inline nruserfn_t* nr_php_wraprec_hashmap_get(nr_hashmap_t* h, zend_function *zf) {\
   nruserfn_t* wraprec = NULL;
@@ -160,8 +160,7 @@ static void nr_php_wrap_zend_function(
                                       zend_function* func,
                                       nruserfn_t* wraprec TSRMLS_DC) {
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-  wraprec->zf = func;
-  nr_php_wraprec_hashmap_set(h, wraprec);
+  nr_php_wraprec_hashmap_set(h, func, wraprec);
 #else
   nr_php_op_array_set_wraprec(&func->op_array, wraprec TSRMLS_CC);
 #endif
@@ -425,9 +424,6 @@ void nr_php_reset_user_instrumentation(void) {
   nruserfn_t* p = nr_wrapped_user_functions;
 
   while (0 != p) {
-#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-    p->zf = NULL;
-#endif
     p->is_wrapped = 0;
     p = p->next;
   }

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -99,6 +99,38 @@ static inline nruserfn_t* nr_php_wraprec_hashmap_get(nr_hashmap_t* h, zend_funct
 
   return wraprec;
 }
+
+/*
+ * Init user instrumentation. This must only be called on request init!
+ * This creates wraprec lookup hashmap and registers wraprec destructor
+ * callback - reset_wraprec - which is called on request shutdown.
+ */
+static void reset_wraprec(void* wraprec);
+void nr_php_init_user_instrumentation(void) {
+  if (NULL != user_function_wrappers) {
+    /* Should not happen */
+    nrl_verbosedebug(NRL_INSTRUMENT, "user_function_wrappers lookup hashmap already initialized!");
+    return;
+  }
+  user_function_wrappers = nr_hashmap_create_buckets(1024, reset_wraprec);
+}
+
+/*
+ * This callback resets user instrumentation. It is called at request shutdown
+ * when user instrumentation is reset - lookup hashmap is destroyed together
+ * with transient wraprecs and non-transient wraprecs are reset (mark as not 
+ * wrapped). This happens because with new request/transaction php is loading
+ * all new user code.
+ */
+static void nr_php_user_wraprec_destroy(nruserfn_t** wraprec_ptr);
+static void reset_wraprec(void* wraprec) {
+  nruserfn_t*p = wraprec;
+  if (p->is_transient) {
+    nr_php_user_wraprec_destroy((nruserfn_t**)&wraprec);
+  } else {
+    p->is_wrapped = 0;
+  }
+}
 #endif
 
 /*
@@ -395,28 +427,23 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
   return wraprec; /* return the new wraprec */
 }
 
-#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-static void reset_wraprec(void* wraprec) {
-  nruserfn_t*p = wraprec;
-  if (p->is_transient) {
-    nr_php_user_wraprec_destroy((nruserfn_t**)&wraprec);
-  } else {
-    p->is_wrapped = 0;
-  }
-}
-#endif
 
 /*
  * Reset the user instrumentation records because we're starting a new
  * transaction and so we'll be loading all new user code.
+ * 
+ * For PHP 7.4+ this function is called on request shutdown to release memory
+ * allocated for lookup hashmap! Additionally hashmap's value destructor 
+ * callback will reset all non-transient wraprecs (mark them as not wrapped),
+ * destroy all transient wraprecs.
+ * 
  */
 void nr_php_reset_user_instrumentation(void) {
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+   // send a metric with the number of transient wrappers
   if (NULL != user_function_wrappers) {
-    nr_hashmap_destroy(&user_function_wrappers);
+    nr_php_wraprec_hashmap_destroy(&user_function_wrappers);
   }
-  // send a metric with the number of transient wrappers
-  user_function_wrappers = nr_hashmap_create_buckets(1024, reset_wraprec);
 #else
   nruserfn_t* p = nr_wrapped_user_functions;
   while (0 != p) {

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -90,10 +90,10 @@ int nr_zend_call_orig_execute_special(nruserfn_t* wraprec,
  * wraprecs. Re-usable wraprecs are not destroyed - they are re-set. */
 static nr_php_wraprec_hashmap_t* user_function_wrappers;
 
-static inline void nr_php_wraprec_lookup_set(nruserfn_t* wr, const zend_function* zf) {
+static inline void nr_php_wraprec_lookup_set(nruserfn_t* wr, zend_function* zf) {
   nr_php_wraprec_hashmap_update(user_function_wrappers, zf, wr);
 }
-static inline nruserfn_t* nr_php_wraprec_lookup_get(const zend_function *zf) {
+static inline nruserfn_t* nr_php_wraprec_lookup_get(zend_function *zf) {
   nruserfn_t* wraprec = NULL;
 
   nr_php_wraprec_hashmap_get_into(user_function_wrappers, zf, &wraprec);

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -265,12 +265,8 @@ static nruserfn_t* nr_php_user_wraprec_create_named(const char* full_name,
     wraprec->classname = nr_strndup(klass, klass_len);
     wraprec->classnamelen = klass_len;
     wraprec->classnameLC = nr_string_to_lowercase(wraprec->classname);
-    wraprec->reportedclass = NULL;
     wraprec->is_method = 1;
   }
-
-  wraprec->lineno = 0;
-  wraprec->filename = NULL;
 
   wraprec->supportability_metric = nr_txn_create_fn_supportability_metric(
       wraprec->funcname, wraprec->classname);
@@ -296,8 +292,6 @@ static void nr_php_user_wraprec_destroy(nruserfn_t** wraprec_ptr) {
   nr_free(wraprec->funcname);
   nr_free(wraprec->classnameLC);
   nr_free(wraprec->funcnameLC);
-  nr_free(wraprec->reportedclass);
-  nr_free(wraprec->filename);
   nr_realfree((void**)wraprec_ptr);
 }
 

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -90,12 +90,12 @@ static nr_hashmap_t* user_function_wrappers;
 static nr_hashmap_t* transient_wrappers;
 
 static inline void nr_php_wraprec_hashmap_set(nr_hashmap_t* h, nruserfn_t* wr) {
-  nr_hashmap_update(h, (const char *)wr->zf, sizeof(zend_function*), wr);
+  nr_hashmap_update(h, (const char *)&wr->zf, sizeof(zend_function*), wr);
 }
 static inline nruserfn_t* nr_php_wraprec_hashmap_get(nr_hashmap_t* h, zend_function *zf) {\
   nruserfn_t* wraprec = NULL;
 
-  nr_hashmap_get_into(h, (const char*)zf, sizeof(zend_function*), (void**)&wraprec);
+  nr_hashmap_get_into(h, (const char*)&zf, sizeof(zend_function*), (void**)&wraprec);
 
   return wraprec;
 }

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -363,12 +363,12 @@ nruserfn_t* nr_php_add_custom_tracer_callable(zend_function* func TSRMLS_DC) {
   nrl_verbosedebug(NRL_INSTRUMENT, "adding custom for callable '%s'", name);
   nr_free(name);
 
-  nr_php_wrap_zend_function(
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-    transient_wrappers,
-#endif
-     func, wraprec TSRMLS_CC);
+  nr_php_wrap_zend_function(transient_wrappers, func, wraprec);
+#else
+  nr_php_wrap_zend_function(func, wraprec TSRMLS_CC);
   nr_php_add_custom_tracer_common(wraprec);
+#endif
 
   return wraprec;
 }

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -83,7 +83,6 @@ typedef struct _nruserfn_t {
 extern nruserfn_t* nr_wrapped_user_functions; /* a singly linked list */
 
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-extern void nr_php_init_transient_user_instrumentation(void);
 extern nruserfn_t* nr_php_get_wraprec(zend_function* zf);
 #else
 /*

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -36,13 +36,6 @@ typedef void (*nruserfn_declared_t)(TSRMLS_D);
 typedef struct _nruserfn_t {
   struct _nruserfn_t* next; /* singly linked list next pointer */
 
-#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-  /* Pointer to zend_function is used as a key into the lookup hashmap. 
-   * It is set at the begining of a transaction when function is being 
-   * wrapped and is re-set when user instrumentation is reset */
-  zend_function* zf; 
-#endif
-
   const char* extra; /* extra naming information about the function */
 
   char* classname;

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -89,7 +89,24 @@ typedef struct _nruserfn_t {
 extern nruserfn_t* nr_wrapped_user_functions; /* a singly linked list */
 
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+/*
+ * Purpose : Init user instrumentation. This must only be called on request
+ * init! This creates wraprec lookup hashmap and registers wraprec destructor
+ * callback which is called on request shutdown.
+ *
+ * Params  : None
+ *
+ * Returns : None
+ */
 extern void nr_php_init_user_instrumentation(void);
+/*
+ * Purpose : Get the wraprec associated with a zend_function.
+ *
+ * Params  : 1. The zend function to find a wraprec for
+ *
+ * Returns : The function wrapper that matches the zend_function or NULL if no
+ * match was found.
+ */
 extern nruserfn_t* nr_php_get_wraprec(zend_function* zf);
 #else
 /*

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -62,27 +62,6 @@ typedef struct _nruserfn_t {
   char* funcnameLC;
 
   /*
-   * Internally, there are cases where the zend_function reports it is one
-   * class; however, the zend_function is also contained in another class_entry
-   * table.
-   * For an example, see tests/integration/laravel
-   * A lookup for the class = Illuminate\Console\Application returns the class
-   * entry named classname = Illuminate\Console\Application
-   * So far so good!
-   * Lookup Illuminate\Console\Application method doRun and a zend_function is
-   * returned.  Ask that zend_func what its classname is and it says:
-   * Symfony\Component\Console\Application.
-   * Okay.
-   * Track both pieces of info for any wraprecs.
-   */
-  char* reportedclass;
-  /*
-   * These are helpful to compare the wraprec more quickly and to differentiate
-   * between closures.
-   */
-  char* filename;
-  uint32_t lineno;
-  /*
    * As an alternative to the current implementation, this could be
    * converted to a linked list so that we can nest wrappers.
    */
@@ -212,17 +191,5 @@ extern void nr_php_user_function_add_declared_callback(
     const char* namestr,
     int namestrlen,
     nruserfn_declared_t callback TSRMLS_DC);
-
-static inline bool chk_reported_class(zend_function* func,
-                                      nruserfn_t* wraprec) {
-  if ((NULL == func) || (NULL == func->common.scope)) {
-    return false;
-  }
-
-  if ((NULL == func->common.scope->name) || (NULL != wraprec->reportedclass)) {
-    return false;
-  }
-  return true;
-}
 
 #endif /* PHP_USER_INSTRUMENT_HDR */

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -11,6 +11,7 @@
 #define PHP_USER_INSTRUMENT_HDR
 
 #include "nr_segment.h"
+#include "php_user_instrument_hashmap_key.h"
 
 struct _nruserfn_t;
 
@@ -35,6 +36,11 @@ typedef void (*nruserfn_declared_t)(TSRMLS_D);
  */
 typedef struct _nruserfn_t {
   struct _nruserfn_t* next; /* singly linked list next pointer */
+
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+  /* wraprec hashmap key */
+  nr_php_wraprec_hashmap_key_t key;
+#endif
 
   const char* extra; /* extra naming information about the function */
 

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -83,6 +83,7 @@ typedef struct _nruserfn_t {
 extern nruserfn_t* nr_wrapped_user_functions; /* a singly linked list */
 
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+extern void nr_php_init_user_instrumentation(void);
 extern nruserfn_t* nr_php_get_wraprec(zend_function* zf);
 #else
 /*

--- a/agent/php_user_instrument_hashmap.c
+++ b/agent/php_user_instrument_hashmap.c
@@ -12,7 +12,7 @@ typedef struct _nr_wraprecs_bucket {
   struct _nr_wraprecs_bucket* prev;
   struct _nr_wraprecs_bucket* next;
   /* for efficiency wraprec is used as both: key and a value */
-  nruserfn_t *wraprec;
+  nruserfn_t* wraprec;
 } nr_wraprecs_bucket_t;
 
 typedef struct _nr_php_wraprec_hashmap {
@@ -26,8 +26,9 @@ static inline size_t nr_count_buckets(const nr_php_wraprec_hashmap_t* hashmap) {
   return (size_t)(1 << hashmap->log2_num_buckets);
 }
 
-static nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_internal(size_t log2_num_buckets,
-                                         nr_php_wraprec_hashmap_dtor_fn_t dtor_fn) {
+static nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_internal(
+    size_t log2_num_buckets,
+    nr_php_wraprec_hashmap_dtor_fn_t dtor_fn) {
   nr_php_wraprec_hashmap_t* hashmap;
 
   if (0 == log2_num_buckets) {
@@ -43,7 +44,8 @@ static nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_internal(size_t l
     log2_num_buckets = 24;
   }
 
-  hashmap = (nr_php_wraprec_hashmap_t*)nr_malloc(sizeof(nr_php_wraprec_hashmap_t));
+  hashmap
+      = (nr_php_wraprec_hashmap_t*)nr_malloc(sizeof(nr_php_wraprec_hashmap_t));
   hashmap->dtor_func = dtor_fn;
   hashmap->log2_num_buckets = log2_num_buckets;
   hashmap->buckets = (nr_wraprecs_bucket_t**)nr_calloc(
@@ -53,8 +55,9 @@ static nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_internal(size_t l
   return hashmap;
 }
 
-nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_buckets(size_t buckets, nr_php_wraprec_hashmap_dtor_fn_t dtor_fn) {
-
+nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_buckets(
+    size_t buckets,
+    nr_php_wraprec_hashmap_dtor_fn_t dtor_fn) {
   size_t actual_buckets;
 
   if (0 == buckets) {
@@ -74,8 +77,9 @@ nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_buckets(size_t buckets, 
   return nr_php_wraprec_hashmap_create_internal(actual_buckets, dtor_fn);
 }
 
-static void nr_destroy_wraprecs_bucket(nr_wraprecs_bucket_t** bucket_ptr,
-                               nr_php_wraprec_hashmap_dtor_fn_t dtor_func) {
+static void nr_destroy_wraprecs_bucket(
+    nr_wraprecs_bucket_t** bucket_ptr,
+    nr_php_wraprec_hashmap_dtor_fn_t dtor_func) {
   nr_wraprecs_bucket_t* bucket = *bucket_ptr;
 
   if (dtor_func) {
@@ -84,7 +88,8 @@ static void nr_destroy_wraprecs_bucket(nr_wraprecs_bucket_t** bucket_ptr,
   nr_realfree((void**)bucket_ptr);
 }
 
-nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(nr_php_wraprec_hashmap_t** hashmap_ptr) {
+nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(
+    nr_php_wraprec_hashmap_t** hashmap_ptr) {
   nr_php_wraprec_hashmap_stats_t stats = {};
   size_t count;
   nr_php_wraprec_hashmap_t* hashmap;
@@ -146,19 +151,20 @@ static bool nr_zf_is_unnamed_closure(const zend_function* zf) {
   return 0 == memcmp("{closure}", ZSTR_VAL(zf->op_array.function_name), 9);
 }
 
-void nr_php_wraprec_hashmap_key_set(nr_php_wraprec_hashmap_key_t *key, const zend_function *zf) {
+void nr_php_wraprec_hashmap_key_set(nr_php_wraprec_hashmap_key_t* key,
+                                    const zend_function* zf) {
   key->lineno = nr_php_zend_function_lineno(zf);
   key->scope_name = NULL;
   key->function_name = NULL;
   key->filename = NULL;
 
   if (NULL != zf->op_array.function_name && !nr_zf_is_unnamed_closure(zf)) {
-      key->function_name = zf->op_array.function_name;
-      zend_string_addref(key->function_name);
-      if (zf->op_array.scope) {
-        key->scope_name = zf->op_array.scope->name;
-        zend_string_addref(key->scope_name);
-      }
+    key->function_name = zf->op_array.function_name;
+    zend_string_addref(key->function_name);
+    if (zf->op_array.scope) {
+      key->scope_name = zf->op_array.scope->name;
+      zend_string_addref(key->scope_name);
+    }
   } else {
     if (NULL != zf->op_array.filename) {
       key->filename = zf->op_array.filename;
@@ -167,7 +173,7 @@ void nr_php_wraprec_hashmap_key_set(nr_php_wraprec_hashmap_key_t *key, const zen
   }
 }
 
-void nr_php_wraprec_hashmap_key_release(nr_php_wraprec_hashmap_key_t *key) {
+void nr_php_wraprec_hashmap_key_release(nr_php_wraprec_hashmap_key_t* key) {
   if (NULL != key->scope_name) {
     zend_string_release(key->scope_name);
   }
@@ -180,7 +186,8 @@ void nr_php_wraprec_hashmap_key_release(nr_php_wraprec_hashmap_key_t *key) {
   key->lineno = 0;
 }
 
-static inline size_t nr_zendfunc2bucketidx(size_t log2_num_buckets, zend_function* zf) {
+static inline size_t nr_zendfunc2bucketidx(size_t log2_num_buckets,
+                                           zend_function* zf) {
   /* default to lineno */
   uint32_t hash = nr_php_zend_function_lineno(zf);
 
@@ -216,8 +223,8 @@ static inline bool zstr_equal(zend_string* zs1, zend_string* zs2) {
   return true;
 }
 
-static bool nr_is_wraprec_for_zend_func(nr_php_wraprec_hashmap_key_t* key, zend_function* zf) {
-
+static bool nr_is_wraprec_for_zend_func(nr_php_wraprec_hashmap_key_t* key,
+                                        zend_function* zf) {
   if (nr_php_zend_function_lineno(zf) != key->lineno) {
     return false;
   }
@@ -227,21 +234,25 @@ static bool nr_is_wraprec_for_zend_func(nr_php_wraprec_hashmap_key_t* key, zend_
       return false;
     }
     /* compare scope if it is set */
-    if (zf->op_array.scope && !zstr_equal(key->scope_name, zf->op_array.scope->name)) {
+    if (zf->op_array.scope
+        && !zstr_equal(key->scope_name, zf->op_array.scope->name)) {
       return false;
     }
     return true;
   }
-  
+
   if (!zstr_equal(key->filename, zf->op_array.filename)) {
-      return false;
+    return false;
   }
 
   return true;
 }
 
-static int nr_php_wraprec_hashmap_fetch_internal(nr_php_wraprec_hashmap_t* hashmap,
-                             size_t hash_key, zend_function* zf, nr_wraprecs_bucket_t** bucket_ptr) {
+static int nr_php_wraprec_hashmap_fetch_internal(
+    nr_php_wraprec_hashmap_t* hashmap,
+    size_t hash_key,
+    zend_function* zf,
+    nr_wraprecs_bucket_t** bucket_ptr) {
   nr_wraprecs_bucket_t* bucket;
 
   for (bucket = hashmap->buckets[hash_key]; bucket; bucket = bucket->next) {
@@ -254,8 +265,10 @@ static int nr_php_wraprec_hashmap_fetch_internal(nr_php_wraprec_hashmap_t* hashm
   return 0;
 }
 
-static void nr_php_wraprec_hashmap_add_internal(nr_php_wraprec_hashmap_t* hashmap,
-                             size_t hash_key, nruserfn_t* wr) {
+static void nr_php_wraprec_hashmap_add_internal(
+    nr_php_wraprec_hashmap_t* hashmap,
+    size_t hash_key,
+    nruserfn_t* wr) {
   nr_wraprecs_bucket_t* bucket;
 
   bucket = (nr_wraprecs_bucket_t*)nr_malloc(sizeof(nr_wraprecs_bucket_t));
@@ -271,7 +284,9 @@ static void nr_php_wraprec_hashmap_add_internal(nr_php_wraprec_hashmap_t* hashma
   ++hashmap->elements;
 }
 
-void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t* hashmap, zend_function* zf, nruserfn_t* wr) {
+void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t* hashmap,
+                                   zend_function* zf,
+                                   nruserfn_t* wr) {
   nr_wraprecs_bucket_t* bucket = NULL;
   size_t bucketidx;
 
@@ -294,8 +309,9 @@ void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t* hashmap, zend_funct
   nr_php_wraprec_hashmap_add_internal(hashmap, bucketidx, wr);
 }
 
-
-int nr_php_wraprec_hashmap_get_into(nr_php_wraprec_hashmap_t* hashmap, zend_function* zf, nruserfn_t** wraprec_ptr) {
+int nr_php_wraprec_hashmap_get_into(nr_php_wraprec_hashmap_t* hashmap,
+                                    zend_function* zf,
+                                    nruserfn_t** wraprec_ptr) {
   nr_wraprecs_bucket_t* bucket = NULL;
   size_t bucketidx;
 

--- a/agent/php_user_instrument_hashmap.c
+++ b/agent/php_user_instrument_hashmap.c
@@ -152,7 +152,18 @@ void nr_php_wraprec_hashmap_key_release(nr_php_wraprec_hashmap_key_t *key) {
 }
 
 static inline size_t nr_zendfunc2bucketidx(size_t log2_num_buckets, const zend_function* zf) {
+  /* default to lineno */
   uint32_t hash = nr_php_zend_function_lineno(zf);
+
+  if (NULL != zf->op_array.function_name && !nr_zf_is_unnamed_closure(zf)) {
+    /* but use hash of function name when possible */
+    hash = zf->op_array.function_name->h;
+  } else if (NULL != zf->op_array.filename) {
+    /* and as last resort try hash of filename if available */
+    hash = zf->op_array.filename->h;
+  }
+
+  /* normalize to stay in-bound */
   return (hash & ((1 << log2_num_buckets) - 1));
 }
 

--- a/agent/php_user_instrument_hashmap.c
+++ b/agent/php_user_instrument_hashmap.c
@@ -252,7 +252,7 @@ static bool nr_is_wraprec_for_zend_func(nr_php_wraprec_hashmap_key_t* key,
     return true;
   }
 
-  /* deal with unnamed colsure: fallback to comparing filename */
+  /* deal with unnamed closure: fallback to comparing filename */
   if (!zstr_equal(key->filename, zf->op_array.filename)) {
     /* no match: filename is different */
     return false;

--- a/agent/php_user_instrument_hashmap.c
+++ b/agent/php_user_instrument_hashmap.c
@@ -144,7 +144,7 @@ nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(
   return stats;
 }
 
-static bool nr_zf_is_unnamed_closure(const zend_function* zf) {
+static inline bool nr_zf_is_unnamed_closure(const zend_function* zf) {
   if (9 != ZSTR_LEN(zf->op_array.function_name)) {
     return false;
   }

--- a/agent/php_user_instrument_hashmap.c
+++ b/agent/php_user_instrument_hashmap.c
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "php_agent.h"
+#include "php_user_instrument_hashmap.h"
+
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+
+typedef struct _nr_wraprecs_bucket {
+  struct _nr_wraprecs_bucket* prev;
+  struct _nr_wraprecs_bucket* next;
+  /* for efficiency wraprec is used as both: key and a value */
+  nruserfn_t *wraprec;
+} nr_wraprecs_bucket_t;
+
+typedef struct _nr_php_wraprec_hashmap {
+  nr_php_wraprec_hashmap_dtor_fn_t dtor_func;
+  size_t log2_num_buckets;
+  nr_wraprecs_bucket_t** buckets;
+  size_t elements;
+} nr_php_wraprec_hashmap_t;
+
+static inline size_t nr_count_buckets(const nr_php_wraprec_hashmap_t* hashmap) {
+  return (size_t)(1 << hashmap->log2_num_buckets);
+}
+
+static nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_internal(size_t log2_num_buckets,
+                                         nr_php_wraprec_hashmap_dtor_fn_t dtor_fn) {
+  nr_php_wraprec_hashmap_t* hashmap;
+
+  if (0 == log2_num_buckets) {
+    /*
+     * Encode the default value in one place: namely, here.
+     */
+    log2_num_buckets = 8;
+  } else if (log2_num_buckets > 24) {
+    /*
+     * Basic sanity check: it's extremely unlikely that we'll ever need a
+     * hashmap for the user function wraprecs that has more than 2^24 buckets.
+     */
+    log2_num_buckets = 24;
+  }
+
+  hashmap = (nr_php_wraprec_hashmap_t*)nr_malloc(sizeof(nr_php_wraprec_hashmap_t));
+  hashmap->dtor_func = dtor_fn;
+  hashmap->log2_num_buckets = log2_num_buckets;
+  hashmap->buckets = (nr_wraprecs_bucket_t**)nr_calloc(
+      (1 << log2_num_buckets), sizeof(nr_wraprecs_bucket_t*));
+  hashmap->elements = 0;
+
+  return hashmap;
+}
+
+nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_buckets(size_t buckets, nr_php_wraprec_hashmap_dtor_fn_t dtor_fn) {
+
+  size_t actual_buckets;
+
+  if (0 == buckets) {
+    actual_buckets = 0;
+  } else {
+    /*
+     * Calculate ceil(log2(buckets)), since that's what
+     * nr_hashmap_create_internal requires.
+     */
+
+    actual_buckets = 1;
+    while (((size_t)(1 << actual_buckets)) < buckets) {
+      actual_buckets += 1;
+    }
+  }
+
+  return nr_php_wraprec_hashmap_create_internal(actual_buckets, dtor_fn);
+}
+
+static void nr_destroy_wraprecs_bucket(nr_wraprecs_bucket_t** bucket_ptr,
+                               nr_php_wraprec_hashmap_dtor_fn_t dtor_func) {
+  nr_wraprecs_bucket_t* bucket = *bucket_ptr;
+
+  if (dtor_func) {
+    (dtor_func)(bucket->wraprec);
+  }
+  nr_realfree((void**)bucket_ptr);
+}
+
+void nr_php_wraprec_hashmap_destroy(nr_php_wraprec_hashmap_t** hashmap_ptr) {
+  size_t count;
+  nr_php_wraprec_hashmap_t* hashmap;
+  size_t i;
+
+  if ((NULL == hashmap_ptr) || (NULL == *hashmap_ptr)) {
+    return;
+  }
+  hashmap = *hashmap_ptr;
+
+  count = nr_count_buckets(hashmap);
+  for (i = 0; i < count; i++) {
+    nr_wraprecs_bucket_t* bucket = hashmap->buckets[i];
+
+    while (bucket) {
+      nr_wraprecs_bucket_t* next = bucket->next;
+
+      nr_destroy_wraprecs_bucket(&bucket, hashmap->dtor_func);
+      bucket = next;
+    }
+  }
+
+  nr_free(hashmap->buckets);
+  nr_realfree((void**)hashmap_ptr);
+}
+
+static bool nr_zf_is_unnamed_closure(const zend_function* zf) {
+  if (9 != ZSTR_LEN(zf->op_array.function_name)) {
+    return false;
+  }
+  return 0 == memcmp("{closure}", ZSTR_VAL(zf->op_array.function_name), 9);
+}
+
+void nr_php_wraprec_hashmap_key_set(nr_php_wraprec_hashmap_key_t *key, const zend_function *zf) {
+  key->lineno = nr_php_zend_function_lineno(zf);
+  key->scope_name = NULL;
+  key->function_name = NULL;
+  key->filename = NULL;
+
+  if (NULL != zf->op_array.function_name && !nr_zf_is_unnamed_closure(zf)) {
+      key->function_name = zf->op_array.function_name;
+      zend_string_addref(key->function_name);
+      if (zf->op_array.scope) {
+        key->scope_name = zf->op_array.scope->name;
+        zend_string_addref(key->scope_name);
+      }
+  } else {
+    if (NULL != zf->op_array.filename) {
+      key->filename = zf->op_array.filename;
+      zend_string_addref(key->filename);
+    }
+  }
+}
+
+void nr_php_wraprec_hashmap_key_release(nr_php_wraprec_hashmap_key_t *key) {
+  if (NULL != key->scope_name) {
+    zend_string_release(key->scope_name);
+  }
+  if (NULL != key->function_name) {
+    zend_string_release(key->function_name);
+  }
+  if (NULL != key->filename) {
+    zend_string_release(key->filename);
+  }
+  key->lineno = 0;
+}
+
+static inline size_t nr_zendfunc2bucketidx(size_t log2_num_buckets, const zend_function* zf) {
+  uint32_t hash = nr_php_zend_function_lineno(zf);
+  return (hash & ((1 << log2_num_buckets) - 1));
+}
+
+static inline bool zstr_equal(const zend_string* zs1, const zend_string* zs2) {
+  if (NULL == zs1 || NULL == zs2) {
+    return false;
+  }
+
+  if (ZSTR_LEN(zs1) != ZSTR_LEN(zs2)) {
+    return false;
+  }
+
+  if (ZSTR_H(zs1) != ZSTR_H(zs2)) {
+    return false;
+  }
+
+  if (0 != memcmp(ZSTR_VAL(zs1), ZSTR_VAL(zs2), ZSTR_LEN(zs1))) {
+    return false;
+  }
+
+  return true;
+}
+
+static bool nr_is_wraprec_for_zend_func(nr_php_wraprec_hashmap_key_t* key, const zend_function* zf) {
+
+  if (nr_php_zend_function_lineno(zf) != key->lineno) {
+    return false;
+  }
+
+  if (zf->op_array.function_name && !nr_zf_is_unnamed_closure(zf)) {
+    if (!zstr_equal(key->function_name, zf->op_array.function_name)) {
+      return false;
+    }
+    /* compare scope if it is set */
+    if (zf->op_array.scope && !zstr_equal(key->scope_name, zf->op_array.scope->name)) {
+      return false;
+    }
+    return true;
+  }
+  
+  if (!zstr_equal(key->filename, zf->op_array.filename)) {
+      return false;
+  }
+
+  return true;
+}
+
+static int nr_php_wraprec_hashmap_fetch_internal(nr_php_wraprec_hashmap_t* hashmap,
+                             size_t hash_key, const zend_function* zf, nr_wraprecs_bucket_t** bucket_ptr) {
+  nr_wraprecs_bucket_t* bucket;
+
+  for (bucket = hashmap->buckets[hash_key]; bucket; bucket = bucket->next) {
+    if (nr_is_wraprec_for_zend_func(&bucket->wraprec->key, zf)) {
+      *bucket_ptr = bucket;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static void nr_php_wraprec_hashmap_add_internal(nr_php_wraprec_hashmap_t* hashmap,
+                             size_t hash_key, nruserfn_t* wr) {
+  nr_wraprecs_bucket_t* bucket;
+
+  bucket = (nr_wraprecs_bucket_t*)nr_malloc(sizeof(nr_wraprecs_bucket_t));
+  bucket->prev = NULL;
+  bucket->next = hashmap->buckets[hash_key];
+  bucket->wraprec = wr;
+
+  if (hashmap->buckets[hash_key]) {
+    hashmap->buckets[hash_key]->prev = bucket;
+  }
+
+  hashmap->buckets[hash_key] = bucket;
+  ++hashmap->elements;
+}
+
+void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t* hashmap, const zend_function* zf, nruserfn_t* wr) {
+  nr_wraprecs_bucket_t* bucket = NULL;
+  size_t bucketidx;
+
+  if ((NULL == hashmap) || (NULL == zf) || (0 == wr)) {
+    return;
+  }
+
+  nr_php_wraprec_hashmap_key_set(&wr->key, zf);
+
+  bucketidx = nr_zendfunc2bucketidx(hashmap->log2_num_buckets, zf);
+  if (nr_php_wraprec_hashmap_fetch_internal(hashmap, bucketidx, zf, &bucket)) {
+    if (hashmap->dtor_func) {
+      (hashmap->dtor_func)(bucket->wraprec);
+    }
+
+    bucket->wraprec = wr;
+    return;
+  }
+
+  nr_php_wraprec_hashmap_add_internal(hashmap, bucketidx, wr);
+}
+
+
+int nr_php_wraprec_hashmap_get_into(nr_php_wraprec_hashmap_t* hashmap, const zend_function* zf, nruserfn_t** wraprec_ptr) {
+  nr_wraprecs_bucket_t* bucket = NULL;
+  size_t bucketidx;
+
+  if ((NULL == hashmap) || (NULL == zf) || (NULL == wraprec_ptr)) {
+    return 0;
+  }
+
+  bucketidx = nr_zendfunc2bucketidx(hashmap->log2_num_buckets, zf);
+  if (nr_php_wraprec_hashmap_fetch_internal(hashmap, bucketidx, zf, &bucket)) {
+    *wraprec_ptr = bucket->wraprec;
+    return 1;
+  }
+
+  return 0;
+}
+
+#endif

--- a/agent/php_user_instrument_hashmap.c
+++ b/agent/php_user_instrument_hashmap.c
@@ -94,7 +94,7 @@ nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(
   size_t count;
   nr_php_wraprec_hashmap_t* hashmap;
   size_t i;
-  size_t collisions;
+  size_t bucket_items_cnt;
 
   if ((NULL == hashmap_ptr) || (NULL == *hashmap_ptr)) {
     return stats;
@@ -107,7 +107,7 @@ nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(
   count = nr_count_buckets(hashmap);
   for (i = 0; i < count; i++) {
     nr_wraprecs_bucket_t* bucket = hashmap->buckets[i];
-    collisions = 0;
+    bucket_items_cnt = 0;
 
     if (bucket) {
       stats.buckets_used++;
@@ -116,21 +116,21 @@ nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(
     while (bucket) {
       nr_wraprecs_bucket_t* next = bucket->next;
 
-      collisions++;
+      bucket_items_cnt++;
 
       nr_destroy_wraprecs_bucket(&bucket, hashmap->dtor_func);
       bucket = next;
     }
 
-    if (0 != collisions && collisions < stats.collisions_min) {
-      stats.collisions_min = collisions;
+    if (0 != bucket_items_cnt && bucket_items_cnt < stats.collisions_min) {
+      stats.collisions_min = bucket_items_cnt;
     }
-    if (collisions > stats.collisions_max) {
-      stats.collisions_max = collisions;
+    if (bucket_items_cnt > stats.collisions_max) {
+      stats.collisions_max = bucket_items_cnt;
     }
-    if (collisions > 1) {
+    if (bucket_items_cnt > 1) {
       stats.buckets_with_collisions++;
-      stats.collisions_mean += collisions;
+      stats.collisions_mean += bucket_items_cnt;
     }
   }
 

--- a/agent/php_user_instrument_hashmap.c
+++ b/agent/php_user_instrument_hashmap.c
@@ -225,26 +225,40 @@ static inline bool zstr_equal(zend_string* zs1, zend_string* zs2) {
 
 static bool nr_is_wraprec_for_zend_func(nr_php_wraprec_hashmap_key_t* key,
                                         zend_function* zf) {
+  /* Start with comparing line number: */
   if (nr_php_zend_function_lineno(zf) != key->lineno) {
+    /* no match: line number is different - no need to check anything else */
     return false;
   }
 
+  /* Next compare function name unless it is unnamed closure. Zend engine sets
+   * function name to '{closure}' for all unnamed closures so function name
+   * cannot be used for them. A fallback method to compare filename is used
+   * for unnamed closures. */
   if (zf->op_array.function_name && !nr_zf_is_unnamed_closure(zf)) {
     if (!zstr_equal(key->function_name, zf->op_array.function_name)) {
+      /* no match: function name is different - no need to check anything else
+       */
       return false;
     }
-    /* compare scope if it is set */
+    /* If function is scoped, compare the scope: */
     if (zf->op_array.scope
         && !zstr_equal(key->scope_name, zf->op_array.scope->name)) {
+      /* no match: scope is different */
       return false;
     }
+    /* match: line number, function name and scope (if function is scoped) are
+     * the same */
     return true;
   }
 
+  /* deal with unnamed colsure: fallback to comparing filename */
   if (!zstr_equal(key->filename, zf->op_array.filename)) {
+    /* no match: filename is different */
     return false;
   }
 
+  /* match: line number and filename are the same */
   return true;
 }
 

--- a/agent/php_user_instrument_hashmap.h
+++ b/agent/php_user_instrument_hashmap.h
@@ -20,6 +20,18 @@
 typedef struct _nr_php_wraprec_hashmap nr_php_wraprec_hashmap_t;
 
 /*
+ * hashmap type stats
+ */
+typedef struct _nr_php_wraprec_hashmap_stats {
+  size_t elements;
+  size_t buckets_used;
+  size_t collisions_min;
+  size_t collisions_max;
+  size_t collisions_mean;
+  size_t buckets_with_collisions;
+} nr_php_wraprec_hashmap_stats_t;
+
+/*
  * Type declaration for destructor functions.
  */
 typedef void (*nr_php_wraprec_hashmap_dtor_fn_t)(nruserfn_t*);
@@ -39,8 +51,10 @@ extern nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_buckets(size_t, n
  * Purpose : Destroy a hashmap.
  *
  * Params  : 1. The address of the hashmap to destroy.
+ * 
+ * Returns : hashmap stats.
  */
-extern void nr_php_wraprec_hashmap_destroy(nr_php_wraprec_hashmap_t**);
+extern nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(nr_php_wraprec_hashmap_t**);
 
 /*
  * Purpose : Update the key in the wraprec using metadata from zend function,

--- a/agent/php_user_instrument_hashmap.h
+++ b/agent/php_user_instrument_hashmap.h
@@ -50,8 +50,12 @@ extern void nr_php_wraprec_hashmap_destroy(nr_php_wraprec_hashmap_t**);
  * Params  : 1. The hashmap.
  *           2. The zend function to set instrumentation for.
  *           3. The wraprec to set the key and store in the hashmap.
+ * 
+ * Caveat: If zend function's zend_string metadata (function_name or filename)
+ *         does not have hash calculated, this function will calculate value
+ *         for zend_string's h property.
  */
-extern void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t*, const zend_function*, nruserfn_t*);
+extern void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t*, zend_function*, nruserfn_t*);
 
 /*
  * Purpose : Get a wraprec pointer from a hashmap into an out parameter.
@@ -63,8 +67,12 @@ extern void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t*, const zend_
  *              unchanged.
  *
  * Returns : Non-zero if the value exists, zero otherwise.
+ * 
+ * Caveat: If zend function's zend_string metadata (function_name or filename)
+ *         does not have hash calculated, this function will calculate value
+ *         for zend_string's h property.
  */
-extern int nr_php_wraprec_hashmap_get_into(nr_php_wraprec_hashmap_t*, const zend_function*, nruserfn_t**);
+extern int nr_php_wraprec_hashmap_get_into(nr_php_wraprec_hashmap_t*, zend_function*, nruserfn_t**);
 #endif
 
 #endif

--- a/agent/php_user_instrument_hashmap.h
+++ b/agent/php_user_instrument_hashmap.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file contains API for the hashmap that's used to lookup
+ * the instrumentation of user functions.
+ */
+#ifndef PHP_USER_INSTRUMENT_HASHMAP_HDR
+#define PHP_USER_INSTRUMENT_HASHMAP_HDR
+
+#include "php_includes.h"
+#include "php_user_instrument.h"
+
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+/*
+ * The opaque hashmap type.
+ */
+typedef struct _nr_php_wraprec_hashmap nr_php_wraprec_hashmap_t;
+
+/*
+ * Type declaration for destructor functions.
+ */
+typedef void (*nr_php_wraprec_hashmap_dtor_fn_t)(nruserfn_t*);
+/*
+ * Purpose : Create a hashmap with a set number of buckets.
+ *
+ * Params  : 1. The number of buckets. If this is not a power of 2, this will
+ *              be rounded up to the next power of 2. The maximum value is
+ *              2^24; values above this will be capped to 2^24.
+ *           2. The destructor function, or NULL if not required.
+ *
+ * Returns : A newly allocated hashmap.
+ */
+extern nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_buckets(size_t, nr_php_wraprec_hashmap_dtor_fn_t);
+
+/*
+ * Purpose : Destroy a hashmap.
+ *
+ * Params  : 1. The address of the hashmap to destroy.
+ */
+extern void nr_php_wraprec_hashmap_destroy(nr_php_wraprec_hashmap_t**);
+
+/*
+ * Purpose : Update the key in the wraprec using metadata from zend function,
+ *           and store updated wraprec pointer in the hashmap. An existing
+ *           element with the same key will be overwritten by this function.
+ *
+ * Params  : 1. The hashmap.
+ *           2. The zend function to set instrumentation for.
+ *           3. The wraprec to set the key and store in the hashmap.
+ */
+extern void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t*, const zend_function*, nruserfn_t*);
+
+/*
+ * Purpose : Get a wraprec pointer from a hashmap into an out parameter.
+ *
+ * Params  : 1. The hashmap.
+ *           2. The zend function to search for.
+ *           3. A pointer to a void pointer that will be set to the element, if
+ *              it exists. If the element doesn't exist, this value will be
+ *              unchanged.
+ *
+ * Returns : Non-zero if the value exists, zero otherwise.
+ */
+extern int nr_php_wraprec_hashmap_get_into(nr_php_wraprec_hashmap_t*, const zend_function*, nruserfn_t**);
+#endif
+
+#endif

--- a/agent/php_user_instrument_hashmap.h
+++ b/agent/php_user_instrument_hashmap.h
@@ -45,16 +45,19 @@ typedef void (*nr_php_wraprec_hashmap_dtor_fn_t)(nruserfn_t*);
  *
  * Returns : A newly allocated hashmap.
  */
-extern nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_buckets(size_t, nr_php_wraprec_hashmap_dtor_fn_t);
+extern nr_php_wraprec_hashmap_t* nr_php_wraprec_hashmap_create_buckets(
+    size_t,
+    nr_php_wraprec_hashmap_dtor_fn_t);
 
 /*
  * Purpose : Destroy a hashmap.
  *
  * Params  : 1. The address of the hashmap to destroy.
- * 
+ *
  * Returns : hashmap stats.
  */
-extern nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(nr_php_wraprec_hashmap_t**);
+extern nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(
+    nr_php_wraprec_hashmap_t**);
 
 /*
  * Purpose : Update the key in the wraprec using metadata from zend function,
@@ -64,12 +67,14 @@ extern nr_php_wraprec_hashmap_stats_t nr_php_wraprec_hashmap_destroy(nr_php_wrap
  * Params  : 1. The hashmap.
  *           2. The zend function to set instrumentation for.
  *           3. The wraprec to set the key and store in the hashmap.
- * 
+ *
  * Caveat: If zend function's zend_string metadata (function_name or filename)
  *         does not have hash calculated, this function will calculate value
  *         for zend_string's h property.
  */
-extern void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t*, zend_function*, nruserfn_t*);
+extern void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t*,
+                                          zend_function*,
+                                          nruserfn_t*);
 
 /*
  * Purpose : Get a wraprec pointer from a hashmap into an out parameter.
@@ -81,12 +86,14 @@ extern void nr_php_wraprec_hashmap_update(nr_php_wraprec_hashmap_t*, zend_functi
  *              unchanged.
  *
  * Returns : Non-zero if the value exists, zero otherwise.
- * 
+ *
  * Caveat: If zend function's zend_string metadata (function_name or filename)
  *         does not have hash calculated, this function will calculate value
  *         for zend_string's h property.
  */
-extern int nr_php_wraprec_hashmap_get_into(nr_php_wraprec_hashmap_t*, zend_function*, nruserfn_t**);
+extern int nr_php_wraprec_hashmap_get_into(nr_php_wraprec_hashmap_t*,
+                                           zend_function*,
+                                           nruserfn_t**);
 #endif
 
 #endif

--- a/agent/php_user_instrument_hashmap_key.h
+++ b/agent/php_user_instrument_hashmap_key.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file contains structure and API for the key of the hashmap that's used
+ * to lookup the instrumentation of user functions.
+ */
+#ifndef PHP_USER_INSTRUMENT_HASHMAP_KEY_HDR
+#define PHP_USER_INSTRUMENT_HASHMAP_KEY_HDR
+
+#include "php_includes.h"
+
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+/*
+ * The hashmap key constructed from zend_function metadata
+ */
+
+typedef struct _nr_php_wraprec_hashmap_key {
+  /* using refcounted zend_string for performance */
+  zend_string* scope_name;
+  zend_string* function_name;
+  zend_string* filename;
+  uint32_t lineno;
+} nr_php_wraprec_hashmap_key_t;
+
+/*
+ * Purpose : Populate key with zend_function's metadata.
+ *
+ * Params  : 1. Pointer to the key to initialize
+ *           2. Pointer to zend_function with metadata
+ *
+ * Returns : void
+ */
+extern void nr_php_wraprec_hashmap_key_set(nr_php_wraprec_hashmap_key_t*, const zend_function*);
+
+/*
+ * Purpose : Release zend_strings referenced by the key.
+ *
+ * Params  : 1. Pointer to the key with metadata to release
+ *
+ * Returns : void
+ */
+extern void nr_php_wraprec_hashmap_key_release(nr_php_wraprec_hashmap_key_t*);
+#endif
+
+#endif

--- a/agent/php_user_instrument_hashmap_key.h
+++ b/agent/php_user_instrument_hashmap_key.h
@@ -33,7 +33,8 @@ typedef struct _nr_php_wraprec_hashmap_key {
  *
  * Returns : void
  */
-extern void nr_php_wraprec_hashmap_key_set(nr_php_wraprec_hashmap_key_t*, const zend_function*);
+extern void nr_php_wraprec_hashmap_key_set(nr_php_wraprec_hashmap_key_t*,
+                                           const zend_function*);
 
 /*
  * Purpose : Release zend_strings referenced by the key.

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -53,6 +53,7 @@ static void test_op_array_wraprec(TSRMLS_D) {
 }
 #endif /* PHP < 7.4 */
 
+#if 0
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
 static void test_get_wraprec_by_func() {
   return;
@@ -213,6 +214,7 @@ static void test_get_wraprec_by_func() {
   tlib_php_request_end();
 }
 #endif /* PHP >= 7.4 */
+#endif
 
 void test_main(void* p NRUNUSED) {
 #if defined(ZTS) && !defined(PHP7)
@@ -224,7 +226,7 @@ void test_main(void* p NRUNUSED) {
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
   test_op_array_wraprec(TSRMLS_C);
 #else
-  test_get_wraprec_by_func();
+  //test_get_wraprec_by_func();
 #endif /* PHP >= 7.4 */
 
   tlib_php_engine_destroy(TSRMLS_C);

--- a/agent/tests/test_user_instrument_hashmap.c
+++ b/agent/tests/test_user_instrument_hashmap.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "tlib_php.h"
+
+#include "php_agent.h"
+#include "php_globals.h"
+#include "php_user_instrument_hashmap.h"
+
+tlib_parallel_info_t parallel_info
+    = {.suggested_nthreads = -1, .state_size = 0};
+
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+
+#define STRING_SZ(s) (s), nr_strlen(s)
+
+static void mock_zend_function(zend_function* zf,
+                               zend_uchar type,
+                               const char* file_name,
+                               const uint32_t line_no,
+                               const char* func_name) {
+  zf->type = type;
+  zf->common.function_name = zend_string_init(STRING_SZ(func_name), 0);
+  if (type == ZEND_USER_FUNCTION && NULL != file_name) {
+    zf->op_array.filename = zend_string_init(STRING_SZ(file_name), 0);
+    zf->op_array.line_start = line_no;
+  }
+}
+
+static void mock_user_function(zend_function* zf,
+                               const char* file_name,
+                               const uint32_t line_no,
+                               const char* func_name) {
+  mock_zend_function(zf, ZEND_USER_FUNCTION, file_name, line_no, func_name);
+}
+
+static void mock_user_function_with_scope(zend_function* zf,
+                                          const char* file_name,
+                                          const uint32_t line_no,
+                                          const char* scope_name,
+                                          const char* func_name) {
+  mock_user_function(zf, file_name, line_no, func_name);
+
+  zend_class_entry* ce = nr_calloc(1, sizeof(zend_class_entry));
+  ce->name = zend_string_init(STRING_SZ(scope_name), 0);
+  zf->common.scope = ce;
+}
+
+static void mock_user_closure(zend_function* zf,
+                              const char* file_name,
+                              const uint32_t line_no) {
+  mock_user_function(zf, file_name, line_no, "{closure}");
+  zf->common.fn_flags |= ZEND_ACC_CLOSURE;
+}
+
+static void mock_zend_function_destroy(zend_function* zf) {
+  zend_string_release(zf->common.function_name);
+  if (zf->op_array.filename) {
+    zend_string_release(zf->op_array.filename);
+  }
+  if (zf->common.scope) {
+    if (zf->common.scope->name) {
+      zend_string_release(zf->common.scope->name);
+    }
+    nr_realfree((void**)&zf->common.scope);
+  }
+}
+
+static void reset_wraprec(nruserfn_t *w) {
+  nr_php_wraprec_hashmap_key_release(&w->key);
+}
+
+static void test_wraprecs_hashmap() {
+#define FILE_NAME "/some/random/path/to/a_file.php"
+#define LINENO_BASE 10
+#define SCOPE_NAME "a_scope"
+#define FUNC_NAME "a_function"
+
+  zend_function user_closure = {0};
+  zend_function user_function = {0};
+  zend_function user_function_with_scope = {0};
+  zend_function zend_function_copy = {0};
+  nruserfn_t wr1 = {0}, wr2 = {0}, wr3 = {0};
+  int rc = 0;
+  nruserfn_t *wraprec_found = NULL;
+  nr_php_wraprec_hashmap_t* h = NULL;
+
+  mock_user_closure(&user_closure, FILE_NAME, LINENO_BASE);
+  mock_user_function(&user_function, FILE_NAME, LINENO_BASE+1, FUNC_NAME);
+  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME, LINENO_BASE+2,
+                                SCOPE_NAME, FUNC_NAME);
+
+  h = nr_php_wraprec_hashmap_create_buckets(16, reset_wraprec);
+  tlib_fail_if_null("hashmap created", h);
+
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function, &wraprec_found);
+  tlib_pass_if_int_equal("can't anything in an empty hashmap", 0, rc);
+  tlib_pass_if_null("can't find anything in an empty hashmap", wraprec_found);
+
+  nr_php_wraprec_hashmap_update(h, &user_closure, &wr1);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_closure.op_array.line_start, wr1.key.lineno);
+  tlib_pass_if_null("adding wraprec for unnamed function does not set function name", wr1.key.function_name);
+  tlib_pass_if_null("adding wraprec for unnamed function does not set scope name", wr1.key.scope_name);
+  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name", wr1.key.filename);
+  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name", FILE_NAME, ZSTR_VAL(wr1.key.filename));
+
+  nr_php_wraprec_hashmap_update(h, &user_function, &wr2);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function.op_array.line_start, wr2.key.lineno);
+  tlib_pass_if_not_null("adding wraprec for named function w/o scope sets function name", wr2.key.function_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/o scope sets function name", FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
+  tlib_pass_if_null("adding wraprec for named function w/o scope does not set scope name", wr2.key.scope_name);
+  tlib_pass_if_null("adding wraprec for named function w/o scope does not set file name", wr2.key.filename);
+
+  nr_php_wraprec_hashmap_update(h, &user_function_with_scope, &wr3);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function_with_scope.op_array.line_start, wr3.key.lineno);
+  tlib_pass_if_not_null("adding wraprec for named function w/scope sets function name", wr3.key.function_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets function name", FUNC_NAME, ZSTR_VAL(wr3.key.function_name));
+  tlib_pass_if_not_null("adding wraprec for named function w/scope sets scope name", wr3.key.scope_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets scope name", SCOPE_NAME, ZSTR_VAL(wr3.key.scope_name));
+  tlib_pass_if_null("adding wraprec for named function w/scope does not set file name", wr3.key.filename);
+
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_closure, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr1, wraprec_found);
+
+  zend_function_copy = user_closure;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr1, wraprec_found);
+
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr2, wraprec_found);
+
+  zend_function_copy = user_function;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr2, wraprec_found);
+
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/scope", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/scope", &wr3, wraprec_found);
+
+  zend_function_copy = user_function_with_scope;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/scope by zend_function copy", &wr3, wraprec_found);
+
+  nr_php_wraprec_hashmap_destroy(&h);
+
+  mock_zend_function_destroy(&user_closure);
+  mock_zend_function_destroy(&user_function);
+  mock_zend_function_destroy(&user_function_with_scope);
+}
+#endif
+
+void test_main(void* p NRUNUSED) {
+#if defined(ZTS) && !defined(PHP7)
+  void*** tsrm_ls = NULL;
+#endif /* ZTS && !PHP7 */
+
+  tlib_php_engine_create("" PTSRMLS_CC);
+
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+  test_wraprecs_hashmap();
+#endif /* PHP >= 7.4 */
+
+  tlib_php_engine_destroy(TSRMLS_C);
+}

--- a/agent/tests/test_user_instrument_hashmap.c
+++ b/agent/tests/test_user_instrument_hashmap.c
@@ -22,9 +22,11 @@ static void mock_zend_function(zend_function* zf,
                                const uint32_t line_no,
                                const char* func_name) {
   zf->type = type;
-  zf->common.function_name = zend_string_init(STRING_SZ(func_name), 0);
+  zf->op_array.function_name = zend_string_init(STRING_SZ(func_name), 0);
+  zend_string_hash_func(zf->op_array.function_name);
   if (type == ZEND_USER_FUNCTION && NULL != file_name) {
     zf->op_array.filename = zend_string_init(STRING_SZ(file_name), 0);
+    zend_string_hash_func(zf->op_array.filename);
     zf->op_array.line_start = line_no;
   }
 }
@@ -45,6 +47,7 @@ static void mock_user_function_with_scope(zend_function* zf,
 
   zend_class_entry* ce = nr_calloc(1, sizeof(zend_class_entry));
   ce->name = zend_string_init(STRING_SZ(scope_name), 0);
+  zend_string_hash_func(ce->name);
   zf->common.scope = ce;
 }
 
@@ -56,7 +59,7 @@ static void mock_user_closure(zend_function* zf,
 }
 
 static void mock_zend_function_destroy(zend_function* zf) {
-  zend_string_release(zf->common.function_name);
+  zend_string_release(zf->op_array.function_name);
   if (zf->op_array.filename) {
     zend_string_release(zf->op_array.filename);
   }
@@ -161,6 +164,189 @@ static void test_wraprecs_hashmap() {
   mock_zend_function_destroy(&user_function);
   mock_zend_function_destroy(&user_function_with_scope);
 }
+
+static void test_zend_string_hash_before_set() {
+#define FILE_NAME "/some/random/path/to/a_file.php"
+#define LINENO_BASE 10
+#define SCOPE_NAME "a_scope"
+#define FUNC_NAME "a_function"
+
+  zend_function user_closure = {0};
+  zend_function user_function = {0};
+  zend_function user_function_with_scope = {0};
+  zend_function zend_function_copy = {0};
+  nruserfn_t wr1 = {0}, wr2 = {0}, wr3 = {0};
+  int rc = 0;
+  nruserfn_t *wraprec_found = NULL;
+  nr_php_wraprec_hashmap_t* h = NULL;
+  uint32_t hash;
+
+  mock_user_closure(&user_closure, FILE_NAME, LINENO_BASE);
+  mock_user_function(&user_function, FILE_NAME, LINENO_BASE+1, FUNC_NAME);
+  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME, LINENO_BASE+2,
+                                SCOPE_NAME, FUNC_NAME);
+
+  h = nr_php_wraprec_hashmap_create_buckets(16, reset_wraprec);
+  tlib_fail_if_null("hashmap created", h);
+
+  hash = ZSTR_H(user_closure.op_array.filename);
+  ZSTR_H(user_closure.op_array.filename) = 0;
+  nr_php_wraprec_hashmap_update(h, &user_closure, &wr1);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_closure.op_array.line_start, wr1.key.lineno);
+  tlib_pass_if_null("adding wraprec for unnamed function does not set function name", wr1.key.function_name);
+  tlib_pass_if_null("adding wraprec for unnamed function does not set scope name", wr1.key.scope_name);
+  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name", wr1.key.filename);
+  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name", FILE_NAME, ZSTR_VAL(wr1.key.filename));
+  tlib_pass_if_uint32_t_equal("adding wraprec for unnamed function sets file name's hash", hash, ZSTR_H(wr1.key.filename));
+
+  hash = ZSTR_H(user_function.op_array.function_name);
+  ZSTR_H(user_function.op_array.function_name) = 0;
+  nr_php_wraprec_hashmap_update(h, &user_function, &wr2);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function.op_array.line_start, wr2.key.lineno);
+  tlib_pass_if_not_null("adding wraprec for named function w/o scope sets function name", wr2.key.function_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/o scope sets function name", FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
+  tlib_pass_if_uint32_t_equal("adding wraprec for named function w/o scope sets function name's hash", hash, ZSTR_H(wr2.key.function_name));
+  tlib_pass_if_null("adding wraprec for named function w/o scope does not set scope name", wr2.key.scope_name);
+  tlib_pass_if_null("adding wraprec for named function w/o scope does not set file name", wr2.key.filename);
+
+  hash = ZSTR_H(user_function_with_scope.op_array.function_name);
+  ZSTR_H(user_function_with_scope.op_array.function_name) = 0;
+  nr_php_wraprec_hashmap_update(h, &user_function_with_scope, &wr3);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function_with_scope.op_array.line_start, wr3.key.lineno);
+  tlib_pass_if_not_null("adding wraprec for named function w/scope sets function name", wr3.key.function_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets function name", FUNC_NAME, ZSTR_VAL(wr3.key.function_name));
+  tlib_pass_if_uint32_t_equal("adding wraprec for named function w/scope sets function name's hash", hash, ZSTR_H(wr2.key.function_name));
+  tlib_pass_if_not_null("adding wraprec for named function w/scope sets scope name", wr3.key.scope_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets scope name", SCOPE_NAME, ZSTR_VAL(wr3.key.scope_name));
+  tlib_pass_if_null("adding wraprec for named function w/scope does not set file name", wr3.key.filename);
+
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_closure, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr1, wraprec_found);
+
+  zend_function_copy = user_closure;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr1, wraprec_found);
+
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr2, wraprec_found);
+
+  zend_function_copy = user_function;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr2, wraprec_found);
+
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/scope", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/scope", &wr3, wraprec_found);
+
+  zend_function_copy = user_function_with_scope;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/scope by zend_function copy", &wr3, wraprec_found);
+
+  nr_php_wraprec_hashmap_destroy(&h);
+
+  mock_zend_function_destroy(&user_closure);
+  mock_zend_function_destroy(&user_function);
+  mock_zend_function_destroy(&user_function_with_scope);
+}
+
+static void test_zend_string_hash_after_set_before_get() {
+#define FILE_NAME "/some/random/path/to/a_file.php"
+#define LINENO_BASE 10
+#define SCOPE_NAME "a_scope"
+#define FUNC_NAME "a_function"
+
+  zend_function user_closure = {0};
+  zend_function user_function = {0};
+  zend_function user_function_with_scope = {0};
+  zend_function zend_function_copy = {0};
+  nruserfn_t wr1 = {0}, wr2 = {0}, wr3 = {0};
+  int rc = 0;
+  nruserfn_t *wraprec_found = NULL;
+  nr_php_wraprec_hashmap_t* h = NULL;
+
+  mock_user_closure(&user_closure, FILE_NAME, LINENO_BASE);
+  mock_user_function(&user_function, FILE_NAME, LINENO_BASE+1, FUNC_NAME);
+  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME, LINENO_BASE+2,
+                                SCOPE_NAME, FUNC_NAME);
+
+  h = nr_php_wraprec_hashmap_create_buckets(16, reset_wraprec);
+  tlib_fail_if_null("hashmap created", h);
+
+  nr_php_wraprec_hashmap_update(h, &user_closure, &wr1);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_closure.op_array.line_start, wr1.key.lineno);
+  tlib_pass_if_null("adding wraprec for unnamed function does not set function name", wr1.key.function_name);
+  tlib_pass_if_null("adding wraprec for unnamed function does not set scope name", wr1.key.scope_name);
+  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name", wr1.key.filename);
+  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name", FILE_NAME, ZSTR_VAL(wr1.key.filename));
+
+  nr_php_wraprec_hashmap_update(h, &user_function, &wr2);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function.op_array.line_start, wr2.key.lineno);
+  tlib_pass_if_not_null("adding wraprec for named function w/o scope sets function name", wr2.key.function_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/o scope sets function name", FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
+  tlib_pass_if_null("adding wraprec for named function w/o scope does not set scope name", wr2.key.scope_name);
+  tlib_pass_if_null("adding wraprec for named function w/o scope does not set file name", wr2.key.filename);
+
+  nr_php_wraprec_hashmap_update(h, &user_function_with_scope, &wr3);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function_with_scope.op_array.line_start, wr3.key.lineno);
+  tlib_pass_if_not_null("adding wraprec for named function w/scope sets function name", wr3.key.function_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets function name", FUNC_NAME, ZSTR_VAL(wr3.key.function_name));
+  tlib_pass_if_not_null("adding wraprec for named function w/scope sets scope name", wr3.key.scope_name);
+  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets scope name", SCOPE_NAME, ZSTR_VAL(wr3.key.scope_name));
+  tlib_pass_if_null("adding wraprec for named function w/scope does not set file name", wr3.key.filename);
+
+  wraprec_found = NULL;
+  ZSTR_H(user_closure.op_array.filename) = 0;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_closure, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope after hash reset", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope after hash reset", &wr1, wraprec_found);
+
+  zend_function_copy = user_closure;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr1, wraprec_found);
+
+  wraprec_found = NULL;
+  ZSTR_H(user_function.op_array.function_name) = 0;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope after hash reset", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope after hash reset", &wr2, wraprec_found);
+
+  zend_function_copy = user_function;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr2, wraprec_found);
+
+  wraprec_found = NULL;
+  ZSTR_H(user_function_with_scope.op_array.function_name) = 0;
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/scope after hash reset", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/scope after hash reset", &wr3, wraprec_found);
+
+  zend_function_copy = user_function_with_scope;
+  wraprec_found = NULL;
+  rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/scope by zend_function copy", &wr3, wraprec_found);
+
+  nr_php_wraprec_hashmap_destroy(&h);
+
+  mock_zend_function_destroy(&user_closure);
+  mock_zend_function_destroy(&user_function);
+  mock_zend_function_destroy(&user_function_with_scope);
+}
 #endif
 
 void test_main(void* p NRUNUSED) {
@@ -172,6 +358,8 @@ void test_main(void* p NRUNUSED) {
 
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
   test_wraprecs_hashmap();
+  test_zend_string_hash_before_set();
+  test_zend_string_hash_after_set_before_get();
 #endif /* PHP >= 7.4 */
 
   tlib_php_engine_destroy(TSRMLS_C);

--- a/agent/tests/test_user_instrument_hashmap.c
+++ b/agent/tests/test_user_instrument_hashmap.c
@@ -547,7 +547,7 @@ static void test_wraprec_hashmap_two_functions() {
                                 FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf1, &wr1);
 
-  /* A function with the same in name in a different file with different scope
+  /* A function with the same name in a different file with different scope
    */
   mock_user_function_with_scope(&zf2, FILE_2_NAME, LINENO_BASE, SCOPE_2_NAME,
                                 FUNC_1_NAME);

--- a/agent/tests/test_user_instrument_hashmap.c
+++ b/agent/tests/test_user_instrument_hashmap.c
@@ -500,6 +500,10 @@ static void test_wraprec_hashmap_two_functions() {
   nr_php_wraprec_hashmap_t* h = NULL;
   nr_php_wraprec_hashmap_stats_t s = {};
 
+#define TEST_DESCRIPTION_1                                                     \
+  "Two functions with the same name in the same file but different scope are " \
+  "stored separetely"
+
   h = nr_php_wraprec_hashmap_create_buckets(16, reset_wraprec);
   tlib_fail_if_null("hashmap created", h);
 
@@ -508,32 +512,20 @@ static void test_wraprec_hashmap_two_functions() {
                                 FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf1, &wr1);
 
-  /* A function with the same in the same file but different scope */
+  /* A function with the same name in the same file but different scope */
   mock_user_function_with_scope(&zf2, FILE_1_NAME, LINENO_BASE, SCOPE_2_NAME,
                                 FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf2, &wr2);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zf1, &wraprec_found);
-  tlib_pass_if_int_equal(
-      "Two functions with the same in the same file but different scope are "
-      "stored separetely",
-      1, rc);
-  tlib_pass_if_ptr_equal(
-      "Two functions with the same in the same file but different scope are "
-      "stored separetely",
-      &wr1, wraprec_found);
+  tlib_pass_if_int_equal(TEST_DESCRIPTION_1, 1, rc);
+  tlib_pass_if_ptr_equal(TEST_DESCRIPTION_1, &wr1, wraprec_found);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zf2, &wraprec_found);
-  tlib_pass_if_int_equal(
-      "Two functions with the same in the same file but different scope are "
-      "stored separetely",
-      1, rc);
-  tlib_pass_if_ptr_equal(
-      "Two functions with the same in the same file but different scope are "
-      "stored separetely",
-      &wr2, wraprec_found);
+  tlib_pass_if_int_equal(TEST_DESCRIPTION_1, 1, rc);
+  tlib_pass_if_ptr_equal(TEST_DESCRIPTION_1, &wr2, wraprec_found);
 
   s = nr_php_wraprec_hashmap_destroy(&h);
   tlib_pass_if_size_t_equal("all elements are stored", 2, s.elements);
@@ -543,6 +535,10 @@ static void test_wraprec_hashmap_two_functions() {
 
   /* -------------------------------------------------------------------  */
 
+#define TEST_DESCRIPTION_2                                                    \
+  "Two functions with the same name in a different file and different scope " \
+  "are stored separetely"
+
   h = nr_php_wraprec_hashmap_create_buckets(16, reset_wraprec);
   tlib_fail_if_null("hashmap created", h);
 
@@ -551,32 +547,21 @@ static void test_wraprec_hashmap_two_functions() {
                                 FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf1, &wr1);
 
-  /* A function with the same in different file with different scope */
+  /* A function with the same in name in a different file with different scope
+   */
   mock_user_function_with_scope(&zf2, FILE_2_NAME, LINENO_BASE, SCOPE_2_NAME,
                                 FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf2, &wr2);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zf1, &wraprec_found);
-  tlib_pass_if_int_equal(
-      "Two functions with the same in the same file but different scope are "
-      "stored separetely",
-      1, rc);
-  tlib_pass_if_ptr_equal(
-      "Two functions with the same in the same file but different scope are "
-      "stored separetely",
-      &wr1, wraprec_found);
+  tlib_pass_if_int_equal(TEST_DESCRIPTION_2, 1, rc);
+  tlib_pass_if_ptr_equal(TEST_DESCRIPTION_2, &wr1, wraprec_found);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zf2, &wraprec_found);
-  tlib_pass_if_int_equal(
-      "Two functions with the same in the same file but different scope are "
-      "stored separetely",
-      1, rc);
-  tlib_pass_if_ptr_equal(
-      "Two functions with the same in the same file but different scope are "
-      "stored separetely",
-      &wr2, wraprec_found);
+  tlib_pass_if_int_equal(TEST_DESCRIPTION_2, 1, rc);
+  tlib_pass_if_ptr_equal(TEST_DESCRIPTION_2, &wr2, wraprec_found);
 
   s = nr_php_wraprec_hashmap_destroy(&h);
   tlib_pass_if_size_t_equal("all elements are stored", 2, s.elements);

--- a/agent/tests/test_user_instrument_hashmap.c
+++ b/agent/tests/test_user_instrument_hashmap.c
@@ -71,7 +71,7 @@ static void mock_zend_function_destroy(zend_function* zf) {
   }
 }
 
-static void reset_wraprec(nruserfn_t *w) {
+static void reset_wraprec(nruserfn_t* w) {
   nr_php_wraprec_hashmap_key_release(&w->key);
 }
 
@@ -87,13 +87,13 @@ static void test_wraprecs_hashmap() {
   zend_function zend_function_copy = {0};
   nruserfn_t wr1 = {0}, wr2 = {0}, wr3 = {0};
   int rc = 0;
-  nruserfn_t *wraprec_found = NULL;
+  nruserfn_t* wraprec_found = NULL;
   nr_php_wraprec_hashmap_t* h = NULL;
 
   mock_user_closure(&user_closure, FILE_NAME, LINENO_BASE);
-  mock_user_function(&user_function, FILE_NAME, LINENO_BASE+1, FUNC_NAME);
-  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME, LINENO_BASE+2,
-                                SCOPE_NAME, FUNC_NAME);
+  mock_user_function(&user_function, FILE_NAME, LINENO_BASE + 1, FUNC_NAME);
+  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME,
+                                LINENO_BASE + 2, SCOPE_NAME, FUNC_NAME);
 
   h = nr_php_wraprec_hashmap_create_buckets(16, reset_wraprec);
   tlib_fail_if_null("hashmap created", h);
@@ -104,59 +104,101 @@ static void test_wraprecs_hashmap() {
   tlib_pass_if_null("can't find anything in an empty hashmap", wraprec_found);
 
   nr_php_wraprec_hashmap_update(h, &user_closure, &wr1);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_closure.op_array.line_start, wr1.key.lineno);
-  tlib_pass_if_null("adding wraprec for unnamed function does not set function name", wr1.key.function_name);
-  tlib_pass_if_null("adding wraprec for unnamed function does not set scope name", wr1.key.scope_name);
-  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name", wr1.key.filename);
-  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name", FILE_NAME, ZSTR_VAL(wr1.key.filename));
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_closure.op_array.line_start, wr1.key.lineno);
+  tlib_pass_if_null(
+      "adding wraprec for unnamed function does not set function name",
+      wr1.key.function_name);
+  tlib_pass_if_null(
+      "adding wraprec for unnamed function does not set scope name",
+      wr1.key.scope_name);
+  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name",
+                        wr1.key.filename);
+  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name",
+                         FILE_NAME, ZSTR_VAL(wr1.key.filename));
 
   nr_php_wraprec_hashmap_update(h, &user_function, &wr2);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function.op_array.line_start, wr2.key.lineno);
-  tlib_pass_if_not_null("adding wraprec for named function w/o scope sets function name", wr2.key.function_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/o scope sets function name", FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
-  tlib_pass_if_null("adding wraprec for named function w/o scope does not set scope name", wr2.key.scope_name);
-  tlib_pass_if_null("adding wraprec for named function w/o scope does not set file name", wr2.key.filename);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_function.op_array.line_start,
+                              wr2.key.lineno);
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/o scope sets function name",
+      wr2.key.function_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/o scope sets function name",
+      FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
+  tlib_pass_if_null(
+      "adding wraprec for named function w/o scope does not set scope name",
+      wr2.key.scope_name);
+  tlib_pass_if_null(
+      "adding wraprec for named function w/o scope does not set file name",
+      wr2.key.filename);
 
   nr_php_wraprec_hashmap_update(h, &user_function_with_scope, &wr3);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function_with_scope.op_array.line_start, wr3.key.lineno);
-  tlib_pass_if_not_null("adding wraprec for named function w/scope sets function name", wr3.key.function_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets function name", FUNC_NAME, ZSTR_VAL(wr3.key.function_name));
-  tlib_pass_if_not_null("adding wraprec for named function w/scope sets scope name", wr3.key.scope_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets scope name", SCOPE_NAME, ZSTR_VAL(wr3.key.scope_name));
-  tlib_pass_if_null("adding wraprec for named function w/scope does not set file name", wr3.key.filename);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_function_with_scope.op_array.line_start,
+                              wr3.key.lineno);
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/scope sets function name",
+      wr3.key.function_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/scope sets function name", FUNC_NAME,
+      ZSTR_VAL(wr3.key.function_name));
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/scope sets scope name",
+      wr3.key.scope_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/scope sets scope name", SCOPE_NAME,
+      ZSTR_VAL(wr3.key.scope_name));
+  tlib_pass_if_null(
+      "adding wraprec for named function w/scope does not set file name",
+      wr3.key.filename);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &user_closure, &wraprec_found);
   tlib_pass_if_int_equal("can find named function w/o scope", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr1, wraprec_found);
+  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr1,
+                         wraprec_found);
 
   zend_function_copy = user_closure;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr1, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/o scope by zend_function copy", &wr1,
+      wraprec_found);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &user_function, &wraprec_found);
   tlib_pass_if_int_equal("can find named function w/o scope", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr2, wraprec_found);
+  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr2,
+                         wraprec_found);
 
   zend_function_copy = user_function;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr2, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/o scope by zend_function copy", &wr2,
+      wraprec_found);
 
   wraprec_found = NULL;
-  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope, &wraprec_found);
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope,
+                                       &wraprec_found);
   tlib_pass_if_int_equal("can find named function w/scope", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/scope", &wr3, wraprec_found);
+  tlib_pass_if_ptr_equal("can find named function w/scope", &wr3,
+                         wraprec_found);
 
   zend_function_copy = user_function_with_scope;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/scope by zend_function copy", &wr3, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/scope by zend_function copy", &wr3,
+      wraprec_found);
 
   nr_php_wraprec_hashmap_destroy(&h);
 
@@ -177,14 +219,14 @@ static void test_zend_string_hash_before_set() {
   zend_function zend_function_copy = {0};
   nruserfn_t wr1 = {0}, wr2 = {0}, wr3 = {0};
   int rc = 0;
-  nruserfn_t *wraprec_found = NULL;
+  nruserfn_t* wraprec_found = NULL;
   nr_php_wraprec_hashmap_t* h = NULL;
   uint32_t hash;
 
   mock_user_closure(&user_closure, FILE_NAME, LINENO_BASE);
-  mock_user_function(&user_function, FILE_NAME, LINENO_BASE+1, FUNC_NAME);
-  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME, LINENO_BASE+2,
-                                SCOPE_NAME, FUNC_NAME);
+  mock_user_function(&user_function, FILE_NAME, LINENO_BASE + 1, FUNC_NAME);
+  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME,
+                                LINENO_BASE + 2, SCOPE_NAME, FUNC_NAME);
 
   h = nr_php_wraprec_hashmap_create_buckets(16, reset_wraprec);
   tlib_fail_if_null("hashmap created", h);
@@ -192,66 +234,114 @@ static void test_zend_string_hash_before_set() {
   hash = ZSTR_H(user_closure.op_array.filename);
   ZSTR_H(user_closure.op_array.filename) = 0;
   nr_php_wraprec_hashmap_update(h, &user_closure, &wr1);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_closure.op_array.line_start, wr1.key.lineno);
-  tlib_pass_if_null("adding wraprec for unnamed function does not set function name", wr1.key.function_name);
-  tlib_pass_if_null("adding wraprec for unnamed function does not set scope name", wr1.key.scope_name);
-  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name", wr1.key.filename);
-  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name", FILE_NAME, ZSTR_VAL(wr1.key.filename));
-  tlib_pass_if_uint32_t_equal("adding wraprec for unnamed function sets file name's hash", hash, ZSTR_H(wr1.key.filename));
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_closure.op_array.line_start, wr1.key.lineno);
+  tlib_pass_if_null(
+      "adding wraprec for unnamed function does not set function name",
+      wr1.key.function_name);
+  tlib_pass_if_null(
+      "adding wraprec for unnamed function does not set scope name",
+      wr1.key.scope_name);
+  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name",
+                        wr1.key.filename);
+  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name",
+                         FILE_NAME, ZSTR_VAL(wr1.key.filename));
+  tlib_pass_if_uint32_t_equal(
+      "adding wraprec for unnamed function sets file name's hash", hash,
+      ZSTR_H(wr1.key.filename));
 
   hash = ZSTR_H(user_function.op_array.function_name);
   ZSTR_H(user_function.op_array.function_name) = 0;
   nr_php_wraprec_hashmap_update(h, &user_function, &wr2);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function.op_array.line_start, wr2.key.lineno);
-  tlib_pass_if_not_null("adding wraprec for named function w/o scope sets function name", wr2.key.function_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/o scope sets function name", FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
-  tlib_pass_if_uint32_t_equal("adding wraprec for named function w/o scope sets function name's hash", hash, ZSTR_H(wr2.key.function_name));
-  tlib_pass_if_null("adding wraprec for named function w/o scope does not set scope name", wr2.key.scope_name);
-  tlib_pass_if_null("adding wraprec for named function w/o scope does not set file name", wr2.key.filename);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_function.op_array.line_start,
+                              wr2.key.lineno);
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/o scope sets function name",
+      wr2.key.function_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/o scope sets function name",
+      FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
+  tlib_pass_if_uint32_t_equal(
+      "adding wraprec for named function w/o scope sets function name's hash",
+      hash, ZSTR_H(wr2.key.function_name));
+  tlib_pass_if_null(
+      "adding wraprec for named function w/o scope does not set scope name",
+      wr2.key.scope_name);
+  tlib_pass_if_null(
+      "adding wraprec for named function w/o scope does not set file name",
+      wr2.key.filename);
 
   hash = ZSTR_H(user_function_with_scope.op_array.function_name);
   ZSTR_H(user_function_with_scope.op_array.function_name) = 0;
   nr_php_wraprec_hashmap_update(h, &user_function_with_scope, &wr3);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function_with_scope.op_array.line_start, wr3.key.lineno);
-  tlib_pass_if_not_null("adding wraprec for named function w/scope sets function name", wr3.key.function_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets function name", FUNC_NAME, ZSTR_VAL(wr3.key.function_name));
-  tlib_pass_if_uint32_t_equal("adding wraprec for named function w/scope sets function name's hash", hash, ZSTR_H(wr2.key.function_name));
-  tlib_pass_if_not_null("adding wraprec for named function w/scope sets scope name", wr3.key.scope_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets scope name", SCOPE_NAME, ZSTR_VAL(wr3.key.scope_name));
-  tlib_pass_if_null("adding wraprec for named function w/scope does not set file name", wr3.key.filename);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_function_with_scope.op_array.line_start,
+                              wr3.key.lineno);
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/scope sets function name",
+      wr3.key.function_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/scope sets function name", FUNC_NAME,
+      ZSTR_VAL(wr3.key.function_name));
+  tlib_pass_if_uint32_t_equal(
+      "adding wraprec for named function w/scope sets function name's hash",
+      hash, ZSTR_H(wr2.key.function_name));
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/scope sets scope name",
+      wr3.key.scope_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/scope sets scope name", SCOPE_NAME,
+      ZSTR_VAL(wr3.key.scope_name));
+  tlib_pass_if_null(
+      "adding wraprec for named function w/scope does not set file name",
+      wr3.key.filename);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &user_closure, &wraprec_found);
   tlib_pass_if_int_equal("can find named function w/o scope", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr1, wraprec_found);
+  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr1,
+                         wraprec_found);
 
   zend_function_copy = user_closure;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr1, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/o scope by zend_function copy", &wr1,
+      wraprec_found);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &user_function, &wraprec_found);
   tlib_pass_if_int_equal("can find named function w/o scope", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr2, wraprec_found);
+  tlib_pass_if_ptr_equal("can find named function w/o scope", &wr2,
+                         wraprec_found);
 
   zend_function_copy = user_function;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr2, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/o scope by zend_function copy", &wr2,
+      wraprec_found);
 
   wraprec_found = NULL;
-  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope, &wraprec_found);
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope,
+                                       &wraprec_found);
   tlib_pass_if_int_equal("can find named function w/scope", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/scope", &wr3, wraprec_found);
+  tlib_pass_if_ptr_equal("can find named function w/scope", &wr3,
+                         wraprec_found);
 
   zend_function_copy = user_function_with_scope;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/scope by zend_function copy", &wr3, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/scope by zend_function copy", &wr3,
+      wraprec_found);
 
   nr_php_wraprec_hashmap_destroy(&h);
 
@@ -272,74 +362,119 @@ static void test_zend_string_hash_after_set_before_get() {
   zend_function zend_function_copy = {0};
   nruserfn_t wr1 = {0}, wr2 = {0}, wr3 = {0};
   int rc = 0;
-  nruserfn_t *wraprec_found = NULL;
+  nruserfn_t* wraprec_found = NULL;
   nr_php_wraprec_hashmap_t* h = NULL;
 
   mock_user_closure(&user_closure, FILE_NAME, LINENO_BASE);
-  mock_user_function(&user_function, FILE_NAME, LINENO_BASE+1, FUNC_NAME);
-  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME, LINENO_BASE+2,
-                                SCOPE_NAME, FUNC_NAME);
+  mock_user_function(&user_function, FILE_NAME, LINENO_BASE + 1, FUNC_NAME);
+  mock_user_function_with_scope(&user_function_with_scope, FILE_NAME,
+                                LINENO_BASE + 2, SCOPE_NAME, FUNC_NAME);
 
   h = nr_php_wraprec_hashmap_create_buckets(16, reset_wraprec);
   tlib_fail_if_null("hashmap created", h);
 
   nr_php_wraprec_hashmap_update(h, &user_closure, &wr1);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_closure.op_array.line_start, wr1.key.lineno);
-  tlib_pass_if_null("adding wraprec for unnamed function does not set function name", wr1.key.function_name);
-  tlib_pass_if_null("adding wraprec for unnamed function does not set scope name", wr1.key.scope_name);
-  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name", wr1.key.filename);
-  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name", FILE_NAME, ZSTR_VAL(wr1.key.filename));
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_closure.op_array.line_start, wr1.key.lineno);
+  tlib_pass_if_null(
+      "adding wraprec for unnamed function does not set function name",
+      wr1.key.function_name);
+  tlib_pass_if_null(
+      "adding wraprec for unnamed function does not set scope name",
+      wr1.key.scope_name);
+  tlib_pass_if_not_null("adding wraprec for unnamed function sets file name",
+                        wr1.key.filename);
+  tlib_pass_if_str_equal("adding wraprec for unnamed function sets file name",
+                         FILE_NAME, ZSTR_VAL(wr1.key.filename));
 
   nr_php_wraprec_hashmap_update(h, &user_function, &wr2);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function.op_array.line_start, wr2.key.lineno);
-  tlib_pass_if_not_null("adding wraprec for named function w/o scope sets function name", wr2.key.function_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/o scope sets function name", FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
-  tlib_pass_if_null("adding wraprec for named function w/o scope does not set scope name", wr2.key.scope_name);
-  tlib_pass_if_null("adding wraprec for named function w/o scope does not set file name", wr2.key.filename);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_function.op_array.line_start,
+                              wr2.key.lineno);
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/o scope sets function name",
+      wr2.key.function_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/o scope sets function name",
+      FUNC_NAME, ZSTR_VAL(wr2.key.function_name));
+  tlib_pass_if_null(
+      "adding wraprec for named function w/o scope does not set scope name",
+      wr2.key.scope_name);
+  tlib_pass_if_null(
+      "adding wraprec for named function w/o scope does not set file name",
+      wr2.key.filename);
 
   nr_php_wraprec_hashmap_update(h, &user_function_with_scope, &wr3);
-  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno", user_function_with_scope.op_array.line_start, wr3.key.lineno);
-  tlib_pass_if_not_null("adding wraprec for named function w/scope sets function name", wr3.key.function_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets function name", FUNC_NAME, ZSTR_VAL(wr3.key.function_name));
-  tlib_pass_if_not_null("adding wraprec for named function w/scope sets scope name", wr3.key.scope_name);
-  tlib_pass_if_str_equal("adding wraprec for named function w/scope sets scope name", SCOPE_NAME, ZSTR_VAL(wr3.key.scope_name));
-  tlib_pass_if_null("adding wraprec for named function w/scope does not set file name", wr3.key.filename);
+  tlib_pass_if_uint32_t_equal("adding wraprec to hashmap updates lineno",
+                              user_function_with_scope.op_array.line_start,
+                              wr3.key.lineno);
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/scope sets function name",
+      wr3.key.function_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/scope sets function name", FUNC_NAME,
+      ZSTR_VAL(wr3.key.function_name));
+  tlib_pass_if_not_null(
+      "adding wraprec for named function w/scope sets scope name",
+      wr3.key.scope_name);
+  tlib_pass_if_str_equal(
+      "adding wraprec for named function w/scope sets scope name", SCOPE_NAME,
+      ZSTR_VAL(wr3.key.scope_name));
+  tlib_pass_if_null(
+      "adding wraprec for named function w/scope does not set file name",
+      wr3.key.filename);
 
   wraprec_found = NULL;
   ZSTR_H(user_closure.op_array.filename) = 0;
   rc = nr_php_wraprec_hashmap_get_into(h, &user_closure, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/o scope after hash reset", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope after hash reset", &wr1, wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope after hash reset",
+                         1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope after hash reset",
+                         &wr1, wraprec_found);
 
   zend_function_copy = user_closure;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr1, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/o scope by zend_function copy", &wr1,
+      wraprec_found);
 
   wraprec_found = NULL;
   ZSTR_H(user_function.op_array.function_name) = 0;
   rc = nr_php_wraprec_hashmap_get_into(h, &user_function, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/o scope after hash reset", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope after hash reset", &wr2, wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/o scope after hash reset",
+                         1, rc);
+  tlib_pass_if_ptr_equal("can find named function w/o scope after hash reset",
+                         &wr2, wraprec_found);
 
   zend_function_copy = user_function;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/o scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/o scope by zend_function copy", &wr2, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/o scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/o scope by zend_function copy", &wr2,
+      wraprec_found);
 
   wraprec_found = NULL;
   ZSTR_H(user_function_with_scope.op_array.function_name) = 0;
-  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/scope after hash reset", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/scope after hash reset", &wr3, wraprec_found);
+  rc = nr_php_wraprec_hashmap_get_into(h, &user_function_with_scope,
+                                       &wraprec_found);
+  tlib_pass_if_int_equal("can find named function w/scope after hash reset", 1,
+                         rc);
+  tlib_pass_if_ptr_equal("can find named function w/scope after hash reset",
+                         &wr3, wraprec_found);
 
   zend_function_copy = user_function_with_scope;
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zend_function_copy, &wraprec_found);
-  tlib_pass_if_int_equal("can find named function w/scope by zend_function copy", 1, rc);
-  tlib_pass_if_ptr_equal("can find named function w/scope by zend_function copy", &wr3, wraprec_found);
+  tlib_pass_if_int_equal(
+      "can find named function w/scope by zend_function copy", 1, rc);
+  tlib_pass_if_ptr_equal(
+      "can find named function w/scope by zend_function copy", &wr3,
+      wraprec_found);
 
   nr_php_wraprec_hashmap_destroy(&h);
 
@@ -361,7 +496,7 @@ static void test_wraprec_hashmap_two_functions() {
   zend_function zf2 = {0};
   nruserfn_t wr1 = {0}, wr2 = {0};
   int rc = 0;
-  nruserfn_t *wraprec_found = NULL;
+  nruserfn_t* wraprec_found = NULL;
   nr_php_wraprec_hashmap_t* h = NULL;
   nr_php_wraprec_hashmap_stats_t s = {};
 
@@ -369,22 +504,36 @@ static void test_wraprec_hashmap_two_functions() {
   tlib_fail_if_null("hashmap created", h);
 
   /* A function */
-  mock_user_function_with_scope(&zf1, FILE_1_NAME, LINENO_BASE, SCOPE_1_NAME, FUNC_1_NAME);
+  mock_user_function_with_scope(&zf1, FILE_1_NAME, LINENO_BASE, SCOPE_1_NAME,
+                                FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf1, &wr1);
 
   /* A function with the same in the same file but different scope */
-  mock_user_function_with_scope(&zf2, FILE_1_NAME, LINENO_BASE, SCOPE_2_NAME, FUNC_1_NAME);
+  mock_user_function_with_scope(&zf2, FILE_1_NAME, LINENO_BASE, SCOPE_2_NAME,
+                                FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf2, &wr2);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zf1, &wraprec_found);
-  tlib_pass_if_int_equal("Two functions with the same in the same file but different scope are stored separetely", 1, rc);
-  tlib_pass_if_ptr_equal("Two functions with the same in the same file but different scope are stored separetely", &wr1, wraprec_found);
+  tlib_pass_if_int_equal(
+      "Two functions with the same in the same file but different scope are "
+      "stored separetely",
+      1, rc);
+  tlib_pass_if_ptr_equal(
+      "Two functions with the same in the same file but different scope are "
+      "stored separetely",
+      &wr1, wraprec_found);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zf2, &wraprec_found);
-  tlib_pass_if_int_equal("Two functions with the same in the same file but different scope are stored separetely", 1, rc);
-  tlib_pass_if_ptr_equal("Two functions with the same in the same file but different scope are stored separetely", &wr2, wraprec_found);
+  tlib_pass_if_int_equal(
+      "Two functions with the same in the same file but different scope are "
+      "stored separetely",
+      1, rc);
+  tlib_pass_if_ptr_equal(
+      "Two functions with the same in the same file but different scope are "
+      "stored separetely",
+      &wr2, wraprec_found);
 
   s = nr_php_wraprec_hashmap_destroy(&h);
   tlib_pass_if_size_t_equal("all elements are stored", 2, s.elements);
@@ -398,22 +547,36 @@ static void test_wraprec_hashmap_two_functions() {
   tlib_fail_if_null("hashmap created", h);
 
   /* A function */
-  mock_user_function_with_scope(&zf1, FILE_1_NAME, LINENO_BASE, SCOPE_1_NAME, FUNC_1_NAME);
+  mock_user_function_with_scope(&zf1, FILE_1_NAME, LINENO_BASE, SCOPE_1_NAME,
+                                FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf1, &wr1);
 
   /* A function with the same in different file with different scope */
-  mock_user_function_with_scope(&zf2, FILE_2_NAME, LINENO_BASE, SCOPE_2_NAME, FUNC_1_NAME);
+  mock_user_function_with_scope(&zf2, FILE_2_NAME, LINENO_BASE, SCOPE_2_NAME,
+                                FUNC_1_NAME);
   nr_php_wraprec_hashmap_update(h, &zf2, &wr2);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zf1, &wraprec_found);
-  tlib_pass_if_int_equal("Two functions with the same in the same file but different scope are stored separetely", 1, rc);
-  tlib_pass_if_ptr_equal("Two functions with the same in the same file but different scope are stored separetely", &wr1, wraprec_found);
+  tlib_pass_if_int_equal(
+      "Two functions with the same in the same file but different scope are "
+      "stored separetely",
+      1, rc);
+  tlib_pass_if_ptr_equal(
+      "Two functions with the same in the same file but different scope are "
+      "stored separetely",
+      &wr1, wraprec_found);
 
   wraprec_found = NULL;
   rc = nr_php_wraprec_hashmap_get_into(h, &zf2, &wraprec_found);
-  tlib_pass_if_int_equal("Two functions with the same in the same file but different scope are stored separetely", 1, rc);
-  tlib_pass_if_ptr_equal("Two functions with the same in the same file but different scope are stored separetely", &wr2, wraprec_found);
+  tlib_pass_if_int_equal(
+      "Two functions with the same in the same file but different scope are "
+      "stored separetely",
+      1, rc);
+  tlib_pass_if_ptr_equal(
+      "Two functions with the same in the same file but different scope are "
+      "stored separetely",
+      &wr2, wraprec_found);
 
   s = nr_php_wraprec_hashmap_destroy(&h);
   tlib_pass_if_size_t_equal("all elements are stored", 2, s.elements);


### PR DESCRIPTION
A more performant data structure is used to lookup user instrumentation:
a hashmap with zend function's metadata (lineno, functioname, scope
and filename) as a hash key, and a pointer to a wraprec as a value.

In order to improve performance of the specialized hashmap key matching,
zend_function's metadata is stored in a key as a refcounted zend_string
rather than raw char*. This allows key matching to take advantage of
the following zend_string attributes: length (len) and hash (h) - values for
both are pre-calculated by Zend engine and available for use by the
agent.  Because the agent instruments only a small fraction of all user
functions in a PHP application, there will be more missed hashmap
lookups than hits. Therefore delaying string value comparison until
absolutely necessary (len and h must match first) is a significant
performance gain.

To save time on lookups, a single hashmap will be used to store pointers
to both types of wraprecs: transient and reusable. For efficiency, the
wraprecs that are re-usable between requests (e.g. for well known
library or framework user functions), are additionally stored in a
linked list.  These wraprecs are created once per interesting function
detection, and destroyed at module shutdown. Transient wraprecs, that
are not re-usable between requests, are not stored in linked list.
Transient wraprecs are created on the fly and destroyed at request
shutdown.  However user function instrumentation installation (aka
wrapping) is done the same way for both types of wraprecs and happens
once per each request, i.e. for each request the hashmap is created
anew, when user function is instrumented, its wraprec is added to the
hashmap, and at the end of the request the hashmap is destroyed together
with transient wraprecs. Re-usable wraprecs are not destroyed - they
remain in linekd list and are re-set (marked as not wrapping a zend
function). This happens because with new request/transaction php is
loading all new user code.