### PR TITLE
Initial build changes for 8.2

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -18,12 +18,12 @@ on:
   push:
     branches: 
       - main
-      - 'php8'
+      - 'php-82'
       - 'dev'
   pull_request:
     branches: 
       - main
-      - 'php8'
+      - 'php-82'
       - 'dev'
 
 jobs:
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        php_ver: ['7.0', '7.1-zts', '7.2', '7.3', '7.4', '8.0', '8.0-zts', '8.1', '8.1-zts']
+        php_ver: ['7.0', '7.1-zts', '7.2', '7.3', '7.4', '8.0', '8.0-zts', '8.1', '8.1-zts', '8.2']
         arch: ['x64', 'x86']
         exclude:
         # Excludes PHP 5.x, 7.x on linux 32-bit
@@ -69,6 +69,9 @@ jobs:
           arch: 'x86'
         - os: linux
           php_ver: '8.1-zts'
+          arch: 'x86'
+        - os: linux
+          php_ver: '8.2'
           arch: 'x86'
     steps:
       - name: Checkout Repo 

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -52,6 +52,7 @@
 #define ZEND_7_4_X_API_NO 20190902
 #define ZEND_8_0_X_API_NO 20200930
 #define ZEND_8_1_X_API_NO 20210902
+#define ZEND_8_2_X_API_NO 20220830
 
 #if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
 #include "Zend/zend_virtual_cwd.h"

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -52,7 +52,7 @@
 #define ZEND_7_4_X_API_NO 20190902
 #define ZEND_8_0_X_API_NO 20200930
 #define ZEND_8_1_X_API_NO 20210902
-#define ZEND_8_2_X_API_NO 20220830
+#define ZEND_8_2_X_API_NO 20220829
 
 #if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
 #include "Zend/zend_virtual_cwd.h"

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2980,10 +2980,16 @@ STD_PHP_INI_ENTRY_EX("newrelic.application_logging.metrics.enabled",
 PHP_INI_END() /* } */
 
 void nr_php_register_ini_entries(int module_number TSRMLS_DC) {
+#if ZEND_MODULE_API_NO >= ZEND_8_2_X_API_NO
+  int type = MODULE_PERSISTENT;
+#endif
   REGISTER_INI_ENTRIES();
 }
 
 void nr_php_unregister_ini_entries(int module_number TSRMLS_DC) {
+#if ZEND_MODULE_API_NO >= ZEND_8_2_X_API_NO
+  int type = MODULE_PERSISTENT;
+#endif
   UNREGISTER_INI_ENTRIES();
 }
 
@@ -3162,11 +3168,10 @@ void zm_info_newrelic(void); /* ctags landing pad only */
 PHP_MINFO_FUNCTION(newrelic) {
   php_info_print_table_start();
   php_info_print_table_header(2, "New Relic RPM Monitoring",
-                              NR_PHP_PROCESS_GLOBALS(enabled)
-                                  ? "enabled"
-                                  : NR_PHP_PROCESS_GLOBALS(mpm_bad)
-                                        ? "disabled due to threaded MPM"
-                                        : "disabled");
+                              NR_PHP_PROCESS_GLOBALS(enabled) ? "enabled"
+                              : NR_PHP_PROCESS_GLOBALS(mpm_bad)
+                                  ? "disabled due to threaded MPM"
+                                  : "disabled");
   php_info_print_table_row(2, "New Relic Version", nr_version_verbose());
   php_info_print_table_end();
 

--- a/agent/tests/tlib_php.c
+++ b/agent/tests/tlib_php.c
@@ -306,7 +306,7 @@ nr_status_t tlib_php_engine_create(const char* extra_ini PTSRMLS_DC) {
     return NR_FAILURE;
   }
 #else
-    if (FAILURE == php_module_startup(&tlib_module, &newrelic_module_entry, 1)) {
+  if (FAILURE == php_module_startup(&tlib_module, &newrelic_module_entry, 1)) {
     return NR_FAILURE;
   }
 #endif

--- a/agent/tests/tlib_php.c
+++ b/agent/tests/tlib_php.c
@@ -301,9 +301,15 @@ nr_status_t tlib_php_engine_create(const char* extra_ini PTSRMLS_DC) {
   /*
    * Actually start the Zend Engine.
    */
-  if (FAILURE == php_module_startup(&tlib_module, &newrelic_module_entry, 1)) {
+#if ZEND_MODULE_API_NO >= ZEND_8_2_X_API_NO
+  if (FAILURE == php_module_startup(&tlib_module, &newrelic_module_entry)) {
     return NR_FAILURE;
   }
+#else
+    if (FAILURE == php_module_startup(&tlib_module, &newrelic_module_entry, 1)) {
+    return NR_FAILURE;
+  }
+#endif
 
   /*
    * As noted above, we now replace the interned string callbacks on PHP

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -9,7 +9,7 @@
 
 ARG PHP_VER
 
-FROM php:${PHP_VER:-8.0}
+FROM php:${PHP_VER:-8.2}
 
 RUN docker-php-source extract
 


### PR DESCRIPTION
Overview:
- cc3c88e5eb2e8b0a2fd85494fea22fe71b9220a1 updates Docker to pull the 8.2 image
- 026e0ba305a70f2ef00639b776c1ca5084e6893a adds the Zend API No
- 3946ab3f0f4ab6d32e019db426e714972cc04cd9 addresses the removal of the [num_additional_modules](https://github.com/php/php-src/blob/PHP-8.2/UPGRADING.INTERNALS#L109)
- 9cb040aab11a9055b032075e39edb1fb5b596396 addresses the addition of a `type` to [REGISTER/UNREGISTER_INI_ENTRIES](https://github.com/php/php-src/blob/PHP-8.2/Zend/zend_ini.h#L199)
- dabca0db641e83c859e0e2fbc8f2bf5504811ddf updates GHA workflow build considerations