### PR TITLE
feat(daemon): Add loglevel for daemon health

### DIFF
--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -160,7 +160,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          rarely need to change this from the default, and usually only under
 ;          the guidance of technical support.
 ;          Must be one of the following values:
-;            always, error, warning, healthcheck, info, debug
+;            always, error, warning, info, healthcheck, debug
 ;
 ;          The values verbose and verbosedebug are deprecated aliases for debug.
 ;

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -160,7 +160,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          rarely need to change this from the default, and usually only under
 ;          the guidance of technical support.
 ;          Must be one of the following values:
-;            always, error, warning, info, debug
+;            always, error, warning, healthcheck, info, debug
 ;
 ;          The values verbose and verbosedebug are deprecated aliases for debug.
 ;

--- a/src/daemon/flags_test.go
+++ b/src/daemon/flags_test.go
@@ -181,7 +181,7 @@ func TestParseConfigFile(t *testing.T) {
 
 	cfgExpected := &Config{
 		ConfigFile: "../newrelic/sample_config/config1.cfg",
-		LogLevel:   4,
+		LogLevel:   5,
 		LogFile:    "/var/log/newrelic/newrelic-daemon.log",
 	}
 

--- a/src/newrelic/log/log.go
+++ b/src/newrelic/log/log.go
@@ -23,6 +23,7 @@ const (
 	LogError
 	LogWarning
 	LogInfo
+	LogHealthCheck
 	LogDebug
 )
 
@@ -46,10 +47,11 @@ func Init(level Level, location string) error {
 	return nil
 }
 
-func Errorf(format string, a ...interface{}) { logf(LogError, format, a...) }
-func Warnf(format string, a ...interface{})  { logf(LogWarning, format, a...) }
-func Infof(format string, a ...interface{})  { logf(LogInfo, format, a...) }
-func Debugf(format string, a ...interface{}) { logf(LogDebug, format, a...) }
+func Errorf(format string, a ...interface{})  { logf(LogError, format, a...) }
+func Warnf(format string, a ...interface{})   { logf(LogWarning, format, a...) }
+func Healthf(format string, a ...interface{}) { logf(LogHealthCheck, format, a...) }
+func Infof(format string, a ...interface{})   { logf(LogInfo, format, a...) }
+func Debugf(format string, a ...interface{})  { logf(LogDebug, format, a...) }
 
 func logf(level Level, format string, a ...interface{}) {
 	maxLevel := atomic.LoadInt32((*int32)(&daemonLevel))
@@ -114,6 +116,8 @@ func (level Level) String() string {
 		return "Error"
 	case LogWarning:
 		return "Warning"
+	case LogHealthCheck:
+		return "HealthCheck"
 	case LogInfo:
 		return "Info"
 	case LogDebug:
@@ -198,6 +202,8 @@ func parseLevel(s string) (Level, error) {
 		return LogError, nil
 	case "warning":
 		return LogWarning, nil
+	case "healthcheck":
+		return LogHealthCheck, nil
 	case "info", "":
 		return LogInfo, nil
 		// verbose and verbosedebug kept for historical compatibility

--- a/src/newrelic/log/log_test.go
+++ b/src/newrelic/log/log_test.go
@@ -20,6 +20,7 @@ func TestParseLevel(t *testing.T) {
 		{LogDebug, "debug"},
 		{LogDebug, "verbose"},
 		{LogDebug, "verbosedebug"},
+		{LogHealthCheck, "healthcheck"},
 	}
 
 	for i := range tests {

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -377,7 +377,7 @@ func (p *Processor) processAppInfo(m AppInfoMessage) {
 	app = NewApp(m.Info)
 	p.apps[key] = app
 	numapps = len(p.apps)
-	log.Healthf("# active apps = %d, max = %d",
+	log.Healthf("current number of apps is %d of a max of %d",
 		numapps, limits.AppLimit)
 	if numapps == limits.AppLimitNotifyHigh {
 		log.Infof("approaching app limit of %d, current number of apps is %d",
@@ -828,7 +828,7 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 			log.Infof("current number of apps is %d",
 				limits.AppLimitNotifyLow)
 		}
-		log.Healthf("# active apps = %d, max = %d",
+		log.Healthf("current number of apps is %d of a max of %d",
 			numapps, limits.AppLimit)
 		p.shutdownAppHarvest(id)
 		delete(p.apps, app.Key())

--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -368,17 +368,22 @@ func (p *Processor) processAppInfo(m AppInfoMessage) {
 	}
 
 	numapps := len(p.apps)
-	if numapps > limits.AppLimit {
+	if numapps >= limits.AppLimit {
 		log.Errorf("unable to add app '%s', limit of %d applications reached",
 			m.Info, limits.AppLimit)
 		return
-	} else if numapps == limits.AppLimitNotifyHigh {
-		log.Infof("approaching app limit of %d, current number of apps is %d",
-			limits.AppLimit, limits.AppLimitNotifyHigh)
 	}
 
 	app = NewApp(m.Info)
 	p.apps[key] = app
+	numapps = len(p.apps)
+	log.Healthf("# active apps = %d, max = %d",
+		numapps, limits.AppLimit)
+	if numapps == limits.AppLimitNotifyHigh {
+		log.Infof("approaching app limit of %d, current number of apps is %d",
+			limits.AppLimit, limits.AppLimitNotifyHigh)
+	}
+
 }
 
 func processConnectMessages(reply collector.RPMResponse) {
@@ -818,10 +823,13 @@ func (p *Processor) doHarvest(ph ProcessorHarvest) {
 	if p.cfg.AppTimeout > 0 && app.Inactive(p.cfg.AppTimeout) {
 		log.Infof("removing %q with run id %q for lack of activity within %v",
 			app, id, p.cfg.AppTimeout)
-		if len(p.apps) == limits.AppLimitNotifyLow {
+		numapps := len(p.apps)
+		if numapps == limits.AppLimitNotifyLow {
 			log.Infof("current number of apps is %d",
 				limits.AppLimitNotifyLow)
 		}
+		log.Healthf("# active apps = %d, max = %d",
+			numapps, limits.AppLimit)
 		p.shutdownAppHarvest(id)
 		delete(p.apps, app.Key())
 


### PR DESCRIPTION
This PR adds a new log level for the daemon called "healthcheck".  It is between "debug" and "info" in verbosity. 
If enabled this log level will currently output a daemon log message of type "HealthCheck" which will output the current number of applications connected to the agent as well as the maximum number of allowed applications.
The format of the line is:
```log.Healthf("current number of apps is %d of a max of %d", numapps, limits.AppLimit)```
where ```numapps``` is the current number of applications and ```limits.AppLimit``` is the compile-time limit for the number of applications a daemon instance will allow.