### PR TITLE
ci: fix on-demand run-integration-tests workflow

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
       - name: Enable arm64 emulation
         if: ${{ matrix.arch == 'arm64' }}
         uses: docker/setup-qemu-action@v2
@@ -74,6 +76,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
       - name: Enable arm64 emulation
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64
@@ -116,6 +120,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
       - name: Get integration_runner
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Checkout the code from `origin` and `ref` inputs :facepalm:!