### PR TITLE
build: don't enforce linking to static libpcre

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ show-vendors:
 	@echo ""
 	@echo -----------------------------------------------------------------------
 	@echo "| Using pcre library from $(PCRE_PREFIX) (from $(origin PCRE_PREFIX))"
+	@echo -n "| Link to "; [ $(PCRE_STATIC) = yes ] && echo -n "static" || echo -n "shared"; echo " libpcre";
 	@echo "| Using protobuf-c library from $(PROTOBUF_C_PREFIX) (from $(origin PROTOBUF_C_PREFIX))"
 	@echo -----------------------------------------------------------------------
 	@echo ""
@@ -134,7 +135,7 @@ agent/configure: agent/config.m4 agent/Makefile.frag
 	cd agent; $(PHPIZE) --clean && $(PHPIZE)
 
 agent/Makefile: agent/configure | axiom
-	cd agent; ./configure $(SILENT) --enable-newrelic --with-axiom=$(realpath axiom) --with-php-config=$(PHP_CONFIG) --with-protobuf-c=$(PROTOBUF_C_PREFIX) --with-pcre=$(PCRE_PREFIX)
+	cd agent; ./configure $(SILENT) --enable-newrelic --with-axiom=$(realpath axiom) --with-php-config=$(PHP_CONFIG) --with-protobuf-c=$(PROTOBUF_C_PREFIX) --with-pcre=$(PCRE_PREFIX) --with-pcre-static=$(PCRE_STATIC)
 
 #
 # Installs the agent into the extension directory of the appropriate PHP

--- a/agent/config.m4
+++ b/agent/config.m4
@@ -37,6 +37,9 @@ dnl "./make.sh pcre" from top level directory of php-build-scripts.
 PHP_ARG_WITH(pcre,,
 [  --with-pcre=DIR   Path to pcre], /opt/nr/pcre/8.40, no)
 
+PHP_ARG_WITH(pcre-static,,
+[  --with-pcre-static=no   link to static pcre], no, no)
+
 if test "$PHP_NEWRELIC" = "yes"; then
   AC_DEFINE(HAVE_NEWRELIC, 1, [Whether you have New Relic])
 
@@ -113,12 +116,19 @@ if test "$PHP_NEWRELIC" = "yes"; then
     dnl to libpcre-pic).
     PCRE_LIBLINE=-lnrpcre-pic
     PCRE_LIBRARY=nrpcre-pic
-  else
+  elif echo "$PHP_PCRE_STATIC" | grep -q yes; then
     dnl Force the agent to use static version of pcre library. This avoids the
     dnl issue with runtime dependency on libpcre shared object that is hard to
     dnl satisfy universally because different Linux distributions use different
     dnl name of the shared object: libpcre.so or libpcre3.so.
     PCRE_LIBLINE="-L$PHP_PCRE -l:libpcre.a"
+    PCRE_LIBRARY=pcre
+  else
+    dnl When casually building from source and not enforcing static linking,
+    dnl through PCRE_STATIC=yes environmental variable, let the linker decide
+    dnl what version of libpcre to link to. This is allowed because usually
+    dnl when building from source, build platform = runtime platform.
+    PCRE_LIBLINE="-L$PHP_PCRE -lpcre"
     PCRE_LIBRARY=pcre
   fi
 

--- a/axiom/tests/Makefile
+++ b/axiom/tests/Makefile
@@ -102,7 +102,11 @@ endif
 # Flags required to link PCRE.
 #
 PCRE_CFLAGS := -I$(PCRE_PREFIX)/include
+ifeq (yes,$(PCRE_STATIC))
 PCRE_LDLIBS := -L$(PCRE_PREFIX)/lib -l:libpcre.a
+else 
+PCRE_LDLIBS := -L$(PCRE_PREFIX)/lib -lpcre
+endif
 
 all: tests
 

--- a/axiom/tests/Makefile
+++ b/axiom/tests/Makefile
@@ -103,7 +103,12 @@ endif
 #
 PCRE_CFLAGS := -I$(PCRE_PREFIX)/include
 ifeq (yes,$(PCRE_STATIC))
-PCRE_LDLIBS := -L$(PCRE_PREFIX)/lib -l:libpcre.a
+  ifneq (,$(findstring /opt/nr/camp,$(shell pcre-config --prefix)))
+    # Special handling for legacy build environments.
+    PCRE_LDLIBS := -L$(PCRE_PREFIX)/lib -lnrpcre-pic
+  else
+    PCRE_LDLIBS := -L$(PCRE_PREFIX)/lib -l:libpcre.a
+  endif
 else 
 PCRE_LDLIBS := -L$(PCRE_PREFIX)/lib -lpcre
 endif

--- a/make/config.mk
+++ b/make/config.mk
@@ -81,9 +81,9 @@ PCRE_PREFIX ?= $(shell PKG_CONFIG_PATH=/opt/nr/pcre/$$(ls /opt/nr/pcre 2>/dev/nu
 # build system will enforce linking to static version of libpcre and if it is
 # not available, the build will abort.
 PCRE_STATIC ?= no
-ifneq ($(findstring /opt/nr/pcre,$(PCRE_PREFIX)), )
-# Legacy agent's build system quirks: link statically to build-scripts' provided
-# pcre library.
+ifneq ($(findstring /opt/nr/,$(PCRE_PREFIX)), )
+# Legacy agent's build systems (nrcamp and build-scripts) quirks: default to 
+# linking with static libpcre.
 PCRE_STATIC=yes
 endif
 


### PR DESCRIPTION
By default let the agent link to whatever libpcre is available on the system (most likely a shared object). However for release builds the agent needs to link with a static version of libpcre to ensure it runs on all Linux distros. This is needed because different Linux distributions use different names for the shared object and its impossible to link to a shared object that works universally on all Linux distributions. If PCRE_STATIC is set to yes, agent's build system will enforce linking to static version of libpcre and if it is not available, the build will abort.

Supplements #613 