### PR TITLE
refactor(agent): improve guzzle detection

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -476,12 +476,8 @@ typedef struct _nr_library_table_t {
 static nr_library_table_t libraries[] = {
     {"Doctrine 2", "doctrine/orm/query.php", nr_doctrine2_enable},
     {"Guzzle 3", "guzzle/http/client.php", nr_guzzle3_enable},
-    /*
-     * NOTE:  This file ClientInterface.php also exists in Guzzle 3 and 6.
-     *        This file also exists in Predis.
-     */
-    {"Guzzle 4-5", "clientinterface.php", nr_guzzle4_enable},
-    {"Guzzle 6", "handlerstack.php", nr_guzzle6_enable},
+    {"Guzzle 4-5", "hasemitterinterface.php", nr_guzzle4_enable},
+    {"Guzzle 6", "guzzle/src/functions_include.php", nr_guzzle6_enable},
 
     {"MongoDB", "mongodb/src/client.php", nr_mongodb_enable},
 

--- a/tests/integration/external/guzzle6/test_cat.php
+++ b/tests/integration/external/guzzle6/test_cat.php
@@ -51,7 +51,6 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransaction/php__FILE__"},                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt.php
+++ b/tests/integration/external/guzzle6/test_dt.php
@@ -42,7 +42,6 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransaction/php__FILE__"},                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
@@ -43,7 +43,6 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransaction/php__FILE__"},                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics.php
@@ -65,7 +65,6 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime"},                            [1, "??", "??", "??", "??", "??"]],
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics_logging_off.php
@@ -68,7 +68,6 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime"},                            [1, "??", "??", "??", "??", "??"]],
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle6/test_no_cat_no_dt.php
@@ -42,7 +42,6 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransaction/php__FILE__"},                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]]

--- a/tests/integration/external/guzzle7/test_cat.php
+++ b/tests/integration/external/guzzle7/test_cat.php
@@ -53,7 +53,6 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"},   
                                                           [3,    0,    0,    0,    0,    0]],

--- a/tests/integration/external/guzzle7/test_dt.php
+++ b/tests/integration/external/guzzle7/test_dt.php
@@ -42,7 +42,6 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
@@ -43,7 +43,6 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"},   
                                                           [3,    0,    0,    0,    0,    0]],

--- a/tests/integration/external/guzzle7/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle7/test_dt_synthetics.php
@@ -65,7 +65,6 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime"},                  [1, "??", "??", "??", "??", "??"]],
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"},   
                                                           [3,    0,    0,    0,    0,    0]],

--- a/tests/integration/external/guzzle7/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle7/test_no_cat_no_dt.php
@@ -42,7 +42,6 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransaction/php__FILE__"},             [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [2, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]]

--- a/tests/integration/predis/test_basic.php
+++ b/tests/integration/predis/test_basic.php
@@ -55,7 +55,6 @@ ok - delete key
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Predis/detected"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/predis/test_basic_logging_off.php
+++ b/tests/integration/predis/test_basic_logging_off.php
@@ -58,7 +58,6 @@ ok - delete key
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Predis/detected"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/disabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/disabled"},         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/predis/test_basic_reporting_disabled.php
+++ b/tests/integration/predis/test_basic_reporting_disabled.php
@@ -55,7 +55,6 @@ ok - no instance metadata found
     [{"name":"OtherTransactionTotalTime"},                                               [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},                                   [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Predis/detected"},                                  [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},                              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},                              [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/predis/test_pipeline.php
+++ b/tests/integration/predis/test_pipeline.php
@@ -48,7 +48,6 @@ are being run, so they are instrumented as "pipeline".
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Predis/detected"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/predis/test_pipeline_atomic.php
+++ b/tests/integration/predis/test_pipeline_atomic.php
@@ -48,7 +48,6 @@ an atomic operation.
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Predis/detected"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/predis/test_pipeline_fire_and_forget.php
+++ b/tests/integration/predis/test_pipeline_fire_and_forget.php
@@ -48,7 +48,6 @@ are being run, so they are instrumented as "pipeline".
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Predis/detected"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]]
   ]

--- a/tests/integration/predis/test_pipeline_fire_and_forget_logging_off.php
+++ b/tests/integration/predis/test_pipeline_fire_and_forget_logging_off.php
@@ -51,7 +51,6 @@ newrelic.application_logging.metrics.enabled = false
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Predis/detected"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/disabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/disabled"},         [1, "??", "??", "??", "??", "??"]]
   ]


### PR DESCRIPTION
Use files that more uniquely identify Guzzle 5, and Guzzle 6. Because 
the file used to identify Guzzle 5 is unique to Guzzle 5, Guzzle 4-5
supportability metrics are no longer generated when predis is detected.
Guzzle 4-5 supportability metrics is also not generated when Guzzle 6
or Guzzle 7 are detected.