### PR TITLE
docs(agent): update INI documentation with CLM warnings

### DIFF
--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -933,9 +933,10 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          pathnames to your PHP files/functions, you may exceed the max message
 ;          size limit set by the Daemon if your max_samples_stored setting is
 ;          too high. To fix this, you can either:
-;           a) set newrelic.code_level_metrics.enabled=false, disabling it
+;           a) enable infinite tracing (newrelic.infinite_tracing.trace_observer.host)
+;           b) set newrelic.code_level_metrics.enabled=false, disabling it
 ;              entirely
-;           b) lower the value for newrelic.span_events.max_samples_stored
+;           c) lower the value for newrelic.span_events.max_samples_stored
 ;
 ;newrelic.span_events.max_samples_stored = 0
 
@@ -1238,9 +1239,10 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          pathnames to your PHP files/functions, you may exceed the max message
 ;          size limit set by the Daemon if your max_samples_stored setting is
 ;          too high. To fix this, you can either:
-;           a) set newrelic.code_level_metrics.enabled=false, disabling it
+;           a) enable infinite tracing (newrelic.infinite_tracing.trace_observer.host)
+;           b) set newrelic.code_level_metrics.enabled=false, disabling it
 ;              entirely
-;           b) lower the value for newrelic.span_events.max_samples_stored
+;           c) lower the value for newrelic.span_events.max_samples_stored
 ;
 ;newrelic.code_level_metrics.enabled = true
 

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -929,6 +929,14 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          per transaction. A value of 0 will use the agent default.  The max
 ;          setting is 10000.
 ;
+;          !IMPORTANT: If you have Code Level Metrics enabled & long absolute
+;          pathnames to your PHP files/functions, you may exceed the max message
+;          size limit set by the Daemon if your max_samples_stored setting is
+;          too high. To fix this, you can either:
+;           a) set newrelic.code_level_metrics.enabled=false, disabling it
+;              entirely
+;           b) lower the value for newrelic.span_events.max_samples_stored
+;
 ;newrelic.span_events.max_samples_stored = 0
 
 
@@ -1225,6 +1233,14 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ; Info   : Toggles whether the agent provides function name, function
 ;          filepath, function namespace, and function lineno as
 ;          attributes on reported spans
+;
+;          !IMPORTANT: If you have Code Level Metrics enabled & long absolute
+;          pathnames to your PHP files/functions, you may exceed the max message
+;          size limit set by the Daemon if your max_samples_stored setting is
+;          too high. To fix this, you can either:
+;           a) set newrelic.code_level_metrics.enabled=false, disabling it
+;              entirely
+;           b) lower the value for newrelic.span_events.max_samples_stored
 ;
 ;newrelic.code_level_metrics.enabled = true
 


### PR DESCRIPTION
Update the INI documentation with warnings and instructions about CLM pulling long filepaths that result in exceeding the max message size limit the daemon adheres to.