### PR TITLE
fix(agent): set oapi callbacks the right way

### DIFF
--- a/agent/php_wrapper.c
+++ b/agent/php_wrapper.c
@@ -25,8 +25,8 @@ nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
 
   /* If any of the callbacks we are attempting to set are already set to
    * something else, we want to exit without setting new callbacks */
-  if (is_instrumentation_set(wraprec->special_instrumentation,
-                             after_callback)) {
+  if (is_instrumentation_set_and_not_equal(wraprec->special_instrumentation,
+                                           after_callback)) {
     nrl_verbosedebug(
         NRL_INSTRUMENT,
         "%s: attempting to set special_instrumentation for %.*s, but "
@@ -35,8 +35,8 @@ nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
     return wraprec;
   }
 
-  if (is_instrumentation_set(wraprec->special_instrumentation_before,
-                             before_callback)) {
+  if (is_instrumentation_set_and_not_equal(wraprec->special_instrumentation_before,
+                                           before_callback)) {
     nrl_verbosedebug(NRL_INSTRUMENT,
                      "%s: attempting to set special_instrumentation_before "
                      "for %.*s, but "
@@ -45,8 +45,8 @@ nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
     return wraprec;
   }
 
-  if (is_instrumentation_set(wraprec->special_instrumentation_clean,
-                             clean_callback)) {
+  if (is_instrumentation_set_and_not_equal(wraprec->special_instrumentation_clean,
+                                           clean_callback)) {
     nrl_verbosedebug(NRL_INSTRUMENT,
                      "%s: attempting to set special_instrumentation_clean "
                      "for %.*s, but "

--- a/agent/php_wrapper.c
+++ b/agent/php_wrapper.c
@@ -25,51 +25,39 @@ nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
 
   /* If any of the callbacks we are attempting to set are already set to
    * something else, we want to exit without setting new callbacks */
-  if (after_callback) {
-    if (is_instrumentation_set(wraprec->special_instrumentation,
-                               after_callback)) {
-      nrl_verbosedebug(
-          NRL_INSTRUMENT,
-          "%s: attempting to set special_instrumentation for %.*s, but "
-          "it is already set",
-          __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
-      return wraprec;
-    }
+  if (is_instrumentation_set(wraprec->special_instrumentation,
+                             after_callback)) {
+    nrl_verbosedebug(
+        NRL_INSTRUMENT,
+        "%s: attempting to set special_instrumentation for %.*s, but "
+        "it is already set",
+        __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
+    return wraprec;
   }
 
-  if (before_callback) {
-    if (is_instrumentation_set(wraprec->special_instrumentation_before,
-                               before_callback)) {
-      nrl_verbosedebug(NRL_INSTRUMENT,
-                       "%s: attempting to set special_instrumentation_before "
-                       "for %.*s, but "
-                       "it is already set",
-                       __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
-      return wraprec;
-    }
+  if (is_instrumentation_set(wraprec->special_instrumentation_before,
+                             before_callback)) {
+    nrl_verbosedebug(NRL_INSTRUMENT,
+                     "%s: attempting to set special_instrumentation_before "
+                     "for %.*s, but "
+                     "it is already set",
+                     __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
+    return wraprec;
   }
 
-  if (clean_callback) {
-    if (is_instrumentation_set(wraprec->special_instrumentation_clean,
-                               clean_callback)) {
-      nrl_verbosedebug(NRL_INSTRUMENT,
-                       "%s: attempting to set special_instrumentation_clean "
-                       "for %.*s, but "
-                       "it is already set",
-                       __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
-      return wraprec;
-    }
+  if (is_instrumentation_set(wraprec->special_instrumentation_clean,
+                             clean_callback)) {
+    nrl_verbosedebug(NRL_INSTRUMENT,
+                     "%s: attempting to set special_instrumentation_clean "
+                     "for %.*s, but "
+                     "it is already set",
+                     __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
+    return wraprec;
   }
 
-  if (after_callback) {
-    wraprec->special_instrumentation = after_callback;
-  }
-  if (before_callback) {
-    wraprec->special_instrumentation_before = before_callback;
-  }
-  if (clean_callback) {
-    wraprec->special_instrumentation_clean = clean_callback;
-  }
+  wraprec->special_instrumentation = after_callback;
+  wraprec->special_instrumentation_before = before_callback;
+  wraprec->special_instrumentation_clean = clean_callback;
 
   return wraprec;
 }

--- a/agent/php_wrapper.c
+++ b/agent/php_wrapper.c
@@ -23,6 +23,8 @@ nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
     return wraprec;
   }
 
+  /* If any of the callbacks we are attempting to set are already set to
+   * something else, we want to exit without setting new callbacks */
   if (after_callback) {
     if (is_instrumentation_set(wraprec->special_instrumentation,
                                after_callback)) {
@@ -31,8 +33,7 @@ nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
           "%s: attempting to set special_instrumentation for %.*s, but "
           "it is already set",
           __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
-    } else {
-      wraprec->special_instrumentation = after_callback;
+      return wraprec;
     }
   }
 
@@ -44,8 +45,7 @@ nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
                        "for %.*s, but "
                        "it is already set",
                        __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
-    } else {
-      wraprec->special_instrumentation_before = before_callback;
+      return wraprec;
     }
   }
 
@@ -57,9 +57,18 @@ nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
                        "for %.*s, but "
                        "it is already set",
                        __func__, NRSAFELEN(namelen), NRBLANKSTR(name));
-    } else {
-      wraprec->special_instrumentation_clean = clean_callback;
+      return wraprec;
     }
+  }
+
+  if (after_callback) {
+    wraprec->special_instrumentation = after_callback;
+  }
+  if (before_callback) {
+    wraprec->special_instrumentation_before = before_callback;
+  }
+  if (clean_callback) {
+    wraprec->special_instrumentation_clean = clean_callback;
   }
 
   return wraprec;

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -327,8 +327,9 @@ extern zval** nr_php_get_return_value_ptr(TSRMLS_D);
     was_executed = 1;                                                \
   }
 
-static inline bool is_instrumentation_set(nrspecialfn_t instrumentation,
-                                          nrspecialfn_t callback) {
+static inline bool is_instrumentation_set_and_not_equal(
+    nrspecialfn_t instrumentation,
+    nrspecialfn_t callback) {
   if ((NULL != instrumentation) && (callback != instrumentation)) {
     return true;
   }


### PR DESCRIPTION
When wrapping a user function do not add special instrumentation is ANY special instrumentation (before/after/cleanup) has already been set. This approach matches pre-oapi instrumentation.