### PR TITLE
chore: make dev-shell compatible with Debian 12

### DIFF
--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -13,18 +13,6 @@ FROM php:${PHP_VER:-8.2}
 
 RUN docker-php-source extract
 
-#
-# Uncomment deb-src lines for all enabled repos. First part of single-quoted
-# string (up the the !) is the pattern of the lines that will be ignored.
-# Needed for apt-get build-dep call later in script
-#
-
-# PHP 8.0
-#RUN sed -Ei '/.*partner/! s/^# (deb-src .*)/\1/g' /etc/apt/sources.list
-
-# PHP 8.1+
-RUN sed -Ei '/.*partner/! s/^# (deb-src .*)/\1/g' /etc/apt/sources.list.d/debian.sources
-
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y build-essential

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -18,7 +18,12 @@ RUN docker-php-source extract
 # string (up the the !) is the pattern of the lines that will be ignored.
 # Needed for apt-get build-dep call later in script
 #
-RUN sed -Ei '/.*partner/! s/^# (deb-src .*)/\1/g' /etc/apt/sources.list
+
+# PHP 8.0
+#RUN sed -Ei '/.*partner/! s/^# (deb-src .*)/\1/g' /etc/apt/sources.list
+
+# PHP 8.1+
+RUN sed -Ei '/.*partner/! s/^# (deb-src .*)/\1/g' /etc/apt/sources.list.d/debian.sources
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
@@ -28,7 +33,7 @@ RUN apt-get install -y build-essential
 # PHP dependencies
 #
 RUN apt-get update \
- && apt-get -y install gcc git netcat \
+ && apt-get -y install gcc git netcat-openbsd \
  libpcre3 libpcre3-dev golang psmisc automake libtool \
  insserv procps vim ${PHP_USER_SPECIFIED_PACKAGES} \
  zlib1g-dev libmcrypt-dev
@@ -64,8 +69,7 @@ RUN apt-get update && apt-get install -y \
   make \
   perl \
   strace \
-  python-dev \
-  python-setuptools \
+  python-dev-is-python3 \
   python3-yaml \
   sqlite3 \
   libsqlite3-dev \


### PR DESCRIPTION
Fix the Dockerfile used by `make dev-shell` in development.
Upstream PHP docker images have migrated to Debian 12 bookworm, which modifies the sources location as well as dependency names.

This fix only resolves running PHP versions 8.0+.