### PR TITLE
fix(agent): Removes deprecation warnings for mysqli::real_connect()

### DIFF
--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -855,7 +855,7 @@ NR_INNER_WRAPPER(mysqli_real_connect) {
    * uses to avoid creating this deprecation warning.
    * For older PHPs continue to use the same specification string as previously
    * to minimize any chances of introducing new problems.
-   */ 
+   */
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
   if (FAILURE
       == zend_parse_parameters_ex(
@@ -895,7 +895,7 @@ NR_INNER_WRAPPER(mysqli_real_connect) {
     }
   }
 #endif /* PHP >= 8.1 */
- 
+
   zcaught = nr_zend_call_old_handler(nr_wrapper->oldhandler,
                                      INTERNAL_FUNCTION_PARAM_PASSTHRU);
 


### PR DESCRIPTION
For PHP >= 8.1 deprecation warnings were being generated by the agent
when parsing arguments to the mysqli::real_connect() function wrapper.
This is a combination of the argument type specification string
enabling checking for null values and PHP 8.1 and later outputing a
deprecation warning if a null is provided in this scenario.
The fix is to change the format specification string to the same as what
is used by mysqli::real_connect() for PHP >= 8.1.