### PR TITLE
fix(agent): Update drupal msg logging level

### DIFF
--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -43,7 +43,7 @@ static void nr_drupal8_add_method_callback(const zend_class_entry* ce,
 
   function = nr_php_find_class_method(ce, method);
   if (NULL == function) {
-    nrl_info(NRL_FRAMEWORK,
+    nrl_verbosedebug(NRL_FRAMEWORK,
              "Drupal 8: cannot get zend_function entry for %.*s::%.*s",
              NRSAFELEN(nr_php_class_entry_name_length(ce)),
              nr_php_class_entry_name(ce), NRSAFELEN(method_len), method);

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -44,7 +44,7 @@ static void nr_drupal8_add_method_callback(const zend_class_entry* ce,
   function = nr_php_find_class_method(ce, method);
   if (NULL == function) {
     nrl_verbosedebug(NRL_FRAMEWORK,
-             "Drupal 8: cannot get zend_function entry for %.*s::%.*s",
+             "Drupal 8+: cannot get zend_function entry for %.*s::%.*s",
              NRSAFELEN(nr_php_class_entry_name_length(ce)),
              nr_php_class_entry_name(ce), NRSAFELEN(method_len), method);
     return;


### PR DESCRIPTION
Since this is called with every request, the message, when triggered, can fill up the logs. It's more appropriate for it to be a `verbosedebug` level similar to the majority of other drupal messages.  Generally, msgs that have a probability of logging with every request should not be info level.