### PR TITLE
ci: make release-build build for PHP 8.2

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -20,15 +20,12 @@ on:
 jobs:
   agent_release:
     env:
-      PHP_VER: ${{ matrix.php_ver }}
-      ARCH: ${{ matrix.arch }}
-      BUILD_TYPE: release
-      OS: ${{ matrix.os }}
-      image_name: ${{ matrix.os }}:${{ matrix.php_ver }}${{ matrix.arch }}
+      IMAGE_NAME: newrelic/nr-php-agent-builder
+      IMAGE_VERSION: v1
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [linux]
+        platform: [gnu, musl]
         php_ver: ['8.2']
         arch: [x64]
     steps:
@@ -36,10 +33,18 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.client_payload.ref }}
-      - name: Build Custom Docker Image
-        run: docker build --build-arg ARCH=$ARCH --build-arg PHP_VER=$PHP_VER --build-arg BUILD_TYPE=$BUILD_TYPE -f ./.github/docker/${OS}/${ARCH}/Dockerfile -t $image_name .
-      - name: Build and Test
-        run: docker run --name runtest --workdir /github/workspace --rm -e GITHUB_WORKSPACE -e GITHUB_ENV -v "${GITHUB_WORKSPACE}":"/github/workspace" $image_name
+          path: newrelic-php-agent
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/newrelic-php-agent":"/usr/local/src/newrelic-php-agent"
+          -e OPTIMIZE=1
+          $IMAGE_NAME:agent-builder-php${{matrix.php_ver}}-${{matrix.platform}}-$IMAGE_VERSION release-${{matrix.php_ver}}-gha
       - name: Save build artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         platform: [gnu, musl]
         php_ver: ['8.2']
-        arch: [x64]
+        arch: [amd64]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -30,7 +30,7 @@ jobs:
         arch: [amd64]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.ref }}
           path: newrelic-php-agent

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,28 +46,8 @@ jobs:
           -e OPTIMIZE=1
           $IMAGE_NAME:agent-builder-php${{matrix.php_ver}}-${{matrix.platform}}-$IMAGE_VERSION release-${{matrix.php_ver}}-gha
       - name: Save build artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.php_ver }}binaries
-          path: releases
-          if-no-files-found: error
-  combine:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    name: Combine artifacts from matrix build
-    needs: agent_release
-    steps:
-      - name: Create directory
-        run: mkdir releases
-      - name: Download to directory
-        uses: actions/download-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: releases
-      - run: sudo apt install tree
-      - run: tree
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: $GITHUB_SHA
-          path: releases
+          name: release-from-gha
           if-no-files-found: error

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -48,6 +48,6 @@ jobs:
       - name: Save build artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: releases
+          path: newrelic-php-agent/releases
           name: release-from-gha
           if-no-files-found: error

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,8 +29,8 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        php_ver: ['8.0-zts']
-        arch: [x64, x86]
+        php_ver: ['8.2']
+        arch: [x64]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -44,6 +44,7 @@ jobs:
           docker run --rm --platform linux/${{matrix.arch}}
           -v "${GITHUB_WORKSPACE}/newrelic-php-agent":"/usr/local/src/newrelic-php-agent"
           -e OPTIMIZE=1
+          -e PCRE_STATIC=yes
           $IMAGE_NAME:agent-builder-php${{matrix.php_ver}}-${{matrix.platform}}-$IMAGE_VERSION release-${{matrix.php_ver}}-gha
       - name: Save build artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Update release-build workflow to:
* only build release artifacts for PHP 8.2 on amd64 arch
* use pre-built container image instead of building the image on the fly
  each time the workflow needs to run