### PR TITLE
ci: version in release build needs build number

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,6 +16,11 @@ on:
   # Run this workflow manually from the Actions tab or using the API
   #
   workflow_dispatch:
+    inputs:
+      build-number:
+        description: 'Build number for agent version'
+        required: true
+        type: string
 
 jobs:
   agent_release:
@@ -45,6 +50,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}/newrelic-php-agent":"/usr/local/src/newrelic-php-agent"
           -e OPTIMIZE=1
           -e PCRE_STATIC=yes
+          -e BUILD_NUMBER=${{inputs.build-number}}
           $IMAGE_NAME:agent-builder-php${{matrix.php_ver}}-${{matrix.platform}}-$IMAGE_VERSION release-${{matrix.php_ver}}-gha
       - name: Save build artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Set the build number part of the agent version to make release artifacts, generated by release-build workflow, compatible with the rest of the release pipeline.