### PR TITLE
tests: fix metrics expectation in drupal tests

### DIFF
--- a/tests/integration/external/drupal7/test_bad_params_integer_headers.php
+++ b/tests/integration/external/drupal7/test_bad_params_integer_headers.php
@@ -14,6 +14,9 @@ newrelic.distributed_tracing_enabled=0
 /*SKIPIF
 <?php
 require("skipif.inc");
+if (version_compare(PHP_VERSION, "8.0", ">=")) {
+  die("skip: PHP >= 8.0 not supported\n");
+}
 */
 
 /*EXPECT_METRICS

--- a/tests/integration/external/drupal7/test_bad_params_integer_headers.php8.php
+++ b/tests/integration/external/drupal7/test_bad_params_integer_headers.php8.php
@@ -14,8 +14,8 @@ newrelic.distributed_tracing_enabled=0
 /*SKIPIF
 <?php
 require("skipif.inc");
-if (version_compare(PHP_VERSION, "8.0", ">=")) {
-  die("skip: PHP >= 8.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
 }
 */
 
@@ -34,12 +34,7 @@ if (version_compare(PHP_VERSION, "8.0", ">=")) {
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/framework/Drupal/forced"}, [1,    0,    0,    0,    0,    0]],
-    [{"name":"External/127.0.0.1/all"},                 [1, "??", "??", "??", "??", "??"]],
-    [{"name":"External/all"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name":"External/allOther"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name":"External/127.0.0.1/all",
-      "scope":"OtherTransaction/php__FILE__"},          [1, "??", "??", "??", "??", "??"]]
+    [{"name":"Supportability/framework/Drupal/forced"}, [1,    0,    0,    0,    0,    0]]
   ]
 ]
 */
@@ -50,4 +45,4 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 
 $url = "http://" . $EXTERNAL_HOST;
 
-drupal_http_request($url, array("headers" => NULL));
+drupal_http_request($url, array("headers" => 22));

--- a/tests/integration/external/drupal7/test_bad_params_null_headers.php8.php
+++ b/tests/integration/external/drupal7/test_bad_params_null_headers.php8.php
@@ -14,8 +14,8 @@ newrelic.distributed_tracing_enabled=0
 /*SKIPIF
 <?php
 require("skipif.inc");
-if (version_compare(PHP_VERSION, "8.0", ">=")) {
-  die("skip: PHP >= 8.0 not supported\n");
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
 }
 */
 
@@ -34,12 +34,7 @@ if (version_compare(PHP_VERSION, "8.0", ">=")) {
     [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/framework/Drupal/forced"}, [1,    0,    0,    0,    0,    0]],
-    [{"name":"External/127.0.0.1/all"},                 [1, "??", "??", "??", "??", "??"]],
-    [{"name":"External/all"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name":"External/allOther"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name":"External/127.0.0.1/all",
-      "scope":"OtherTransaction/php__FILE__"},          [1, "??", "??", "??", "??", "??"]]
+    [{"name":"Supportability/framework/Drupal/forced"}, [1,    0,    0,    0,    0,    0]]
   ]
 ]
 */


### PR DESCRIPTION
External metrics should not be generated when call to `drupal_http_request` fails due to uncaught error. This works correctly in PHPs 8+, when Observer API is used to hook into Zend Engine but doesn't work correctly for previous method of hooking into Zend Engine hence two flavors of tests.

Additional notes from @zsistla: 

For drupal7, external metrics were getting generated inconsistently for uncaught exception cases. Going forward, the agent will not generate external segment metrics in all cases where an exception occurred.

The 2 tests failed when instrumenting with observer api because an uncaught error occurred which made the drupal_http_request end function handling not get called so the external METRICS were not getting generated.

The agent actually handled this inconsistently in the past.
Case in point, the following two generate an uncaught exception but only one generates external segment metrics:
tests/integration/external/drupal7/test_bad_params_integer_options.php
tests/integration/external/drupal7/test_bad_params_integer_headers.php
If we add the the metrics whenever the call is made even if it ends up throwing an uncaught error, tests/integration/external/drupal7/test_bad_params_integer_options.php will fail but tests/integration/external/drupal7/test_bad_params_integer_headers.php will succeed.
We either need to add metrics to all calls to the function even if they generate an uncaught exception(there is a working local solution that does this) or only to the calls to http_request that succeeded(this is what the current PR does).

In discussions, it seems the pre-oapi instrumentation with [these lines](https://github.com/newrelic/newrelic-php-agent/blob/main/agent/fw_drupal.c#L193-L200) (which skip over External metric creation, when agent detects that call to drupal_http_request will result in an exception, because 2nd argument is of incorrect type, int instead of array) tried to achieve what oapi instrumentation gets ‘for free’. However [these lines](https://github.com/newrelic/newrelic-php-agent/blob/main/agent/fw_drupal.c#L193-L200) do not handle the situation when 2nd argument is of correct type but is of incorrect structure (i.e. $options is an array but the ‘headers’ key value is not an array). Hence the inconsistency in test expectations: tests/integration/external/drupal7/test_bad_params_integer_options.php does not expect External metrics but tests/integration/external/drupal7/test_bad_params_integer_options.php expects External metrics despite drupal_http_request throwing exception before actually making an external call.