### PR TITLE
fix: rework generic callable instrumentation to properly handle transience

### DIFF
--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -420,6 +420,10 @@ NR_PHP_WRAPPER(nr_drupal94_invoke_all_with) {
   NRPRG(drupal_module_invoke_all_hook_len) = Z_STRLEN_P(hook);
 
   callback = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  /* This instrumentation will fail if callback has already been wrapped
+   * with a special instrumentation callback in a different context.
+   * In this scenario, we will be unable to instrument hooks and modules for
+   * this particular call */
   nr_php_wrap_generic_callable(callback, nr_drupal94_invoke_all_with_callback TSRMLS_CC);
 
   NR_PHP_WRAPPER_CALL;

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -173,14 +173,16 @@ static void reset_wraprec(nruserfn_t* wraprec) {
  * `newrelic.transaction_tracer.custom` 3)
  * nr_php_user_function_add_declared_callback (prior to PHP 7.3) 4) from
  * function `nr_php_wrap_user_function` called from php_wrapper sets the wraprec
- * with framework specific instrumentation. Optionally sets `is_transient`.
+ * with framework specific instrumentation. Optionally specifies transience.
    5) from function `nr_php_wrap_callable` (in `php_wrapper.c`) used only by
- * Wordpress and predis for custom instrumentation that adds `is_transient`.
+ * Wordpress and predis for custom instrumentation that sets
+ * `NR_WRAPREC_IS_TRANSIENT`.
+ *
  * Transient wrappers get disposed of at the end of each request at RSHUTDOWN lifecycle.
  *
  * When overwriting the zend_execute_ex function, every effort was made to
  * reduce performance overhead because until the agent returns control, we are
- * the bottleneck of PHP execution on a customer's machine.  Overwriting the
+ * the bottleneck of PHP execution on a customer's machine. Overwriting the
  * reserved field was seen as a quick way to check if a function is instrumented
  * or not.
  *

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -433,7 +433,7 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
     wraprec->transience = NR_WRAPREC_IS_TRANSIENT;
   } else {
     /* non-transient wraprecs are added to both the hashmap and linked list.
-     * At request shutfown, the hashmap will free transients, but leave
+     * At request shutdown, the hashmap will free transients, but leave
      * non-transients to be freed by the linked list */
     nr_php_add_custom_tracer_common(wraprec);
   }

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -131,7 +131,7 @@ static void nr_php_user_wraprec_destroy(nruserfn_t** wraprec_ptr);
 static void reset_wraprec(nruserfn_t* wraprec) {
   nruserfn_t* p = wraprec;
   nr_php_wraprec_hashmap_key_release(&p->key);
-  if (p->is_transient) {
+  if (p->transience == NR_WRAPREC_IS_TRANSIENT) {
     nr_php_user_wraprec_destroy((nruserfn_t**)&wraprec);
   } else {
     p->is_wrapped = 0;
@@ -381,7 +381,7 @@ nruserfn_t* nr_php_add_custom_tracer_callable(zend_function* func TSRMLS_DC) {
   }
 
   wraprec = nr_php_user_wraprec_create();
-  wraprec->is_transient = 1;
+  wraprec->transience = NR_WRAPREC_IS_TRANSIENT;
 
   nrl_verbosedebug(NRL_INSTRUMENT, "adding custom for callable '%s'", name);
   nr_free(name);
@@ -396,7 +396,7 @@ nruserfn_t* nr_php_add_custom_tracer_callable(zend_function* func TSRMLS_DC) {
 
 nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
                                            size_t namestrlen,
-                                           bool is_transient TSRMLS_DC) {
+                                           nr_transience_t transience TSRMLS_DC) {
   nruserfn_t* wraprec;
   nruserfn_t* p;
 
@@ -429,8 +429,8 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
       (0 == wraprec->classname) ? "" : "::", NRP_PHP(wraprec->funcname));
 
   nr_php_wrap_user_function_internal(wraprec TSRMLS_CC);
-  if (is_transient) {
-    wraprec->is_transient = true;
+  if (transience == NR_WRAPREC_IS_TRANSIENT) {
+    wraprec->transience = NR_WRAPREC_IS_TRANSIENT;
   } else {
     /* non-transient wraprecs are added to both the hashmap and linked list.
      * At request shutfown, the hashmap will free transients, but leave
@@ -482,7 +482,7 @@ void nr_php_remove_transient_user_instrumentation(void) {
   nruserfn_t* prev = NULL;
 
   while (NULL != p) {
-    if (p->is_transient) {
+    if (p->transience == NR_WRAPREC_IS_TRANSIENT) {
       nruserfn_t* trans = p;
 
       if (prev) {
@@ -519,7 +519,7 @@ void nr_php_add_transaction_naming_function(const char* namestr,
                                             int namestrlen TSRMLS_DC) {
   nruserfn_t* wraprec
       = nr_php_add_custom_tracer_named(namestr, namestrlen,
-                                       false /*is_transient*/ TSRMLS_CC);
+                                       NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
 
   if (NULL != wraprec) {
     wraprec->is_names_wt_simple = 1;
@@ -529,7 +529,7 @@ void nr_php_add_transaction_naming_function(const char* namestr,
 void nr_php_add_custom_tracer(const char* namestr, int namestrlen TSRMLS_DC) {
   nruserfn_t* wraprec
       = nr_php_add_custom_tracer_named(namestr, namestrlen,
-                                       false /*is_transient*/ TSRMLS_CC);
+                                       NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
 
   if (NULL != wraprec) {
     wraprec->create_metric = 1;
@@ -588,7 +588,7 @@ void nr_php_user_function_add_declared_callback(const char* namestr,
                                                     TSRMLS_DC) {
   nruserfn_t* wraprec
       = nr_php_add_custom_tracer_named(namestr, namestrlen,
-                                       false /*is_transient*/ TSRMLS_CC);
+                                       NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
 
   if (0 != wraprec) {
     wraprec->declared_callback = callback;

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -434,7 +434,7 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
   } else {
     /* non-transient wraprecs are added to both the hashmap and linked list.
      * At request shutdown, the hashmap will free transients, but leave
-     * non-transients to be freed by the linked list */
+     * non-transients to be freed when the linked list is disposed of which is at module shutdown */
     nr_php_add_custom_tracer_common(wraprec);
   }
 

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -176,7 +176,7 @@ static void reset_wraprec(nruserfn_t* wraprec) {
  * with framework specific instrumentation. Optionally sets `is_transient`.
    5) from function `nr_php_wrap_callable` (in `php_wrapper.c`) used only by
  * Wordpress and predis for custom instrumentation that adds `is_transient`.
- * Transient wrappers get cleaned up with each shutdown.
+ * Transient wrappers get disposed of at the end of each request at RSHUTDOWN lifecycle.
  *
  * When overwriting the zend_execute_ex function, every effort was made to
  * reduce performance overhead because until the agent returns control, we are

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -150,7 +150,8 @@ extern void nr_php_add_custom_tracer(const char* namestr,
 extern nruserfn_t* nr_php_add_custom_tracer_callable(
     zend_function* func TSRMLS_DC);
 extern nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
-                                                  size_t namestrlen TSRMLS_DC);
+                                                  size_t namestrlen,
+                                                  bool is_transient TSRMLS_DC);
 extern void nr_php_reset_user_instrumentation(void);
 extern void nr_php_remove_transient_user_instrumentation(void);
 extern void nr_php_add_user_instrumentation(TSRMLS_D);

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -81,7 +81,7 @@ typedef struct _nruserfn_t {
                                  the first such function does the naming */
   nr_transience_t transience; /* Wraprecs that are transient are destroyed
                                  after each request. Wraprecs that are
-                                 non-transient are kept indefinitely.
+                                 non-transient are kept until module shutdown.
                                  Currently, while all wraprecs are stored
                                  in a hashmap, non-transients are also
                                  stored in a linked list to repopulate

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -89,6 +89,11 @@ extern nruserfn_t* nr_php_wrap_user_function(const char* name,
                                              size_t namelen,
                                              nrspecialfn_t callback TSRMLS_DC);
 
+extern nruserfn_t* nr_php_wrap_user_function_transience(const char* name,
+                                                       size_t namelen,
+                                                       nrspecialfn_t callback,
+                                                       bool is_transient TSRMLS_DC);
+
 extern nruserfn_t* nr_php_wrap_user_function_extra(const char* name,
                                                    size_t namelen,
                                                    nrspecialfn_t callback,

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -89,10 +89,10 @@ extern nruserfn_t* nr_php_wrap_user_function(const char* name,
                                              size_t namelen,
                                              nrspecialfn_t callback TSRMLS_DC);
 
-extern nruserfn_t* nr_php_wrap_user_function_transience(const char* name,
-                                                       size_t namelen,
-                                                       nrspecialfn_t callback,
-                                                       bool is_transient TSRMLS_DC);
+extern nruserfn_t* nr_php_wrap_user_function_with_transience(const char* name,
+                                                             size_t namelen,
+                                                             nrspecialfn_t callback,
+                                                             nr_transience_t TSRMLS_DC);
 
 extern nruserfn_t* nr_php_wrap_user_function_extra(const char* name,
                                                    size_t namelen,

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -97,7 +97,7 @@ static void test_hashmap_wraprec() {
 
   /* instrument user function */
   user_func1_wraprec = nr_php_add_custom_tracer_named(
-      user_func1_name, nr_strlen(user_func1_name));
+      user_func1_name, nr_strlen(user_func1_name), false /*is_transient*/ );
   wraprec_found = nr_php_get_wraprec(user_func1_zf);
   tlib_pass_if_ptr_equal("lookup instrumented user function succeeds",
                          wraprec_found, user_func1_wraprec);

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -97,7 +97,7 @@ static void test_hashmap_wraprec() {
 
   /* instrument user function */
   user_func1_wraprec = nr_php_add_custom_tracer_named(
-      user_func1_name, nr_strlen(user_func1_name), false /*is_transient*/ );
+      user_func1_name, nr_strlen(user_func1_name), NR_WRAPREC_NOT_TRANSIENT );
   wraprec_found = nr_php_get_wraprec(user_func1_zf);
   tlib_pass_if_ptr_equal("lookup instrumented user function succeeds",
                          wraprec_found, user_func1_wraprec);

--- a/tests/integration/frameworks/drupal/mock_module_handler.php
+++ b/tests/integration/frameworks/drupal/mock_module_handler.php
@@ -22,6 +22,9 @@ namespace Drupal\Core\Extension {
             } else if ($hook_str == "hook_3") {
                 $module = "module_a";
                 $callback($module . "_" . $hook_str, $module);
+            } else if ($hook_str == "hook_4") {
+                $module = "module_b";
+                $callback($module . "_" . $hook_str, $module);
             }
         }
     }

--- a/tests/integration/frameworks/drupal/mock_page_cache_get.php
+++ b/tests/integration/frameworks/drupal/mock_page_cache_get.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Mock a drupal function that we instrument, that for the purposes
+ * of this test, is valid to pass into invokeAllWith(...). This is
+ * used to test attempts to overwrite special instrumentation */
+namespace Drupal\page_cache\StackMiddleware {
+    class PageCache {
+        public function get(callable $hook, string $module) {
+            $hook();
+        }
+    }
+}


### PR DESCRIPTION
Adds a transient argument to `nr_php_add_custom_tracer_named`, so that when adding a tracer from name we can decide the transience at creation. Previously, all tracers from name were non-transient. To facilitate this change, an additional `nr_php_wrap_*` function has been created: `nr_php_wrap_user_function_with_transience`. This wrapping function takes transience as a parameter and properly plumbs it into `nr_php_add_custom_tracer_named`. Due to this change and to reduce code duplication, `nr_php_wrap_user_function` simply calls `nr_php_wrap_user_function_with_transience` with `transience` argument value set to `NR_WRAPREC_NOT_TRANSIENT`. This effectively works as a default parameter and keeps the top-level API consistent for all previous instrumentation.

Additional tests have been added to ensure `nr_php_wrap_generic_callable` functionality when 1) wrapping an already wrapped function and 2) wrapping an already "specially" wrapped function.