### PR TITLE
fix(daemon): remove duplicate harvests

### DIFF
--- a/src/newrelic/processor.go
+++ b/src/newrelic/processor.go
@@ -695,8 +695,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType, du_chan ch
 		errors := harvest.Errors
 		slowSQLs := harvest.SlowSQLs
 		txnTraces := harvest.TxnTraces
-		spanEvents := harvest.SpanEvents
-		logEvents := harvest.LogEvents
 
 		harvest.Metrics = NewMetricTable(limits.MaxMetrics, time.Now())
 		harvest.Errors = NewErrorHeap(limits.MaxErrors)
@@ -709,8 +707,6 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType, du_chan ch
 		considerHarvestPayload(errors, args, duc)
 		considerHarvestPayload(slowSQLs, args, duc)
 		considerHarvestPayload(txnTraces, args, duc)
-		considerHarvestPayload(spanEvents, args, duc)
-		considerHarvestPayload(logEvents, args, duc)
 	}
 
 	eventConfigs := ah.App.connectReply.EventHarvestConfig.EventConfigs


### PR DESCRIPTION
The DefaultData harvest is only for data which can't/won't have its rate dictated by the Collector. All other data, which can have its own individual report rate, must be handled outside of the DefaultData block. SpanEvents and LogEvents already have their rates handled as such ([here](https://github.com/newrelic/newrelic-php-agent/pull/745/files#diff-d34a767f316aaeded794ac3a231f867d3ffb42de19365ed338eace17f5876d94R740) and [here](https://github.com/newrelic/newrelic-php-agent/pull/745/files#diff-d34a767f316aaeded794ac3a231f867d3ffb42de19365ed338eace17f5876d94R748)), and therefore should not also be reported with DefaultData. Because the DefaultData block was not resetting the above event containers, duplicate harvests were possible.