### PR TITLE
feat: deprecate php 5.5 and 5.6

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1043,9 +1043,11 @@ for this copy of PHP. We apologize for the inconvenience.
 
   case "${pi_ver}" in
     5.5.*)
+      log "${pdir}: deprecated php version '${pi_ver}'"
       ;;
 
     5.6.*)
+      log "${pdir}: deprecated php version '${pi_ver}'"
       ;;
 
     7.0.*)


### PR DESCRIPTION
Log a deprecation warning when detecting php 5.5 or 5.6 when running the newrelic-install script