### PR TITLE
fix: rework generic callable instrumentation to properly handle transience

### DIFF
--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -420,6 +420,10 @@ NR_PHP_WRAPPER(nr_drupal94_invoke_all_with) {
   NRPRG(drupal_module_invoke_all_hook_len) = Z_STRLEN_P(hook);
 
   callback = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  /* This instrumentation will fail if callback has already been wrapped
+   * with a special instrumentation callback in a different context.
+   * In this scenario, we will be unable to instrument hooks and modules for
+   * this particular call */
   nr_php_wrap_generic_callable(callback, nr_drupal94_invoke_all_with_callback TSRMLS_CC);
 
   NR_PHP_WRAPPER_CALL;

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -150,7 +150,8 @@ extern void nr_php_add_custom_tracer(const char* namestr,
 extern nruserfn_t* nr_php_add_custom_tracer_callable(
     zend_function* func TSRMLS_DC);
 extern nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
-                                                  size_t namestrlen TSRMLS_DC);
+                                                  size_t namestrlen,
+                                                  bool is_transient TSRMLS_DC);
 extern void nr_php_reset_user_instrumentation(void);
 extern void nr_php_remove_transient_user_instrumentation(void);
 extern void nr_php_add_user_instrumentation(TSRMLS_D);

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -89,6 +89,11 @@ extern nruserfn_t* nr_php_wrap_user_function(const char* name,
                                              size_t namelen,
                                              nrspecialfn_t callback TSRMLS_DC);
 
+extern nruserfn_t* nr_php_wrap_user_function_transience(const char* name,
+                                                       size_t namelen,
+                                                       nrspecialfn_t callback,
+                                                       bool is_transient TSRMLS_DC);
+
 extern nruserfn_t* nr_php_wrap_user_function_extra(const char* name,
                                                    size_t namelen,
                                                    nrspecialfn_t callback,

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -97,7 +97,7 @@ static void test_hashmap_wraprec() {
 
   /* instrument user function */
   user_func1_wraprec = nr_php_add_custom_tracer_named(
-      user_func1_name, nr_strlen(user_func1_name));
+      user_func1_name, nr_strlen(user_func1_name), false /*is_transient*/ );
   wraprec_found = nr_php_get_wraprec(user_func1_zf);
   tlib_pass_if_ptr_equal("lookup instrumented user function succeeds",
                          wraprec_found, user_func1_wraprec);

--- a/tests/integration/frameworks/drupal/mock_module_handler.php
+++ b/tests/integration/frameworks/drupal/mock_module_handler.php
@@ -22,6 +22,9 @@ namespace Drupal\Core\Extension {
             } else if ($hook_str == "hook_3") {
                 $module = "module_a";
                 $callback($module . "_" . $hook_str, $module);
+            } else if ($hook_str == "hook_4") {
+                $module = "module_b";
+                $callback($module . "_" . $hook_str, $module);
             }
         }
     }

--- a/tests/integration/frameworks/drupal/mock_page_cache_get.php
+++ b/tests/integration/frameworks/drupal/mock_page_cache_get.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Mock a drupal function that we instrument, that for the purposes
+ * of this test, is valid to pass into invokeAllWith(...). This is
+ * used to test attempts to overwrite special instrumentation */
+namespace Drupal\page_cache\StackMiddleware {
+    class PageCache {
+        public function get(callable $hook, string $module) {
+            $hook();
+        }
+    }
+}


### PR DESCRIPTION
Adds a transient argument to `nr_php_add_custom_tracer_named`, so that when adding a tracer from name we can decide the transience at creation. Previously, all tracers from name were non-transient. To facilitate this change, an additional `nr_php_wrap_*` function has been created: `nr_php_wrap_user_function_transience`. This wrapping function takes transience as a parameter and properly plumbs it into `nr_php_add_custom_tracer_named`. Due to this change and to reduce code duplication, `nr_php_wrap_user_function` simply calls `nr_php_wrap_user_function_transience` with is_transient=false. This effectively works as a default parameter and keeps the top-level API consistent for all previous instrumentation.

Additional tests have been added to ensure `nr_php_wrap_generic_callable` functionality when 1) wrapping an already wrapped function and 2) wrapping an already "specially" wrapped function.