### PR TITLE
build: enhance pcre and protobuf-c dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,17 @@ echo_config:
 	@echo GIT_COMMIT=$(GIT_COMMIT)
 
 #
+# Print information where do the build dependencies come from
+#
+.PHONY: show-vendors
+show-vendors:
+	@echo ""
+	@echo -----------------------------------------------------------------------
+	@echo "| Using pcre library from $(PCRE_PREFIX) (from $(origin PCRE_PREFIX))"
+	@echo "| Using protobuf-c library from $(VENDOR_PREFIX) (from $(origin VENDOR_PREFIX))"
+	@echo -----------------------------------------------------------------------
+	@echo ""
+#
 # Let's build an agent! Building an agent is a three step process: using phpize
 # to build a configure script, using configure to build a Makefile, and then
 # actually using that Makefile to build the agent extension.
@@ -116,7 +127,7 @@ PHPIZE := phpize
 PHP_CONFIG := php-config
 
 .PHONY: agent
-agent: agent/Makefile
+agent: show-vendors agent/Makefile
 	$(MAKE) -C agent
 
 agent/configure: agent/config.m4 agent/Makefile.frag

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ agent/configure: agent/config.m4 agent/Makefile.frag
 	cd agent; $(PHPIZE) --clean && $(PHPIZE)
 
 agent/Makefile: agent/configure | axiom
-	cd agent; ./configure $(SILENT) --enable-newrelic --with-axiom=$(realpath axiom) --with-php-config=$(PHP_CONFIG) --with-protobuf-c=$(VENDOR_PREFIX) --with-pcre=$(PCRE_PREFIX)
+	cd agent; ./configure $(SILENT) --enable-newrelic --with-axiom=$(realpath axiom) --with-php-config=$(PHP_CONFIG) --with-protobuf-c=$(PROTOBUF_C_PREFIX) --with-pcre=$(PCRE_PREFIX)
 
 #
 # Installs the agent into the extension directory of the appropriate PHP

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ show-vendors:
 	@echo ""
 	@echo -----------------------------------------------------------------------
 	@echo "| Using pcre library from $(PCRE_PREFIX) (from $(origin PCRE_PREFIX))"
-	@echo "| Using protobuf-c library from $(VENDOR_PREFIX) (from $(origin VENDOR_PREFIX))"
+	@echo "| Using protobuf-c library from $(PROTOBUF_C_PREFIX) (from $(origin PROTOBUF_C_PREFIX))"
 	@echo -----------------------------------------------------------------------
 	@echo ""
 #

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ agent/configure: agent/config.m4 agent/Makefile.frag
 	cd agent; $(PHPIZE) --clean && $(PHPIZE)
 
 agent/Makefile: agent/configure | axiom
-	cd agent; ./configure $(SILENT) --enable-newrelic --with-axiom=$(realpath axiom) --with-php-config=$(PHP_CONFIG)
+	cd agent; ./configure $(SILENT) --enable-newrelic --with-axiom=$(realpath axiom) --with-php-config=$(PHP_CONFIG) --with-protobuf-c=$(VENDOR_PREFIX)
 
 #
 # Installs the agent into the extension directory of the appropriate PHP
@@ -305,7 +305,7 @@ daemon-protobuf: src/newrelic/infinite_tracing/com_newrelic_trace_v1/v1.pb.go
 src/newrelic/infinite_tracing/com_newrelic_trace_v1/v1.pb.go: protocol/infinite_tracing/v1.proto
 	$(MAKE) vendor # Only build vendor stuff if v1.proto has changed. Otherwise
 	               # this rule will be triggered every time the daemon is built.
-	$(VENDOR_BASE)/local/bin/protoc \
+	$(VENDOR_PREFIX)/bin/protoc \
 	    -I=./protocol/infinite_tracing \
 	    --go_out="paths=source_relative,plugins=grpc:src/newrelic/infinite_tracing/com_newrelic_trace_v1" \
 	    protocol/infinite_tracing/v1.proto
@@ -467,11 +467,17 @@ lasp-test-all:
 export GIT
 
 .PHONY: vendor vendor-clean
+ifeq (0,$(HAVE_PROTOBUF_C))
 vendor:
 	$(MAKE) -C vendor all
 
 vendor-clean:
 	$(MAKE) -C vendor clean
+else
+vendor: ;
+
+vendor-clean: ;
+endif
 
 #
 # Extras

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ agent/configure: agent/config.m4 agent/Makefile.frag
 	cd agent; $(PHPIZE) --clean && $(PHPIZE)
 
 agent/Makefile: agent/configure | axiom
-	cd agent; ./configure $(SILENT) --enable-newrelic --with-axiom=$(realpath axiom) --with-php-config=$(PHP_CONFIG) --with-protobuf-c=$(VENDOR_PREFIX)
+	cd agent; ./configure $(SILENT) --enable-newrelic --with-axiom=$(realpath axiom) --with-php-config=$(PHP_CONFIG) --with-protobuf-c=$(VENDOR_PREFIX) --with-pcre=$(PCRE_PREFIX)
 
 #
 # Installs the agent into the extension directory of the appropriate PHP

--- a/agent/config.m4
+++ b/agent/config.m4
@@ -26,7 +26,7 @@ dnl file, as built by running "make" in the axiom directory.
 PHP_ARG_WITH(axiom,,
 [  --with-axiom=DIR        Path to axiom], ../axiom, no)
 
-dnl The path to protobuf-c. The default is to look for a local vendored
+dnl The path to libprotobuf-c.a. The default is to look for a local vendored
 dnl install, as built by running "make" at the level above this.
 PHP_ARG_WITH(protobuf-c,,
 [  --with-protobuf-c=DIR   Path to protobuf-c], ../vendor/local, no)
@@ -145,7 +145,7 @@ if test "$PHP_NEWRELIC" = "yes"; then
     dnl protobuf-c directory, and there's no way to prevent it.
     dnl Note that the -lprotobuf-c has to be _after_ axiom for the symbols
     dnl to be resolved properly, hence the different order to the above.
-    NEWRELIC_SHARED_LIBADD="$NEWRELIC_SHARED_LIBADD -L$PHP_PROTOBUF_C/lib -lprotobuf-c"
+    NEWRELIC_SHARED_LIBADD="$NEWRELIC_SHARED_LIBADD -L$PHP_PROTOBUF_C/lib -l:libprotobuf-c.a"
   ],[
     AC_MSG_ERROR([protobuf-c not found])
   ],[

--- a/agent/config.m4
+++ b/agent/config.m4
@@ -31,6 +31,12 @@ dnl install, as built by running "make" at the level above this.
 PHP_ARG_WITH(protobuf-c,,
 [  --with-protobuf-c=DIR   Path to protobuf-c], ../vendor/local, no)
 
+dnl The path to libpcre.a. The default is to look for a php-build-scripts
+dnl install in /opt/nr/pcre/8.40 local vendored as built by running 
+dnl "./make.sh pcre" from top level directory of php-build-scripts.
+PHP_ARG_WITH(pcre,,
+[  --with-pcre=DIR   Path to pcre], /opt/nr/pcre/8.40, no)
+
 if test "$PHP_NEWRELIC" = "yes"; then
   AC_DEFINE(HAVE_NEWRELIC, 1, [Whether you have New Relic])
 
@@ -95,24 +101,13 @@ if test "$PHP_NEWRELIC" = "yes"; then
     AC_MSG_ERROR([unknown or unsupported system])
   fi
 
-  dnl Our one external dependency is libpcre, which axiom needs. We'll use
-  dnl pcre-config to find it, since every modern version of PCRE provides it.
-  PCRE_INCLINE=`pcre-config --cflags`
-  if pcre-config --prefix | grep -q /opt/nr/camp; then
-    PCRE_LIBLINE=-lnrpcre-pic
-    PCRE_LIBRARY=nrpcre-pic
-  else
-    PCRE_LIBLINE=`pcre-config --libs`
-    PCRE_LIBRARY=pcre
-  fi
-
-  PHP_CHECK_LIBRARY($PCRE_LIBRARY, pcre_exec, [
-    PHP_EVAL_INCLINE($PCRE_INCLINE)
-    PHP_EVAL_LIBLINE($PCRE_LIBLINE, NEWRELIC_SHARED_LIBADD)
+  PHP_CHECK_LIBRARY(pcre, pcre_exec, [
+    PHP_EVAL_INCLINE($PHP_PCRE)
+    NEWRELIC_SHARED_LIBADD="-L$PHP_PCRE -l:libpcre.a $NEWRELIC_SHARED_LIBADD"
   ],[
     AC_MSG_ERROR([PCRE not found])
   ],[
-    $PCRE_LIBLINE
+    -L$PHP_PCRE/lib
   ])
 
   dnl Check for axiom.

--- a/axiom/Makefile
+++ b/axiom/Makefile
@@ -193,7 +193,7 @@ nr_config.h: configure Makefile
 # Build the 8T protobuf code.
 #
 v1.pb-c.c: v1.proto
-	$(VENDOR_PREFIX)/bin/protoc-c --c_out=. $<
+	$(PROTOBUF_C_PREFIX)/bin/protoc-c --c_out=. $<
 
 #
 # The generated code is not warning-free with current compilers, so we'll

--- a/axiom/Makefile
+++ b/axiom/Makefile
@@ -193,7 +193,7 @@ nr_config.h: configure Makefile
 # Build the 8T protobuf code.
 #
 v1.pb-c.c: v1.proto
-	$(VENDOR_BASE)/local/bin/protoc-c --c_out=. $<
+	$(VENDOR_PREFIX)/bin/protoc-c --c_out=. $<
 
 #
 # The generated code is not warning-free with current compilers, so we'll

--- a/axiom/tests/Makefile
+++ b/axiom/tests/Makefile
@@ -101,16 +101,8 @@ endif
 #
 # Flags required to link PCRE.
 #
-PCRE_CFLAGS := $(shell pcre-config --cflags)
-
-#
-# Special handling for outdated build environments.
-#
-ifneq (,$(findstring /opt/nr/camp,$(shell pcre-config --prefix)))
-  PCRE_LDLIBS := -lnrpcre-pic
-else
-  PCRE_LDLIBS := $(shell pcre-config --libs)
-endif
+PCRE_CFLAGS := -I$(PCRE_PREFIX)/include
+PCRE_LDLIBS := -L$(PCRE_PREFIX)/lib -l:libpcre.a
 
 all: tests
 

--- a/make/config.mk
+++ b/make/config.mk
@@ -42,6 +42,11 @@ HAVE_BACKTRACE := $(shell $(CC) $(dir $(abspath $(lastword $(MAKEFILE_LIST))))ba
 # Whether you have libexecinfo
 HAVE_LIBEXECINFO := $(shell test -e /usr/lib/libexecinfo.so -o -e /usr/lib/libexecinfo.a && echo 1 || echo 0)
 
+# Whether you have protoc-c and libprotobuf-c.a
+# Look in /usr by default but can be overriden from environment)
+VENDOR_PREFIX ?= /usr
+HAVE_PROTOBUF_C := $(shell test -x $(VENDOR_PREFIX)/bin/protoc-c && find $(VENDOR_PREFIX)/lib -name 'libprotobuf-c.a' | grep -q 'libprotobuf-c.a' && echo 1 || echo 0)
+
 # Whether you have PTHREAD_MUTEX_ERRORCHECK
 #
 # The interesting dir/abspath/lastword/$(MAKEFILE_LIST) construct is required to

--- a/make/config.mk
+++ b/make/config.mk
@@ -72,7 +72,7 @@ endif
 # includedir is %prefix%/include.
 # Note that we need static version because different linux distributions use 
 # different names for shared object, which causes installation to fail.
-PCRE_PREFIX ?= $(shell pkg-config libpcre --variable=prefix 2>/dev/null)
+PCRE_PREFIX ?= $(shell PKG_CONFIG_PATH=/opt/nr/pcre/$$(ls /opt/nr/pcre 2>/dev/null)/lib/pkgconfig:$$PKG_CONFIG_PATH pkg-config libpcre --variable=prefix 2>/dev/null)
 HAVE_PCRE := $(shell \
                 test -d "$(PCRE_PREFIX)" \
                 && test -d "$(PCRE_PREFIX)/lib" \

--- a/make/config.mk
+++ b/make/config.mk
@@ -47,6 +47,12 @@ HAVE_LIBEXECINFO := $(shell test -e /usr/lib/libexecinfo.so -o -e /usr/lib/libex
 VENDOR_PREFIX ?= /usr
 HAVE_PROTOBUF_C := $(shell test -x $(VENDOR_PREFIX)/bin/protoc-c && find $(VENDOR_PREFIX)/lib -name 'libprotobuf-c.a' | grep -q 'libprotobuf-c.a' && echo 1 || echo 0)
 
+# Our one external dependency is libpcre.a, which axiom needs. We'll assume
+# it is installed in the system but allow user to override it. Note that
+# we need static version because different linux distributions use different
+# names for shared object which causes installation to fail.
+PCRE_PREFIX ?= /usr
+
 # Whether you have PTHREAD_MUTEX_ERRORCHECK
 #
 # The interesting dir/abspath/lastword/$(MAKEFILE_LIST) construct is required to

--- a/make/config.mk
+++ b/make/config.mk
@@ -46,7 +46,7 @@ HAVE_LIBEXECINFO := $(shell test -e /usr/lib/libexecinfo.so -o -e /usr/lib/libex
 # for install location. This can be overriden by environment.
 # Agent's build system assumes that libprotobuf-c's libdir is %prefix%/lib,
 # includedir is %prefix%/include and bindir is %prefix%/bin.
-PROTOBUF_C_PREFIX ?= $(shell pkg-config libprotobuf-c --variable=prefix)
+PROTOBUF_C_PREFIX ?= $(shell pkg-config libprotoobuf-c --variable=prefix 2>/dev/null)
 HAVE_PROTOBUF_C := $(shell \
                       test -d "$(PROTOBUF_C_PREFIX)" \
                       && test -d "$(PROTOBUF_C_PREFIX)/bin" \
@@ -72,7 +72,7 @@ endif
 # includedir is %prefix%/include.
 # Note that we need static version because different linux distributions use 
 # different names for shared object, which causes installation to fail.
-PCRE_PREFIX ?= $(shell pkg-config libpcre --variable=prefix)
+PCRE_PREFIX ?= $(shell pkg-config libpcre --variable=prefix 2>/dev/null)
 HAVE_PCRE := $(shell \
                 test -d "$(PCRE_PREFIX)" \
                 && test -d "$(PCRE_PREFIX)/lib" \

--- a/make/config.mk
+++ b/make/config.mk
@@ -46,7 +46,7 @@ HAVE_LIBEXECINFO := $(shell test -e /usr/lib/libexecinfo.so -o -e /usr/lib/libex
 # for install location. This can be overriden by environment.
 # Agent's build system assumes that libprotobuf-c's libdir is %prefix%/lib,
 # includedir is %prefix%/include and bindir is %prefix%/bin.
-PROTOBUF_C_PREFIX ?= $(shell pkg-config libprotoobuf-c --variable=prefix 2>/dev/null)
+PROTOBUF_C_PREFIX ?= $(shell pkg-config libprotobuf-c --variable=prefix 2>/dev/null)
 HAVE_PROTOBUF_C := $(shell \
                       test -d "$(PROTOBUF_C_PREFIX)" \
                       && test -d "$(PROTOBUF_C_PREFIX)/bin" \

--- a/make/config.mk
+++ b/make/config.mk
@@ -55,7 +55,7 @@ HAVE_PROTOBUF_C := $(shell \
                       && find -L "$(PROTOBUF_C_PREFIX)/lib" -name 'libprotobuf-c.a' 2>/dev/null | grep -q 'libprotobuf-c.a' \
                       && echo 1 \
                       || echo 0)
-ifneq ($(findstring environment,$(origin PROTOBUF_C_PREFIX))", "")
+ifneq ($(findstring environment,$(origin PROTOBUF_C_PREFIX)), )
   ifeq ($(HAVE_PROTOBUF_C), 0)
     $(error User provided 'protobuf-c' installation is not valid!)
   endif
@@ -79,7 +79,7 @@ HAVE_PCRE := $(shell \
                 && find -L "$(PCRE_PREFIX)/lib" -name 'libpcre.a' 2>/dev/null | grep -q 'libpcre.a' \
                 && echo 1 \
                 || echo 0)
-ifneq ($(findstring environment,$(origin PCRE_PREFIX)), "")
+ifneq ($(findstring environment,$(origin PCRE_PREFIX)), )
   ifeq ($(HAVE_PCRE), 0)
     $(error User provided 'pcre' installation is not valid!)
   endif

--- a/make/config.mk
+++ b/make/config.mk
@@ -42,16 +42,17 @@ HAVE_BACKTRACE := $(shell $(CC) $(dir $(abspath $(lastword $(MAKEFILE_LIST))))ba
 # Whether you have libexecinfo
 HAVE_LIBEXECINFO := $(shell test -e /usr/lib/libexecinfo.so -o -e /usr/lib/libexecinfo.a && echo 1 || echo 0)
 
-# Whether you have protoc-c and libprotobuf-c.a
-# Look in /usr by default but can be overriden from environment)
-VENDOR_PREFIX ?= /usr
+# Whether you have protoc-c and libprotobuf-c.a. By default, ask pkg-config
+# for install location. This can be overriden by environment.
+VENDOR_PREFIX ?= $(shell pkg-config libprotobuf-c --variable=prefix)
 HAVE_PROTOBUF_C := $(shell test -x $(VENDOR_PREFIX)/bin/protoc-c && find $(VENDOR_PREFIX)/lib -name 'libprotobuf-c.a' | grep -q 'libprotobuf-c.a' && echo 1 || echo 0)
 
-# Our one external dependency is libpcre.a, which axiom needs. We'll assume
-# it is installed in the system but allow user to override it. Note that
-# we need static version because different linux distributions use different
-# names for shared object which causes installation to fail.
-PCRE_PREFIX ?= /usr
+
+# Our one external dependency is libpcre.a, which axiom needs. By default, ask
+# pkg-config for install location. This can be overriden by environment.
+# Note that we need static version because different linux distributions use 
+# different names for shared object, which causes installation to fail.
+PCRE_PREFIX ?= $(shell pkg-config libpcre --variable=prefix)
 
 # Whether you have PTHREAD_MUTEX_ERRORCHECK
 #

--- a/make/config.mk
+++ b/make/config.mk
@@ -44,6 +44,8 @@ HAVE_LIBEXECINFO := $(shell test -e /usr/lib/libexecinfo.so -o -e /usr/lib/libex
 
 # Whether you have protoc-c and libprotobuf-c.a. By default, ask pkg-config
 # for install location. This can be overriden by environment.
+# Agent's build system assumes that libprotobuf-c's libdir is %prefix%/lib,
+# includedir is %prefix%/include and bindir is %prefix%/bin.
 PROTOBUF_C_PREFIX ?= $(shell pkg-config libprotobuf-c --variable=prefix)
 HAVE_PROTOBUF_C := $(shell \
                       test -d "$(PROTOBUF_C_PREFIX)" \
@@ -66,6 +68,8 @@ endif
 
 # Our one external dependency is libpcre.a, which axiom needs. By default, ask
 # pkg-config for install location. This can be overriden by environment.
+# Agent's build system assumes that pcre's libdir is %prefix%/lib,
+# includedir is %prefix%/include.
 # Note that we need static version because different linux distributions use 
 # different names for shared object, which causes installation to fail.
 PCRE_PREFIX ?= $(shell pkg-config libpcre --variable=prefix)

--- a/make/config.mk
+++ b/make/config.mk
@@ -44,16 +44,16 @@ HAVE_LIBEXECINFO := $(shell test -e /usr/lib/libexecinfo.so -o -e /usr/lib/libex
 
 # Whether you have protoc-c and libprotobuf-c.a. By default, ask pkg-config
 # for install location. This can be overriden by environment.
-VENDOR_PREFIX ?= $(shell pkg-config libprotobuf-c --variable=prefix)
+PROTOBUF_C_PREFIX ?= $(shell pkg-config libprotobuf-c --variable=prefix)
 HAVE_PROTOBUF_C := $(shell \
-                      test -d "$(VENDOR_PREFIX)" \
-                      && test -d "$(VENDOR_PREFIX)/bin" \
-                      && test -d "$(VENDOR_PREFIX)/lib" \
-                      && test -x "$(VENDOR_PREFIX)/bin/protoc-c" \
-                      && find -L "$(VENDOR_PREFIX)/lib" -name 'libprotobuf-c.a' 2>/dev/null | grep -q 'libprotobuf-c.a' \
+                      test -d "$(PROTOBUF_C_PREFIX)" \
+                      && test -d "$(PROTOBUF_C_PREFIX)/bin" \
+                      && test -d "$(PROTOBUF_C_PREFIX)/lib" \
+                      && test -x "$(PROTOBUF_C_PREFIX)/bin/protoc-c" \
+                      && find -L "$(PROTOBUF_C_PREFIX)/lib" -name 'libprotobuf-c.a' 2>/dev/null | grep -q 'libprotobuf-c.a' \
                       && echo 1 \
                       || echo 0)
-ifneq ($(findstring environment,$(origin VENDOR_PREFIX))", "")
+ifneq ($(findstring environment,$(origin PROTOBUF_C_PREFIX))", "")
   ifeq ($(HAVE_PROTOBUF_C), 0)
     $(error User provided 'protobuf-c' installation is not valid!)
   endif

--- a/make/vendor.mk
+++ b/make/vendor.mk
@@ -13,7 +13,9 @@
 
 # We need to find where the project's vendored dependencies live for these
 # variables.
-VENDOR_BASE := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../vendor)
+ifeq (0,$(HAVE_PROTOBUF_C))
+VENDOR_PREFIX := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../vendor/local)
+endif
 
 #
 # protobuf-c
@@ -21,9 +23,10 @@ VENDOR_BASE := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../vendo
 # Note that this does not require protobuf, which is a build time dependency
 # only.
 #
-PROTOBUF_C_CFLAGS := -I$(VENDOR_BASE)/local/include
-PROTOBUF_C_LDFLAGS := -L$(VENDOR_BASE)/local/lib
-PROTOBUF_C_LDLIBS := -lprotobuf-c
+PROTOBUF_C_CFLAGS := -I$(VENDOR_PREFIX)/include
+PROTOBUF_C_LDFLAGS := -L$(VENDOR_PREFIX)/lib
+# Always link to static library
+PROTOBUF_C_LDLIBS := -l:libprotobuf-c.a
 
 #
 # Aggregated flag variables for use in other Makefiles.

--- a/make/vendor.mk
+++ b/make/vendor.mk
@@ -14,7 +14,7 @@
 # We need to find where the project's vendored dependencies live for these
 # variables.
 ifeq (0,$(HAVE_PROTOBUF_C))
-PROTOBUF_C_PREFIX := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../vendor/local)
+PROTOBUF_C_PREFIX := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../vendor)/local
 endif
 
 #

--- a/make/vendor.mk
+++ b/make/vendor.mk
@@ -14,7 +14,7 @@
 # We need to find where the project's vendored dependencies live for these
 # variables.
 ifeq (0,$(HAVE_PROTOBUF_C))
-VENDOR_PREFIX := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../vendor/local)
+PROTOBUF_C_PREFIX := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../vendor/local)
 endif
 
 #
@@ -23,8 +23,8 @@ endif
 # Note that this does not require protobuf, which is a build time dependency
 # only.
 #
-PROTOBUF_C_CFLAGS := -I$(VENDOR_PREFIX)/include
-PROTOBUF_C_LDFLAGS := -L$(VENDOR_PREFIX)/lib
+PROTOBUF_C_CFLAGS := -I$(PROTOBUF_C_PREFIX)/include
+PROTOBUF_C_LDFLAGS := -L$(PROTOBUF_C_PREFIX)/lib
 # Always link to static library
 PROTOBUF_C_LDLIBS := -l:libprotobuf-c.a
 


### PR DESCRIPTION
Give the user an option to use `protobuf-c` from location alternative to
`vendor` subdirectory via `PROTOBUF_C_PREFIX` environmental variable.
`$PROTOBUF_C_PREFIX/bin` needs to have `protoc-c` binary, 
`$PROTOBUF_C_PREFIX/include` needs to have `protobuf-c/protobuf-c.h`
header file and `$PROTOBUF_C_PREFIX/lib` needs to have `libprotobuf-c.a`. 
By default agent's build system will try to look for `protobuf-c` dependency
in location returned by `pkg-config libprotobuf-c --variable=prefix`, a
location where `protobuf-c` is installed in the system via package
managers. If that location does not have `protobuf-c`, agent's build
system will fallback to using `protobuf-c` from `vendor` directory. This
enhancement speeds up agent build because neither `vendor/protobuf` nor
`vendor/protobuf-c` need to be build if `protobuf-c` is installed in the
system by the user.

If user or system provided `protobuf-c` does not meet agent's build system
requirements, the build will abort with an error message.

Force the agent to use static version of pcre library. This avoids the
issue with runtime dependency on libpcre shared object that is hard to
satisfy universally because different Linux distributions use different
name of the shared object: libpcre.so or libpcre3.so. Additionally the
user has an option to point to pcre library installation via
`PCRE_PREFIX` environmental variable. By default agent's build system 
will try to look for pcre dependency using `pkg-config`.

If user or system provided `pcre` does not meet agent's build system
requirements, the build will abort with an error message.

To troubleshoot build issues caused by dependencies, agent will log which
dependencies it is using.