### PR TITLE
refactor: use GitHub Action to enable arm64

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -38,8 +38,10 @@ jobs:
           path: php-agent
       - name: Enable arm64 emulation
         if: ${{ matrix.arch == 'arm64' }}
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt --install arm64
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
+          platforms: arm64
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Use docker/setup-qemu-action to enable arm64 emulation and pin tonistiigi/binfmt image version. Use repository variable BINFMT_IMAGE_VERSION to control which version of this dependency will be used.