### PR TITLE
feat: optional instrumentated function metric

### DIFF
--- a/agent/fw_cakephp.c
+++ b/agent/fw_cakephp.c
@@ -331,9 +331,13 @@ void nr_cakephp_enable_2(TSRMLS_D) {
                             nr_cakephp_name_the_wt_2 TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+    NR_WRAPREC_NOT_TRANSIENT,
+    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("CakeException::__construct"), nr_cakephp_problem_2, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 #else
   nr_php_wrap_user_function(NR_PSTR("CakeException::__construct"),
                             nr_cakephp_problem_2 TSRMLS_CC);

--- a/agent/fw_cakephp.c
+++ b/agent/fw_cakephp.c
@@ -331,13 +331,8 @@ void nr_cakephp_enable_2(TSRMLS_D) {
                             nr_cakephp_name_the_wt_2 TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-    NR_WRAPREC_NOT_TRANSIENT,
-    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("CakeException::__construct"), nr_cakephp_problem_2, NULL, NULL,
-      options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("CakeException::__construct"), nr_cakephp_problem_2, NULL, NULL);
 #else
   nr_php_wrap_user_function(NR_PSTR("CakeException::__construct"),
                             nr_cakephp_problem_2 TSRMLS_CC);

--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -815,16 +815,20 @@ void nr_drupal_enable(TSRMLS_D) {
                             nr_drupal_cron_run TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+    NR_WRAPREC_NOT_TRANSIENT,
+    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("QFormBase::Run"), nr_drupal_qdrupal_name_the_wt, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+      options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("drupal_page_cache_header"), nr_drupal_name_wt_as_cached_page,
-      NULL, NULL, NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+      NULL, NULL, options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("drupal_http_request"), nr_drupal_http_request_before,
       nr_drupal_http_request_after, nr_drupal_http_request_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 #else
   nr_php_wrap_user_function(NR_PSTR("QFormBase::Run"),
                             nr_drupal_qdrupal_name_the_wt TSRMLS_CC);
@@ -843,10 +847,10 @@ void nr_drupal_enable(TSRMLS_D) {
                               nr_drupal_wrap_module_invoke TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-    nr_php_wrap_user_function_before_after_clean_with_transience(
+    nr_php_wrap_user_function_before_after_clean_with_options(
         NR_PSTR("module_invoke_all"), nr_drupal_wrap_module_invoke_all_before,
         nr_drupal_wrap_module_invoke_all_after,
-        nr_drupal_wrap_module_invoke_all_clean, NR_WRAPREC_NOT_TRANSIENT);
+        nr_drupal_wrap_module_invoke_all_clean, options);
 #else
     nr_php_wrap_user_function(NR_PSTR("module_invoke_all"),
                               nr_drupal_wrap_module_invoke_all TSRMLS_CC);

--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -815,20 +815,14 @@ void nr_drupal_enable(TSRMLS_D) {
                             nr_drupal_cron_run TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-    NR_WRAPREC_NOT_TRANSIENT,
-    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("QFormBase::Run"), nr_drupal_qdrupal_name_the_wt, NULL, NULL,
-      options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("QFormBase::Run"), nr_drupal_qdrupal_name_the_wt, NULL, NULL);
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("drupal_page_cache_header"), nr_drupal_name_wt_as_cached_page,
-      NULL, NULL, options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
+      NULL, NULL);
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("drupal_http_request"), nr_drupal_http_request_before,
-      nr_drupal_http_request_after, nr_drupal_http_request_clean,
-      options);
+      nr_drupal_http_request_after, nr_drupal_http_request_clean);
 #else
   nr_php_wrap_user_function(NR_PSTR("QFormBase::Run"),
                             nr_drupal_qdrupal_name_the_wt TSRMLS_CC);
@@ -847,10 +841,10 @@ void nr_drupal_enable(TSRMLS_D) {
                               nr_drupal_wrap_module_invoke TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-    nr_php_wrap_user_function_before_after_clean_with_options(
+    nr_php_wrap_user_function_before_after_clean(
         NR_PSTR("module_invoke_all"), nr_drupal_wrap_module_invoke_all_before,
         nr_drupal_wrap_module_invoke_all_after,
-        nr_drupal_wrap_module_invoke_all_clean, options);
+        nr_drupal_wrap_module_invoke_all_clean);
 #else
     nr_php_wrap_user_function(NR_PSTR("module_invoke_all"),
                               nr_drupal_wrap_module_invoke_all TSRMLS_CC);

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -103,14 +103,9 @@ static void nr_drupal8_add_method_callback_before_after_clean(
         "%.*s::%.*s", NRSAFELEN(nr_php_class_entry_name_length(ce)),
         nr_php_class_entry_name(ce), NRSAFELEN(method_len), method);
 
-    nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-    };
-    nr_php_wrap_user_function_before_after_clean_with_options(
+    nr_php_wrap_user_function_before_after_clean(
                               class_method, nr_strlen(class_method),
-                              before_callback, after_callback, clean_callback,
-                              options);
+                              before_callback, after_callback, clean_callback);
 
     nr_free(class_method);
   }
@@ -671,14 +666,10 @@ void nr_drupal8_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-    NR_WRAPREC_NOT_TRANSIENT,
-    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Symfony\\Component\\HttpKernel\\EventListe"
               "ner\\RouterListener::onKernelRequest"),
-      nr_drupal8_name_the_wt_via_symfony, NULL, NULL, options);
+      nr_drupal8_name_the_wt_via_symfony, NULL, NULL);
 #else
   nr_php_wrap_user_function(NR_PSTR("Symfony\\Component\\HttpKernel\\EventListe"
                                     "ner\\RouterListener::onKernelRequest"),

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -103,10 +103,14 @@ static void nr_drupal8_add_method_callback_before_after_clean(
         "%.*s::%.*s", NRSAFELEN(nr_php_class_entry_name_length(ce)),
         nr_php_class_entry_name(ce), NRSAFELEN(method_len), method);
 
-    nr_php_wrap_user_function_before_after_clean_with_transience(
+    nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+    };
+    nr_php_wrap_user_function_before_after_clean_with_options(
                               class_method, nr_strlen(class_method),
                               before_callback, after_callback, clean_callback,
-                              NR_WRAPREC_NOT_TRANSIENT);
+                              options);
 
     nr_free(class_method);
   }
@@ -667,10 +671,14 @@ void nr_drupal8_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+    NR_WRAPREC_NOT_TRANSIENT,
+    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Symfony\\Component\\HttpKernel\\EventListe"
               "ner\\RouterListener::onKernelRequest"),
-      nr_drupal8_name_the_wt_via_symfony, NULL, NULL, NR_WRAPREC_NOT_TRANSIENT);
+      nr_drupal8_name_the_wt_via_symfony, NULL, NULL, options);
 #else
   nr_php_wrap_user_function(NR_PSTR("Symfony\\Component\\HttpKernel\\EventListe"
                                     "ner\\RouterListener::onKernelRequest"),

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -813,13 +813,8 @@ static void nr_laravel5_wrap_middleware(zval* app TSRMLS_DC) {
                         Z_STRVAL_P(classname));
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-      nr_wrap_user_function_options_t options = {
-          NR_WRAPREC_NOT_TRANSIENT,
-          NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-      };
-      nr_php_wrap_user_function_before_after_clean_with_options(
-          name, nr_strlen(name), nr_laravel5_middleware_handle, NULL, NULL,
-          options);
+      nr_php_wrap_user_function_before_after_clean(
+          name, nr_strlen(name), nr_laravel5_middleware_handle, NULL, NULL);
 #else
       nr_php_wrap_user_function(name, nr_strlen(name),
                                 nr_laravel5_middleware_handle TSRMLS_CC);
@@ -879,13 +874,8 @@ static void nr_laravel_add_callback_method(const zend_class_entry* ce,
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      class_method, nr_strlen(class_method), callback, NULL, NULL,
-      options);
+  nr_php_wrap_user_function_before_after_clean(
+      class_method, nr_strlen(class_method), callback, NULL, NULL);
 #else
   nr_php_wrap_user_function(class_method, nr_strlen(class_method),
                             callback TSRMLS_CC);
@@ -1270,14 +1260,9 @@ void nr_laravel_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Illuminate\\Console\\Application::doRun"),
-      nr_laravel_console_application_dorun, NULL, NULL,
-      options);
+      nr_laravel_console_application_dorun, NULL, NULL);
 #else
   nr_php_wrap_user_function(NR_PSTR("Illuminate\\Console\\Application::doRun"),
                             nr_laravel_console_application_dorun TSRMLS_CC);

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -813,9 +813,13 @@ static void nr_laravel5_wrap_middleware(zval* app TSRMLS_DC) {
                         Z_STRVAL_P(classname));
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-      nr_php_wrap_user_function_before_after_clean_with_transience(
+      nr_wrap_user_function_options_t options = {
+          NR_WRAPREC_NOT_TRANSIENT,
+          NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+      };
+      nr_php_wrap_user_function_before_after_clean_with_options(
           name, nr_strlen(name), nr_laravel5_middleware_handle, NULL, NULL,
-          NR_WRAPREC_NOT_TRANSIENT);
+          options);
 #else
       nr_php_wrap_user_function(name, nr_strlen(name),
                                 nr_laravel5_middleware_handle TSRMLS_CC);
@@ -875,9 +879,13 @@ static void nr_laravel_add_callback_method(const zend_class_entry* ce,
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       class_method, nr_strlen(class_method), callback, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 #else
   nr_php_wrap_user_function(class_method, nr_strlen(class_method),
                             callback TSRMLS_CC);
@@ -1262,10 +1270,14 @@ void nr_laravel_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Illuminate\\Console\\Application::doRun"),
       nr_laravel_console_application_dorun, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 #else
   nr_php_wrap_user_function(NR_PSTR("Illuminate\\Console\\Application::doRun"),
                             nr_laravel_console_application_dorun TSRMLS_CC);

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -221,13 +221,9 @@ void nr_lumen_enable(TSRMLS_D) {
       nr_lumen_handle_found_route TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-    NR_WRAPREC_NOT_TRANSIENT,
-    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Laravel\\Lumen\\Application::sendExceptionToHandler"),
-      nr_lumen_exception, NULL, NULL, options);
+      nr_lumen_exception, NULL, NULL);
 #else
   nr_php_wrap_user_function(
       NR_PSTR("Laravel\\Lumen\\Application::sendExceptionToHandler"),

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -221,9 +221,13 @@ void nr_lumen_enable(TSRMLS_D) {
       nr_lumen_handle_found_route TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+    NR_WRAPREC_NOT_TRANSIENT,
+    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Laravel\\Lumen\\Application::sendExceptionToHandler"),
-      nr_lumen_exception, NULL, NULL, NR_WRAPREC_NOT_TRANSIENT);
+      nr_lumen_exception, NULL, NULL, options);
 #else
   nr_php_wrap_user_function(
       NR_PSTR("Laravel\\Lumen\\Application::sendExceptionToHandler"),

--- a/agent/fw_magento2.c
+++ b/agent/fw_magento2.c
@@ -440,13 +440,9 @@ void nr_magento2_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Magento\\Framework\\App\\Action\\Action::dispatch"),
-      nr_magento2_action_dispatch, NULL, NULL, options);
+      nr_magento2_action_dispatch, NULL, NULL);
 #else
   nr_php_wrap_user_function(
       NR_PSTR("Magento\\Framework\\App\\Action\\Action::dispatch"),
@@ -476,11 +472,10 @@ void nr_magento2_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR(
           "Magento\\Webapi\\Controller\\Rest\\InputParamsResolver::resolve"),
-      nr_magento2_inputparamsresolver_resolve, NULL, NULL,
-      options);
+      nr_magento2_inputparamsresolver_resolve, NULL, NULL);
 #else
   nr_php_wrap_user_function(
       NR_PSTR(
@@ -502,16 +497,14 @@ void nr_magento2_enable(TSRMLS_D) {
       nr_magento2_soap_iswsdllistrequest TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Magento\\Webapi\\Controller\\Soap\\Request\\Handler::_"
               "prepareRequestData"),
-      nr_magento2_soap_handler_preparerequestdata, NULL, NULL,
-      options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
+      nr_magento2_soap_handler_preparerequestdata, NULL, NULL);
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Magento\\Webapi\\Controller\\Soap\\Request\\Handler::"
               "prepareOperationInput"),
-      nr_magento2_soap_handler_prepareoperationinput, NULL, NULL,
-      options);
+      nr_magento2_soap_handler_prepareoperationinput, NULL, NULL);
 
 #else
   nr_php_wrap_user_function(

--- a/agent/fw_magento2.c
+++ b/agent/fw_magento2.c
@@ -440,9 +440,13 @@ void nr_magento2_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Magento\\Framework\\App\\Action\\Action::dispatch"),
-      nr_magento2_action_dispatch, NULL, NULL, NR_WRAPREC_NOT_TRANSIENT);
+      nr_magento2_action_dispatch, NULL, NULL, options);
 #else
   nr_php_wrap_user_function(
       NR_PSTR("Magento\\Framework\\App\\Action\\Action::dispatch"),
@@ -472,11 +476,11 @@ void nr_magento2_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR(
           "Magento\\Webapi\\Controller\\Rest\\InputParamsResolver::resolve"),
       nr_magento2_inputparamsresolver_resolve, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 #else
   nr_php_wrap_user_function(
       NR_PSTR(
@@ -498,16 +502,16 @@ void nr_magento2_enable(TSRMLS_D) {
       nr_magento2_soap_iswsdllistrequest TSRMLS_CC);
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Magento\\Webapi\\Controller\\Soap\\Request\\Handler::_"
               "prepareRequestData"),
       nr_magento2_soap_handler_preparerequestdata, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+      options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Magento\\Webapi\\Controller\\Soap\\Request\\Handler::"
               "prepareOperationInput"),
       nr_magento2_soap_handler_prepareoperationinput, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 
 #else
   nr_php_wrap_user_function(

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -267,10 +267,14 @@ void nr_symfony4_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),
       nr_symfony4_console_application_run, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 #else
   nr_php_wrap_user_function(
       NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -267,14 +267,9 @@ void nr_symfony4_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),
-      nr_symfony4_console_application_run, NULL, NULL,
-      options);
+      nr_symfony4_console_application_run, NULL, NULL);
 #else
   nr_php_wrap_user_function(
       NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -711,25 +711,29 @@ NR_PHP_WRAPPER_END
 void nr_wordpress_enable(TSRMLS_D) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+    NR_WRAPREC_NOT_TRANSIENT,
+    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("apply_filters"), nr_wordpress_apply_filters,
       nr_wordpress_apply_filters_after, nr_wordpress_handle_tag_stack_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("apply_filters_ref_array"), nr_wordpress_exec_handle_tag,
       nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("do_action"), nr_wordpress_exec_handle_tag,
       nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("do_action_ref_array"), nr_wordpress_exec_handle_tag,
       nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 
 #else
   nr_php_wrap_user_function(NR_PSTR("apply_filters"),

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -711,29 +711,21 @@ NR_PHP_WRAPPER_END
 void nr_wordpress_enable(TSRMLS_D) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-    NR_WRAPREC_NOT_TRANSIENT,
-    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("apply_filters"), nr_wordpress_apply_filters,
-      nr_wordpress_apply_filters_after, nr_wordpress_handle_tag_stack_clean,
-      options);
+      nr_wordpress_apply_filters_after, nr_wordpress_handle_tag_stack_clean);
 
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("apply_filters_ref_array"), nr_wordpress_exec_handle_tag,
-      nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean,
-      options);
+      nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean);
 
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("do_action"), nr_wordpress_exec_handle_tag,
-      nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean,
-      options);
+      nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean);
 
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("do_action_ref_array"), nr_wordpress_exec_handle_tag,
-      nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean,
-      options);
+      nr_wordpress_handle_tag_stack_after, nr_wordpress_handle_tag_stack_clean);
 
 #else
   nr_php_wrap_user_function(NR_PSTR("apply_filters"),

--- a/agent/fw_yii.c
+++ b/agent/fw_yii.c
@@ -91,12 +91,16 @@ NR_PHP_WRAPPER_END
 void nr_yii_enable(TSRMLS_D) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("CAction::runWithParams"), nr_yii_runWithParams_wrapper, NULL,
-      NULL, NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+      NULL, options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("CInlineAction::runWithParams"), nr_yii_runWithParams_wrapper,
-      NULL, NULL, NR_WRAPREC_NOT_TRANSIENT);
+      NULL, NULL, options);
 #else
   nr_php_wrap_user_function(NR_PSTR("CAction::runWithParams"),
                             nr_yii_runWithParams_wrapper TSRMLS_CC);

--- a/agent/fw_yii.c
+++ b/agent/fw_yii.c
@@ -91,16 +91,12 @@ NR_PHP_WRAPPER_END
 void nr_yii_enable(TSRMLS_D) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("CAction::runWithParams"), nr_yii_runWithParams_wrapper, NULL,
-      NULL, options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
+      NULL);
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("CInlineAction::runWithParams"), nr_yii_runWithParams_wrapper,
-      NULL, NULL, options);
+      NULL, NULL);
 #else
   nr_php_wrap_user_function(NR_PSTR("CAction::runWithParams"),
                             nr_yii_runWithParams_wrapper TSRMLS_CC);

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -97,14 +97,9 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 void nr_doctrine2_enable(TSRMLS_D) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Doctrine\\ORM\\Query::_doExecute"), nr_doctrine2_cache_dql,
-      nr_doctrine2_cache_dql_after, nr_doctrine2_cache_dql_clean,
-      options);
+      nr_doctrine2_cache_dql_after, nr_doctrine2_cache_dql_clean);
 #else
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -97,10 +97,14 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 void nr_doctrine2_enable(TSRMLS_D) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Doctrine\\ORM\\Query::_doExecute"), nr_doctrine2_cache_dql,
       nr_doctrine2_cache_dql_after, nr_doctrine2_cache_dql_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 #else
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -795,26 +795,30 @@ void nr_predis_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Predis\\Pipeline\\Pipeline::executePipeline"),
       nr_predis_pipeline_executePipeline,
       nr_predis_pipeline_executePipeline_after,
-      nr_predis_pipeline_executePipeline_clean, NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+      nr_predis_pipeline_executePipeline_clean, options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Predis\\Pipeline\\Atomic::executePipeline"),
       nr_predis_pipeline_executePipeline,
       nr_predis_pipeline_executePipeline_after,
-      nr_predis_pipeline_executePipeline_clean, NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+      nr_predis_pipeline_executePipeline_clean, options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Predis\\Pipeline\\ConnectionErrorProof::executePipeline"),
       nr_predis_pipeline_executePipeline,
       nr_predis_pipeline_executePipeline_after,
-      nr_predis_pipeline_executePipeline_clean, NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+      nr_predis_pipeline_executePipeline_clean, options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("Predis\\Pipeline\\FireAndForget::executePipeline"),
       nr_predis_pipeline_executePipeline,
       nr_predis_pipeline_executePipeline_after,
-      nr_predis_pipeline_executePipeline_clean, NR_WRAPREC_NOT_TRANSIENT);
+      nr_predis_pipeline_executePipeline_clean, options);
 #else
   nr_php_wrap_user_function(
       NR_PSTR("Predis\\Pipeline\\Pipeline::executePipeline"),

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -795,30 +795,26 @@ void nr_predis_enable(TSRMLS_D) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\Pipeline::executePipeline"),
       nr_predis_pipeline_executePipeline,
       nr_predis_pipeline_executePipeline_after,
-      nr_predis_pipeline_executePipeline_clean, options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
+      nr_predis_pipeline_executePipeline_clean);
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\Atomic::executePipeline"),
       nr_predis_pipeline_executePipeline,
       nr_predis_pipeline_executePipeline_after,
-      nr_predis_pipeline_executePipeline_clean, options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
+      nr_predis_pipeline_executePipeline_clean);
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\ConnectionErrorProof::executePipeline"),
       nr_predis_pipeline_executePipeline,
       nr_predis_pipeline_executePipeline_after,
-      nr_predis_pipeline_executePipeline_clean, options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
+      nr_predis_pipeline_executePipeline_clean);
+  nr_php_wrap_user_function_before_after_clean(
       NR_PSTR("Predis\\Pipeline\\FireAndForget::executePipeline"),
       nr_predis_pipeline_executePipeline,
       nr_predis_pipeline_executePipeline_after,
-      nr_predis_pipeline_executePipeline_clean, options);
+      nr_predis_pipeline_executePipeline_clean);
 #else
   nr_php_wrap_user_function(
       NR_PSTR("Predis\\Pipeline\\Pipeline::executePipeline"),

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -440,13 +440,13 @@ nruserfn_t* nr_php_add_custom_tracer_callable(zend_function* func TSRMLS_DC) {
 
 nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
                                            size_t namestrlen,
-                                           nr_wrap_user_function_options_t options
+                                           const nr_wrap_user_function_options_t* options
                                            TSRMLS_DC) {
   nruserfn_t* wraprec;
   nruserfn_t* p;
 
   wraprec = nr_php_user_wraprec_create_named(namestr, namestrlen,
-                                             options.instrumented_function_metric);
+                                             options->instrumented_function_metric);
   if (0 == wraprec) {
     return 0;
   }
@@ -475,7 +475,7 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
       (0 == wraprec->classname) ? "" : "::", NRP_PHP(wraprec->funcname));
 
   nr_php_wrap_user_function_internal(wraprec TSRMLS_CC);
-  if (NR_WRAPREC_IS_TRANSIENT == options.transience) {
+  if (NR_WRAPREC_IS_TRANSIENT == options->transience) {
     wraprec->transience = NR_WRAPREC_IS_TRANSIENT;
   } else {
     /* non-transient wraprecs are added to both the hashmap and linked list.
@@ -569,7 +569,7 @@ void nr_php_add_transaction_naming_function(const char* namestr,
   };
   nruserfn_t* wraprec
       = nr_php_add_custom_tracer_named(namestr, namestrlen,
-                                       options TSRMLS_CC);
+                                       &options TSRMLS_CC);
 
   if (NULL != wraprec) {
     wraprec->is_names_wt_simple = 1;
@@ -583,7 +583,7 @@ void nr_php_add_custom_tracer(const char* namestr, int namestrlen TSRMLS_DC) {
   };
   nruserfn_t* wraprec
       = nr_php_add_custom_tracer_named(namestr, namestrlen,
-                                       options TSRMLS_CC);
+                                       &options TSRMLS_CC);
 
   if (NULL != wraprec) {
     wraprec->create_metric = 1;
@@ -646,7 +646,7 @@ void nr_php_user_function_add_declared_callback(const char* namestr,
   };
   nruserfn_t* wraprec
       = nr_php_add_custom_tracer_named(namestr, namestrlen,
-                                       options TSRMLS_CC);
+                                       &options TSRMLS_CC);
 
   if (0 != wraprec) {
     wraprec->declared_callback = callback;

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -189,7 +189,7 @@ extern nruserfn_t* nr_php_add_custom_tracer_callable(
     zend_function* func TSRMLS_DC);
 extern nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
                                                   size_t namestrlen,
-                                                  nr_wrap_user_function_options_t options
+                                                  const nr_wrap_user_function_options_t* options
                                                   TSRMLS_DC);
 extern void nr_php_reset_user_instrumentation(void);
 extern void nr_php_remove_transient_user_instrumentation(void);

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -27,10 +27,22 @@ typedef struct nrspecialfn_return_t (*nrspecialfn_t)(
 
 typedef void (*nruserfn_declared_t)(TSRMLS_D);
 
+/* Options for wrapping a user function */
 typedef enum {
   NR_WRAPREC_NOT_TRANSIENT = 0,
   NR_WRAPREC_IS_TRANSIENT = 1
 } nr_transience_t;
+
+typedef enum {
+  NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC = 0,
+  NR_WRAPREC_NO_INSTRUMENTED_FUNCTION_METRIC = 1
+} nr_instrumented_function_metric_t;
+
+typedef struct _nr_wrap_user_function_options_t {
+  nr_transience_t                   transience;
+  nr_instrumented_function_metric_t instrumented_function_metric;
+} nr_wrap_user_function_options_t;
+
 /*
  * An equivalent data structure for user functions.
  *
@@ -177,7 +189,8 @@ extern nruserfn_t* nr_php_add_custom_tracer_callable(
     zend_function* func TSRMLS_DC);
 extern nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
                                                   size_t namestrlen,
-                                                  nr_transience_t transience TSRMLS_DC);
+                                                  nr_wrap_user_function_options_t options
+                                                  TSRMLS_DC);
 extern void nr_php_reset_user_instrumentation(void);
 extern void nr_php_remove_transient_user_instrumentation(void);
 extern void nr_php_add_user_instrumentation(TSRMLS_D);

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -136,13 +136,20 @@
  * see how it works with frameworks.
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+extern nruserfn_t* nr_php_wrap_user_function_before_after_clean(
+    const char* name,
+    size_t namelen,
+    nrspecialfn_t before_callback,
+    nrspecialfn_t after_callback,
+    nrspecialfn_t clean_callback);
+
 extern nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_options(
     const char* name,
     size_t namelen,
     nrspecialfn_t before_callback,
     nrspecialfn_t after_callback,
     nrspecialfn_t clean_callback,
-    nr_wrap_user_function_options_t options);
+    const nr_wrap_user_function_options_t* options);
 
 extern nruserfn_t* nr_php_wrap_callable_before_after_clean(
     zend_function* callable,
@@ -158,7 +165,7 @@ extern nruserfn_t* nr_php_wrap_user_function_with_options(
     const char* name,
     size_t namelen,
     nrspecialfn_t callback,
-    nr_wrap_user_function_options_t TSRMLS_DC);
+    const nr_wrap_user_function_options_t* TSRMLS_DC);
 
 extern nruserfn_t* nr_php_wrap_user_function_extra(const char* name,
                                                    size_t namelen,

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -136,13 +136,13 @@
  * see how it works with frameworks.
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
-extern nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_transience(
+extern nruserfn_t* nr_php_wrap_user_function_before_after_clean_with_options(
     const char* name,
     size_t namelen,
     nrspecialfn_t before_callback,
     nrspecialfn_t after_callback,
     nrspecialfn_t clean_callback,
-    nr_transience_t transience);
+    nr_wrap_user_function_options_t options);
 
 extern nruserfn_t* nr_php_wrap_callable_before_after_clean(
     zend_function* callable,
@@ -154,11 +154,11 @@ extern nruserfn_t* nr_php_wrap_user_function(const char* name,
                                              size_t namelen,
                                              nrspecialfn_t callback TSRMLS_DC);
 
-extern nruserfn_t* nr_php_wrap_user_function_with_transience(
+extern nruserfn_t* nr_php_wrap_user_function_with_options(
     const char* name,
     size_t namelen,
     nrspecialfn_t callback,
-    nr_transience_t TSRMLS_DC);
+    nr_wrap_user_function_options_t TSRMLS_DC);
 
 extern nruserfn_t* nr_php_wrap_user_function_extra(const char* name,
                                                    size_t namelen,

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -149,17 +149,12 @@ static void execute_nested_framework_calls(nrspecialfn_t one_before,
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("one"), one_before, one_after, NULL, options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("two"), two_before, two_after, NULL, options);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("three"), three_before, three_after, NULL,
-      options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("one"), one_before, one_after, NULL);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("two"), two_before, two_after, NULL);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("three"), three_before, three_after, NULL);
 #else
   /*
    * This will pick up whichever one isn't null.
@@ -617,42 +612,32 @@ static void test_add_arg(TSRMLS_D) {
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
   tlib_php_request_eval("function arg0_def0() { return 4; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("arg0_def0"), test_add_array, NULL, NULL,
-      options TSRMLS_CC);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("arg0_def0"), test_add_array, NULL, NULL TSRMLS_CC);
 
   tlib_php_request_eval("function arg1_def0($a) { return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("arg1_def0"), test_add_array, NULL, NULL,
-      options TSRMLS_CC);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("arg1_def0"), test_add_array, NULL, NULL TSRMLS_CC);
 
   tlib_php_request_eval(
       "function arg0_def1($a = null) { return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("arg0_def1"), test_add_array, NULL, NULL,
-      options TSRMLS_CC);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("arg0_def1"), test_add_array, NULL, NULL TSRMLS_CC);
 
   tlib_php_request_eval(
       "function arg1_def1($a, $b = null) { return $b; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("arg1_def1"), test_add_array, NULL, NULL,
-      options TSRMLS_CC);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("arg1_def1"), test_add_array, NULL, NULL TSRMLS_CC);
 
   tlib_php_request_eval(
       "function arg1_def1_2($a, $b = null) { return $b; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("arg1_def1_2"), test_add_2_arrays, NULL, NULL,
-      options TSRMLS_CC);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("arg1_def1_2"), test_add_2_arrays, NULL, NULL TSRMLS_CC);
 
   tlib_php_request_eval("function splat(...$a) { return $a[0]; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("splat"), test_add_array, NULL, NULL,
-      options TSRMLS_CC);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("splat"), test_add_array, NULL, NULL TSRMLS_CC);
 #else
   tlib_php_request_eval("function arg0_def0() { return 4; }" TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("arg0_def0"), test_add_array TSRMLS_CC);
@@ -818,13 +803,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function all_set($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_wrap_user_function_options_t options = {
-      NR_WRAPREC_NOT_TRANSIENT,
-      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
-  };
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("all_set"), test_before, test_after, test_clean,
-      options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("all_set"), test_before, test_after, test_clean);
   /*
    * pass argument that will not throw exception.
    * before/after should be called.
@@ -870,9 +850,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function before_after($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("before_after"), test_before, test_after, NULL,
-      options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("before_after"), test_before, test_after, NULL);
 
   /*
    * pass argument that will not throw exception.
@@ -921,9 +900,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function before_clean($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("before_clean"), test_before, NULL, test_clean,
-      options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("before_clean"), test_before, NULL, test_clean);
 
   /*
    * pass argument that will not throw exception.
@@ -969,9 +947,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function after_clean($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("after_clean"), NULL, test_after, test_clean,
-      options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("after_clean"), NULL, test_after, test_clean);
   /*
    * pass argument that will not throw exception.
    * after should be called.
@@ -1014,9 +991,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function before_only($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("before_only"), test_before, NULL, NULL,
-      options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("before_only"), test_before, NULL, NULL);
   /*
    * pass argument that will not throw exception.
    * before should be called.
@@ -1058,8 +1034,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function after_only($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("after_only"), NULL, test_after, NULL, options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("after_only"), NULL, test_after, NULL);
   /*
    * pass argument that will not throw exception.
    * after should be called.
@@ -1101,8 +1077,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function clean_only($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_options(
-      NR_PSTR("clean_only"), NULL, NULL, test_clean, options);
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("clean_only"), NULL, NULL, test_clean);
   /*
    * pass argument that will not throw exception.
    * clean should be called.

--- a/agent/tests/test_php_wrapper.c
+++ b/agent/tests/test_php_wrapper.c
@@ -149,13 +149,17 @@ static void execute_nested_framework_calls(nrspecialfn_t one_before,
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_php_wrap_user_function_before_after_clean_with_transience(
-      NR_PSTR("one"), one_before, one_after, NULL, NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
-      NR_PSTR("two"), two_before, two_after, NULL, NR_WRAPREC_NOT_TRANSIENT);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
+      NR_PSTR("one"), one_before, one_after, NULL, options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
+      NR_PSTR("two"), two_before, two_after, NULL, options);
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("three"), three_before, three_after, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 #else
   /*
    * This will pick up whichever one isn't null.
@@ -613,38 +617,42 @@ static void test_add_arg(TSRMLS_D) {
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
   tlib_php_request_eval("function arg0_def0() { return 4; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("arg0_def0"), test_add_array, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
+      options TSRMLS_CC);
 
   tlib_php_request_eval("function arg1_def0($a) { return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("arg1_def0"), test_add_array, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
+      options TSRMLS_CC);
 
   tlib_php_request_eval(
       "function arg0_def1($a = null) { return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("arg0_def1"), test_add_array, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
+      options TSRMLS_CC);
 
   tlib_php_request_eval(
       "function arg1_def1($a, $b = null) { return $b; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("arg1_def1"), test_add_array, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
+      options TSRMLS_CC);
 
   tlib_php_request_eval(
       "function arg1_def1_2($a, $b = null) { return $b; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("arg1_def1_2"), test_add_2_arrays, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
+      options TSRMLS_CC);
 
   tlib_php_request_eval("function splat(...$a) { return $a[0]; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("splat"), test_add_array, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
+      options TSRMLS_CC);
 #else
   tlib_php_request_eval("function arg0_def0() { return 4; }" TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("arg0_def0"), test_add_array TSRMLS_CC);
@@ -810,9 +818,13 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function all_set($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_wrap_user_function_options_t options = {
+      NR_WRAPREC_NOT_TRANSIENT,
+      NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("all_set"), test_before, test_after, test_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
   /*
    * pass argument that will not throw exception.
    * before/after should be called.
@@ -858,9 +870,9 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function before_after($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("before_after"), test_before, test_after, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 
   /*
    * pass argument that will not throw exception.
@@ -909,9 +921,9 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function before_clean($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("before_clean"), test_before, NULL, test_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
 
   /*
    * pass argument that will not throw exception.
@@ -957,9 +969,9 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function after_clean($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("after_clean"), NULL, test_after, test_clean,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
   /*
    * pass argument that will not throw exception.
    * after should be called.
@@ -1002,9 +1014,9 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function before_only($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
+  nr_php_wrap_user_function_before_after_clean_with_options(
       NR_PSTR("before_only"), test_before, NULL, NULL,
-      NR_WRAPREC_NOT_TRANSIENT);
+      options);
   /*
    * pass argument that will not throw exception.
    * before should be called.
@@ -1046,8 +1058,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function after_only($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
-      NR_PSTR("after_only"), NULL, test_after, NULL, NR_WRAPREC_NOT_TRANSIENT);
+  nr_php_wrap_user_function_before_after_clean_with_options(
+      NR_PSTR("after_only"), NULL, test_after, NULL, options);
   /*
    * pass argument that will not throw exception.
    * after should be called.
@@ -1089,8 +1101,8 @@ static void test_before_after_clean() {
   tlib_php_request_eval(
       "function clean_only($a) { if (0 == $a) { throw new "
       "RuntimeException('Division by zero'); } else return $a; }" TSRMLS_CC);
-  nr_php_wrap_user_function_before_after_clean_with_transience(
-      NR_PSTR("clean_only"), NULL, NULL, test_clean, NR_WRAPREC_NOT_TRANSIENT);
+  nr_php_wrap_user_function_before_after_clean_with_options(
+      NR_PSTR("clean_only"), NULL, NULL, test_clean, options);
   /*
    * pass argument that will not throw exception.
    * clean should be called.

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -101,7 +101,7 @@ static void test_hashmap_wraprec() {
     NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
   };
   user_func1_wraprec = nr_php_add_custom_tracer_named(
-      user_func1_name, nr_strlen(user_func1_name), options );
+      user_func1_name, nr_strlen(user_func1_name), &options );
   wraprec_found = nr_php_get_wraprec(user_func1_zf);
   tlib_pass_if_ptr_equal("lookup instrumented user function succeeds",
                          wraprec_found, user_func1_wraprec);

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -96,8 +96,12 @@ static void test_hashmap_wraprec() {
                          user_func1_wraprec);
 
   /* instrument user function */
+  nr_wrap_user_function_options_t options = {
+    NR_WRAPREC_NOT_TRANSIENT,
+    NR_WRAPREC_CREATE_INSTRUMENTED_FUNCTION_METRIC
+  };
   user_func1_wraprec = nr_php_add_custom_tracer_named(
-      user_func1_name, nr_strlen(user_func1_name), NR_WRAPREC_NOT_TRANSIENT );
+      user_func1_name, nr_strlen(user_func1_name), options );
   wraprec_found = nr_php_get_wraprec(user_func1_zf);
   tlib_pass_if_ptr_equal("lookup instrumented user function succeeds",
                          wraprec_found, user_func1_wraprec);


### PR DESCRIPTION
There still exists a default wrapper, `nr_php_wrap_user_function`, which (for OAPI) creates an 'after' wraprec that is non-transient and creates an `InstrumentedFunction` metric. Before this PR, there was the option to create 'before', 'after', and 'clean' wrappers and define the transience.

This PR extends the options available when creating a wraprec to no longer create the InstrumentedFunction metric. It wraps this option with the other bool option (transience) into an options struct.

Additionally, if the top-most default, `nr_php_wrap_user_function`, is not used, every single option must be defined ('before', 'after', 'clean', transience, and instrumented metric). This takes the concept that if a single one of these fields is non-default, it is much more likely that other fields will also be non-default. The code writer will be forced to explicitly consider each option available. 

This does not add the option to create the InstrumentedFunction metric when calling `nr_wrap_callable`.