### PR TITLE
fix(agent): Explicitly call some special function instrumentation in oapi func_begin for txn naming.

### DIFF
--- a/agent/fw_cakephp.c
+++ b/agent/fw_cakephp.c
@@ -141,7 +141,7 @@ NR_PHP_WRAPPER_END
  *
  * txn naming scheme:
  * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
-`NR_NOT_OK_TO_OVERWRITE`
+ * `NR_NOT_OK_TO_OVERWRITE`
  * This entails that the last wrapped call gets to name the txn.
  * No changes required to ensure OAPI compatibility this corresponds to the
 default way of calling the wrapped function in func_end.

--- a/agent/fw_cakephp.c
+++ b/agent/fw_cakephp.c
@@ -137,7 +137,7 @@ NR_PHP_WRAPPER_END
  * with the word "Controller" appended which is what the CakePHP code does).
  *
  * CakePHP 2.x is end-of-life and in maintenance mode (critical bugfixes only).
-As such, functionality added in PHP 7.1+ is not well supported.
+ * As such, functionality added in PHP 7.1+ is not well supported.
  *
  * txn naming scheme:
  * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with

--- a/agent/fw_cakephp.c
+++ b/agent/fw_cakephp.c
@@ -289,13 +289,13 @@ NR_PHP_WRAPPER_END
  * handler to be completely replaced.
  *
  *  CakePHP 2.x is end-of-life and in maintenance mode (critical bugfixes only).
-As such, functionality added in PHP 7.1+ is not well supported.
+ * As such, functionality added in PHP 7.1+ is not well supported.
  *
  * txn naming scheme:
  * In this case, `nr_txn_set_path` is called before `NR_PHP_WRAPPER_CALL` with
-`NR_NOT_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
-in func_begin it needs to be explicitly set as a before_callback to ensure OAPI
-compatibility.
+ * `NR_NOT_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_begin it needs to be explicitly set as a before_callback to ensure OAPI
+ * compatibility.
  * This entails that the first wrapped call gets to name the txn.
  */
 NR_PHP_WRAPPER(nr_cakephp_problem_2) {

--- a/agent/fw_cakephp.c
+++ b/agent/fw_cakephp.c
@@ -144,7 +144,7 @@ NR_PHP_WRAPPER_END
  * `NR_NOT_OK_TO_OVERWRITE`
  * This entails that the last wrapped call gets to name the txn.
  * No changes required to ensure OAPI compatibility this corresponds to the
-default way of calling the wrapped function in func_end.
+ * default way of calling the wrapped function in func_end.
  *
  */
 NR_PHP_WRAPPER(nr_cakephp_name_the_wt_2) {

--- a/agent/fw_cakephp.c
+++ b/agent/fw_cakephp.c
@@ -39,6 +39,11 @@ nr_framework_classification_t nr_cakephp_special_2(
  * Component::initialize(). This function takes a controller as a parameter
  * and we look into the params array of that controller object, and pick up
  * the controller and action out of that array.
+ *
+ * CakePHP 1.x is end-of-life and no longer supported by the agent.
+ * Cake PHP 1.x does not support PHP 8+ and this wrapper is not updated for OAPI
+ * compatibility.
+ *
  */
 NR_PHP_WRAPPER(nr_cakephp_name_the_wt_pre20) {
   zval* arg1 = 0;
@@ -130,6 +135,17 @@ NR_PHP_WRAPPER_END
  * and we get the action from the params array in that object. The
  * controller object ($this) has a name, and that name is used (along
  * with the word "Controller" appended which is what the CakePHP code does).
+ *
+ * CakePHP 2.x is end-of-life and in maintenance mode (critical bugfixes only).
+As such, functionality added in PHP 7.1+ is not well supported.
+ *
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+`NR_NOT_OK_TO_OVERWRITE`
+ * This entails that the last wrapped call gets to name the txn.
+ * No changes required to ensure OAPI compatibility this corresponds to the
+default way of calling the wrapped function in func_end.
+ *
  */
 NR_PHP_WRAPPER(nr_cakephp_name_the_wt_2) {
   zval* arg1 = 0;
@@ -243,6 +259,11 @@ NR_PHP_WRAPPER_END
  *
  * Dispatch::cakeError will be called if there is a problem during dispatch
  * (action or controller not found).
+ *
+ * CakePHP 1.x is end-of-life and no longer supported by the agent.
+ * Cake PHP 1.x does not support PHP 8+ and this wrapper is not updated for OAPI
+ * compatibility.
+ *
  */
 NR_PHP_WRAPPER(nr_cakephp_problem_1) {
   const char* name = "Dispatcher::cakeError";
@@ -266,6 +287,16 @@ NR_PHP_WRAPPER_END
  * appropriate Exception will be created and thrown. We wrap the CakeException
  * constructor instead of the Exception handler, since CakePHP allows for the
  * handler to be completely replaced.
+ *
+ *  CakePHP 2.x is end-of-life and in maintenance mode (critical bugfixes only).
+As such, functionality added in PHP 7.1+ is not well supported.
+ *
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called before `NR_PHP_WRAPPER_CALL` with
+`NR_NOT_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+in func_begin it needs to be explicitly set as a before_callback to ensure OAPI
+compatibility.
+ * This entails that the first wrapped call gets to name the txn.
  */
 NR_PHP_WRAPPER(nr_cakephp_problem_2) {
   const char* name = "Exception";
@@ -298,6 +329,12 @@ void nr_cakephp_enable_1(TSRMLS_D) {
 void nr_cakephp_enable_2(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("Controller::invokeAction"),
                             nr_cakephp_name_the_wt_2 TSRMLS_CC);
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("CakeException::__construct"), nr_cakephp_problem_2, NULL, NULL);
+#else
   nr_php_wrap_user_function(NR_PSTR("CakeException::__construct"),
                             nr_cakephp_problem_2 TSRMLS_CC);
+#endif
 }

--- a/agent/fw_laminas3.c
+++ b/agent/fw_laminas3.c
@@ -67,6 +67,14 @@
  * presumably that was some optimization due to the return value not being used.
  */
 
+/*
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_end no change is needed to ensure OAPI compatibility as it will use
+ * the default func_end after callback. This entails that the first wrapped
+ * function call of this type gets to name the txn.
+ */
 NR_PHP_WRAPPER(nr_laminas3_name_the_wt) {
   zval* path = NULL;
   zval* this_var = NULL;

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -529,6 +529,7 @@ static char* nr_laravel_version(zval* app TSRMLS_DC) {
  * render() method.
  *
  * See: http://laravel.com/docs/5.0/errors#handling-errors
+ *
  */
 NR_PHP_WRAPPER(nr_laravel5_exception_render) {
 #if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
@@ -642,6 +643,9 @@ NR_PHP_WRAPPER(nr_laravel5_exception_report) {
 }
 NR_PHP_WRAPPER_END
 
+/*
+ * Not applicable to OAPI.
+ */
 static void nr_laravel_register_after_filter(zval* app TSRMLS_DC) {
   zval* filter = NULL;
   zval* retval = NULL;
@@ -668,6 +672,7 @@ static void nr_laravel_register_after_filter(zval* app TSRMLS_DC) {
   /*
    * Only install our filter if this version of Laravel supports them.
    * Filters were deprecated in Laravel 5.0 and removed in version 5.2.
+   * As such, not applicable to OAPI.
    */
   if (0 == nr_php_object_has_concrete_method(router, "after" TSRMLS_CC)) {
     nrl_verbosedebug(NRL_FRAMEWORK, "%s: Router does not support filters",
@@ -698,7 +703,9 @@ end:
   nr_php_zval_free(&filter);
   nr_php_zval_free(&retval);
 }
-
+/*
+ * Not applicable to OAPI.
+ */
 NR_PHP_WRAPPER(nr_laravel4_application_run) {
   zval* this_var = NULL;
 
@@ -728,6 +735,13 @@ NR_PHP_WRAPPER_END
  *           the transaction name. This ensures the transaction is named if
  *           the middleware short-circuits request processing by returning
  *           a response instead of invoking its successor.
+ *
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called before `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_begin it needs to be explicitly set as a before_callback to ensure
+ * OAPI compatibility. This entails that the last wrapped call gets to name the
+ * txn (as detailed in the purpose above).
  */
 NR_PHP_WRAPPER(nr_laravel5_middleware_handle) {
   NR_UNUSED_SPECIALFN;
@@ -797,8 +811,14 @@ static void nr_laravel5_wrap_middleware(zval* app TSRMLS_DC) {
 
       name = nr_formatf("%.*s::handle", (int)Z_STRLEN_P(classname),
                         Z_STRVAL_P(classname));
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+      nr_php_wrap_user_function_before_after_clean(
+          name, nr_strlen(name), nr_laravel5_middleware_handle, NULL, NULL);
+#else
       nr_php_wrap_user_function(name, nr_strlen(name),
                                 nr_laravel5_middleware_handle TSRMLS_CC);
+#endif
       nr_free(name);
     }
   }
@@ -819,6 +839,11 @@ leave:
  *           2. The method name.
  *           3. The length of the method name.
  *           4. The post callback.
+ *
+ * Note: In this case, all functions utilized this execute before calling
+ * `NR_PHP_WRAPPER_CALL` and as this corresponds to calling the wrapped function
+ * in func_begin it needs to be explicitly set as a before_callback to ensure
+ * OAPI compatibility.
  */
 static void nr_laravel_add_callback_method(const zend_class_entry* ce,
                                            const char* method,
@@ -847,9 +872,14 @@ static void nr_laravel_add_callback_method(const zend_class_entry* ce,
   char* class_method = nr_formatf("%.*s::%.*s", NRSAFELEN(class_name_len),
                                   class_name, NRSAFELEN(method_len), method);
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_php_wrap_user_function_before_after_clean(
+      class_method, nr_strlen(class_method), callback, NULL, NULL);
+#else
   nr_php_wrap_user_function(class_method, nr_strlen(class_method),
                             callback TSRMLS_CC);
-
+#endif
   nr_free(class_method);
 }
 
@@ -905,6 +935,13 @@ NR_PHP_WRAPPER_END
 /*
  * This is a generic callback for any post hook on an Illuminate\Routing\Router
  * method where the method receives a request object as its first parameter.
+ *
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to the OAPI default of calling
+ * the wrapped function callback in func_end, there are no changes required to
+ * ensure OAPI compatibility. This entails that the first call to this function
+ * gets to name the txn.
  */
 NR_PHP_WRAPPER(nr_laravel_router_method_with_request) {
   zval* request = NULL;
@@ -1012,6 +1049,14 @@ NR_PHP_WRAPPER(nr_laravel_application_construct) {
 }
 NR_PHP_WRAPPER_END
 
+/*
+ * * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called before `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_begin it needs to be explicitly set as a before_callback to ensure
+ * OAPI compatibility.
+ * This entails that the last wrapped call gets to name the txn.
+ */
 NR_PHP_WRAPPER(nr_laravel_console_application_dorun) {
   zval* command = NULL;
   zval* input = NULL;
@@ -1059,6 +1104,14 @@ leave:
 }
 NR_PHP_WRAPPER_END
 
+/*
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds the OAPI default of calling the
+ * wrapped function callback in func_end, there are no changes required to
+ * ensure OAPI compatibility. This entails that the first call to this function
+ * gets to name the txn.
+ */
 NR_PHP_WRAPPER(nr_laravel_routes_get_route_for_methods) {
   zval* arg_request = NULL;
   zval* http_method = NULL;
@@ -1205,9 +1258,15 @@ void nr_laravel_enable(TSRMLS_D) {
   /*
    * Listen for Artisan commands so we can name those appropriately.
    */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("Illuminate\\Console\\Application::doRun"),
+      nr_laravel_console_application_dorun, NULL, NULL);
+#else
   nr_php_wrap_user_function(NR_PSTR("Illuminate\\Console\\Application::doRun"),
                             nr_laravel_console_application_dorun TSRMLS_CC);
-
+#endif
   /*
    * Start Laravel queue instrumentation, provided it's not disabled.
    */

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -66,6 +66,13 @@ static int nr_lumen_name_the_wt_from_zval(const zval* name TSRMLS_DC,
 /*
  * Core transaction naming logic. Wraps the function that correlates
  * requests to routes
+ *
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_end no change is needed to ensure OAPI compatibility as it will use
+ * the default func_end after callback. This entails that the last wrapped
+ * function call of this type gets to name the txn.
  */
 NR_PHP_WRAPPER(nr_lumen_handle_found_route) {
   zval* route_info = NULL;
@@ -105,7 +112,8 @@ NR_PHP_WRAPPER(nr_lumen_handle_found_route) {
 
   if (NULL != route_name) {
     if (NR_SUCCESS
-        != nr_lumen_name_the_wt_from_zval(route_name TSRMLS_CC, "Lumen", false)) {
+        != nr_lumen_name_the_wt_from_zval(route_name TSRMLS_CC, "Lumen",
+                                          false)) {
       nrl_verbosedebug(NRL_TXN, "Lumen: located route name is a non-string");
     }
   } else {
@@ -139,6 +147,12 @@ NR_PHP_WRAPPER_END
 /*
  * Exception handling logic. Wraps the function that routes
  * exceptions to their respective handlers
+ *
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_end no change is needed to ensure OAPI compatibility as it will use
+ * the default func_end after callback. This entails that the first wrapped
+ * function call of this type gets to name the txn.
  */
 NR_PHP_WRAPPER(nr_lumen_exception) {
   zval* exception = NULL;

--- a/agent/fw_mediawiki.c
+++ b/agent/fw_mediawiki.c
@@ -24,6 +24,14 @@
  * done by trapping ApiMain::__construct. This takes as its first argument a
  * WebRequest object. That object has an array called 'data'. That array will
  * contain a member named 'action'.
+ *
+ *
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called before `NR_PHP_WRAPPER_CALL` with
+ * `NR_NOT_OK_TO_OVERWRITE`. This entails that the first wrapped call gets to
+ * name the txn. Corresponds to mediawiki version less than 1.18 and is not
+ * applicable to OAPI/PHP8+ since they recommend if using PHP8 to use
+ * MediaWiki 1.38.4+ or 1.39.0+.
  */
 NR_PHP_WRAPPER(nr_mediawiki_name_the_wt_non_api) {
   char* name = NULL;
@@ -70,6 +78,14 @@ leave:
 }
 NR_PHP_WRAPPER_END
 
+/*
+ * * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called before `NR_PHP_WRAPPER_CALL` with
+ * `NR_NOT_OK_TO_OVERWRITE`. This entails that the first wrapped call gets to
+ * name the txn. Corresponds to mediawiki version less than 1.18 and is not
+ * applicable to OAPI/PHP8+ since they recommend if using PHP8 to use
+ * MediaWiki 1.38.4+ or 1.39.0+.
+ */
 NR_PHP_WRAPPER(nr_mediawiki_name_the_wt_api) {
   zval* data = NULL;
   zval* arg1 = NULL;
@@ -132,6 +148,14 @@ NR_PHP_WRAPPER_END
  * custom actions are supported by either adding a listener to the
  * UnknownAction hook (in 1.18 and older) or by adding to the $wgActions
  * global.
+ *
+ * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_end no change is needed to ensure OAPI compatibility as it will use
+ * the default func_end after callback. This entails that the first wrapped call
+ * gets to name the txn.
+ *
  */
 NR_PHP_WRAPPER(nr_mediawiki_getaction) {
   char* name = NULL;
@@ -175,6 +199,13 @@ NR_PHP_WRAPPER_END
  * ApiMain object. The action name is kept in the mAction property on that
  * object, but that property isn't set until ApiMain::setupExecuteAction() is
  * called, so we'll wait until after that's done.
+ *
+ *  * txn naming scheme:
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_NOT_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped
+ * function in func_end no change is needed to ensure OAPI compatibility as it
+ * will use the default func_end after callback. This entails that the last
+ * wrapped call gets to name the txn.
  */
 NR_PHP_WRAPPER(nr_mediawiki_apimain_setupexecuteaction) {
   zval* action = NULL;

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -41,6 +41,12 @@ static char* nr_slim_path_from_route(zval* route TSRMLS_DC) {
  * Wrap the \Slim\Route::dispatch method, which is the happy path for Slim 2.x
  * routing. i.e. The router has succesfully matched the URL and dispatched the
  * request to a route.
+ *
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_end no change is needed to ensure OAPI compatibility as it will use
+ * the default func_end after callback. This entails that the first wrapped
+ * function call of this type gets to name the txn.
  */
 NR_PHP_WRAPPER(nr_slim2_route_dispatch) {
   zval* this_var = NULL;
@@ -75,6 +81,12 @@ NR_PHP_WRAPPER_END
  * Wrap the \Slim\Route::run method, which is the happy path for Slim routing.
  * i.e. The router has succesfully matched the URL and dispatched the request
  * to a route.
+ *
+ * In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+ * `NR_OK_TO_OVERWRITE` and as this corresponds to calling the wrapped function
+ * in func_end no change is needed to ensure OAPI compatibility as it will use
+ * the default func_end after callback. This entails that the first wrapped
+ * function call of this type gets to name the txn.
  */
 NR_PHP_WRAPPER(nr_slim3_4_route_run) {
   zval* this_var = NULL;

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -593,6 +593,11 @@ static void nr_wordpress_name_the_wt(const zval* tag,
 /*
  * apply_filters() is special, since we're interested in it both for
  * WordPress hook/plugin metrics and for transaction naming.
+ *
+ * * txn naming scheme:
+* In this case, `nr_txn_set_path` is called after `NR_PHP_WRAPPER_CALL` with
+* `NR_NOT_OK_TO_OVERWRITE`.  There is an explicit after function `nr_wordpress_apply_filters_after`. This entails that the last wrapped call gets to name the
+* txn.
  */
 NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
   zval* tag = NULL;

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -106,27 +106,34 @@
  * functions:
  *
  * 1) IF wrapper function is called before NR_PHP_WRAPPER_CALL or called in
- * func_begin AND NR_NOT_OK_TO_OVERWRITE is set THEN the FIRST wrapped function
- * encountered determines the txn name.
+ * func_begin AND NR_NOT_OK_TO_OVERWRITE is set for all THEN the FIRST wrapped
+ * function encountered determines the txn name.
  *
  * 2) IF wrapper function is called before NR_PHP_WRAPPER_CALL or called in
- * func_begin AND NR_OK_TO_OVERWRITE is set THEN the LAST wrapped function
- * encountered determines the txn name.
+ * func_begin then the LAST wrapped function with NR_OK_TO_OVERWRITE determines
+ * the txn name.
  *
  * 3) IF wrapper function is called after NR_PHP_WRAPPER_CALL or called in
- * func_end AND NR_NOT_OK_TO_OVERWRITE is set THEN the LAST wrapped function
- * encountered determines the txn name.
+ * func_end AND NR_NOT_OK_TO_OVERWRITE is set for all THEN the LAST wrapped
+ * function encountered determines the txn name.
  *
  * 4) IF wrapper function is called after NR_PHP_WRAPPER_CALL or called in
- * func_end AND NR_OK_TO_OVERWRITE is set THEN the FIRST wrapped function
- * encountered determines the txn name.
+ * func_end then the FIRST wrapped function with NR_OK_TO_OVERWRITE determines
+ * the txn name.
  *
  * 5) If there are nested functions that have wrapped functions called before
  * NR_PHP_WRAPPER_CALL or called in func_begin AND that also have called after
- * NR_PHP_WRAPPER_CALL or called in func_end if the before call uses
- * NR_NOT_OK_TO_OVERWRITE, rule 1 occurs; otherwise, the txn naming winner will
- * be as specified in rule 3 or 4.
+ * NR_PHP_WRAPPER_CALL or called in func_end if the after call uses
+ * NR_NOT_OK_TO_OVERWRITE, then rule 1 or 2 applies depending on whether a
+ * before_func used NR_NOT_OK_TO_OVERWRITE or NR_NOT_TO_OVERWRITE.
  *
+ * 6) If there are nested functions that have wrapped functions called before
+ * NR_PHP_WRAPPER_CALL or called in func_begin AND that also have called after
+ * NR_PHP_WRAPPER_CALL or called in func_end if the after call uses
+ * NR_OK_TO_OVERWRITE, then rule 4 applies.
+ *
+ * See agent/tests/test_php_wrapper.c `function test_framework_txn_naming` to
+ * see how it works with frameworks.
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
 extern nruserfn_t* nr_php_wrap_user_function_before_after_clean(

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -1123,7 +1123,13 @@ void test_main(void* p NRUNUSED) {
   test_before_after_clean();
 #endif
   tlib_php_engine_destroy(TSRMLS_C);
+  /*
+   * The Jenkins PHP 7.3 nodes are unable to handle the multiple
+   * create/destroys, but works on more recent OSs.
+   */
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
   test_framework_txn_naming();
+#endif
 }
 #else  /* PHP 7.3 */
 void test_main(void* p NRUNUSED) {}

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -210,18 +210,17 @@ static void execute_nested_framework_calls(nrspecialfn_t one_before,
  *
  *                      7) `three` ends
  *
- *                   8) oapi: `three` after callback OR legacy:
- * any statements after the `three` PHP_CALL_WRAPPER
+ *                   8) oapi: `three` after callback OR legacy: any statements
+ * after the `three` PHP_CALL_WRAPPER
  *
  *               9) `two` ends
  *
- *          10) oapi:
- * `two` after callback OR legacy: any statements after the `two`
- * PHP_CALL_WRAPPER
+ *          10) oapi:`two` after callback OR legacy: any statements after the
+ * `two` PHP_CALL_WRAPPER
  *
  *      11) `one` ends
  *
- * 11) oapi: `one` after callback OR legacy: any statements after the `one`
+ * 12) oapi: `one` after callback OR legacy: any statements after the `one`
  * PHP_CALL_WRAPPER
  */
 static void test_framework_txn_naming() {

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -1129,10 +1129,9 @@ void test_main(void* p NRUNUSED) {
    * create/destroys, but works on more recent OSs.
    */
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-  if (0 != nr_strcmp(PHP_VERSION, "8.0.2"))
-    || (0 != nr_strcmp(PHP_VERSION, "8.0.0")) {
-      test_framework_txn_naming();
-    }
+  if (PHP_VERSION_ID < 80000 && PHP_VERSION_ID > 80002) {
+    test_framework_txn_naming();
+  }
 #endif
 }
 #else  /* PHP 7.3 */

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -1128,9 +1128,10 @@ void test_main(void* p NRUNUSED) {
    * The Jenkins PHP 7.3 nodes are unable to handle the multiple
    * create/destroys, but works on more recent OSs.
    */
-#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO \
-    || ZEND_MODULE_API_NO == ZEND_8_0_X_API_NO
-  test_framework_txn_naming();
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+  if (0 != nr_strcmp(PHP_VERSION, "8.0.2")) {
+    test_framework_txn_naming();
+  }
 #endif
 }
 #else  /* PHP 7.3 */

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -85,6 +85,449 @@ NR_PHP_WRAPPER(test_add_2_arrays) {
   NR_PHP_WRAPPER_CALL;
 }
 NR_PHP_WRAPPER_END
+
+NR_PHP_WRAPPER(test_name_txn_before_not_ok) {
+  nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
+                  NR_PATH_TYPE_ACTION, NR_NOT_OK_TO_OVERWRITE);
+
+  NR_PHP_WRAPPER_CALL;
+}
+NR_PHP_WRAPPER_END
+
+NR_PHP_WRAPPER(test_name_txn_before_ok) {
+  nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
+                  NR_PATH_TYPE_ACTION, NR_OK_TO_OVERWRITE);
+
+  NR_PHP_WRAPPER_CALL;
+}
+NR_PHP_WRAPPER_END
+
+NR_PHP_WRAPPER(test_name_txn_after_not_ok) {
+  NR_PHP_WRAPPER_CALL;
+  nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
+                  NR_PATH_TYPE_ACTION, NR_NOT_OK_TO_OVERWRITE);
+}
+NR_PHP_WRAPPER_END
+
+NR_PHP_WRAPPER(test_name_txn_after_ok) {
+  NR_PHP_WRAPPER_CALL;
+  nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
+                  NR_PATH_TYPE_ACTION, NR_OK_TO_OVERWRITE);
+}
+NR_PHP_WRAPPER_END
+
+static void populate_functions() {
+  tlib_php_request_eval("function three($a) { return $a; }");
+  tlib_php_request_eval("function two($a) { return three($a); }");
+  tlib_php_request_eval("function one($a) { return two($a); }");
+}
+
+static void setup_nested_framework_calls(nrspecialfn_t one_before,
+                                         nrspecialfn_t one_after,
+                                         nrspecialfn_t two_before,
+                                         nrspecialfn_t two_after,
+                                         nrspecialfn_t three_before,
+                                         nrspecialfn_t three_after,
+                                         char* expected_name,
+                                         char* message) {
+  zval* expr = NULL;
+  zval* arg = NULL;
+
+  tlib_php_engine_create("");
+  tlib_php_request_start();
+  populate_functions();
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  nr_php_wrap_user_function_before_after_clean(NR_PSTR("one"), one_before,
+                                               one_after, NULL);
+  nr_php_wrap_user_function_before_after_clean(NR_PSTR("two"), two_before,
+                                               two_after, NULL);
+  nr_php_wrap_user_function_before_after_clean(NR_PSTR("three"), three_before,
+                                               three_after, NULL);
+#else
+  nr_php_wrap_user_function(NR_PSTR("one"), one_after TSRMLS_CC);
+  nr_php_wrap_user_function(NR_PSTR("two"), two_after TSRMLS_CC);
+  nr_php_wrap_user_function(NR_PSTR("three"), three_after TSRMLS_CC);
+#endif
+
+  arg = tlib_php_request_eval_expr("1" TSRMLS_CC);
+  expr = nr_php_call(NULL, "one", arg);
+  tlib_pass_if_not_null("Runs fine.", expr);
+  tlib_pass_if_zval_type_is("Should have received the arg value.", IS_LONG,
+                            expr);
+  tlib_pass_if_str_equal(message, expected_name, NRTXN(path));
+
+  nr_php_zval_free(&expr);
+  nr_php_zval_free(&arg);
+  tlib_php_request_end();
+  tlib_php_engine_destroy();
+}
+
+/*
+ * to customize txn naming per framework, PHP agent uses the order in which
+functions are processed, NR_NOT_OK_TO_OVERWRITE/NR_OK_TO_OVERWRITE, and whether
+it is called either before or after NR_PHP_WRAPPER_CALL (for pre PHP 8+) or
+whether it is called in func_begin or func_end (for PHP 8+ / OAPI).
+ *
+ * This test serves to illustrate and test *framework* txn naming conventions
+and how they are affected by calling nr_tx_set path either 1) before
+nr_wrapper_call for preoapi and in func_begin as a before callback in oapi 2)
+after nr_wrapper_call for preoapi and in func_end as an after callback in oapi
+ */
+static void test_framework_txn_naming() {
+  /*
+   * This function both tests and illustrates how to use the wrapped function
+   * special callbacks in the various framework scenarios for naming the txn
+   * when there are multiple routes for naming (i.e. nested calls that have
+   * wrapper special functions that all call nr_set_txn_path in different ways.
+   * Each test case can be considered a "framework" with three different ways of
+   * naming the txn called by the three nested functions. For all cases,
+   * function `one` calls `two` calls `three`.
+   */
+
+  /*
+   * case 1) IF wrapper function is called before NR_PHP_WRAPPER_CALL or called
+   * in func_begin AND NR_NOT_OK_TO_OVERWRITE is set THEN the FIRST wrapped
+   * function encountered determines the txn name.
+   *
+   * All functions set the txn before NR_PHP_WRAPPER_CALL and/or in OAPI
+   * func_begin and use NR_NOT_OK_TO_OVERWRITE.
+   *
+   * Expecting `one` to name txn.
+   */
+  setup_nested_framework_calls(
+      test_name_txn_before_not_ok, NULL, test_name_txn_before_not_ok, NULL,
+      test_name_txn_before_not_ok, NULL, "one",
+      "one:beforenotok,two:beforenotok,three:beforenotok");
+  /*
+   *
+   * 2) IF wrapper function is called before NR_PHP_WRAPPER_CALL or called in
+   * func_begin AND NR_OK_TO_OVERWRITE is set THEN the LAST wrapped function
+   * encountered determines the txn name.
+   *
+   * All functions set the txn before NR_PHP_WRAPPER_CALL and/or in OAPI
+   * func_begin and use NR_OK_TO_OVERWRITE.
+   *
+   * Expecting `three` to name txn.
+   */
+  setup_nested_framework_calls(test_name_txn_before_ok, NULL,
+                               test_name_txn_before_ok, NULL,
+                               test_name_txn_before_ok, NULL, "three",
+                               "one:beforeok,two:beforeok,three:beforeok");
+  /*
+   *
+   * 3) IF wrapper function is called after NR_PHP_WRAPPER_CALL or called in
+   * func_end AND NR_NOT_OK_TO_OVERWRITE is set THEN the LAST wrapped function
+   * encountered determines the txn name.
+   * All functions set the txn after NR_PHP_WRAPPER_CALL and/or in OAPI
+   * func_begin and use NR_NOT_OK_TO_OVERWRITE.
+   *
+   * Expecting `three` to name txn.
+   */
+  setup_nested_framework_calls(
+      NULL, test_name_txn_after_not_ok, NULL, test_name_txn_after_not_ok, NULL,
+      test_name_txn_after_not_ok, "three",
+      "one:afternotok,two:afternotok,three:afternotok");
+
+  /*
+   * 4) IF wrapper function is called after NR_PHP_WRAPPER_CALL or called in
+   * func_end AND NR_OK_TO_OVERWRITE is set THEN the FIRST wrapped function
+   * encountered determines the txn name.
+   *
+   * All functions set the txn before NR_PHP_WRAPPER_CALL and/or in OAPI
+   * func_begin and use NR_OK_TO_OVERWRITE.
+   *
+   * Expecting `one` to name txn.
+   */
+  setup_nested_framework_calls(
+      NULL, test_name_txn_after_ok, NULL, test_name_txn_after_ok, NULL,
+      test_name_txn_after_ok, "one", "one:afterok,two:afterok,three:afterok");
+
+  /*
+   * 5) If there are nested functions that have wrapped functions called before
+   * NR_PHP_WRAPPER_CALL or called in func_begin AND that also have called after
+   * NR_PHP_WRAPPER_CALL or called in func_end if the after call uses
+   * NR_NOT_OK_TO_OVERWRITE, then rule 1 or 2 applies depending on whether a
+   * before_func used NR_NOT_OK_TO_OVERWRITE or NR_NOT_TO_OVERWRITE.
+   *
+   * 6) If there are nested functions that have wrapped functions called before
+   * NR_PHP_WRAPPER_CALL or called in func_begin AND that also have called after
+   * NR_PHP_WRAPPER_CALL or called in func_end if the after call uses
+   * NR_OK_TO_OVERWRITE, then rule 4 applies.
+   *
+   * Basically a mix and match situation where we have some best tries at naming
+   * a nested function transaction via one txn naming wrapped function, but if
+   * something better comes along via a DIFFERENT wrapped function, we'd prefer
+   * that. Special functions are mixed with regards to calling before/after and
+   * NR_NOT_OK_TO_OVERWRITE/NR_OK_TO_OVERWRITE
+   */
+
+  /*
+   * After only mixes of NR_NOT_OK_TO_OVERWRITE/NR_NOT_OK_TO_OVERWRITE
+   */
+
+  /*
+   * special function for one is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `two`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_not_ok, NULL,
+                               test_name_txn_after_ok, NULL,
+                               test_name_txn_after_ok, "two",
+                               "one:afternotok,two:afterok,three:afterok");
+
+  /*
+   * special function for one is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `three`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_not_ok, NULL,
+                               test_name_txn_after_not_ok, NULL,
+                               test_name_txn_after_ok, "three",
+                               "one:afternotok,two:afternotok,three:afterok");
+
+  /*
+   * special function for one is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `two`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_not_ok, NULL,
+                               test_name_txn_after_ok, NULL,
+                               test_name_txn_after_not_ok, "two",
+                               "one:afternotok,two:afterok,three:afternotok");
+
+  /*
+   * special function for one is called after and uses NR_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `one`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_ok, NULL,
+                               test_name_txn_after_not_ok, NULL,
+                               test_name_txn_after_ok, "one",
+                               "one:afterok,two:afternotok,three:afterok");
+
+  /*
+   * special function for one is called after and uses NR_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `one`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_ok, NULL,
+                               test_name_txn_after_not_ok, NULL,
+                               test_name_txn_after_not_ok, "one",
+                               "one:afterok,two:afternotok,three:afternotok");
+
+  /*
+   * special function for one is called after and uses NR_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `one`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_ok, NULL,
+                               test_name_txn_after_ok, NULL,
+                               test_name_txn_after_not_ok, "one",
+                               "one:afterok,two:afterok,three:afternotok");
+
+  /*
+   * Before only mixes of NR_NOT_OK_TO_OVERWRITE/NR_NOT_OK_TO_OVERWRITE
+   */
+
+  /*
+   * special function for one is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `three`
+   */
+  setup_nested_framework_calls(test_name_txn_before_not_ok, NULL,
+                               test_name_txn_before_ok, NULL,
+                               test_name_txn_before_ok, NULL, "three",
+                               "one:beforenotok,two:beforeok,three:beforeok");
+
+  /*
+   * special function for one is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `three`
+   */
+  setup_nested_framework_calls(
+      test_name_txn_before_not_ok, NULL, test_name_txn_before_not_ok, NULL,
+      test_name_txn_before_ok, NULL, "three",
+      "one:beforenotok,two:beforenotok,three:beforeok");
+
+  /*
+   * special function for one is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `two`
+   */
+  setup_nested_framework_calls(
+      test_name_txn_before_not_ok, NULL, test_name_txn_before_ok, NULL,
+      test_name_txn_before_not_ok, NULL, "two",
+      "one:beforenotok,two:beforeok,three:beforenotok");
+
+  /*
+   * special function for one is called before and uses NR_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `three`
+   */
+  setup_nested_framework_calls(test_name_txn_before_ok, NULL,
+                               test_name_txn_before_not_ok, NULL,
+                               test_name_txn_before_ok, NULL, "three",
+                               "one:beforeok,two:beforenotok,three:beforeok");
+
+  /*
+   * special function for one is called before and uses NR_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `one`
+   */
+  setup_nested_framework_calls(
+      test_name_txn_before_ok, NULL, test_name_txn_before_not_ok, NULL,
+      test_name_txn_before_not_ok, NULL, "one",
+      "one:beforeok,two:beforenotok,three:beforenotok");
+
+  /*
+   * special function for one is called before and uses NR_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `two`
+   */
+  setup_nested_framework_calls(test_name_txn_before_ok, NULL,
+                               test_name_txn_before_ok, NULL,
+                               test_name_txn_before_not_ok, NULL, "two",
+                               "one:beforeok,two:beforeok,three:beforenotok");
+
+  /*
+   * Before/After and NR_NOT_OK_TO_OVERWRITE/NR_NOT_OK_TO_OVERWRITE mixes
+   */
+
+  /*
+   * special function for one is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `three`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_not_ok,
+                               test_name_txn_before_ok, NULL,
+                               test_name_txn_before_ok, NULL, "three",
+                               "one:afternotok,two:beforeok,three:beforeok");
+
+  /*
+   * special function for one is called after and uses NR_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `one`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_ok,
+                               test_name_txn_before_ok, NULL,
+                               test_name_txn_before_ok, NULL, "one",
+                               "one:afterok,two:beforeok,three:beforeok");
+
+  /*
+   * special function for one is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `three`
+   */
+  setup_nested_framework_calls(test_name_txn_before_not_ok, NULL, NULL,
+                               test_name_txn_after_not_ok,
+                               test_name_txn_before_ok, NULL, "three",
+                               "one:beforenotok,two:afternotok,three:beforeok");
+
+  /*
+   * special function for one is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `two`
+   */
+  setup_nested_framework_calls(test_name_txn_before_not_ok, NULL, NULL,
+                               test_name_txn_after_ok, test_name_txn_before_ok,
+                               NULL, "two",
+                               "one:beforenotok,two:afterok,three:beforeok");
+
+  /*
+   * special function for one is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `two`
+   */
+  setup_nested_framework_calls(test_name_txn_before_not_ok, NULL,
+                               test_name_txn_before_ok, NULL, NULL,
+                               test_name_txn_after_not_ok, "two",
+                               "one:beforenotok,two:beforeok,three:afternotok");
+
+  /*
+   * special function for one is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `three`
+   */
+  setup_nested_framework_calls(test_name_txn_before_not_ok, NULL,
+                               test_name_txn_before_ok, NULL, NULL,
+                               test_name_txn_after_ok, "three",
+                               "one:beforenotok,two:beforeok,three:afterok");
+
+  /*
+   * special function for one is called after and uses NR_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called before and uses NR_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `one`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_ok, NULL,
+                               test_name_txn_after_not_ok,
+                               test_name_txn_before_ok, NULL, "one",
+                               "one:afterok,two:afternotok,three:beforeok");
+
+  /*
+   * special function for one is called after and uses NR_OK_TO_OVERWRITE
+   * special function for two is called before and uses NR_NOT_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `two`
+   */
+  setup_nested_framework_calls(NULL, test_name_txn_after_not_ok,
+                               test_name_txn_before_not_ok, NULL, NULL,
+                               test_name_txn_after_not_ok, "two",
+                               "one:afterok,two:beforenotok,three:afternotok");
+
+  /*
+   * special function for one is called before and uses NR_OK_TO_OVERWRITE
+   * special function for two is called after and uses NR_OK_TO_OVERWRITE
+   * special function for three is called after and uses NR_NOT_OK_TO_OVERWRITE
+   *
+   * expect txn to be named `two`
+   */
+  setup_nested_framework_calls(test_name_txn_before_ok, NULL, NULL,
+                               test_name_txn_after_ok, NULL,
+                               test_name_txn_after_not_ok, "two",
+                               "one:beforeok,two:afterok,three:afternotok");
+}
+
 static void test_add_arg(TSRMLS_D) {
   zval* expr = NULL;
   zval* arg = NULL;
@@ -605,6 +1048,7 @@ void test_main(void* p NRUNUSED) {
   test_before_after_clean();
 #endif
   tlib_php_engine_destroy(TSRMLS_C);
+  test_framework_txn_naming();
 }
 #else  /* PHP 7.3 */
 void test_main(void* p NRUNUSED) {}

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -91,6 +91,7 @@ NR_PHP_WRAPPER(test_add_2_arrays) {
 }
 NR_PHP_WRAPPER_END
 
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
 NR_PHP_WRAPPER(test_name_txn_before_not_ok) {
   nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
                   NR_PATH_TYPE_ACTION, NR_NOT_OK_TO_OVERWRITE);
@@ -602,6 +603,7 @@ static void test_framework_txn_naming() {
       "one:name_before_call:will_overwrite,two:name_after_call:will_overwrite,"
       "three:name_after_call:will_not_overwrite");
 }
+#endif /* ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO */
 
 static void test_add_arg(TSRMLS_D) {
   zval* expr = NULL;

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -146,9 +146,9 @@ static void setup_nested_framework_calls(nrspecialfn_t one_before,
   nr_php_wrap_user_function_before_after_clean(NR_PSTR("three"), three_before,
                                                three_after, NULL);
 #else
-  void(one_before);
-  void(two_before);
-  void(three_before);
+  (void)one_before;
+  (void)two_before;
+  (void)three_before;
   nr_php_wrap_user_function(NR_PSTR("one"), one_after TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("two"), two_after TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("three"), three_after TSRMLS_CC);

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -106,7 +106,6 @@ NR_PHP_WRAPPER(test_name_txn_after_not_ok) {
   NR_PHP_WRAPPER_CALL;
   nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
                   NR_PATH_TYPE_ACTION, NR_NOT_OK_TO_OVERWRITE);
-
 }
 NR_PHP_WRAPPER_END
 
@@ -114,7 +113,6 @@ NR_PHP_WRAPPER(test_name_txn_after_ok) {
   NR_PHP_WRAPPER_CALL;
   nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
                   NR_PATH_TYPE_ACTION, NR_OK_TO_OVERWRITE);
-
 }
 NR_PHP_WRAPPER_END
 
@@ -212,7 +210,7 @@ static void test_framework_txn_naming() {
       test_name_txn_before_not_ok, NULL, test_name_txn_before_not_ok, NULL,
       test_name_txn_before_not_ok, NULL, "one",
       "one:beforenotok,two:beforenotok,three:beforenotok");
-  return;
+
   /*
    *
    * 2) IF wrapper function is called before NR_PHP_WRAPPER_CALL or called in

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -53,6 +53,11 @@ NR_PHP_WRAPPER(test_clean) {
 }
 NR_PHP_WRAPPER_END
 #endif
+/*
+ * endif to match:
+ * ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+ *  && !defined OVERWRITE_ZEND_EXECUTE_DATA
+ */
 
 NR_PHP_WRAPPER(test_add_array) {
   zval* arg = nr_php_zval_alloc();
@@ -117,9 +122,9 @@ NR_PHP_WRAPPER(test_name_txn_after_ok) {
 NR_PHP_WRAPPER_END
 
 static void populate_functions() {
-  tlib_php_request_eval("function three($a) { return $a; }");
-  tlib_php_request_eval("function two($a) { return three($a); }");
-  tlib_php_request_eval("function one($a) { return two($a); }");
+  tlib_php_request_eval("function three($a) { return $a; }" TSRMLS_CC);
+  tlib_php_request_eval("function two($a) { return three($a); }" TSRMLS_CC);
+  tlib_php_request_eval("function one($a) { return two($a); }" TSRMLS_CC);
 }
 /*
  * This function is meant to wrap/test when only ONE before/after special

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -89,9 +89,6 @@ NR_PHP_WRAPPER_END
 NR_PHP_WRAPPER(test_name_txn_before_not_ok) {
   nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
                   NR_PATH_TYPE_ACTION, NR_NOT_OK_TO_OVERWRITE);
-  nrl_verbosedebug(
-      NRL_TXN, "from %s amber: wraprec->funcname is %s and path is %s",
-      __func__, wraprec->funcname, NRTXN(path) ? NRTXN(path) : "null");
 
   NR_PHP_WRAPPER_CALL;
 }
@@ -100,9 +97,7 @@ NR_PHP_WRAPPER_END
 NR_PHP_WRAPPER(test_name_txn_before_ok) {
   nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
                   NR_PATH_TYPE_ACTION, NR_OK_TO_OVERWRITE);
-  nrl_verbosedebug(
-      NRL_TXN, "from %s amber: wraprec->funcname is %s and path is %s",
-      __func__, wraprec->funcname, NRTXN(path) ? NRTXN(path) : "null");
+
   NR_PHP_WRAPPER_CALL;
 }
 NR_PHP_WRAPPER_END
@@ -111,9 +106,7 @@ NR_PHP_WRAPPER(test_name_txn_after_not_ok) {
   NR_PHP_WRAPPER_CALL;
   nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
                   NR_PATH_TYPE_ACTION, NR_NOT_OK_TO_OVERWRITE);
-  nrl_verbosedebug(
-      NRL_TXN, "from %s amber: wraprec->funcname is %s and path is %s",
-      __func__, wraprec->funcname, NRTXN(path) ? NRTXN(path) : "null");
+
 }
 NR_PHP_WRAPPER_END
 
@@ -121,9 +114,7 @@ NR_PHP_WRAPPER(test_name_txn_after_ok) {
   NR_PHP_WRAPPER_CALL;
   nr_txn_set_path("UnitTest", NRPRG(txn), wraprec->funcname,
                   NR_PATH_TYPE_ACTION, NR_OK_TO_OVERWRITE);
-  nrl_verbosedebug(
-      NRL_TXN, "from %s amber: wraprec->funcname is %s and path is %s",
-      __func__, wraprec->funcname, NRTXN(path) ? NRTXN(path) : "null");
+
 }
 NR_PHP_WRAPPER_END
 
@@ -151,8 +142,6 @@ static void setup_nested_framework_calls(nrspecialfn_t one_before,
   tlib_php_engine_create("");
   tlib_php_request_start();
   populate_functions();
-
-  nrl_verbosedebug(NRL_TXN, "from %s amber: message is %s", __func__, message);
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -137,7 +137,7 @@ static void setup_nested_framework_calls(nrspecialfn_t one_before,
   zval* expr = NULL;
   zval* arg = NULL;
 
-  tlib_php_engine_create("");
+  tlib_php_engine_create("" PTSRMLS_CC);
   tlib_php_request_start();
   populate_functions();
 
@@ -171,7 +171,7 @@ static void setup_nested_framework_calls(nrspecialfn_t one_before,
   nr_php_zval_free(&expr);
   nr_php_zval_free(&arg);
   tlib_php_request_end();
-  tlib_php_engine_destroy();
+  tlib_php_engine_destroy(TSRMLS_C);
 }
 
 /*

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -1128,7 +1128,8 @@ void test_main(void* p NRUNUSED) {
    * The Jenkins PHP 7.3 nodes are unable to handle the multiple
    * create/destroys, but works on more recent OSs.
    */
-#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO \
+    || ZEND_MODULE_API_NO == ZEND_8_0_X_API_NO
   test_framework_txn_naming();
 #endif
 }

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -146,6 +146,9 @@ static void setup_nested_framework_calls(nrspecialfn_t one_before,
   nr_php_wrap_user_function_before_after_clean(NR_PSTR("three"), three_before,
                                                three_after, NULL);
 #else
+  void(one_before);
+  void(two_before);
+  void(three_before);
   nr_php_wrap_user_function(NR_PSTR("one"), one_after TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("two"), two_after TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("three"), three_after TSRMLS_CC);

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -1129,9 +1129,10 @@ void test_main(void* p NRUNUSED) {
    * create/destroys, but works on more recent OSs.
    */
 #if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
-  if (0 != nr_strcmp(PHP_VERSION, "8.0.2")) {
-    test_framework_txn_naming();
-  }
+  if (0 != nr_strcmp(PHP_VERSION, "8.0.2"))
+    || (0 != nr_strcmp(PHP_VERSION, "8.0.0")) {
+      test_framework_txn_naming();
+    }
 #endif
 }
 #else  /* PHP 7.3 */


### PR DESCRIPTION
For OAPI, wrapping default makes all wrapped special functions execute during func_end.  This caused issues since to customize txn naming per framework, PHP agent uses the order in which functions
are processed, NR_NOT_OK_TO_OVERWRITE/NR_OK_TO_OVERWRITE, and whether it is
called either before or after NR_PHP_WRAPPER_CALL (for pre PHP 8+) or whether
it is called in func_begin or func_end (for PHP 8+ / OAPI). By defaulting to calling all callbacks "after" during func_end, it changed the order in which nr_txn_set_path was being set.  To fix this, we need to verify which callback functions set the txn before NR_PHP_WRAPPER_CALL and which set it after, and have the wrapped functions act similarly to call before/after.


This PR 
1) reviewed all frameworks (exceptions listed below) and use of nr_txn_set_path on a case by case basis.
2) Explicitly commented to detail the naming schemes in use with each use of nr_txn_set_path in all frameworks
3) used the before/after/clean wrapping function as needed when txn naming needed to occur before function execution to match what is done in legacy instrumentation.
4) for functions not needing to be called before, comments were still added noting that it was being called by the default (after callback/func_end)

Calling the wrapper special function by default before a function executes was a solution initially considered; however, after investigation/testing, it was deemed inappropriate for multiple reasons:
1)too invasive 
2)some wrapped functions do not have all the values they need before a function is executed, for example 
 functions that need the return value (I.e. all those special functions that continue to do things after `NR_PHP_WRAPPER_CALL`
3) Additionally, each framework has individualized, specialized ways of setting the txn name via `nr_txn_set_path`.

As such, calling a wrapper function in func_end as default is still the most appropriate choice.

These frameworks are either unsupported, do not support PHP 8+, or both and no change to the txn naming scheme:
fw_kohana.c, fw_joomla.c, fw_magneto.c(magento 1.x), fw_silex.c, fw_symfony.c, fw_symfony2.c, fw_zend.c fw_zend2.c

Unit tests that run on all versions of PHP ensure the txn naming behavior is identical.