### PR TITLE
feat(newrelic-install): include link to docs in install error message

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1088,7 +1088,9 @@ for this copy of PHP. We apologize for the inconvenience.
     *)
       error "unsupported version '${pi_ver}' of PHP found at:
     ${pdir}
-Ignoring this particular instance of PHP.
+Ignoring this particular instance of PHP. Please visit:
+  https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/
+to view compatibilty requirements for the the New Relic PHP agent.
 "
       log "${pdir}: unsupported version '${pi_ver}'"
       unsupported_php=1


### PR DESCRIPTION
When installing the agent on unsupported version of php on specific arch, include link to docs in the error message. Small output change as I personally got stuck here. The other output on incompatibility always include the link so I copied it into this error message.

This is #686 moved to upstream.