### PR TITLE
tests: 'enhance' logging libraries mocks

### DIFF
--- a/tests/integration/logging/analog/vendor/analog/analog/lib/Analog/Analog.php
+++ b/tests/integration/logging/analog/vendor/analog/analog/lib/Analog/Analog.php
@@ -1,3 +1,6 @@
 <?php
 
 /* This is a mock of Analog library as it would have been installed by a composer */
+
+/* Empty files don't get executed by PHP 8.2 therefore the mock needs to do something */
+echo "";

--- a/tests/integration/logging/cakephp-log/vendor/cakephp/log/Log.php
+++ b/tests/integration/logging/cakephp-log/vendor/cakephp/log/Log.php
@@ -1,3 +1,6 @@
 <?php
 
 /* This is a mock of cakephp-log library as it would have been installed by a composer */
+
+/* Empty files don't get executed by PHP 8.2 therefore the mock needs to do something */
+echo "";

--- a/tests/integration/logging/consolidation-log/vendor/consolidation/log/src/Logger.php
+++ b/tests/integration/logging/consolidation-log/vendor/consolidation/log/src/Logger.php
@@ -1,3 +1,6 @@
 <?php
 
 /* This is a mock of consolidation-log library as it would have been installed by a composer */
+
+/* Empty files don't get executed by PHP 8.2 therefore the mock needs to do something */
+echo "";

--- a/tests/integration/logging/laminas-log/vendor/laminas/laminas-log/src/Logger.php
+++ b/tests/integration/logging/laminas-log/vendor/laminas/laminas-log/src/Logger.php
@@ -1,3 +1,6 @@
 <?php
 
 /* This is a mock of laminas-log library as it would have been installed by a composer */
+
+/* Empty files don't get executed by PHP 8.2 therefore the mock needs to do something */
+echo "";


### PR DESCRIPTION
Empty files don't get executed by PHP 8.2 therefore mocks needs to do something.