### PR TITLE
fix(agent):Update logic needed to call PHP functions from the agent.

### DIFF
--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -23,7 +23,7 @@ zval* nr_php_call_user_func(zval* object_ptr,
   zval* fname = NULL;
   HashTable* symbol_table = NULL;
   zval* param_values = NULL;
-  zval retval = {0};
+  zval retval = {{0}};
   zval* retval_copy = NULL;
 #ifndef PHP8
   int no_separation = 0;

--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -121,6 +121,7 @@ zval* nr_php_call_user_func(zval* object_ptr,
       retval_copy = nr_php_zval_alloc();
       ZVAL_DUP(retval_copy, &retval);
       zval_ptr_dtor(&retval);
+      return retval_copy;
   }
   zval_ptr_dtor(&retval);
   return NULL;

--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -50,6 +50,7 @@ zval* nr_php_call_user_func(zval* object_ptr,
   }
   fname = nr_php_zval_alloc();
   nr_php_zval_str(fname, function_name);
+  ZVAL_UNDEF(&retval);
   /*
    * For PHP 8+, in the case of exceptions according to:
    * https://www.php.net/manual/en/function.call-user-func.php
@@ -118,10 +119,12 @@ zval* nr_php_call_user_func(zval* object_ptr,
   nr_free(param_values);
 
   if (SUCCESS == zend_result) {
-    retval_copy = nr_php_zval_alloc();
-    ZVAL_DUP(retval_copy, &retval);
-    zval_ptr_dtor(&retval);
-    return retval_copy;
+    if (IS_UNDEF != Z_TYPE(retval)) {
+      retval_copy = nr_php_zval_alloc();
+      ZVAL_DUP(retval_copy, &retval);
+      zval_ptr_dtor(&retval);
+      return retval_copy;
+    }
   }
   zval_ptr_dtor(&retval);
   return NULL;

--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -50,7 +50,6 @@ zval* nr_php_call_user_func(zval* object_ptr,
   }
   fname = nr_php_zval_alloc();
   nr_php_zval_str(fname, function_name);
-  ZVAL_UNDEF(&retval);
   /*
    * For PHP 8+, in the case of exceptions according to:
    * https://www.php.net/manual/en/function.call-user-func.php
@@ -119,12 +118,9 @@ zval* nr_php_call_user_func(zval* object_ptr,
   nr_free(param_values);
 
   if (SUCCESS == zend_result) {
-    if (IS_UNDEF != Z_TYPE(retval)) {
       retval_copy = nr_php_zval_alloc();
       ZVAL_DUP(retval_copy, &retval);
       zval_ptr_dtor(&retval);
-      return retval_copy;
-    }
   }
   zval_ptr_dtor(&retval);
   return NULL;

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1930,26 +1930,12 @@ void php_observer_handle_exception_hook(zval* exception, zval* exception_this) {
 
 static void nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_PROTO) {
   NR_UNUSED_FUNC_RETURN_VALUE;
-
-  if (NULL == execute_data || NULL == execute_data->opline) {
-    return;
-  }
-
   if (NULL == execute_data->prev_execute_data) {
-    nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous execute data",
-                     __func__);
+    nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous execute data", __func__);
     return;
   }
   if (NULL == execute_data->prev_execute_data->opline) {
     nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous opline", __func__);
-    return;
-  }
-
-  /*
-   * First, since all of the logic below depends on what we know about
-   * ZEND_DO_FCALL, verify this is actually a ZEND_DO_FCALL otherwise exit.
-   */
-  if (ZEND_DO_FCALL != execute_data->prev_execute_data->opline->opcode) {
     return;
   }
 
@@ -1994,16 +1980,12 @@ static void nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_PROTO) {
       return;
     }
 
-    if (UNEXPECTED(
-            NULL
-            == execute_data->prev_execute_data->func->common.function_name)) {
-      nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous function name",
-                       __func__);
+    if (UNEXPECTED(NULL == execute_data->prev_execute_data->func->common.function_name)) {
+      nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous function name", __func__);
       return;
     }
 
-    nr_php_call_user_func_array_handler(NRPRG(cufa_callback),
-                                        execute_data->func,
+    nr_php_call_user_func_array_handler(NRPRG(cufa_callback), execute_data->func,
                                         execute_data->prev_execute_data);
   }
 }
@@ -2032,16 +2014,15 @@ static void nr_php_instrument_func_begin(NR_EXECUTE_PROTO) {
   }
   if (UNEXPECTED(NULL != NRPRG(cufa_callback))) {
     /*
-     * For PHP 7+, call_user_func_array() is flattened into an inline by
-     * default. Because of this, we must check the opcodes set to see whether we
-     * are calling it flattened. If we have a cufa callback, we want to call
-     * that here. This will create the wraprec for the user function we want to
-     * instrument and thus must be called before we search the wraprecs
+     * For PHP 7+, call_user_func_array() is flattened into an inline by default. Because
+     * of this, we must check the opcodes set to see whether we are calling it flattened.
+     * If we have a cufa callback, we want to call that here. This will create the wraprec
+     * for the user function we want to instrument and thus must be called before we search
+     * the wraprecs
      *
-     * For non-OAPI, this is handled in php_vm.c by overwriting the
-     * ZEND_DO_FCALL opcode.
+     * For non-OAPI, this is handled in php_vm.c by overwriting the ZEND_DO_FCALL opcode.
      */
-    nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_ORIG_ARGS);
+     nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_ORIG_ARGS);
   }
   wraprec = nr_php_get_wraprec(execute_data->func);
   /*

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1930,6 +1930,9 @@ void php_observer_handle_exception_hook(zval* exception, zval* exception_this) {
 
 static void nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_PROTO) {
   NR_UNUSED_FUNC_RETURN_VALUE;
+  if (NULL == execute_data) {
+    return;
+  }
   if (NULL == execute_data->prev_execute_data) {
     nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous execute data", __func__);
     return;

--- a/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php8.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php8.php
@@ -52,6 +52,10 @@ function apply_filters($tag, ...$args) {
     call_user_func_array($tag, $args);
 }
 
+// Simple mock of wordpress's get_theme_roots
+function get_theme_roots() {
+}
+
 function h($str) {
     echo "h: ";
     echo $str;

--- a/tests/integration/frameworks/wordpress/test_wordpress_do_action.php8.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_do_action.php8.php
@@ -52,6 +52,10 @@ function do_action($tag, ...$args) {
     call_user_func_array($tag, $args);
 }
 
+//Simple mock of wordpress's get_theme_roots
+function get_theme_roots() {
+}
+
 function h() {
     echo "h\n";
     throw new Exception("Test Exception");


### PR DESCRIPTION
The try/catch block was added for PHP 8+ because in the case of exceptions according to:  https://www.php.net/manual/en/function.call-user-func.php Callbacks registered with functions such as call_user_func() and call_user_func_array() will not be called if there is an uncaught exception thrown in a previous callback. So if we call something that causes an exception, it will block us from future calls that use call_user_func or call_user_func_array.

Valgrind showed the agent and/or the php system wasn't properly cleaning up after such cases.

Newer compilers had issues with this when compiling with any optimization and generated the following error: `might be clobbered by 'longjmp' or 'vfork' [-Werror=clobbered]`

This PR addresses the error by moving assignment of the offending variables into the try/catch block then @lavarou used a local variable to store retval until we are sure we will use it.

@lavarou read more about using the local variable here:
While I was looking for some information about -Wclobber and learning about zend_try/zend_catch I found these two interesting resources:
https://github.com/php/php-src/pull/5151 - this basically shows that PHP team is aware of issues caused by -Wclobber and basically turn these warnings off (I don’t know if it’s good or bad that PHP is ignoring compiler warnings though; maybe they know what they’re doing)
https://github.com/php/php-src/blob/master/main/streams/userspace.c#L335-L340 - this is an example in PHP source code how zend_call_method_if_exists is called. It is a nice little trick of using an automatic variable to store user function call result. Based on this I came up with this idea: https://github.com/newrelic/newrelic-php-agent/compare/compiler_error...lavarou/fix/php-call-try-catch?expand=1. It seems to resolve the issue - I haven’t tested it past agent’s unit tests (make agent-valgrind) for PHP 8.2. Using automatic/local variable has this advantage that memory allocation is delayed until it is certain retval is good for use - i.e. zend_call_method_if_exists succeeded. Clobbering (longjmp called from within zend_call_method_if_exists which will cause [this line](https://github.com/newrelic/newrelic-php-agent/blob/compiler_error/agent/php_call.c#L73) to jump [here](https://github.com/newrelic/newrelic-php-agent/blob/compiler_error/agent/php_call.c#L107)) may invalidate the value of retval pointer and at the time it is freed [here](https://github.com/newrelic/newrelic-php-agent/blob/compiler_error/agent/php_call.c#L92) it may point to invalid memory and cause segfault.

There are unit tests that test that were added with oapi that exercise this functionality(nr_php_call).  Adding the tests [here](https://github.com/newrelic/newrelic-php-agent/pull/542/files#diff-c175fdeafd6ad73c1b624822523084b3f5a3a98a303c9db389083a4bb2d50387R122) and [here](https://github.com/newrelic/newrelic-php-agent/blob/4209f55f749c5718bd86ed9adec53965cc57a86d/agent/tests/test_php_wrapper.c)(extensively used, with exception and non exception cases search for nr_php_call) and also [here](https://github.com/newrelic/newrelic-php-agent/pull/542/files#diff-c175fdeafd6ad73c1b624822523084b3f5a3a98a303c9db389083a4bb2d50387R146) are what initially caused the try/catch to be added because we weren't handling those cases properly and were causing multiple valgrind issues.


Additionally, combined the 8+ blocks for functionality and simplicity.

`zend_call_method_if_exists` that had been used in the 8.2+ block was suppressing a valid warning message.

When we ran it, because we forced Wordpress as a framework, we made a call in fw_wordpress.c which makes a call to get_theme_roots.
However, in the test case 
get_theme_roots (which normally exists in Wordpress) does not exist in our "mocked" Wordpress so we received a perfectly valid error msg.

Fatal error: Uncaught Error: Invalid callback get_theme_roots, function "get_theme_roots" not found or invalid function name in /usr/local/src/newrelic-php-agent/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php8.php:66
Stack trace:
#0 /usr/local/src/newrelic-php-agent/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php8.php(52): g('string2')
#1 /usr/local/src/newrelic-php-agent/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php8.php(75): apply_filters('g', 'string2')
#2 /usr/local/src/newrelic-php-agent/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php8.php(52): f('string1')
#3 /usr/local/src/newrelic-php-agent/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php8.php(79): apply_filters('f', 'string1')
#4 {main}
  thrown in /usr/local/src/newrelic-php-agent/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php8.php on line 66

If we use nr_php_call we don't want it silently suppressing exceptions and continuing on as if nothing had happened.  The exceptions are warnings for us to keep things updated.

The error message is good, the problem is that after this, we weren't detecting that something invalid happened and were copying/returning retval even though we shouldn't.
The fix is to 
a) check retval for undef and if so, return NULL.
b) add get_theme_roots to the test case.

2) initialize retval to prevent segfaults.
zval retval = {0};

ETA:
Unrolling the change to use `call_user_function` for all.  Using call_user_function for all was simpler and more maintainable and worked for tested PHP versions across multiple apps but could not handle the Wordpress/php8.2 combo.
zend_call_method_if_exists seems to be the more robust function that wordpress/php 8.2 needs.