### PR TITLE
fix(agent): Add more stringent opcache checking.

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1686,11 +1686,15 @@ void nr_php_user_instrumentation_from_opcache(TSRMLS_D) {
                 "status, even though opcache.preload is set");
     return;
   }
-
   if (IS_ARRAY != Z_TYPE_P(status)) {
-    nrl_warning(NRL_INSTRUMENT,
-                "User instrumentation from opcache: opcache status "
-                "information is not an array");
+    /*
+     * `opcache_get_status` returns either an array or false.  If it's not an
+     * array, it must have returned false indicating we are unable to get the
+     * status yet.
+     */
+    nrl_debug(NRL_INSTRUMENT,
+              "User instrumentation from opcache: opcache status "
+              "information is not an array");
     goto end;
   }
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -918,12 +918,15 @@ nr_status_t nr_php_txn_begin(const char* appnames,
 
   /*
    * Only try to instrument preloaded opcache scripts when opcache enabled and
-   * preload is not null.  If an INI value does not exist, INI_INT/INI_BOOL returns 0 and
-   * INI_STR returns NULL.
+   * preload is not null.  If an INI value does not exist, INI_INT/INI_BOOL
+   * returns 0 and INI_STR returns NULL.
    */
   if (NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
-    if ((1 == INI_BOOL("opcache.enable"))
-        && (NULL != INI_STR("opcache.preload"))) {
+    bool opcache_enabled = (0 != NR_PHP_PROCESS_GLOBALS(cli))
+                               ? INI_BOOL("opcache.enable_cli")
+                               : INI_BOOL("opcache.enable");
+    if ((opcache_enabled)
+        && (nr_php_ini_setting_is_set_by_user("opcache.preload"))) {
       nr_php_user_instrumentation_from_opcache(TSRMLS_C);
     }
   }

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -921,7 +921,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
    * returns 0 and INI_STR returns NULL.
    */
   if (NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
-    bool opcache_enabled = (0 != NR_PHP_PROCESS_GLOBALS(cli))
+    bool opcache_enabled = is_cli
                                ? INI_BOOL("opcache.enable_cli")
                                : INI_BOOL("opcache.enable");
     if ((opcache_enabled)

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -704,7 +704,8 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   }
 
   opts.custom_events_enabled = (int)NRINI(custom_events_enabled);
-  opts.custom_events_max_samples_stored = NRINI(custom_events_max_samples_stored);
+  opts.custom_events_max_samples_stored
+      = NRINI(custom_events_max_samples_stored);
   opts.synthetics_enabled = (int)NRINI(synthetics_enabled);
   opts.instance_reporting_enabled = (int)NRINI(instance_reporting_enabled);
   opts.database_name_reporting_enabled
@@ -782,12 +783,13 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   info.span_queue_size = NRINI(span_queue_size);
   info.span_events_max_samples_stored = NRINI(span_events_max_samples_stored);
 
-  /* Need to initialize custom and log event max samples to value negotiated between that
-   * requested in the INI file and the value returned from the daaemon (based in
-   * part on the collector connect response harvest limits) */
+  /* Need to initialize custom and log event max samples to value negotiated
+   * between that requested in the INI file and the value returned from the
+   * daaemon (based in part on the collector connect response harvest limits) */
   info.log_events_max_samples_stored = NRINI(log_events_max_samples_stored);
-  info.custom_events_max_samples_stored = NRINI(custom_events_max_samples_stored);
-  
+  info.custom_events_max_samples_stored
+      = NRINI(custom_events_max_samples_stored);
+
   NRPRG(app) = nr_agent_find_or_add_app(
       nr_agent_applist, &info,
       /*
@@ -914,17 +916,17 @@ nr_status_t nr_php_txn_begin(const char* appnames,
     nr_php_txn_log_error_dt_on_tt_off();
   }
 
-#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
-  if (nr_php_ini_setting_is_set_by_user("opcache.enable")
-      && NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
-    nr_php_user_instrumentation_from_opcache(TSRMLS_C);
+  /*
+   * Only try to instrument preloaded opcache scripts when opcache enabled and
+   * preload is nt null.  If an INI value does not exist, INI_INT returns 0 and
+   * INI_STR returns NULL.
+   */
+  if (NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
+    if ((1 == INI_INT("opcache.enable"))
+        && (NULL != INI_STR("opcache.preload"))) {
+      nr_php_user_instrumentation_from_opcache(TSRMLS_C);
+    }
   }
-#else
-  if (nr_php_ini_setting_is_set_by_user("opcache.preload")
-      && NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
-    nr_php_user_instrumentation_from_opcache(TSRMLS_C);
-  }
-#endif
 
   return NR_SUCCESS;
 }

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -918,7 +918,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
 
   /*
    * Only try to instrument preloaded opcache scripts when opcache enabled and
-   * preload is nt null.  If an INI value does not exist, INI_INT returns 0 and
+   * preload is not null.  If an INI value does not exist, INI_INT returns 0 and
    * INI_STR returns NULL.
    */
   if (NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -918,11 +918,11 @@ nr_status_t nr_php_txn_begin(const char* appnames,
 
   /*
    * Only try to instrument preloaded opcache scripts when opcache enabled and
-   * preload is not null.  If an INI value does not exist, INI_INT returns 0 and
+   * preload is not null.  If an INI value does not exist, INI_INT/INI_BOOL returns 0 and
    * INI_STR returns NULL.
    */
   if (NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection)) {
-    if ((1 == INI_INT("opcache.enable"))
+    if ((1 == INI_BOOL("opcache.enable"))
         && (NULL != INI_STR("opcache.preload"))) {
       nr_php_user_instrumentation_from_opcache(TSRMLS_C);
     }


### PR DESCRIPTION
More stringent checks are required for PHP 8.1+ prior to querying opcache to prevent warning messages from being thrown. Additionally, the severity level of the messages should be downgraded to `debug`.

1) If `opcache.enable` is true and `opcache.preload`  is not null then call the attempt to instrument the preloaded functions.
2) According to https://www.php.net/manual/en/function.opcache-get-status.php will return either an array or false. Hence https://github.com/newrelic/newrelic-php-agent/blob/main/agent/php_execute.c#L1690 will be either an array or false 
both of which could be valid depending on the state of PHP.
Therefore the warning message:
`User instrumentation from opcache: opcache status information is not an array` is downgraded to debug.
3) clang format picked up a few changes.

Passes unit and integration tests.
Tested locally for functionality and for error msg using slim soak tests.