### PR TITLE
fix(agent): Fixes 8T distributed traces

### DIFF
--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -431,6 +431,8 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
     nr_span_event_set_trusted_parent_id(
         event, nr_distributed_trace_inbound_get_trusted_parent_id(
                    segment->txn->distributed_trace));
+    nr_span_event_set_parent_id(event, 
+        nr_distributed_trace_inbound_get_guid(segment->txn->distributed_trace);
 
     nr_span_event_set_transaction_name(event, segment->txn->name);
 

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -432,7 +432,7 @@ nr_span_event_t* nr_segment_to_span_event(nr_segment_t* segment) {
         event, nr_distributed_trace_inbound_get_trusted_parent_id(
                    segment->txn->distributed_trace));
     nr_span_event_set_parent_id(event, 
-        nr_distributed_trace_inbound_get_guid(segment->txn->distributed_trace);
+        nr_distributed_trace_inbound_get_guid(segment->txn->distributed_trace));
 
     nr_span_event_set_transaction_name(event, segment->txn->name);
 

--- a/axiom/tests/test_segment.c
+++ b/axiom/tests/test_segment.c
@@ -2458,7 +2458,9 @@ static void test_segment_ensure_id(void) {
                         nr_span_event_get_parent_attribute(                    \
                             _common_span, NR_SPAN_PARENT_TRANSPORT_TYPE));     \
     } else {                                                                   \
-      tlib_pass_if_null(M ": parent ID",                                       \
+      tlib_pass_if_str_equal(M ": parent ID",                                  \
+                        nr_distributed_trace_inbound_get_guid(                 \
+                            _common_txn->distributed_trace),                   \
                         nr_span_event_get_parent_id(_common_span));            \
       tlib_pass_if_bool_equal(M ": entry point", true,                         \
                               nr_span_event_is_entry_point(_common_span));     \
@@ -2828,6 +2830,12 @@ static void test_segment_to_span_event(void) {
   tlib_pass_if_not_null("valid root segment results in valid span event", span);
   test_common_span_event_fields_against_segment("valid root segment",
                                                 txn->segment_root, span);
+
+   printf("intrinscs = %s\n", nro_to_json(span->intrinsics));
+   printf("agent attr = %s\n", nro_to_json(span->agent_attributes));
+   printf("user attr = %s\n", nro_to_json(span->user_attributes));
+   printf("parentId = %s\n", nro_get_hash_string(span->intrinsics, "parentId", NULL));
+
   tlib_pass_if_str_equal(
       "valid root segment results in valid span event",
       nro_get_hash_string(span->agent_attributes, "request.method", NULL),

--- a/axiom/tests/test_segment.c
+++ b/axiom/tests/test_segment.c
@@ -2830,12 +2830,6 @@ static void test_segment_to_span_event(void) {
   tlib_pass_if_not_null("valid root segment results in valid span event", span);
   test_common_span_event_fields_against_segment("valid root segment",
                                                 txn->segment_root, span);
-
-   printf("intrinscs = %s\n", nro_to_json(span->intrinsics));
-   printf("agent attr = %s\n", nro_to_json(span->agent_attributes));
-   printf("user attr = %s\n", nro_to_json(span->user_attributes));
-   printf("parentId = %s\n", nro_get_hash_string(span->intrinsics, "parentId", NULL));
-
   tlib_pass_if_str_equal(
       "valid root segment results in valid span event",
       nro_get_hash_string(span->agent_attributes, "request.method", NULL),


### PR DESCRIPTION
When using 8T the 'parentId' intrinsics attribute was not being set for
the root span of a service to a value based on the inbound header.  This caused
fragmented traces.  This commit added the required 'parentId' attribute.

Normal DT (not 8T) was working correctly because the 'parentId' was
being added to a span returned from nr_segement_to_span_event()
in a different code path dedicated to JSON creation starting with
nr_segment_tree_finalise().

A test in test_segment.c was modified to check that the 'parentId'
is correctly set based on the inbound DT header.