### PR TITLE
fix: typo in install-newrelic script

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1157,7 +1157,7 @@ Ignoring this particular instance of PHP.
     return 1
   fi
 
-  if [ "${pi_arch}" = "aarch64" ] && [ pi_php8 != "yes" ]; then
+  if [ "${pi_arch}" = "aarch64" ] && [ "${pi_php8}" != "yes" ]; then
     error "unsupported aarch64 version '${pi_ver}' of PHP found at:
     ${pdir}
 Ignoring this particular instance of PHP.


### PR DESCRIPTION
Expand `pi_php8` variable correctly when checking aarch64 support.