### PR TITLE
ci: refactor run-integration-tests to use larger runners

### DIFF
--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -1,0 +1,68 @@
+name: _make-agent
+
+on:
+  workflow_call:
+    inputs:
+      origin:
+        description: 'newrelic-php-agent origin'
+        required: true
+        default: 'newrelic' 
+        type: string
+      ref:
+        description: 'Branch or tag'
+        required: true
+        type: string
+      arch:
+        description: 'Target architecture'
+        required: true
+        type: string
+      runs-on:
+        description: 'runner type'
+        required: true
+        type: string
+
+jobs:
+  build-agent:
+    name: make agent (${{ matrix.platform }}, ${{ inputs.arch }}, ${{ matrix.php }})
+    runs-on: ${{inputs.runs-on}}
+    env:
+      IMAGE_NAME: newrelic/nr-php-agent-builder
+      IMAGE_TAG: make-php
+      IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
+    strategy:
+      matrix:
+        platform: [gnu, musl]
+        php: ['8.0', '8.1', '8.2']
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
+      - name: Enable arm64 emulation
+        if: ${{ inputs.arch == 'arm64' }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
+          platforms: arm64
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build axiom
+        run: >
+          docker run --rm --platform linux/${{inputs.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom 
+      - name: Build agent
+        run: >
+          docker run --rm --platform linux/${{inputs.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent
+      - name: Save newrelic.so for integration tests
+        uses: actions/upload-artifact@v3
+        with:
+          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
+          path: php-agent/agent/modules/newrelic.so

--- a/.github/workflows/make-for-platform-on-arch.yml
+++ b/.github/workflows/make-for-platform-on-arch.yml
@@ -1,0 +1,84 @@
+name: _make-target
+
+on:
+  workflow_call:
+    inputs:
+      origin:
+        description: 'newrelic-php-agent origin'
+        required: true
+        default: 'newrelic' 
+        type: string
+      ref:
+        description: 'Branch or tag'
+        required: true
+        type: string
+      make-variant:
+        description: 'Builder image tag'
+        required: true
+        type: string
+      make-variant-version:
+        description: 'Builder image version'
+        required: true
+        type: string
+      make-target:
+        description: 'make target'
+        required: true
+        type: string
+      artifact-name:
+        description: 'Build artifact name'
+        required: true
+        type: string
+      artifact-pattern:
+        description: 'Build artifact pattern'
+        required: true
+        type: string
+      arch:
+        description: 'Target architecture'
+        required: true
+        type: string
+      runs-on:
+        description: 'runner type'
+        required: true
+        type: string
+
+jobs:
+  make-target:
+    name: make ${{ inputs.make-target }} using ${{inputs.make-variant}} (${{ matrix.platform }}, ${{inputs.arch}})
+    runs-on: ${{inputs.runs-on}}
+    env:
+      IMAGE_NAME: newrelic/nr-php-agent-builder
+      IMAGE_TAG: make-${{inputs.make-variant}}
+      IMAGE_VERSION: ${{inputs.make-variant-version}}
+    strategy:
+      matrix:
+        platform: [gnu, musl]
+    steps:
+      - name: Checkout newrelic-php-agent code
+        uses: actions/checkout@v3
+        with:
+          path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
+      - name: Enable arm64 emulation
+        if: ${{ inputs.arch == 'arm64' }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
+          platforms: arm64
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build ${{inputs.make-target}}
+        run: >
+          docker run --rm --platform linux/${{inputs.arch}}
+          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
+          -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}}
+          -e APP_supportability=${{secrets.APP_SUPPORTABILITY}}
+          $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION ${{inputs.make-target}}
+      - name: Save ${{inputs.make-target}} artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}
+          path: php-agent/${{ inputs.artifact-pattern }}

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -1,0 +1,99 @@
+name: _make-integration-tests
+
+on:
+  workflow_call:
+    inputs:
+      origin:
+        description: 'newrelic-php-agent origin'
+        required: true
+        default: 'newrelic' 
+        type: string
+      ref:
+        description: 'Branch or tag'
+        required: true
+        type: string
+      arch:
+        description: 'Target architecture'
+        required: true
+        type: string
+      continue-on-error:
+        description: 'Continue on error'
+        required: true
+        type: boolean
+      runs-on:
+        description: 'runner type'
+        required: true
+        type: string
+
+jobs:
+  test-agent:
+    name: test agent (${{ matrix.platform }}, ${{ inputs.arch }}, ${{ matrix.php }})
+    runs-on: ${{inputs.runs-on}}
+    continue-on-error: ${{inputs.continue-on-error}}
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: [gnu, musl]
+        php: ['8.0', '8.1', '8.2']
+    steps:
+      - name: Checkout integration tests
+        uses: actions/checkout@v3
+        with:
+          path: php-agent
+          repository: ${{ inputs.origin }}/newrelic-php-agent
+          ref: ${{ inputs.ref }}
+      - name: Get integration_runner
+        uses: actions/download-artifact@v3
+        with:
+          name: integration_runner-${{matrix.platform}}-${{inputs.arch}}
+          path: php-agent/bin
+      - name: Get newrelic.so
+        uses: actions/download-artifact@v3
+        with:
+          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
+          path: php-agent/agent/modules
+      - name: Prep artifacts for use
+        run: |
+          chmod 755 php-agent/bin/integration_runner
+          chmod 755 php-agent/agent/modules/newrelic.so
+      - name: Enable arm64 emulation
+        if: ${{ inputs.arch == 'arm64' }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
+          platforms: arm64
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Start services
+        env:
+          PHP: ${{matrix.php}}
+          LIBC: ${{matrix.platform}}
+          PLATFORM: linux/${{inputs.arch}}
+          AGENT_CODE: ${{github.workspace}}/php-agent
+          IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
+        working-directory: ./php-agent
+        run: |
+          make test-services-start
+      - name: Run integration tests
+        working-directory: ./php-agent
+        shell: bash
+        run: |
+          docker exec \
+          -e PHPS=${{matrix.php}} \
+          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
+          -e APP_supportability=${{secrets.APP_SUPPORTABILITY}} \
+          -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}} \
+          -e ACCOUNT_supportability_trusted=${{secrets.ACCOUNT_SUPPORTABILITY_TRUSTED}} \
+          -e SYNTHETICS_HEADER_supportability=${{secrets.SYNTHETICS_HEADER_SUPPORTABILITY}} \
+          nr-php make integration-tests
+      - name: Stop services
+        env:
+          PHP: ${{matrix.php}}
+          LIBC: ${{matrix.platform}}
+          AGENT_CODE: ${{github.workspace}}/php-agent
+        working-directory: ./php-agent
+        run: |
+          make test-services-stop

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -81,6 +81,6 @@ jobs:
       origin: ${{ inputs.origin }}
       ref: ${{ inputs.ref }}
       arch: arm64
-      runs-on: ubuntu-20.04-8core
+      runs-on: ubuntu-20.04-4core
       continue-on-error: true
     secrets: inherit

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -18,6 +18,17 @@ on:
         required: true
         default: 'dev' 
         type: string
+      runner-type:
+        description: 'Type of a runner to use for integration tests on arm64'
+        required: true
+        default: 'ubuntu-20.04-4core' 
+        type: choice
+        options: 
+        - ubuntu-20.04-4core
+        - ubuntu-20.04-8core
+        - ubuntu-20.04-16core
+        - ubuntu-22.04-4core
+        - ubuntu-latest
 
 jobs:
   build-test-runner-amd64:
@@ -81,6 +92,6 @@ jobs:
       origin: ${{ inputs.origin }}
       ref: ${{ inputs.ref }}
       arch: arm64
-      runs-on: ubuntu-20.04-4core
+      runs-on: ${{inputs.runner-type}}
       continue-on-error: true
     secrets: inherit

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
       artifact-name: integration_runner
       artifact-pattern: bin/integration_runner
       arch: arm64
-      runs-on: ubuntu-20.04-16core
+      runs-on: ubuntu-latest
     secrets: inherit
 
   build-agent-amd64:
@@ -61,7 +61,7 @@ jobs:
       origin: ${{ inputs.origin }}
       ref: ${{ inputs.ref }}
       arch: arm64
-      runs-on: ubuntu-20.04-16core
+      runs-on: ubuntu-latest
     secrets: inherit
 
   test-amd64:
@@ -81,6 +81,6 @@ jobs:
       origin: ${{ inputs.origin }}
       ref: ${{ inputs.ref }}
       arch: arm64
-      runs-on: ubuntu-20.04-16core
+      runs-on: ubuntu-20.04-8core
       continue-on-error: true
     secrets: inherit

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -20,165 +20,67 @@ on:
         type: string
 
 jobs:
-  build-test-runner:
-    runs-on: 
-      labels: ubuntu-20.04-8core
-    env:
-      IMAGE_NAME: newrelic/nr-php-agent-builder
-      IMAGE_TAG: make-go
-      IMAGE_VERSION: ${{vars.MAKE_GO_VERSION}}
-    strategy:
-      matrix:
-        platform: [gnu, musl]
-        arch: [amd64, arm64]
-    steps:
-      - name: Checkout newrelic-php-agent code
-        uses: actions/checkout@v3
-        with:
-          path: php-agent
-          repository: ${{ inputs.origin }}/newrelic-php-agent
-          ref: ${{ inputs.ref }}
-      - name: Enable arm64 emulation
-        if: ${{ matrix.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
-        with:
-          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
-          platforms: arm64
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build integration_runner
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}}
-          -e APP_supportability=${{secrets.APP_SUPPORTABILITY}}
-          $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION bin/integration_runner
-      - name: Save integration_runner for integration tests
-        uses: actions/upload-artifact@v3
-        with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
-          path: php-agent/bin/integration_runner
-  build-agent:
-    runs-on: 
-      labels: ubuntu-20.04-8core
-    env:
-      IMAGE_NAME: newrelic/nr-php-agent-builder
-      IMAGE_TAG: make-php
-      IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
-    strategy:
-      matrix:
-        platform: [gnu, musl]
-        arch: [amd64, arm64]
-        php: ['8.0', '8.1', '8.2']
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          path: php-agent
-          repository: ${{ inputs.origin }}/newrelic-php-agent
-          ref: ${{ inputs.ref }}
-      - name: Enable arm64 emulation
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt --install arm64
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build axiom
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom 
-      - name: Build agent
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent
-      - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v3
-        with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
-          path: php-agent/agent/modules/newrelic.so
-  test:
-    needs: [build-test-runner, build-agent]
-    runs-on: 
-      labels: ubuntu-20.04-8core
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      fail-fast: true
-      matrix:
-        platform: [gnu, musl]
-        arch: [amd64, arm64]
-        php: ['8.0', '8.1', '8.2']
-        include:
-          - arch: amd64
-            experimental: false
-          - arch: arm64
-            experimental: true
-    name: test ${{ matrix.php }} ${{ matrix.platform }} ${{ matrix.arch }} (${{ matrix.experimental }})
-    steps:
-      - name: Checkout integration tests
-        uses: actions/checkout@v3
-        with:
-          path: php-agent
-          repository: ${{ inputs.origin }}/newrelic-php-agent
-          ref: ${{ inputs.ref }}
-      - name: Get integration_runner
-        uses: actions/download-artifact@v3
-        with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
-          path: php-agent/bin
-      - name: Get newrelic.so
-        uses: actions/download-artifact@v3
-        with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
-          path: php-agent/agent/modules
-      - name: Prep artifacts for use
-        run: |
-          chmod 755 php-agent/bin/integration_runner
-          chmod 755 php-agent/agent/modules/newrelic.so
-      - name: Enable arm64 emulation
-        if: ${{ matrix.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
-        with:
-          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
-          platforms: arm64
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Start services
-        env:
-          PHP: ${{matrix.php}}
-          LIBC: ${{matrix.platform}}
-          PLATFORM: linux/${{matrix.arch}}
-          AGENT_CODE: ${{github.workspace}}/php-agent
-          IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
-        working-directory: ./php-agent
-        run: |
-          make test-services-start
-      - name: Run integration tests
-        working-directory: ./php-agent
-        shell: bash
-        run: |
-          docker exec \
-          -e PHPS=${{matrix.php}} \
-          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
-          -e APP_supportability=${{secrets.APP_SUPPORTABILITY}} \
-          -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}} \
-          -e ACCOUNT_supportability_trusted=${{secrets.ACCOUNT_SUPPORTABILITY_TRUSTED}} \
-          -e SYNTHETICS_HEADER_supportability=${{secrets.SYNTHETICS_HEADER_SUPPORTABILITY}} \
-          nr-php make integration-tests
-      - name: Stop services
-        env:
-          PHP: ${{matrix.php}}
-          LIBC: ${{matrix.platform}}
-          AGENT_CODE: ${{github.workspace}}/php-agent
-        working-directory: ./php-agent
-        run: |
-          make test-services-stop
+  build-test-runner-amd64:
+    uses: ./.github/workflows/make-for-platform-on-arch.yml
+    with:
+      origin: ${{ inputs.origin }}
+      ref: ${{ inputs.ref }}
+      make-variant: go
+      make-variant-version: ${{vars.MAKE_GO_VERSION}}
+      make-target: bin/integration_runner
+      artifact-name: integration_runner
+      artifact-pattern: bin/integration_runner
+      arch: amd64
+      runs-on: ubuntu-latest
+    secrets: inherit
+  build-test-runner-arm64:
+    uses: ./.github/workflows/make-for-platform-on-arch.yml
+    with:
+      origin: ${{ inputs.origin }}
+      ref: ${{ inputs.ref }}
+      make-variant: go
+      make-variant-version: ${{vars.MAKE_GO_VERSION}}
+      make-target: bin/integration_runner
+      artifact-name: integration_runner
+      artifact-pattern: bin/integration_runner
+      arch: arm64
+      runs-on: ubuntu-20.04-16core
+    secrets: inherit
+
+  build-agent-amd64:
+    uses: ./.github/workflows/make-agent.yml
+    with:
+      origin: ${{ inputs.origin }}
+      ref: ${{ inputs.ref }}
+      arch: amd64
+      runs-on: ubuntu-latest
+    secrets: inherit
+  build-agent-arm64:
+    uses: ./.github/workflows/make-agent.yml
+    with:
+      origin: ${{ inputs.origin }}
+      ref: ${{ inputs.ref }}
+      arch: arm64
+      runs-on: ubuntu-20.04-16core
+    secrets: inherit
+
+  test-amd64:
+    needs: [build-test-runner-amd64, build-agent-amd64]
+    uses: ./.github/workflows/make-integration-tests.yml
+    with:
+      origin: ${{ inputs.origin }}
+      ref: ${{ inputs.ref }}
+      arch: amd64
+      runs-on: ubuntu-latest
+      continue-on-error: false
+    secrets: inherit
+  test-arm64:
+    needs: [build-test-runner-arm64, build-agent-arm64]
+    uses: ./.github/workflows/make-integration-tests.yml
+    with:
+      origin: ${{ inputs.origin }}
+      ref: ${{ inputs.ref }}
+      arch: arm64
+      runs-on: ubuntu-20.04-16core
+      continue-on-error: true
+    secrets: inherit

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -21,7 +21,8 @@ on:
 
 jobs:
   build-test-runner:
-    runs-on: ubuntu-latest
+    runs-on: 
+      labels: ubuntu-20.04-8core
     env:
       IMAGE_NAME: newrelic/nr-php-agent-builder
       IMAGE_TAG: make-go
@@ -61,7 +62,8 @@ jobs:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin/integration_runner
   build-agent:
-    runs-on: ubuntu-latest
+    runs-on: 
+      labels: ubuntu-20.04-8core
     env:
       IMAGE_NAME: newrelic/nr-php-agent-builder
       IMAGE_TAG: make-php
@@ -103,7 +105,8 @@ jobs:
           path: php-agent/agent/modules/newrelic.so
   test:
     needs: [build-test-runner, build-agent]
-    runs-on: ubuntu-latest
+    runs-on: 
+      labels: ubuntu-20.04-8core
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true


### PR DESCRIPTION
Refactor run-integration-tests workflow into reusable workflows to allow fine tuning which runners to use for which job depending on architecture. Experiments showed that building on default runner but using larger runner (4cores) for running integration tests on arm64 achieves best time/cost results. I.e. using larger runners to build on arm64 cuts the workflow runtime from about 30 minutes to about 20 minutes and therefore does not seem necessary. However, using larger runners to run test on arm64 is necessary not as much for time savings but for performance - without larger runners, tests run too slow and more spans are captured which causes actual results not to match test expectations.