### PR TITLE
style(daemon): go test warnings

### DIFF
--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -651,7 +651,7 @@ func deleteSockfile(network, address string) {
 		err := os.Remove(address)
 		if err != nil && !os.IsNotExist(err) {
 			fmt.Fprintf(os.Stderr, "unable to remove stale sock file: %v"+
-				" - another daemon may already be running?", err)
+				" - another daemon may already be running?\n", err)
 		}
 	}
 }

--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -650,7 +650,7 @@ func deleteSockfile(network, address string) {
 	if network == "unix" && !(address[0] == '@') {
 		err := os.Remove(address)
 		if err != nil && !os.IsNotExist(err) {
-			fmt.Fprintln(os.Stderr, "unable to remove stale sock file: %v"+
+			fmt.Fprintf(os.Stderr, "unable to remove stale sock file: %v"+
 				" - another daemon may already be running?", err)
 		}
 	}

--- a/src/stressor/main.go
+++ b/src/stressor/main.go
@@ -83,7 +83,8 @@ EXAMPLES
      25 concurrent transactions.
 
   stressor --rpm 0
-     Simulate an unlimited number of transactions per minute.`
+     Simulate an unlimited number of transactions per minute.
+`
 
 const (
 	DefaultApps     = 1
@@ -574,7 +575,7 @@ func reportDaemonStats(stats *MemStats, numMsg uint64, lifespan time.Duration) {
 }
 
 func main() {
-	flag.Usage = func() { fmt.Fprintln(os.Stderr, helpMessage) }
+	flag.Usage = func() { fmt.Fprint(os.Stderr, helpMessage, '\n') }
 	flag.Parse()
 
 	if *flagCPUProfile != "" {

--- a/src/stressor/main.go
+++ b/src/stressor/main.go
@@ -83,8 +83,7 @@ EXAMPLES
      25 concurrent transactions.
 
   stressor --rpm 0
-     Simulate an unlimited number of transactions per minute.
-`
+     Simulate an unlimited number of transactions per minute.`
 
 const (
 	DefaultApps     = 1


### PR DESCRIPTION
Fixes two minor daemon issues that newer go test versions (1.10+) dislike. ([further discussion here](https://github.com/golang/go/issues/23062))

1) format directives in Fprintln. There is an Fprintln call that should be an Fprintf because it contains formatting directives. Previously, the directive was ignored and the additional arguments were added to the end of the string.

2) passing an extra newline to Fprintln. Go dislikes Fprintln being passed a string that ends in a newline. To achieve the exact same previous functionality, it is now a Fprint call with an additional newline character.

