### PR TITLE
Revert "chore(install): Disable ZTS installs"

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -40,13 +40,16 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        php_ver: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php_ver: ['7.0', '7.1-zts', '7.2', '7.3', '7.4', '8.0', '8.0-zts', '8.1', '8.1-zts', '8.2']
         arch: ['x64', 'x86']
         exclude:
         # Excludes PHP 5.x, 7.x on linux 32-bit
         # Excludes PHP 8.x as only 64bit is supported for these versions
         - os: linux
           php_ver: '7.0'
+          arch: 'x86'
+        - os: linux
+          php_ver: '7.1-zts'
           arch: 'x86'
         - os: linux
           php_ver: '7.2'
@@ -61,7 +64,13 @@ jobs:
           php_ver: '8.0'
           arch: 'x86'
         - os: linux
+          php_ver: '8.0-zts'
+          arch: 'x86'
+        - os: linux
           php_ver: '8.1'
+          arch: 'x86'
+        - os: linux
+          php_ver: '8.1-zts'
           arch: 'x86'
         - os: linux
           php_ver: '8.2'

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -343,6 +343,8 @@ check_file "${ilibdir}/scripts/newrelic.ini.template"
 for pmv in "20121212" "20131226" "20151012" "20160303" "20170718" \
 "20180731" "20190902" "20200930" "20210902" "20220829"; do
   check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
+  # remove following line when ZTS removed from releases
+  check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}-zts.so"
 done
 
 if [ -n "${fmissing}" ]; then
@@ -1289,20 +1291,20 @@ does not exist. This particular instance of PHP will be skipped.
   fi
   log "${pdir}: pi_zts=${pi_zts}"
 
-# zts installs are no longer supported
-  if [ "${pi_zts}" = "yes" ]; then
-    msg=$(
-    cat << EOF
-
-An unsupported PHP ZTS build has been detected. Please refer to this link:
-  https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/
-to view compatibilty requirements for the the New Relic PHP agent.
-The install will now exit.
-EOF
-)
-    error "${msg}"
-    exit 1
-  fi
+# uncomment when ZTS binaries are removed
+#  if [ "${pi_zts}" = "yes" ]; then
+#    msg=$(
+#    cat << EOF
+#
+#An unsupported PHP ZTS build has been detected. Please refer to this link:
+#  https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/
+#to view compatibilty requirements for the the New Relic PHP agent.
+#The install will now exit.
+#EOF
+#)
+#    error "${msg}"
+#    exit 1
+#  fi
 
 #
 # This is where we figure out where to put the ini file, if at all. We only do

--- a/make/release.mk
+++ b/make/release.mk
@@ -95,6 +95,14 @@ release-agent: Makefile | releases/$(RELEASE_OS)/agent/$(RELEASE_ARCH)/
 	for PHP in $(SUPPORTED_PHP) ; do \
 		$(MAKE) agent-clean; $(MAKE) release-$$PHP-no-zts; \
         done
+#
+# Next build ZTS binaries of the PHP versions requested that are supported
+# on this OS.
+#
+	for PHP in $(SUPPORTED_PHP) ; do \
+		$(MAKE) agent-clean; $(MAKE) release-$$PHP-zts; \
+	done
+
 
 #
 # Add a new target to build the agent against build machines.
@@ -113,11 +121,26 @@ release-$1-gha: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
 	@cp agent/modules/newrelic.so "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2.so"
 	@test -e agent/newrelic.map && cp agent/newrelic.map "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2.map" || true
 
+#
+# Target for zts GHA releases.
+#
+release-$1-zts-gha: PHPIZE := /usr/local/bin/phpize
+release-$1-zts-gha: PHP_CONFIG := /usr/local/bin/php-config
+release-$1-zts-gha: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
+	@cp agent/modules/newrelic.so "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2-zts.so"
+	 @test -e agent/newrelic.map && cp agent/newrelic.map "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2-zts.map" || true
+
 release-$1-no-zts: PHPIZE := /opt/nr/lamp/bin/phpize-$1-no-zts
 release-$1-no-zts: PHP_CONFIG := /opt/nr/lamp/bin/php-config-$1-no-zts
 release-$1-no-zts: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
 	@cp agent/modules/newrelic.so "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2.so"
 	@test -e agent/newrelic.map && cp agent/newrelic.map "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2.map" || true
+
+release-$1-zts: PHPIZE := /opt/nr/lamp/bin/phpize-$1-zts
+release-$1-zts: PHP_CONFIG := /opt/nr/lamp/bin/php-config-$1-zts
+release-$1-zts: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
+	@cp agent/modules/newrelic.so "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2-zts.so"
+	@test -e agent/newrelic.map && cp agent/newrelic.map "releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/newrelic-$2-zts.map" || true
 
 endef
 


### PR DESCRIPTION
Reverts newrelic/newrelic-php-agent#636. This change is obsoleted by #661. Revert is needed to avoid conflicts when dev is merged into oapi.