### PR TITLE
ci: make test-pull-request more useful

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -94,8 +94,11 @@ jobs:
         with:
           path: php-agent
       - name: Enable arm64 emulation
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt --install arm64
+        if: ${{ matrix.arch == 'arm64' }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
+          platforms: arm64
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -15,11 +15,9 @@ on:
     branches: 
       - main
       - 'dev'
+  # trigger job for each pull request, regardless of the target branch
   pull_request:
-    branches: 
-      - main
-      - 'dev'
-      - 'oapi'
+
 jobs:
   daemon-unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -159,6 +159,7 @@ jobs:
     needs: [daemon-unit-tests, agent-unit-test]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: [gnu, musl]
         arch: [amd64, arm64]


### PR DESCRIPTION
1. [always finish all integration tests](https://github.com/newrelic/newrelic-php-agent/commit/a8e635ce6255eddda628732bcca68f4c0bbf26bc) 
Don't cancel all in-progress and queued integration tests jobs if one of them
fails.

2. [trigger job for each pull request](https://github.com/newrelic/newrelic-php-agent/commit/48b8f8e9dbde630280297a1bc40945ca31734d8f) 
Test all pull requests targeting any branch, not only targeting `main`, `dev`
and `oapi` branches.

3. [fix 'Enable arm64 emulation' in agent-unit-test](https://github.com/newrelic/newrelic-php-agent/commit/b3f104808bb445a09dc370867a0d3a7b7b454f53)
There's no need to enable arm64 emulation when not testing arm64 agent. Use
the right way to enable arm64.