### PR TITLE
feat: deprecate php 5.5 and 5.6

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1043,11 +1043,19 @@ for this copy of PHP. We apologize for the inconvenience.
 
   case "${pi_ver}" in
     5.5.*)
-      log "${pdir}: deprecated php version '${pi_ver}'"
+      warning_message="${pdir}: deprecated php version '${pi_ver}'"
+      if [ -z “${NR_INSTALL_SILENT}” ]; then
+         echo $warning_message
+      fi
+      log $warning_message
       ;;
 
     5.6.*)
-      log "${pdir}: deprecated php version '${pi_ver}'"
+      warning_message="${pdir}: deprecated php version '${pi_ver}'"
+      if [ -z “${NR_INSTALL_SILENT}” ]; then
+         echo $warning_message
+      fi
+      log $warning_message
       ;;
 
     7.0.*)

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1044,7 +1044,7 @@ for this copy of PHP. We apologize for the inconvenience.
   case "${pi_ver}" in
     5.5.*)
       warning_message="${pdir}: deprecated php version '${pi_ver}'"
-      if [ -z “${NR_INSTALL_SILENT}” ]; then
+      if [ -z "${NR_INSTALL_SILENT}" ]; then
          echo $warning_message
       fi
       log $warning_message
@@ -1052,7 +1052,7 @@ for this copy of PHP. We apologize for the inconvenience.
 
     5.6.*)
       warning_message="${pdir}: deprecated php version '${pi_ver}'"
-      if [ -z “${NR_INSTALL_SILENT}” ]; then
+      if [ -z "${NR_INSTALL_SILENT}" ]; then
          echo $warning_message
       fi
       log $warning_message

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1043,9 +1043,11 @@ for this copy of PHP. We apologize for the inconvenience.
 
   case "${pi_ver}" in
     5.5.*)
+      log "${pdir}: deprecated php version '${pi_ver}'"
       ;;
 
     5.6.*)
+      log "${pdir}: deprecated php version '${pi_ver}'"
       ;;
 
     7.0.*)


### PR DESCRIPTION
Log a deprecation warning when detecting php 5.5 or 5.6 when running the newrelic-install script

