### PR TITLE
ci: fix on-demand run-integration-tests workflow

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -107,10 +107,9 @@ jobs:
         platform: [gnu, musl]
         arch: [amd64, arm64]
         php: ['8.0', '8.1', '8.2']
-        experimental: [false]
         include:
-          - platform: [gnu, musl]
-          - php: ['8.0', '8.1', '8.2']
+          - arch: amd64
+            experimental: false
           - arch: arm64
             experimental: true
     steps:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -109,6 +109,8 @@ jobs:
         php: ['8.0', '8.1', '8.2']
         experimental: [false]
         include:
+          - platform: [gnu, musl]
+          - php: ['8.0', '8.1', '8.2']
           - arch: arm64
             experimental: true
     steps:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -112,6 +112,7 @@ jobs:
             experimental: false
           - arch: arm64
             experimental: true
+    name: test ${{ matrix.php }} ${{ matrix.platform }} ${{ matrix.arch }} (${{ matrix.experimental }})
     steps:
       - name: Checkout integration tests
         uses: actions/checkout@v3


### PR DESCRIPTION
Fix `experimental` flag in strategy matrix of on-demand run-integration-tests workflow. It is expected that running tests on aarch64 architecture will cause test failures because tests run slower on emulated platform and more spans are generated and therefore this arch is marked as `experimental` and failed tests on that arch will not mark the whole workflow as failed.