### PR TITLE
suppress `Invalid read` error in test_redis

### DIFF
--- a/agent/tests/valgrind-suppressions
+++ b/agent/tests/valgrind-suppressions
@@ -128,3 +128,25 @@
   ...
   fun:zend_string_equal_val
 }
+
+{
+   <invalid-read-see-gh-10783>
+   Memcheck:Addr8
+   fun:_zend_observe_fcall_begin
+   ...
+   fun:tlib_php_request_eval_expr
+   fun:test_*_datastore_instance
+   fun:test_main
+   ...
+}
+
+{
+  <invalid-read-see-gh-10783>
+  Memcheck:Addr8
+  fun:_zend_observe_fcall_begin
+  ...
+  fun:nr_php_zval_free
+  fun:test_*_datastore_instance
+  fun:test_main
+  ...
+}


### PR DESCRIPTION
A call to `zend_map_ptr_reset` in `zend_deactivate` triggers `Invalid read of size 8` valgrind error in test_redis during `tlib_php_request_eval_expr` and `nr_php_zval_free` in the last php request lifecycle when Observer API is used to hook into Zend engine. This error is triggered on all PHPs with this patch: https://github.com/php/php-src/commit/ff62d117a35509699f8bac8b0750a956914da1b7