### PR TITLE
ci: add code-coverage-baseline workflow

### DIFF
--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -87,23 +87,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Determine if valgrind can be used
-        id: get-check-variant
-        run: |
-          if [[ ${{ matrix.platform }} = 'gnu' && ${{matrix.arch}} = 'amd64' ]]; then
-            echo "AXIOM_CHECK_VARIANT=valgrind" >> $GITHUB_OUTPUT
-          else
-            echo "AXIOM_CHECK_VARIANT=check" >> $GITHUB_OUTPUT
-          fi
-          if [[ ${{matrix.arch}} = 'arm64' ]]; then
-            echo "AGENT_CHECK_VARIANT=check" >> $GITHUB_OUTPUT
-          elif [[ ${{ matrix.platform }} = 'gnu' ]]; then
-            echo "AGENT_CHECK_VARIANT=valgrind" >> $GITHUB_OUTPUT
-          elif [[ ${{matrix.php}} = '5.5' || ${{matrix.php}} = '5.6' || ${{matrix.php}} = '7.0' || ${{matrix.php}} = '7.1' ]]; then
-            echo "AGENT_CHECK_VARIANT=check" >> $GITHUB_OUTPUT
-          else 
-            echo "AGENT_CHECK_VARIANT=valgrind" >> $GITHUB_OUTPUT
-          fi
       - name: Build axiom
         run: >
           docker run --rm --platform linux/${{matrix.arch}}
@@ -127,7 +110,7 @@ jobs:
           docker run --rm --platform linux/${{matrix.arch}}
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           -e ENABLE_COVERAGE=${{matrix.codecov}}
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom-${{ steps.get-check-variant.outputs.AXIOM_CHECK_VARIANT }}
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom-check
       - name: Build agent unit tests
         run: >
           docker run --rm --platform linux/${{matrix.arch}}
@@ -139,7 +122,7 @@ jobs:
           docker run --rm --platform linux/${{matrix.arch}}
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           -e ENABLE_COVERAGE=${{matrix.codecov}}
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-${{ steps.get-check-variant.outputs.AGENT_CHECK_VARIANT }}
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-check
       - name: Save newrelic.so for integration tests
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -1,0 +1,359 @@
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: code-coverage-baseline
+run-name: Generating code coverage baseline for ${{ inputs.origin }}:${{ inputs.ref }} with code coverage (by @${{ github.actor }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      origin:
+        description: 'newrelic-php-agent origin'
+        required: true
+        default: 'newrelic' 
+        type: string
+      ref:
+        description: 'Branch or tag'
+        required: true
+        default: 'dev' 
+        type: string
+
+jobs:
+  daemon-unit-tests:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: newrelic/nr-php-agent-builder
+      IMAGE_TAG: make-go
+      IMAGE_VERSION: ${{vars.MAKE_GO_VERSION}}
+    strategy:
+      matrix:
+        platform: [gnu, musl]
+        arch: [amd64, arm64]
+        exclude:
+          - platform: gnu
+            arch: arm64
+          - platform: musl
+            arch: arm64
+    steps:
+      - name: Checkout newrelic-php-agent code
+        uses: actions/checkout@v3
+        with:
+          path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
+      - name: Enable arm64 emulation
+        if: ${{ matrix.arch == 'arm64' }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
+          platforms: arm64
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build daemon
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}}
+          -e APP_supportability=${{secrets.APP_SUPPORTABILITY}}
+          $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon
+      - name: Run daemon tests
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon_test
+      - name: Save integration_runner for integration tests
+        uses: actions/upload-artifact@v3
+        with:
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
+          path: php-agent/bin/integration_runner
+  agent-unit-test:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: newrelic/nr-php-agent-builder
+      IMAGE_TAG: make-php
+      IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
+    strategy:
+      matrix:
+        platform: [gnu, musl]
+        arch: [amd64, arm64]
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        exclude:
+          - arch: arm64
+            php: '5.5'
+          - arch: arm64
+            php: '5.6'
+          - arch: arm64
+            php: '7.0'
+          - arch: arm64
+            php: '7.1'
+          - arch: arm64
+            php: '7.2'
+          - arch: arm64
+            php: '7.3'
+          - arch: arm64
+            php: '7.4'
+          - arch: arm64
+            php: '8.0'
+          - arch: arm64
+            php: '8.1'
+          - arch: arm64
+            php: '8.2'
+        include:
+          - codecov: 0
+          - platform: gnu
+            arch: amd64
+            codecov: 1
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
+      - name: Enable arm64 emulation
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt --install arm64
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Determine if valgrind can be used
+        id: get-check-variant
+        run: |
+          if [[ ${{ matrix.platform }} = 'gnu' && ${{matrix.arch}} = 'amd64' ]]; then
+            echo "AXIOM_CHECK_VARIANT=valgrind" >> $GITHUB_OUTPUT
+          else
+            echo "AXIOM_CHECK_VARIANT=check" >> $GITHUB_OUTPUT
+          fi
+          if [[ ${{matrix.arch}} = 'arm64' ]]; then
+            echo "AGENT_CHECK_VARIANT=check" >> $GITHUB_OUTPUT
+          elif [[ ${{ matrix.platform }} = 'gnu' ]]; then
+            echo "AGENT_CHECK_VARIANT=valgrind" >> $GITHUB_OUTPUT
+          elif [[ ${{matrix.php}} = '5.5' || ${{matrix.php}} = '5.6' || ${{matrix.php}} = '7.0' || ${{matrix.php}} = '7.1' ]]; then
+            echo "AGENT_CHECK_VARIANT=check" >> $GITHUB_OUTPUT
+          else 
+            echo "AGENT_CHECK_VARIANT=valgrind" >> $GITHUB_OUTPUT
+          fi
+      - name: Build axiom
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          -e ENABLE_COVERAGE=${{matrix.codecov}}
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom 
+      - name: Build agent
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          -e ENABLE_COVERAGE=${{matrix.codecov}}
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent
+      - name: Build axiom unit tests
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          -e ENABLE_COVERAGE=${{matrix.codecov}}
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom-tests
+      - name: Run axiom unit tests
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          -e ENABLE_COVERAGE=${{matrix.codecov}}
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom-${{ steps.get-check-variant.outputs.AXIOM_CHECK_VARIANT }}
+      - name: Build agent unit tests
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          -e ENABLE_COVERAGE=${{matrix.codecov}}
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-tests
+      - name: Run agent unit tests
+        run: >
+          docker run --rm --platform linux/${{matrix.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          -e ENABLE_COVERAGE=${{matrix.codecov}}
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-${{ steps.get-check-variant.outputs.AGENT_CHECK_VARIANT }}
+      - name: Save newrelic.so for integration tests
+        uses: actions/upload-artifact@v3
+        with:
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          path: php-agent/agent/modules/newrelic.so
+      - name: Save axiom gcov data files (*.gcno, *.gcna)
+        if: ${{ matrix.codecov == 1 }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          path: php-agent/axiom/*.gc*
+      - name: Save agent gcov data files (*.gcno, *.gcna)
+        if: ${{ matrix.codecov == 1 }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          path: php-agent/agent/.libs/*.gc*
+  integration-tests:
+    needs: [daemon-unit-tests, agent-unit-test]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [gnu, musl]
+        arch: [amd64, arm64]
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        exclude:
+          - arch: arm64
+            php: '5.5'
+          - arch: arm64
+            php: '5.6'
+          - arch: arm64
+            php: '7.0'
+          - arch: arm64
+            php: '7.1'
+          - arch: arm64
+            php: '7.2'
+          - arch: arm64
+            php: '7.3'
+          - arch: arm64
+            php: '7.4'
+          - arch: arm64
+            php: '8.0'
+          - arch: arm64
+            php: '8.1'
+          - arch: arm64
+            php: '8.2'
+        include:
+          - codecov: 0
+          - platform: gnu
+            arch: amd64
+            codecov: 1
+    steps:
+      - name: Checkout integration tests
+        uses: actions/checkout@v3
+        with:
+          path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
+      - name: Get integration_runner
+        uses: actions/download-artifact@v3
+        with:
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
+          path: php-agent/bin
+      - name: Get newrelic.so
+        uses: actions/download-artifact@v3
+        with:
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          path: php-agent/agent/modules
+      - name: Get axiom gcov data files
+        if: ${{ matrix.codecov == 1 }}
+        uses: actions/download-artifact@v3
+        with:
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          path: php-agent/axiom
+      - name: Get agent gcov data files
+        if: ${{ matrix.codecov == 1 }}
+        uses: actions/download-artifact@v3
+        with:
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          path: php-agent/agent/.libs
+      - name: Prep artifacts for use
+        run: |
+          chmod 755 php-agent/bin/integration_runner
+          chmod 755 php-agent/agent/modules/newrelic.so
+      - name: Enable arm64 emulation
+        if: ${{ matrix.arch == 'arm64' }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
+          platforms: arm64
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Start services
+        env:
+          PHP: ${{matrix.php}}
+          LIBC: ${{matrix.platform}}
+          PLATFORM: linux/${{matrix.arch}}
+          AGENT_CODE: ${{github.workspace}}/php-agent
+          IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
+        working-directory: ./php-agent
+        run: |
+          make test-services-start
+      - name: Test events limits
+        working-directory: ./php-agent
+        shell: bash
+        run: |
+          docker exec \
+          -e PHPS=${{matrix.php}} \
+          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
+          nr-php make integration-events-limits
+      - name: Test LASP
+        working-directory: ./php-agent
+        shell: bash
+        run: |
+          docker exec \
+          -e PHPS=${{matrix.php}} \
+          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
+          -e LICENSE_lasp_suite_most_secure=${{secrets.LICENSE_LASP_SUITE_MOST_SECURE}} \
+          -e LICENSE_lasp_suite_least_secure=${{secrets.LICENSE_LASP_SUITE_LEAST_SECURE}} \
+          -e LICENSE_lasp_suite_random_1=${{secrets.LICENSE_LASP_SUITE_RANDOM_1}} \
+          -e LICENSE_lasp_suite_random_2=${{secrets.LICENSE_LASP_SUITE_RANDOM_2}} \
+          -e LICENSE_lasp_suite_random_3=${{secrets.LICENSE_LASP_SUITE_RANDOM_3}} \
+          nr-php make lasp-test-all
+      - name: Run integration tests
+        if: ${{ matrix.arch == 'amd64' }}
+        working-directory: ./php-agent
+        shell: bash
+        run: |
+          docker exec \
+          -e PHPS=${{matrix.php}} \
+          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
+          -e APP_supportability=${{secrets.APP_SUPPORTABILITY}} \
+          -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}} \
+          -e ACCOUNT_supportability_trusted=${{secrets.ACCOUNT_SUPPORTABILITY_TRUSTED}} \
+          -e SYNTHETICS_HEADER_supportability=${{secrets.SYNTHETICS_HEADER_SUPPORTABILITY}} \
+          nr-php make integration-tests
+      - name: Debug gcov 1
+        if: ${{ matrix.codecov == 1 }}
+        working-directory: ./php-agent
+        shell: bash
+        run: |
+          find . -name '*.gcda'
+      - name: Generate gcov reports
+        if: ${{ matrix.codecov == 1 }}
+        working-directory: ./php-agent
+        shell: bash
+        run: |
+          docker exec \
+          -e PHPS=${{matrix.php}} \
+          nr-php make gcov
+      - name: Debug gcov 2
+        if: ${{ matrix.codecov == 1 }}
+        working-directory: ./php-agent
+        shell: bash
+        run: |
+          find . -name '*.gcov'
+      - name: Determine commit hash
+        id: get-commit-hash
+        working-directory: ./php-agent
+        shell: bash
+        run: |
+          echo "COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Upload coverage reports to Codecov
+        if: ${{ matrix.codecov == 1 }}
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          working-directory: ./php-agent
+          flags: agent-for-php-${{matrix.php}}
+          override_branch: ${{inputs.ref}}
+          override_commit: ${{ steps.get-commit-hash.outputs.COMMIT_HASH }}
+      - name: Stop services
+        env:
+          PHP: ${{matrix.php}}
+          LIBC: ${{matrix.platform}}
+          AGENT_CODE: ${{github.workspace}}/php-agent
+        working-directory: ./php-agent
+        run: |
+          make test-services-stop

--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -251,12 +251,6 @@ jobs:
           -e ACCOUNT_supportability_trusted=${{secrets.ACCOUNT_SUPPORTABILITY_TRUSTED}} \
           -e SYNTHETICS_HEADER_supportability=${{secrets.SYNTHETICS_HEADER_SUPPORTABILITY}} \
           nr-php make integration-tests
-      - name: Debug gcov 1
-        if: ${{ matrix.codecov == 1 }}
-        working-directory: ./php-agent
-        shell: bash
-        run: |
-          find . -name '*.gcda'
       - name: Generate gcov reports
         if: ${{ matrix.codecov == 1 }}
         working-directory: ./php-agent
@@ -265,12 +259,6 @@ jobs:
           docker exec \
           -e PHPS=${{matrix.php}} \
           nr-php make gcov
-      - name: Debug gcov 2
-        if: ${{ matrix.codecov == 1 }}
-        working-directory: ./php-agent
-        shell: bash
-        run: |
-          find . -name '*.gcov'
       - name: Determine commit hash
         id: get-commit-hash
         working-directory: ./php-agent

--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -29,12 +29,7 @@ jobs:
     strategy:
       matrix:
         platform: [gnu, musl]
-        arch: [amd64, arm64]
-        exclude:
-          - platform: gnu
-            arch: arm64
-          - platform: musl
-            arch: arm64
+        arch: [amd64]
     steps:
       - name: Checkout newrelic-php-agent code
         uses: actions/checkout@v3
@@ -42,12 +37,6 @@ jobs:
           path: php-agent
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
-      - name: Enable arm64 emulation
-        if: ${{ matrix.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
-        with:
-          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
-          platforms: arm64
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -79,29 +68,8 @@ jobs:
     strategy:
       matrix:
         platform: [gnu, musl]
-        arch: [amd64, arm64]
+        arch: [amd64]
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-        exclude:
-          - arch: arm64
-            php: '5.5'
-          - arch: arm64
-            php: '5.6'
-          - arch: arm64
-            php: '7.0'
-          - arch: arm64
-            php: '7.1'
-          - arch: arm64
-            php: '7.2'
-          - arch: arm64
-            php: '7.3'
-          - arch: arm64
-            php: '7.4'
-          - arch: arm64
-            php: '8.0'
-          - arch: arm64
-            php: '8.1'
-          - arch: arm64
-            php: '8.2'
         include:
           - codecov: 0
           - platform: gnu
@@ -114,9 +82,6 @@ jobs:
           path: php-agent
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
-      - name: Enable arm64 emulation
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt --install arm64
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -198,29 +163,8 @@ jobs:
     strategy:
       matrix:
         platform: [gnu, musl]
-        arch: [amd64, arm64]
+        arch: [amd64]
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-        exclude:
-          - arch: arm64
-            php: '5.5'
-          - arch: arm64
-            php: '5.6'
-          - arch: arm64
-            php: '7.0'
-          - arch: arm64
-            php: '7.1'
-          - arch: arm64
-            php: '7.2'
-          - arch: arm64
-            php: '7.3'
-          - arch: arm64
-            php: '7.4'
-          - arch: arm64
-            php: '8.0'
-          - arch: arm64
-            php: '8.1'
-          - arch: arm64
-            php: '8.2'
         include:
           - codecov: 0
           - platform: gnu
@@ -259,12 +203,6 @@ jobs:
         run: |
           chmod 755 php-agent/bin/integration_runner
           chmod 755 php-agent/agent/modules/newrelic.so
-      - name: Enable arm64 emulation
-        if: ${{ matrix.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
-        with:
-          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
-          platforms: arm64
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -302,7 +240,6 @@ jobs:
           -e LICENSE_lasp_suite_random_3=${{secrets.LICENSE_LASP_SUITE_RANDOM_3}} \
           nr-php make lasp-test-all
       - name: Run integration tests
-        if: ${{ matrix.arch == 'amd64' }}
         working-directory: ./php-agent
         shell: bash
         run: |


### PR DESCRIPTION
Add a workflow to generate and upload code coverage data for selected
origin and ref to establish code coverage baseline. This workflow is
useful to establish code coverage baseline for long lasting branches
that are target of pull requests.