### PR TITLE
fix(agent): disable CAT when DT enabled

### DIFF
--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -252,6 +252,23 @@ static nr_status_t nr_php_check_8T_DT_config(TSRMLS_D) {
   return NR_SUCCESS;
 }
 
+static void nr_php_check_CAT_DT_config(TSRMLS_D) {
+  if (NRINI(distributed_tracing_enabled) && NRINI(cross_process_enabled)) {
+    // send a warning message to agent log
+    nrl_warning(NRL_INIT,
+                "Cross Application Tracing will be DISABLED because "
+                "Distributed Tracing is enabled. CAT functionality has been "
+                "superseded by DT and will be removed in a future release. The "
+                "New Relic PHP Agent Team suggests manually disabling CAT via "
+                "the 'newrelic.cross_application_tracer.enabled' INI setting "
+                "in your INI file and enabling DT via the "
+                "'newrelic.distributed_tracing_enabled' INI setting.");
+    
+    // set CAT INI value to disabled (just to be safe)
+    NRINI(cross_process_enabled) = 0;
+  }
+}
+
 /*
  * @brief Check the INI values for 'logging_enabled' and
  *        'log_forwarding_enabled' and log a warning on
@@ -610,6 +627,8 @@ PHP_MINIT_FUNCTION(newrelic) {
    * config issue and also that 8T will be disabled
    */
   nr_php_check_8T_DT_config(TSRMLS_C);
+
+  nr_php_check_CAT_DT_config(TSRMLS_C);
 
   nr_php_check_logging_config(TSRMLS_C);
   nr_php_check_high_security_log_forwarding(TSRMLS_C);

--- a/tests/integration/external/curl_exec/test_dt_enabled_cat_enabled.php
+++ b/tests/integration/external/curl_exec/test_dt_enabled_cat_enabled.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Generate a DT request and ensure that the agent does NOT add: 
+    - X-NewRelic-ID and X-NewRelic-Transaction headers
+to external calls when cross application tracing is enabled in the INI
+ */
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.cross_application_tracer.enabled = true
+*/
+
+/*SKIPIF
+<?php
+if (!extension_loaded("curl")) {
+  die("skip: curl extension required");
+}
+*/
+
+/*EXPECT
+traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRelic-Transaction=missing tracing endpoint reached
+ok - DT only request
+*/
+
+/*EXPECT_RESPONSE_HEADERS
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? start time",
+  "?? stop time",
+  [
+    [{"name":"External/all"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name":"External/allOther"},                                  [1, "??", "??", "??", "??", "??"]],
+    [{"name":"External/127.0.0.1/all"},                             [1, "??", "??", "??", "??", "??"]],
+    [{"name":"External/127.0.0.1/all",
+      "scope":"OtherTransaction/php__FILE__"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransaction/all"},                               [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransaction/php__FILE__"},                       [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/TraceContext/Create/Success"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/DistributedTrace/CreatePayload/Success"}, [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+
+$url = make_tracing_url(realpath(dirname(__FILE__)) . '/../../../include/tracing_endpoint.php');
+$ch = curl_init($url);
+tap_not_equal(false, curl_exec($ch), "DT only request");
+curl_close($ch);


### PR DESCRIPTION
### Internally disable the global for CAT when both CAT and DT are enabled

This PR will throw a warning message in the agent log about the CAT + DT conflict, suggest to the end user that they modify the setting, and will modify the `cross_process_enabled` INI value for the duration of the transaction to safeguard against any potential holes in the code that could allow both CAT and DT functionality present in the same transaction.

This PR does not modify the INI file, and checking INI settings (with `phpinfo()` or `php -i`) will not show this change reflected. As far as I'm aware, that's only possible by modifying the INI file itself, which is not something we should do.

A test has been added to verify this scenario.