### PR TITLE
fix(installer): Add php82 api

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -336,7 +336,7 @@ if [ -z "${ispkg}" ]; then
 fi
 check_file "${ilibdir}/scripts/newrelic.ini.template"
 for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" \
-"20180731" "20190902" "20200930" "20210902"; do
+"20180731" "20190902" "20200930" "20210902" "20220829"; do
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
   # remove following line when ZTS removed from releases
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -338,6 +338,8 @@ check_file "${ilibdir}/scripts/newrelic.ini.template"
 # Check that exxtension artifacts exist for all supported PHP versions
 # MAKE SURE TO UPDATE THIS LIST WHENEVER SUPPORT IS ADDED OR REMOVED
 # FOR A PHP VERSION
+# Currently supported versions:
+#    (5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2)
 for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" \
 "20180731" "20190902" "20200930" "20210902" "20220829"; do
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -335,6 +335,9 @@ if [ -z "${ispkg}" ]; then
   check_file "${ilibdir}/scripts/newrelic-daemon.logrotate"
 fi
 check_file "${ilibdir}/scripts/newrelic.ini.template"
+# Check that exxtension artifacts exist for all supported PHP versions
+# MAKE SURE TO UPDATE THIS LIST WHENEVER SUPPORT IS ADDED OR REMOVED
+# FOR A PHP VERSION
 for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" \
 "20180731" "20190902" "20200930" "20210902" "20220829"; do
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"


### PR DESCRIPTION
This PR added the PHP 8.2 API to the list of extension artifacts to check when verifying the integrity of the install payload.
Also added a comment to the relevant section of code to make it more obvious it needs to be changed the next time the script is updated.