### PR TITLE
fix(agent): Additional checks needed before iterating backwards in opcodes.

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1930,15 +1930,26 @@ void php_observer_handle_exception_hook(zval* exception, zval* exception_this) {
 
 static void nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_PROTO) {
   NR_UNUSED_FUNC_RETURN_VALUE;
-  if (NULL == execute_data) {
+
+  if (NULL == execute_data || NULL == execute_data->opline) {
     return;
   }
+
   if (NULL == execute_data->prev_execute_data) {
-    nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous execute data", __func__);
+    nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous execute data",
+                     __func__);
     return;
   }
   if (NULL == execute_data->prev_execute_data->opline) {
     nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous opline", __func__);
+    return;
+  }
+
+  /*
+   * First, since all of the logic below depends on what we know about
+   * ZEND_DO_FCALL, verify this is actually a ZEND_DO_FCALL otherwise exit.
+   */
+  if (ZEND_DO_FCALL != execute_data->prev_execute_data->opline->opcode) {
     return;
   }
 
@@ -1983,12 +1994,16 @@ static void nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_PROTO) {
       return;
     }
 
-    if (UNEXPECTED(NULL == execute_data->prev_execute_data->func->common.function_name)) {
-      nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous function name", __func__);
+    if (UNEXPECTED(
+            NULL
+            == execute_data->prev_execute_data->func->common.function_name)) {
+      nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous function name",
+                       __func__);
       return;
     }
 
-    nr_php_call_user_func_array_handler(NRPRG(cufa_callback), execute_data->func,
+    nr_php_call_user_func_array_handler(NRPRG(cufa_callback),
+                                        execute_data->func,
                                         execute_data->prev_execute_data);
   }
 }
@@ -2017,15 +2032,16 @@ static void nr_php_instrument_func_begin(NR_EXECUTE_PROTO) {
   }
   if (UNEXPECTED(NULL != NRPRG(cufa_callback))) {
     /*
-     * For PHP 7+, call_user_func_array() is flattened into an inline by default. Because
-     * of this, we must check the opcodes set to see whether we are calling it flattened.
-     * If we have a cufa callback, we want to call that here. This will create the wraprec
-     * for the user function we want to instrument and thus must be called before we search
-     * the wraprecs
+     * For PHP 7+, call_user_func_array() is flattened into an inline by
+     * default. Because of this, we must check the opcodes set to see whether we
+     * are calling it flattened. If we have a cufa callback, we want to call
+     * that here. This will create the wraprec for the user function we want to
+     * instrument and thus must be called before we search the wraprecs
      *
-     * For non-OAPI, this is handled in php_vm.c by overwriting the ZEND_DO_FCALL opcode.
+     * For non-OAPI, this is handled in php_vm.c by overwriting the
+     * ZEND_DO_FCALL opcode.
      */
-     nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_ORIG_ARGS);
+    nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_ORIG_ARGS);
   }
   wraprec = nr_php_get_wraprec(execute_data->func);
   /*

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1931,7 +1931,9 @@ void php_observer_handle_exception_hook(zval* exception, zval* exception_this) {
 static void nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_PROTO) {
   NR_UNUSED_FUNC_RETURN_VALUE;
 
-  if (NULL == execute_data || NULL == execute_data->opline) {
+  if (NULL == execute_data) {
+      nrl_verbosedebug(NRL_AGENT, "%s: The current execute data is NULL.",
+                     __func__);
     return;
   }
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1930,6 +1930,9 @@ void php_observer_handle_exception_hook(zval* exception, zval* exception_this) {
 
 static void nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_PROTO) {
   NR_UNUSED_FUNC_RETURN_VALUE;
+  if (NULL == execute_data) {
+    return;
+  }
   if (NULL == execute_data->prev_execute_data) {
     nrl_verbosedebug(NRL_AGENT, "%s: cannot get previous execute data", __func__);
     return;


### PR DESCRIPTION
`nr_php_observer_attempt_call_cufa_handler` is a new function with oapi.  The equivalent function for non-oapi is in php_vm.c.  In that case, it has been called while we are in the middle of php_execute and can assume certain things among them being we can just check the execute_data opcodes and that the start opcode is ZEND_DO_FCALL (of which we know certain facts) and iterate back as needed.

In legacy, to determine determine this is a call_user_func_array() call we have to look at the previous opcodes of zend_execute_data. 
In oapi, to determine if this is a call_user_func_array() call we have to look at the previous opcodes of zend_execute_data->prev_execute_data.
For both we know: 
ZEND_DO_FCALL will never be the first opcode in an op array -- minimally, there is always at least a ZEND_INIT_FCALL before it -- so it is safe to iterate backwards in the opcode like `execute_data->prev_execute_data->opline - 1`

In oapi, the path to the equivalent function didn't have a guaranteed existence of zend_execute_data and therefore was causing some segfaults (specifically noticed for PHP 8.2 on wordpress which makes extensive use of cufa for hook implementation).  Additionally, we are not guaranteed that the prev_execute_data opcode is ZEND_DO_FCALL so we can't blindly iterate backwards on it.

This PR does two things:
1) Check if execute_data is NULL before attempting to access its elements.
2) verify the opcode is ZEND_DO_FCALL before we iterate back to determine if it was called from call_user_func_array.

Testing:
Build from source soak tests for PHP 8.2 and wordpress no longer segfault.