### PR TITLE
feat(testing): Implement EXPECT_SPAN_EVENTS_LIKE

### DIFF
--- a/src/newrelic/integration/parse.go
+++ b/src/newrelic/integration/parse.go
@@ -29,6 +29,7 @@ var (
 		"EXPECT_CUSTOM_EVENTS":    parseCustomEvents,
 		"EXPECT_ERROR_EVENTS":     parseErrorEvents,
 		"EXPECT_SPAN_EVENTS":      parseSpanEvents,
+		"EXPECT_SPAN_EVENTS_LIKE": parseSpanEventsLike,
 		"EXPECT_LOG_EVENTS":       parseLogEvents,
 		"EXPECT_METRICS":          parseMetrics,
 		"EXPECT":                  parseExpect,
@@ -209,6 +210,10 @@ func parseErrorEvents(test *Test, content []byte) error {
 }
 func parseSpanEvents(test *Test, content []byte) error {
 	test.spanEvents = content
+	return nil
+}
+func parseSpanEventsLike(test *Test, content []byte) error {
+	test.spanEventsLike = content
 	return nil
 }
 func parseLogEvents(test *Test, content []byte) error {

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -328,6 +328,7 @@ func (t *Test) compareSpanEventsLike(harvest *newrelic.Harvest) {
 
 	if err := json.Unmarshal(t.spanEventsLike, &x2); nil != err {
 		t.Fatal(fmt.Errorf("unable to parse expected spans like json for fuzzy matching: %v", err))
+		return
 	}
 
 	// expected will be represented as an array of "interface{}"
@@ -345,6 +346,7 @@ func (t *Test) compareSpanEventsLike(harvest *newrelic.Harvest) {
 	actualJSON, err := es.Data(id, time.Now())
 	if nil != err {
 		t.Fatal(fmt.Errorf("unable to access span event JSON data: %v", err))
+		return
 	}
 
 	// scrub actual spans
@@ -355,6 +357,7 @@ func (t *Test) compareSpanEventsLike(harvest *newrelic.Harvest) {
 	// parse to internal format
 	if err := json.Unmarshal(scrubjson, &x1); nil != err {
 		t.Fatal(fmt.Errorf("unable to parse actual spans like json for fuzzy matching: %v", err))
+		return
 	}
 
 	// expect x1 to be of type "[]interface {}" which wraps the entire span event data
@@ -371,12 +374,14 @@ func (t *Test) compareSpanEventsLike(harvest *newrelic.Harvest) {
 	case []interface{}:
 	default:
 		t.Fatal(errors.New("span event data json doesnt match expected format"))
+		return
 	}
 
 	// expect array of len 3
 	v2, _ := x1.([]interface{})
 	if 3 != len(v2) {
 		t.Fatal(errors.New("span event data json doesnt match expected format - expected 3 elements"))
+		return
 	}
 
 	// get array of actual spans from 3rd element
@@ -422,7 +427,7 @@ func (t *Test) compareSpanEventsLike(harvest *newrelic.Harvest) {
 				Expect: string(expectedJSON),
 				Actual: actualPretty.String(),
 			})
-
+			return
 		}
 	}
 }

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -403,8 +403,8 @@ func (t *Test) compareSpanEventsLike(harvest *newrelic.Harvest) {
 				continue
 			}
 
-			match := isFuzzyMatchRecursive(expected[j], actual[i])
-			if nil == match {
+			err := isFuzzyMatchRecursive(expected[j], actual[i])
+			if nil == err {
 				haveMatched[j] = true
 				numMatched++
 				break


### PR DESCRIPTION
Adds a new feature (`EXPECT_SPAN_EVENTS_LIKE`) for the `integration_runner` which allows testing for the existence of a set of spans in the actual spans created.  It differs from `EXPECT_SPAN_EVENTS` in that it is not necessary to list ALL expected spans.  For tests involving PHP frameworks the number of generated spans can be in the hundreds so it is not practical to use `EXPECT_SPAN_EVENTS` and thus `EXPECT_SPAN_EVENTS_LIKE` was added.

Here is an example:

```
/*EXPECT_SPAN_EVENTS_LIKE
[
  [
    {
        "category": "generic",
        "type": "Span",
        "guid": "??",
        "traceId": "??",
        "transactionId": "??",
        "name": "WebTransaction\/Action\/dispatch",
        "timestamp": "??",
        "duration": "??",
        "priority": "??",
        "sampled": true,
        "nr.entryPoint": true,
        "transaction.name": "WebTransaction\/Action\/dispatch"
    },
    {},
    {
        "response.headers.contentType": "text\/html",
        "http.statusCode": 200,
        "response.statusCode": 200,
        "httpResponseCode": "200",
        "request.uri": "\/dispatch",
        "request.method": "GET",
        "request.headers.host": "127.0.0.1"
    }
  ],
  [
    {
        "category": "generic",
        "type": "Span",
        "guid": "??",
        "traceId": "??",
        "transactionId": "??",
        "name": "Custom\/App\\Http\\Controllers\\JobOne::dispatch",
        "timestamp": "??",
        "duration": "??",
        "priority": "??",
        "sampled": true,
        "parentId": "??"
    },
    {},
    {
        "code.lineno": "??",
        "code.namespace": "App\\Http\\Controllers\\JobOne",
        "code.filepath": "??",
        "code.function": "dispatch"
    }
  ]
]
*/
```