### PR TITLE
fix(agent): Ensure txn exists before we try to reference it.

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1793,6 +1793,11 @@ static inline void nr_php_observer_exception_segments_end(
   if (NULL == exception || NULL == execute_data_this) {
     return;
   }
+
+  if (NULL == NRPRG(txn)) {
+    return;
+  }
+
   segment = NRTXN(force_current_segment);
   while ((NULL != segment)
          && (NRTXN(segment_root) != NRTXN(force_current_segment))) {
@@ -1814,6 +1819,10 @@ void nr_php_observer_segment_end(zval* exception) {
    * if null.  The segment would only have been created if we are recording and
    * if wraprec is set or if tt is greater than 0.
    */
+
+  if (NULL == NRPRG(txn)) {
+    return;
+  }
 
   if (NULL != exception) {
     nr_status_t status;
@@ -1982,7 +1991,7 @@ static void nr_php_instrument_func_begin(NR_EXECUTE_PROTO) {
           "Uncaught exception ", &NRPRG(exception_filters) TSRMLS_CC);
       php_observer_clear_uncaught_exception_globals();
     }
-  } else {
+  } else if (NULL != NRPRG(txn)) {
     /*
      * Check if NRPRG(uncaught_exception) exists because if it's not handled,
      * we'll parent the new segment on the wrong stacked segment. Close off

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -118,15 +118,19 @@ void nr_throw_exception_hook(zend_object* exception) {
   zval* exception_zval = NULL;
 
   /*
-   * Since PHP 7, EG(exception) is stored as a zend_object, and is therefore
-   * only wrapped in a zval when it actually needs to be.
+   * Don't track the exception if we don't have a valid txn.
    */
-  ZVAL_OBJ(&new_exception, exception);
-  exception_zval = &new_exception;
+  if (NULL != NRPRG(txn)) {
+    /*
+     * Since PHP 7, EG(exception) is stored as a zend_object, and is therefore
+     * only wrapped in a zval when it actually needs to be.
+     */
+    ZVAL_OBJ(&new_exception, exception);
+    exception_zval = &new_exception;
 
-  php_observer_handle_exception_hook(exception_zval,
-                                     &(EG(current_execute_data)->This));
-
+    php_observer_handle_exception_hook(exception_zval,
+                                       &(EG(current_execute_data)->This));
+  }
   if (original_zend_throw_exception_hook != NULL) {
     original_zend_throw_exception_hook(exception);
   }


### PR DESCRIPTION
Consistent with other functions in php_execute, check if txn exists before trying to use it.

The issue occurred during the first request, and because it is the first, the appname is unknown and we don't create a txn.  However, an exception happened in that first request, our exception_hook handler got triggered, and if that is triggered, we always try to close off dangling segments.  In this case, because we didn't check for txn==null, it segfaulted as we tried to access txn elements.
Pr fixes that in two ways, 1) check for txn==null before closing off segments.  2) don't record uncaught exception info generated from our exception_hook handler if a txn is null.
```
2023-01-26 21:03:16.816 +0000 (29813 29813) verbosedebug: RINIT processing started
2023-01-26 21:03:16.816 +0000 (29813 29813) debug: added app='PHP Test Apps Laravel ads v2' license='07...4a'
2023-01-26 21:03:16.816 +0000 (29813 29813) verbosedebug: querying app='PHP Test Apps Laravel ads v2' from parent=4
2023-01-26 21:03:16.816 +0000 (29813 29813) verbosedebug: sending appinfo message, len=6492
2023-01-26 21:03:16.817 +0000 (29813 29813) debug: APPINFO reply unknown app='PHP Test Apps Laravel ads v2'
2023-01-26 21:03:16.817 +0000 (29813 29813) debug: unable to begin transaction: app 'PHP Test Apps Laravel ads v2' is unknown
```
note the last line: debug: 
unable to begin transaction: app 'PHP Test Apps Laravel ads v2' is unknown