### PR TITLE
refactor(agent): improve phpunit instrumentation

### DIFF
--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -472,8 +472,8 @@ NR_PHP_WRAPPER(nr_phpunit_instrument_testresult_endtest) {
   }
 
   /*
-   * PHPUnit 6+ started passing "tests skipped due to dependency failures"
-   * to the endTest method -- however, we already catch these tests in
+   * PHPUnit passes "tests skipped due to dependency failures"
+   * to the endTest method. For PHPUnit 5.x, we already catch these tests in
    * our nr_phpunit_instrument_testresult_adderror wrapper.  This check
    * ensures these skipped tests aren't double counted by bailing if
    * a test's status isn't set.
@@ -490,8 +490,13 @@ NR_PHP_WRAPPER(nr_phpunit_instrument_testresult_endtest) {
   duration = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   if (!nr_php_is_zval_valid_double(duration)) {
     nrl_verbosedebug(NRL_INSTRUMENT, "%s: invalid test duration", __func__);
-    NR_PHP_WRAPPER_CALL;
-    goto end;
+  /*
+   * When PHPUnit 6.x+ passes "tests skipped due to dependency failures"
+   * to the endTest method the second argument - $time - has the value of 0.
+   * However Zend Engine does not correctly set the type for this argument
+   * in this case and therefore we need to fix the type of duration here:
+  */
+    ZVAL_DOUBLE(duration, 0.0);
   }
 
   NR_PHP_WRAPPER_CALL;
@@ -688,8 +693,5 @@ void nr_phpunit_enable(TSRMLS_D) {
 
   nr_php_wrap_user_function(
       NR_PSTR("PHPUnit_Framework_TestResult::addError"),
-      nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
-  nr_php_wrap_user_function(
-      NR_PSTR("PHPUnit\\Framework\\TestResult::addError"),
       nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
 }

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -491,8 +491,8 @@ static nr_library_table_t libraries[] = {
      * /usr/local/bin. While BaseTestRunner isn't the very first file to load,
      * it contains the test status constants and loads before tests can run.
      */
-    {"PHPUnit", "phpunit/src/runner/basetestrunner.php", nr_phpunit_enable},
-    {"PHPUnit", "phpunit/runner/basetestrunner.php", nr_phpunit_enable},
+    {"PHPUnit", "phpunit/src/framework/test.php", nr_phpunit_enable},
+    {"PHPUnit", "phpunit/framework/test.php", nr_phpunit_enable},
 
     {"Predis", "predis/src/client.php", nr_predis_enable},
     {"Predis", "predis/client.php", nr_predis_enable},


### PR DESCRIPTION
* [improve phpunit detection](https://github.com/newrelic/newrelic-php-agent/commit/d2b65d4bb66b958c7fe1681dc9205e1fb6210243) 
Use file that is loaded also on PHP 8.2 with include/require optimizations that
don't execute files without executable statements.

* [improve skipped tests handling](https://github.com/newrelic/newrelic-php-agent/commit/f6928af15178c4a1eacd8fe4f088cafccd25aa72) 
PHPUnit passes skipped tests to `addError` as well as `endTest` regardless of
the version. The difference is that in PHPUnit 5.x it is not possible to obtain
test outcome for skipped test - `$test.getStatus()` returns 'null'. Because of
that, `endTest` instrumentation bails out and does not generate test event and
therefore `addError` needs to be instrumented. It is possible to obtain test
outcome for skipped tests in PHPUnit 9.x. However, the `$time` for skipped test
is not received in `endTest` as a valid double and therefore it needs to be
'fixed'. Moreover testcase.getStatusMessage returns 'null' for tests skipped due
to dependency failure and therefore it is not possible to expect it in the test
event.