### PR TITLE
feat(agent): Adds INI for log context attributes

### DIFF
--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -308,6 +308,9 @@ nr_php_ini_attribute_config_t
 nr_php_ini_attribute_config_t
     browser_monitoring_attributes; /* newrelic.browser_monitoring.attributes.*
                                     */
+nr_php_ini_attribute_config_t
+    log_context_data_attributes; /* newrelic.application_logging.forwarding.context_data.*
+                                  */
 
 nrinibool_t custom_events_enabled; /* newrelic.custom_insights_events.enabled */
 nriniuint_t custom_events_max_samples_stored; /* newrelic.custom_events.max_samples_stored

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -2984,6 +2984,30 @@ STD_PHP_INI_ENTRY_EX("newrelic.application_logging.metrics.enabled",
                      zend_newrelic_globals,
                      newrelic_globals,
                      nr_enabled_disabled_dh)
+STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.context_data.enabled",
+                     "0",
+                     NR_PHP_REQUEST,
+                     nr_boolean_mh,
+                     log_context_data_attributes.enabled,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     nr_enabled_disabled_dh)
+STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.context_data.include",
+                     "",
+                     NR_PHP_REQUEST,
+                     nr_string_mh,
+                     log_context_data_attributes.include,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     0)
+STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.context_data.exclude",
+                     "",
+                     NR_PHP_REQUEST,
+                     nr_string_mh,
+                     log_context_data_attributes.exclude,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     0)
 
 PHP_INI_END() /* } */
 

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1239,6 +1239,47 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;newrelic.application_logging.metrics.enabled = true
 
+; Setting: newrelic.application_logging.forwarding.context_data.enabled
+; Type   : boolean
+; Scope  : per-directory
+; Default: false
+; Info   : Control if context data associated with log messages is
+;          converted to log event attributes which are forwarded to New Relic.
+;
+;newrelic.application_logging.forwarding.context_data.enabled = false
+
+; Setting: newrelic.application_logging.forwarding.context_data.include
+;          newrelic.application_logging.forwarding.context_data.include
+; Type   : string
+; Scope  : per-directory
+; Default: none
+; Info   : This configuration options allow complete control over the
+;          context data array keys which are converted to log event attributes.
+;
+;          To include context data whose key is 'alpha', the configuration is:
+;          newrelic.application_logging.forwarding.context_data.include = alpha
+;
+;          To exclude context data whose key is 'alpha', the configuration is:
+;          newrelic.application_logging.forwarding.context_data.excludee = alpha
+;
+;          The newrelic.attributes.exclude and newrelic.attributes.include
+;          settings affect the conversion of custom data as well.
+;
+;          To exclude the attributes 'beta' and 'gamma' from all destinations,
+;          including log events, the configuration is:
+;          newrelic.attributes.exclude = beta,gamma
+;
+;          If one of the values in the comma separated list ends in a '*',
+;          it will match any suffix. For example, to exclude any attribute
+;          which begin with 'psi', the configuration is:
+;          newrelic.attributes.exclude = psi*
+;
+;          For more information, please refer to:
+;          https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-metrics/agent-attributes
+;
+;newrelic.application_logging.forwarding.context_data.include = ""
+;newrelic.application_logging.forwarding.context_data.exclude = ""
+
 ; Setting: newrelic.code_level_metrics.enabled
 ; Type   : boolean
 ; Scope  : per-directory

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1249,7 +1249,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;newrelic.application_logging.forwarding.context_data.enabled = false
 
 ; Setting: newrelic.application_logging.forwarding.context_data.include
-;          newrelic.application_logging.forwarding.context_data.include
+;          newrelic.application_logging.forwarding.context_data.exclude
 ; Type   : string
 ; Scope  : per-directory
 ; Default: none

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1260,7 +1260,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          newrelic.application_logging.forwarding.context_data.include = alpha
 ;
 ;          To exclude context data whose key is 'alpha', the configuration is:
-;          newrelic.application_logging.forwarding.context_data.excludee = alpha
+;          newrelic.application_logging.forwarding.context_data.exclude = alpha
 ;
 ;          The newrelic.attributes.exclude and newrelic.attributes.include
 ;          settings affect the conversion of custom data as well.


### PR DESCRIPTION
Adds the required INI values for APM log forwarding context data.
This PR adds the INI value parsing and data structures needed to hold these values.
The integration of these values into the capture and forwarding of context data will occur in following PRs.