### PR TITLE
feat(integration_runner): Add 'warn' test result

### DIFF
--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -556,7 +556,7 @@ func runTest(t *integration.Test) {
 		t.Skip(reason)
 		return
 	}
-	
+
 	if warnRE.Match(body) {
 		reason := string(bytes.TrimSpace(head(body)))
 		t.Warn(reason)

--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -49,6 +49,7 @@ var (
 	flagWorkers         = flag.Int("threads", 1, "")
 	flagTime            = flag.Bool("time", false, "time each test")
 	flagMaxCustomEvents = flag.Int("max_custom_events", 30000, "value for newrelic.custom_events.max_samples_stored")
+	flagWarnIsFail      = flag.Bool("warnisfail", false, "warn result is treated as a fail")
 
 	// externalPort is the port on which we start a server to handle
 	// external calls.
@@ -384,7 +385,7 @@ func main() {
 
 		handler.Lock()
 		for _, tc := range tests {
-			if !tc.Failed && !tc.Skipped {
+			if !tc.Failed && !tc.Skipped && !tc.Warned {
 				if handler.harvests[tc.Name] == nil {
 					testsToRetry <- tc
 				}
@@ -403,15 +404,19 @@ func main() {
 	deleteSockfile("unix", *flagPort)
 
 	var numFailed int
+	var numWarned int
 
 	// Compare the output
 	handler.Lock()
 	for _, tc := range tests {
-		if !tc.Failed && !tc.Skipped {
+		if !tc.Failed && !tc.Skipped && !tc.Warned {
 			tc.Compare(handler.harvests[tc.Name])
 		}
 		if tc.Failed && tc.Xfail == "" {
 			numFailed++
+		}
+		if tc.Warned {
+			numWarned++
 		}
 	}
 
@@ -420,11 +425,15 @@ func main() {
 	if numFailed > 0 {
 		os.Exit(1)
 	}
+	if *flagWarnIsFail && numWarned > 0 {
+		os.Exit(2)
+	}
 }
 
 var (
 	skipRE  = regexp.MustCompile(`^(?i)\s*skip`)
 	xfailRE = regexp.MustCompile(`^(?i)\s*xfail`)
+	warnRE  = regexp.MustCompile(`^(?i)\s*warn`)
 )
 
 func runTests(testsToRun chan *integration.Test, numWorkers int) {
@@ -545,6 +554,12 @@ func runTest(t *integration.Test) {
 	if skipRE.Match(body) {
 		reason := string(bytes.TrimSpace(head(body)))
 		t.Skip(reason)
+		return
+	}
+	
+	if warnRE.Match(body) {
+		reason := string(bytes.TrimSpace(head(body)))
+		t.Warn(reason)
 		return
 	}
 

--- a/src/integration_runner/reports.go
+++ b/src/integration_runner/reports.go
@@ -34,6 +34,7 @@ var (
 type TestRunTotals struct {
 	passed  int
 	skipped int
+	warned  int
 	failed  int
 	xfail   int
 }
@@ -49,6 +50,10 @@ func Color(colorString string) func(...interface{}) string {
 func (totals *TestRunTotals) Accumulate(test *integration.Test) {
 	if test.Skipped {
 		totals.skipped++
+		return
+	}
+	if test.Warned {
+		totals.warned++
 		return
 	}
 	if test.Failed {
@@ -71,6 +76,8 @@ func tapOutput(tests []*integration.Test) {
 		switch {
 		case test.Skipped:
 			fmt.Println(Warn("skip -"), name, "#", Warn(test.Err))
+		case test.Warned:
+			fmt.Println(Warn("warn -"), name, "#", Warn(test.Err))
 		case test.Failed:
 			if "" != test.Xfail {
 				fmt.Println("xfail -", name)
@@ -100,6 +107,7 @@ func tapOutput(tests []*integration.Test) {
 	}
 	fmt.Println("#", totals.passed, "passed")
 	fmt.Println("#", totals.skipped, "skipped")
+	fmt.Println("#", totals.warned, "warned")
 	if totals.failed == 0 {
 		fmt.Println("#", Good(totals.failed), Good("failed"))
 	} else {

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -63,6 +63,7 @@ type Test struct {
 
 	// Remaining fields are populated after the test is run.
 	Skipped bool
+    Warned bool
 
 	// If the test was skipped or the test could not be run due to an
 	// error, describes the reason.
@@ -134,6 +135,19 @@ func (t *Test) Skip(reason string) {
 // according to the format, and records the text as the reason.
 func (t *Test) Skipf(format string, args ...interface{}) {
 	t.Skipped = true
+	t.Err = fmt.Errorf(format, args...)
+}
+
+// Warn marks the test as unable to be run and records the given reason.
+func (t *Test) Warn(reason string) {
+	t.Warned = true
+	t.Err = errors.New(reason)
+}
+
+// Warnf marks the test as unable to be run  and formats its arguments
+// according to the format, and records the text as the reason.
+func (t *Test) Warnf(format string, args ...interface{}) {
+	t.Warned = true
 	t.Err = fmt.Errorf(format, args...)
 }
 
@@ -460,6 +474,7 @@ func (t *Test) Compare(harvest *newrelic.Harvest) {
 func (t *Test) Reset() {
 	t.Xfail = ""
 	t.Skipped = false
+	t.Warned = false
 	t.Err = nil
 	t.Output = nil
 	t.Failed = false

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -63,7 +63,7 @@ type Test struct {
 
 	// Remaining fields are populated after the test is run.
 	Skipped bool
-    Warned bool
+	Warned  bool
 
 	// If the test was skipped or the test could not be run due to an
 	// error, describes the reason.


### PR DESCRIPTION
This commit adds a 'warn' test result which is intended to be used to represent tests which could not be run due to something not being correct in the environment.  

The intention is 'skip' is for tests which cannot be run because of the PHP version or some other expected condition which would make the test not run in all environments.   However, currently 'skip' is used to also represent when a test which is expected to run could not run due to a misconfiguration of the environment.  This can cover up potential test run deficiencies.

The use of 'warn' means the test environment is mis-configured. 

A new integration_runner boolean option 'warnisfail' will cause any warnings to be treated as a failure and the integration_runner will exit with a non-zero exit code to signify the failure.

The 'warn' result can be returned by doing something like:

 ```die("warn: could not load important thing so test not run")```.