### PR TITLE
fix(agent): fix wrapping transient user functions

### DIFF
--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -501,7 +501,11 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
     }
 
     if (NULL != orig_func) {
+#if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
+      p = nr_php_op_array_get_wraprec(&orig_func->op_array TSRMLS_CC);
+#else
       p = nr_php_wraprec_lookup_get(orig_func);
+#endif
 
       if (p) {
         nrl_verbosedebug(NRL_INSTRUMENT, "reusing custom wrapper for callable '%s'",

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -451,7 +451,28 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
     return 0;
   }
 
-  /* Make sure that we are not duplicating an existing wraprecord */
+  /* Make sure that we are not duplicating an existing wraprecord.
+   *
+   * For non-transient wrappers (standard instrumentation), the wrapper
+   * is stored in both the hashmap and linked-list. For transient wrappers,
+   * the wrapper is only stored in the hashmap. HOWEVER! non-transient
+   * wrappers MAY only be in the linked-list. This normally happens if it
+   * is wrapping a function that hasn't been loaded by PHP yet. Once the
+   * function is loaded, there are many hooks to ensure the wrapper is also
+   * added to the hashmap.
+   *
+   * The implications of the above are: For non-transient wrappers, we only
+   * need to check the linked-list to ensure that we are not duplicating a
+   * wrapper. If a wrapper is only in the hashmap, it is transient and will
+   * be overwritten by the non-transient wrapper.
+   *
+   * For transient wrappers, however, we must check both the linked
+   * list and the hashmap. This is because it is possible to attempt to
+   * create a transient wrapper around an already non-transiently wrapped
+   * function. This will return the non-transient wrapper and will attempt
+   * to set the transient callbacks if that wrapper has those callbacks free.
+   * This means that it is possible for callbacks intended to be transient
+   * are attached onto a wrapper that isn't. */
   p = nr_wrapped_user_functions;
 
   while (0 != p) {
@@ -467,6 +488,29 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
       return p; /* return the wraprec we are duplicating */
     }
     p = p->next;
+  }
+  if (NR_WRAPREC_IS_TRANSIENT == options->transience) {
+    zend_function* orig_func = 0;
+    if (0 == wraprec->classname) {
+      orig_func = nr_php_find_function(wraprec->funcnameLC TSRMLS_CC);
+    } else {
+      zend_class_entry* orig_class = 0;
+
+      orig_class = nr_php_find_class(wraprec->classnameLC TSRMLS_CC);
+      orig_func = nr_php_find_class_method(orig_class, wraprec->funcnameLC);
+    }
+
+    if (NULL != orig_func) {
+      p = nr_php_wraprec_lookup_get(orig_func);
+
+      if (p) {
+        nrl_verbosedebug(NRL_INSTRUMENT, "reusing custom wrapper for callable '%s'",
+                         namestr);
+        nr_php_user_wraprec_destroy(&wraprec);
+        nr_php_wrap_user_function_internal(p TSRMLS_CC);
+        return p;
+      }
+    }
   }
 
   nrl_verbosedebug(

--- a/tests/integration/frameworks/drupal/test_invoke_all_with.php
+++ b/tests/integration/frameworks/drupal/test_invoke_all_with.php
@@ -26,6 +26,7 @@ b2
 a3
 b4
 b4
+b2
 */
 
 /*EXPECT_METRICS
@@ -37,11 +38,11 @@ b4
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Framework/Drupal/Hook/hook_1"},                         [2, "??", "??", "??", "??", "??"]],
-    [{"name":"Framework/Drupal/Hook/hook_2"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Hook/hook_2"},                         [2, "??", "??", "??", "??", "??"]],
     [{"name":"Framework/Drupal/Hook/hook_3"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Framework/Drupal/Hook/hook_4"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Framework/Drupal/Module/module_a"},                     [2, "??", "??", "??", "??", "??"]],
-    [{"name":"Framework/Drupal/Module/module_b"},                     [3, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Module/module_b"},                     [4, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                            [1, "??", "??", "??", "??", "??"]],
@@ -49,9 +50,12 @@ b4
     [{"name":"Supportability/framework/Drupal8/forced"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/api/add_custom_tracer"},                 [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/api/add_custom_tracer"},                 [2, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/invoke_callback_instrumented"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Custom/invoke_callback"},                               [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/invoke_callback_instrumented",
+      "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Custom/invoke_callback",
       "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]]
   ]
 ]
@@ -125,5 +129,15 @@ $handler->invokeallwith("hook_4", [$page_cache, "get"]);
 /* At this point, module_b_hook_4 should NOT be instrumented */
 
 // test string callback; function already instrumented
+// This will reuse the existing wraprec and successfully
+// add instrumentation because the "before" callback is unset
 $func_name = "invoke_callback_instrumented";
 $handler->invokeallwith("hook_4", $func_name);
+
+// test non-transiently wrapping an already transiently instrumented function
+// This will overwrite the existing transient wrapper
+$func_name = "invoke_callback";
+newrelic_add_custom_tracer($func_name);
+// Now this test will function the same as above: adding special instrumentation
+// to an already existing wrapper
+$handler->invokeallwith("hook_2", $func_name);

--- a/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php
@@ -24,6 +24,7 @@ add filter
 add filter
 add filter
 f: string1
+add filter
 h: string3
 g: string2
 */
@@ -69,6 +70,7 @@ function f($str) {
     echo "f: ";
     echo $str;
     echo "\n";
+    add_filter("hook", "f");
     try {
         apply_filters("h", "string3");
     } catch (Exception $e) {

--- a/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php
@@ -70,6 +70,7 @@ function f($str) {
     echo "f: ";
     echo $str;
     echo "\n";
+    // For OAPI: attempt to overwrite the currently executing transient wrapper
     add_filter("hook", "f");
     try {
         apply_filters("h", "string3");


### PR DESCRIPTION
Prevent adding transient wraprecs for already wrapped transient functions by checking if wraprec already exists in the hashmap. Additionally prevent adding transient wraprecs for if the transient function is already wrapped as non-transient function by checking if wraprec already exists in the linked list.

For non-transient wrappers (standard instrumentation), the wrapper
is stored in both the hashmap and linked-list. For transient wrappers,
the wrapper is only stored in the hashmap. HOWEVER! non-transient
wrappers MAY only be in the linked-list. This normally happens if it
is wrapping a function that hasn't been loaded by PHP yet. Once the
function is loaded, there are many hooks to ensure the wrapper is also
added to the hashmap.

The implications of the above are: For non-transient wrappers, we only
need to check the linked-list to ensure that we are not duplicating a
wrapper. If a wrapper is only in the hashmap, it is transient and will
be overwritten by the non-transient wrapper.

For transient wrappers, however, we must check both the linked
list and the hashmap. This is because it is possible to attempt to
create a transient wrapper around an already non-transiently wrapped
function. This will return the non-transient wrapper and will attempt
to set the transient callbacks if that wrapper has those callbacks free.
This means that it is possible for callbacks intended to be transient
are attached onto a wrapper that isn't.