### PR TITLE
build: cleanup code to build with gcc12

### DIFF
--- a/agent/php_call.h
+++ b/agent/php_call.h
@@ -49,7 +49,8 @@ extern zval* nr_php_call_user_func(zval* object_ptr,
     zval* call_params[] = {params};                                   \
     size_t num_call_params = sizeof(call_params) / sizeof(zval*);     \
     nr_php_call_user_func(object_ptr, function_name, num_call_params, \
-                          call_params TSRMLS_CC);                     \
+                          (num_call_params > 0 ? call_params : NULL)  \
+                              TSRMLS_CC);                             \
   })
 
 /*
@@ -79,12 +80,13 @@ extern zval* nr_php_call_callable_zval(zval* callable,
                                        zend_uint param_count,
                                        zval* params[] TSRMLS_DC);
 
-#define nr_php_call_callable(callable, params...)                 \
-  ({                                                              \
-    zval* call_params[] = {params};                               \
-    size_t num_call_params = sizeof(call_params) / sizeof(zval*); \
-    nr_php_call_callable_zval(callable, num_call_params,          \
-                              call_params TSRMLS_CC);             \
+#define nr_php_call_callable(callable, params...)                        \
+  ({                                                                     \
+    zval* call_params[] = {params};                                      \
+    size_t num_call_params = sizeof(call_params) / sizeof(zval*);        \
+    nr_php_call_callable_zval(callable, num_call_params,                 \
+                              (num_call_params > 0 ? call_params : NULL) \
+                                  TSRMLS_CC);                            \
   })
 
 extern zval* nr_php_call_fcall_info_zval(zend_fcall_info fci,
@@ -92,12 +94,13 @@ extern zval* nr_php_call_fcall_info_zval(zend_fcall_info fci,
                                          zend_uint param_count,
                                          zval* params[] TSRMLS_DC);
 
-#define nr_php_call_fcall_info(fci, fcc, params...)               \
-  ({                                                              \
-    zval* call_params[] = {params};                               \
-    size_t num_call_params = sizeof(call_params) / sizeof(zval*); \
-    nr_php_call_fcall_info_zval(fci, fcc, num_call_params,        \
-                                call_params TSRMLS_CC);           \
+#define nr_php_call_fcall_info(fci, fcc, params...)                        \
+  ({                                                                       \
+    zval* call_params[] = {params};                                        \
+    size_t num_call_params = sizeof(call_params) / sizeof(zval*);          \
+    nr_php_call_fcall_info_zval(fci, fcc, num_call_params,                 \
+                                (num_call_params > 0 ? call_params : NULL) \
+                                    TSRMLS_CC);                            \
   })
 
 extern void nr_php_call_user_func_array_handler(

--- a/agent/php_file_get_contents.c
+++ b/agent/php_file_get_contents.c
@@ -132,7 +132,7 @@ static void nr_php_file_get_contents_add_headers_internal(zval* context,
     return;
   }
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-compare"
+#pragma GCC diagnostic ignored "-Waddress"
   if (Z_STRLEN_P(http_header) <= 0 || NULL == Z_STRVAL_P(http_header)) {
 #pragma GCC diagnostic pop
     /* No header string to preserve. */

--- a/agent/php_file_get_contents.c
+++ b/agent/php_file_get_contents.c
@@ -132,7 +132,7 @@ static void nr_php_file_get_contents_add_headers_internal(zval* context,
     return;
   }
 
-  if ((Z_STRLEN_P(http_header) <= 0) || (0 == Z_STRVAL_P(http_header))) {
+  if (Z_STRLEN_P(http_header) <= 0) {
     /* No header string to preserve. */
     nr_php_add_assoc_string(http_context_options, "header", headers);
     return;

--- a/agent/php_file_get_contents.c
+++ b/agent/php_file_get_contents.c
@@ -131,8 +131,10 @@ static void nr_php_file_get_contents_add_headers_internal(zval* context,
   if (!nr_php_is_zval_valid_string(http_header)) {
     return;
   }
-
-  if (Z_STRLEN_P(http_header) <= 0) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+  if (Z_STRLEN_P(http_header) <= 0 || NULL == Z_STRVAL_P(http_header)) {
+#pragma GCC diagnostic pop
     /* No header string to preserve. */
     nr_php_add_assoc_string(http_context_options, "header", headers);
     return;

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2998,7 +2998,7 @@ static void nr_ini_displayer_cb(zend_ini_entry* ini_entry, int type TSRMLS_DC) {
   }
 
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-compare"
+#pragma GCC diagnostic ignored "-Waddress"
   if ((ZEND_INI_DISPLAY_ORIG == type) && ini_entry->modified
       && PHP_INI_ENTRY_ORIG_VALUE(ini_entry)
       && PHP_INI_ENTRY_ORIG_VALUE_LEN(ini_entry)) {
@@ -3051,7 +3051,7 @@ static int nr_ini_displayer_global(zend_ini_entry* ini_entry,
    * settings.
    */
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-compare"
+#pragma GCC diagnostic ignored "-Waddress"
   if (NULL == PHP_INI_ENTRY_VALUE(ini_entry)
       || 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
 #pragma GCC diagnostic pop
@@ -3210,7 +3210,7 @@ static int nr_ini_settings(zend_ini_entry* ini_entry,
 
   if (!(ini_entry->modifiable & PHP_INI_PERDIR)) {
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-compare"
+#pragma GCC diagnostic ignored "-Waddress"
     if (NULL == PHP_INI_ENTRY_VALUE(ini_entry)
         || 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
 #pragma GCC diagnostic pop
@@ -3247,7 +3247,7 @@ static int nr_ini_settings(zend_ini_entry* ini_entry,
   }
 
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-compare"
+#pragma GCC diagnostic ignored "-Waddress"
   if (NULL == PHP_INI_ENTRY_VALUE(ini_entry)
       || 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
 #pragma GCC diagnostic push

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -3053,7 +3053,7 @@ static int nr_ini_displayer_global(zend_ini_entry* ini_entry,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtautological-compare"
   if (NULL == PHP_INI_ENTRY_VALUE(ini_entry)
-      && 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+      || 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
 #pragma GCC diagnostic pop
     if (0
         == nr_strncmp(PHP_INI_ENTRY_NAME(ini_entry),
@@ -3212,7 +3212,7 @@ static int nr_ini_settings(zend_ini_entry* ini_entry,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtautological-compare"
     if (NULL == PHP_INI_ENTRY_VALUE(ini_entry)
-        && 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+        || 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
 #pragma GCC diagnostic pop
       if (0
           == nr_strncmp(PHP_INI_ENTRY_NAME(ini_entry),
@@ -3248,8 +3248,8 @@ static int nr_ini_settings(zend_ini_entry* ini_entry,
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtautological-compare"
-  if (0 == PHP_INI_ENTRY_VALUE(ini_entry)
-      && 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+  if (NULL == PHP_INI_ENTRY_VALUE(ini_entry)
+      || 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
 #pragma GCC diagnostic push
     nro_set_hash_string(setarg->obj, PHP_INI_ENTRY_NAME(ini_entry), "no value");
   } else {

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2997,11 +2997,15 @@ static void nr_ini_displayer_cb(zend_ini_entry* ini_entry, int type TSRMLS_DC) {
     return;
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
   if ((ZEND_INI_DISPLAY_ORIG == type) && ini_entry->modified
+      && PHP_INI_ENTRY_ORIG_VALUE(ini_entry)
       && PHP_INI_ENTRY_ORIG_VALUE_LEN(ini_entry)) {
     display_string = PHP_INI_ENTRY_ORIG_VALUE(ini_entry);
     display_string_length = PHP_INI_ENTRY_ORIG_VALUE_LEN(ini_entry);
     esc_html = sapi_module.phpinfo_as_text ? 0 : 1;
+#pragma GCC diagnostic pop
   } else if (PHP_INI_ENTRY_VALUE(ini_entry)
              && PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
     display_string = PHP_INI_ENTRY_VALUE(ini_entry);
@@ -3046,7 +3050,11 @@ static int nr_ini_displayer_global(zend_ini_entry* ini_entry,
    * If there is no value, then don't print anything for the "special" ini
    * settings.
    */
-  if (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+  if (NULL == PHP_INI_ENTRY_VALUE(ini_entry)
+      && 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+#pragma GCC diagnostic pop
     if (0
         == nr_strncmp(PHP_INI_ENTRY_NAME(ini_entry),
                       NR_PSTR("newrelic.special"))) {
@@ -3201,7 +3209,11 @@ static int nr_ini_settings(zend_ini_entry* ini_entry,
   }
 
   if (!(ini_entry->modifiable & PHP_INI_PERDIR)) {
-    if (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+    if (NULL == PHP_INI_ENTRY_VALUE(ini_entry)
+        && 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+#pragma GCC diagnostic pop
       if (0
           == nr_strncmp(PHP_INI_ENTRY_NAME(ini_entry),
                         NR_PSTR("newrelic.special"))) {
@@ -3234,7 +3246,11 @@ static int nr_ini_settings(zend_ini_entry* ini_entry,
     return 0;
   }
 
-  if (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+  if (0 == PHP_INI_ENTRY_VALUE(ini_entry)
+      && 0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
+#pragma GCC diagnostic push
     nro_set_hash_string(setarg->obj, PHP_INI_ENTRY_NAME(ini_entry), "no value");
   } else {
     if (0

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2998,7 +2998,6 @@ static void nr_ini_displayer_cb(zend_ini_entry* ini_entry, int type TSRMLS_DC) {
   }
 
   if ((ZEND_INI_DISPLAY_ORIG == type) && ini_entry->modified
-      && PHP_INI_ENTRY_ORIG_VALUE(ini_entry)
       && PHP_INI_ENTRY_ORIG_VALUE_LEN(ini_entry)) {
     display_string = PHP_INI_ENTRY_ORIG_VALUE(ini_entry);
     display_string_length = PHP_INI_ENTRY_ORIG_VALUE_LEN(ini_entry);
@@ -3047,8 +3046,7 @@ static int nr_ini_displayer_global(zend_ini_entry* ini_entry,
    * If there is no value, then don't print anything for the "special" ini
    * settings.
    */
-  if ((NULL == PHP_INI_ENTRY_VALUE(ini_entry))
-      || (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry))) {
+  if (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
     if (0
         == nr_strncmp(PHP_INI_ENTRY_NAME(ini_entry),
                       NR_PSTR("newrelic.special"))) {
@@ -3162,11 +3160,10 @@ void zm_info_newrelic(void); /* ctags landing pad only */
 PHP_MINFO_FUNCTION(newrelic) {
   php_info_print_table_start();
   php_info_print_table_header(2, "New Relic RPM Monitoring",
-                              NR_PHP_PROCESS_GLOBALS(enabled)
-                                  ? "enabled"
-                                  : NR_PHP_PROCESS_GLOBALS(mpm_bad)
-                                        ? "disabled due to threaded MPM"
-                                        : "disabled");
+                              NR_PHP_PROCESS_GLOBALS(enabled) ? "enabled"
+                              : NR_PHP_PROCESS_GLOBALS(mpm_bad)
+                                  ? "disabled due to threaded MPM"
+                                  : "disabled");
   php_info_print_table_row(2, "New Relic Version", nr_version_verbose());
   php_info_print_table_end();
 
@@ -3204,8 +3201,7 @@ static int nr_ini_settings(zend_ini_entry* ini_entry,
   }
 
   if (!(ini_entry->modifiable & PHP_INI_PERDIR)) {
-    if ((NULL == PHP_INI_ENTRY_VALUE(ini_entry))
-        || (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry))) {
+    if (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
       if (0
           == nr_strncmp(PHP_INI_ENTRY_NAME(ini_entry),
                         NR_PSTR("newrelic.special"))) {
@@ -3238,8 +3234,7 @@ static int nr_ini_settings(zend_ini_entry* ini_entry,
     return 0;
   }
 
-  if ((NULL == PHP_INI_ENTRY_VALUE(ini_entry))
-      || (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry))) {
+  if (0 == PHP_INI_ENTRY_VALUE_LEN(ini_entry)) {
     nro_set_hash_string(setarg->obj, PHP_INI_ENTRY_NAME(ini_entry), "no value");
   } else {
     if (0

--- a/agent/php_zval.h
+++ b/agent/php_zval.h
@@ -175,8 +175,7 @@ static inline int nr_php_is_zval_valid_string(const zval* z) {
  * Returns : a 1 if the argument is a valid non-empty PHP string; 0 otherwise
  */
 static inline int nr_php_is_zval_non_empty_string(const zval* z) {
-  if (!nr_php_is_zval_valid_string(z) || (0 == Z_STRVAL_P(z))
-      || (Z_STRLEN_P(z) <= 0)) {
+  if (!nr_php_is_zval_valid_string(z) || (Z_STRLEN_P(z) <= 0)) {
     return 0;
   }
   return 1;
@@ -287,9 +286,8 @@ static inline bool nr_php_is_zval_null(const zval* z) {
  *
  */
 static inline long nr_php_zval_resource_id(const zval* zv) {
-  if (!nr_php_is_zval_valid_resource(zv))
-  {
-      return 0;
+  if (!nr_php_is_zval_valid_resource(zv)) {
+    return 0;
   }
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
   return Z_RES_P(zv)->handle;
@@ -307,9 +305,8 @@ static inline long nr_php_zval_resource_id(const zval* zv) {
  *
  */
 static inline long nr_php_zval_object_id(const zval* zv) {
-  if (!nr_php_is_zval_valid_object(zv))
-  {
-      return 0;
+  if (!nr_php_is_zval_valid_object(zv)) {
+    return 0;
   }
   return Z_OBJ_HANDLE_P(zv);
 }

--- a/agent/php_zval.h
+++ b/agent/php_zval.h
@@ -176,7 +176,7 @@ static inline int nr_php_is_zval_valid_string(const zval* z) {
  */
 static inline int nr_php_is_zval_non_empty_string(const zval* z) {
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-compare"
+#pragma GCC diagnostic ignored "-Waddress"
   if (!nr_php_is_zval_valid_string(z) || (NULL == Z_STRVAL_P(z))
       || (Z_STRLEN_P(z) <= 0)) {
 #pragma GCC diagnostic pop

--- a/agent/php_zval.h
+++ b/agent/php_zval.h
@@ -175,7 +175,11 @@ static inline int nr_php_is_zval_valid_string(const zval* z) {
  * Returns : a 1 if the argument is a valid non-empty PHP string; 0 otherwise
  */
 static inline int nr_php_is_zval_non_empty_string(const zval* z) {
-  if (!nr_php_is_zval_valid_string(z) || (Z_STRLEN_P(z) <= 0)) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+  if (!nr_php_is_zval_valid_string(z) || (NULL == Z_STRVAL_P(z))
+      || (Z_STRLEN_P(z) <= 0)) {
+#pragma GCC diagnostic pop
     return 0;
   }
   return 1;

--- a/axiom/util_memory.c
+++ b/axiom/util_memory.c
@@ -96,7 +96,7 @@ void* NRMALLOCSZ(2) nr_realloc(void* oldptr, size_t newsize) {
   }
 
   ret = (realloc)(oldptr, newsize);
-  if (nrunlikely(0 == ret)) {
+  if (NULL == ret) {
     nrl_error(NRL_MEMORY, "failed to reallocate %p for %zu bytes", oldptr,
               newsize);
     nr_signal_tracer_common(31); /* SIGSYS(31) - bad system call */


### PR DESCRIPTION
This PR addresses compilation warnings/errors encountered when building the agent with GCC 12.

#### Example Error References:

```bash
In file included from util_memory.c:15:
util_memory.c: In function 'nr_realloc':
util_logging.h:223:7: error: pointer 'oldptr' may be used after 'realloc' [-Werror=use-after-free]
  223 |       nrl_send_log_message(NRL_ERROR, __VA_ARGS__); \
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
util_memory.c:100:5: note: in expansion of macro 'nrl_error'
  100 |     nrl_error(NRL_MEMORY, "failed to reallocate %p for %zu bytes", oldptr,
      |     ^~~~~~~~~
util_memory.c:98:9: note: call to 'realloc' here
   98 |   ret = (realloc)(oldptr, newsize);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

```bash
In file included from /usr/src/myapp/newrelic-php-agent/agent/php_agent.h:41,
                 from /usr/src/myapp/newrelic-php-agent/agent/fw_cakephp.c:6:
/usr/src/myapp/newrelic-php-agent/agent/php_zval.h: In function 'nr_php_is_zval_non_empty_string':
/usr/src/myapp/newrelic-php-agent/agent/php_zval.h:178:45: error: the comparison will always evaluate as 'false' for the address of 'val' will never be NULL [-Werror=address]
  178 |   if (!nr_php_is_zval_valid_string(z) || (0 == Z_STRVAL_P(z))
      |                                             ^~
In file included from /usr/local/include/php/Zend/zend.h:27,
                 from /usr/src/myapp/newrelic-php-agent/agent/php_includes.h:17,
                 from /usr/src/myapp/newrelic-php-agent/agent/php_agent.h:38:
/usr/local/include/php/Zend/zend_types.h:350:27: note: 'val' declared here
  350 |         char              val[1];
      |                           ^~~
At top level:
cc1: note: unrecognized command-line option '-Wno-typedef-redefinition' may have been intended to silence earlier diagnostics
```

```bash
In file included from /usr/src/myapp/newrelic-php-agent/agent/php_zval.h:21,
                 from /usr/src/myapp/newrelic-php-agent/agent/php_agent.h:41,
                 from /usr/src/myapp/newrelic-php-agent/agent/fw_drupal8.c:6:
/usr/src/myapp/newrelic-php-agent/agent/fw_drupal8.c: In function 'nr_drupal8_wrap_view_execute':
/usr/src/myapp/newrelic-php-agent/agent/php_call.h:51:5: error: 'nr_php_call_user_func' accessing 8 bytes in a region of size 0 [-Werror=stringop-overflow=]
   51 |     nr_php_call_user_func(object_ptr, function_name, num_call_params, \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   52 |                           call_params TSRMLS_CC);                     \
      |                           ~~~~~~~~~~~~~~~~~~~~~~
```

```bash
usr/src/myapp/newrelic-php-agent/agent/php_file_get_contents.c: In function 'nr_php_file_get_contents_add_headers_internal':
/usr/src/myapp/newrelic-php-agent/agent/php_file_get_contents.c:135:44: error: the comparison will always evaluate as 'false' for the address of 'val' will never be NULL [-Werror=address]
  135 |   if ((Z_STRLEN_P(http_header) <= 0) || (0 == Z_STRVAL_P(http_header))) {
      |                                            ^~
In file included from /usr/local/include/php/Zend/zend.h:27,
                 from /usr/src/myapp/newrelic-php-agent/agent/php_includes.h:17,
                 from /usr/src/myapp/newrelic-php-agent/agent/php_agent.h:38,
                 from /usr/src/myapp/newrelic-php-agent/agent/php_file_get_contents.c:5:
/usr/local/include/php/Zend/zend_types.h:350:27: note: 'val' declared here
  350 |         char              val[1];
      |                           ^~~

```