### PR TITLE
build: pin libc's symbol versions

### DIFF
--- a/axiom/nr_app_harvest.c
+++ b/axiom/nr_app_harvest.c
@@ -25,6 +25,8 @@
 #if (((__GLIBC__) > 2) || (((__GLIBC__) == 2) && ((__GLIBC_MINOR__) > 17)))
 #if defined (__x86_64__)
   __asm__(".symver pow,pow@GLIBC_2.2.5");
+#elif defined (__aarch64__)
+  __asm__(".symver pow,pow@GLIBC_2.17");
 #endif
 #endif
 #endif

--- a/axiom/nr_app_harvest.c
+++ b/axiom/nr_app_harvest.c
@@ -23,7 +23,11 @@
  */
 #if defined(__GLIBC__)
 #if ((__GLIBC__) >= 2) && ((__GLIBC_MINOR__) > 17)
-__asm__(".symver pow,pow@GLIBC_2.17");
+#if defined (__x86_64__)
+  __asm__(".symver pow,pow@GLIBC_2.2.5");
+#elif defined (__aarch64__)
+  __asm__(".symver pow,pow@GLIBC_2.17");
+#endif
 #endif
 #endif
 

--- a/axiom/nr_app_harvest.c
+++ b/axiom/nr_app_harvest.c
@@ -19,7 +19,7 @@
  *
  * To pin the version of `pow` to a version compatible with all NR PHP Agent
  * supported OSes, we utilize `asm()` and `.symver` to instruct the linker to
- * select an older version- in this case, 2.17.
+ * select an older version of the symbol.
  */
 #if defined(__GLIBC__)
 #if ((__GLIBC__) >= 2) && ((__GLIBC_MINOR__) > 17)

--- a/axiom/nr_app_harvest.c
+++ b/axiom/nr_app_harvest.c
@@ -22,9 +22,7 @@
  * select an older version- in this case, 2.17.
  */
 #if defined(__GLIBC__)
-#if ZEND_MODULE_API_NO == ZEND_8_2_API_NO
 __asm__(".symver pow,pow@GLIBC_2.17");
-#endif
 #endif
 
 void nr_app_harvest_init(nr_app_harvest_t* ah,

--- a/axiom/nr_app_harvest.c
+++ b/axiom/nr_app_harvest.c
@@ -22,7 +22,7 @@
  * select an older version of the symbol.
  */
 #if defined(__GLIBC__)
-#if ((__GLIBC__) >= 2) && ((__GLIBC_MINOR__) > 17)
+#if (((__GLIBC__) > 2) || (((__GLIBC__) == 2) && ((__GLIBC_MINOR__) > 17)))
 #if defined (__x86_64__)
   __asm__(".symver pow,pow@GLIBC_2.2.5");
 #endif

--- a/axiom/nr_app_harvest.c
+++ b/axiom/nr_app_harvest.c
@@ -22,7 +22,9 @@
  * select an older version- in this case, 2.17.
  */
 #if defined(__GLIBC__)
+#if ((__GLIBC__) >= 2) && ((__GLIBC_MINOR__) > 17)
 __asm__(".symver pow,pow@GLIBC_2.17");
+#endif
 #endif
 
 void nr_app_harvest_init(nr_app_harvest_t* ah,

--- a/axiom/nr_app_harvest.c
+++ b/axiom/nr_app_harvest.c
@@ -25,8 +25,6 @@
 #if ((__GLIBC__) >= 2) && ((__GLIBC_MINOR__) > 17)
 #if defined (__x86_64__)
   __asm__(".symver pow,pow@GLIBC_2.2.5");
-#elif defined (__aarch64__)
-  __asm__(".symver pow,pow@GLIBC_2.17");
 #endif
 #endif
 #endif

--- a/axiom/nr_app_harvest.c
+++ b/axiom/nr_app_harvest.c
@@ -12,6 +12,21 @@
 #include "nr_app_harvest_private.h"
 #include "util_logging.h"
 
+/*
+ * The build pipeline for PHP 8.2 uses a Debian image that is built on a
+ * version of glibc that contains an newer glibc version symbol for `pow()`
+ * which is incompatible with older distributions, causing RPM installs to fail.
+ *
+ * To pin the version of `pow` to a version compatible with all NR PHP Agent
+ * supported OSes, we utilize `asm()` and `.symver` to instruct the linker to
+ * select an older version- in this case, 2.17.
+ */
+#if defined(__GLIBC__)
+#if ZEND_MODULE_API_NO == ZEND_8_2_API_NO
+__asm__(".symver pow,pow@GLIBC_2.17");
+#endif
+#endif
+
 void nr_app_harvest_init(nr_app_harvest_t* ah,
                          nrtime_t connect_timestamp,
                          nrtime_t harvest_frequency,


### PR DESCRIPTION
To maintain New Relic's PHP Agent compatibility with older runtime platforms, use GNU's Assembler's [as](https://sourceware.org/binutils/docs/as/index.html) [.symver](https://sourceware.org/binutils/docs/as/Symver.html) directive to pin glibc's symbols to versions compatible with RHEL7, which uses glibc version 2.17.