### PR TITLE
feat(agent): Adds log attribute capture [DO NOT REVIEW]

### DIFF
--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -89,6 +89,7 @@ TEST_BINARIES = \
 	tests/test_internal_instrument \
 	tests/test_hash \
 	tests/test_mongodb \
+	tests/test_monolog \
 	tests/test_mysql \
 	tests/test_mysqli \
 	tests/test_output \

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -30,6 +30,11 @@
 #define LOG_DECORATE_PROC_FUNC_NAME \
   "newrelic_phpagent_monolog_decorating_processor"
 
+/*
+ * Prefix for log context attributes 
+ */
+#define NR_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX "context."
+
 // clang-format off
 /*
  * This macro affects how instrumentation $context argument of
@@ -453,7 +458,7 @@ nr_attributes_t* nr_monolog_convert_context_data_to_attributes(
     nrobj_t* obj = nr_monolog_context_data_zval_to_attribute_obj(val);
 
     if (NULL != obj) {
-      char* buf = nr_formatf(NR_TXN_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX "%s",
+      char* buf = nr_formatf(NR_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX "%s",
                              ZSTR_VAL(key));
       st = nr_attributes_user_add(attributes, NR_ATTRIBUTE_DESTINATION_LOG, buf,
                                   obj);

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -441,15 +441,13 @@ nr_attributes_t* nr_monolog_convert_context_data_to_attributes(
   nr_attributes_t* attributes = NULL;
   nr_status_t st;
 
-  if (NULL == context_data) {
+  if (NULL == context_data || !nr_php_is_zval_valid_array(context_data)) {
     return NULL;
   }
 
   attributes = nr_attributes_create(NRPRG(txn)->attribute_config);
 
   ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARR_P(context_data), key, val) {
-    (void)key;
-    (void)val;
 
     if (NULL == key) {
       continue;

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -349,7 +349,6 @@ nrobj_t* nr_monolog_context_data_zval_to_attribute_obj(
       retobj = nro_new_double(Z_DVAL_P(z));
       break;
 
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
     case IS_TRUE:
       retobj = nro_new_boolean(true);
       break;
@@ -357,11 +356,6 @@ nrobj_t* nr_monolog_context_data_zval_to_attribute_obj(
     case IS_FALSE:
       retobj = nro_new_boolean(false);
       break;
-#else
-    case IS_BOOL:
-      retobj = nro_new_boolean(Z_BVAL_P(z));
-      break;
-#endif /* PHP 7.0+ */
 
     case IS_STRING:
       if (!nr_php_is_zval_valid_string(z)) {

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -583,8 +583,8 @@ NR_PHP_WRAPPER(nr_monolog_logger_addrecord) {
   }
 
   /* Record the log event */
-  nr_txn_record_log_event_ex(NRPRG(txn), level_name, message, timestamp,
-                             context_attributes, NRPRG(app));
+  nr_txn_record_log_event(NRPRG(txn), level_name, message, timestamp,
+                          context_attributes, NRPRG(app));
 
   nr_free(level_name);
   nr_free(message);

--- a/agent/lib_monolog_private.h
+++ b/agent/lib_monolog_private.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIB_MONOLOG_PRIVATE_HDR
+#define LIB_MONOLOG_PRIVATE_HDR
+
+/*
+ * Purpose : ONLY for testing to verify that the appropriate behavior of
+ *           the conversion of zvals to attribute via nro.
+ *
+ * Returns : Pointer to nr_object_t representation of zval or
+ *           NULL if zval is not a supported type for conversion
+ *           to an attribute
+ */
+extern nrobj_t* nr_monolog_context_data_zval_to_attribute_obj(
+    const zval* z TSRMLS_DC);
+
+/*
+ * Purpose : ONLY for testing to verify that the appropriate behavior of
+ *           the conversion of a Monolog context array to attributes.
+ *
+ * Returns : Caller takes ownership of attributes struct
+ *
+ */
+extern nr_attributes_t* nr_monolog_convert_context_data_to_attributes(
+    zval* context_data TSRMLS_DC);
+#endif /* LIB_MONOLOG_PRIVATE_HDR */

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -447,6 +447,11 @@ static nr_attribute_config_t* nr_php_create_attribute_config(TSRMLS_D) {
       NRINI(browser_monitoring_capture_attributes),
       NR_ATTRIBUTE_DESTINATION_BROWSER);
 
+  disabled_destinations |= nr_php_attribute_disable_destination_helper(
+      "newrelic.application_logging.forwarding.context_data.enabled",
+      NRINI(log_context_data_attributes.enabled), 0,
+      NR_ATTRIBUTE_DESTINATION_LOG);
+
   if (0 == NRINI(attributes.enabled)) {
     disabled_destinations |= NR_ATTRIBUTE_DESTINATION_ALL;
   }
@@ -490,6 +495,15 @@ static nr_attribute_config_t* nr_php_create_attribute_config(TSRMLS_D) {
   nr_php_modify_attribute_destinations(
       config, 0, NRINI(browser_monitoring_attributes.exclude), 0,
       NR_ATTRIBUTE_DESTINATION_BROWSER);
+
+  nr_php_modify_attribute_destinations(
+      config, NR_TXN_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX,
+      NRINI(log_context_data_attributes.include), NR_ATTRIBUTE_DESTINATION_LOG,
+      0);
+  nr_php_modify_attribute_destinations(
+      config, NR_TXN_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX,
+      NRINI(log_context_data_attributes.exclude), 0,
+      NR_ATTRIBUTE_DESTINATION_LOG);
 
   nr_php_modify_attribute_destinations(config, 0, NRINI(attributes.include),
                                        NR_ATTRIBUTE_DESTINATION_ALL, 0);
@@ -747,6 +761,8 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   opts.logging_enabled = NRINI(logging_enabled);
   opts.log_decorating_enabled = NRINI(log_decorating_enabled);
   opts.log_forwarding_enabled = NRINI(log_forwarding_enabled);
+  opts.log_forwarding_context_data_enabled
+      = NRINI(log_context_data_attributes.enabled);
   opts.log_forwarding_log_level = NRINI(log_forwarding_log_level);
   opts.log_events_max_samples_stored = NRINI(log_events_max_samples_stored);
   opts.log_metrics_enabled = NRINI(log_metrics_enabled);

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -497,12 +497,10 @@ static nr_attribute_config_t* nr_php_create_attribute_config(TSRMLS_D) {
       NR_ATTRIBUTE_DESTINATION_BROWSER);
 
   nr_php_modify_attribute_destinations(
-      config, NR_TXN_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX,
-      NRINI(log_context_data_attributes.include), NR_ATTRIBUTE_DESTINATION_LOG,
-      0);
+      config, 0, NRINI(log_context_data_attributes.include),
+      NR_ATTRIBUTE_DESTINATION_LOG, 0);
   nr_php_modify_attribute_destinations(
-      config, NR_TXN_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX,
-      NRINI(log_context_data_attributes.exclude), 0,
+      config, 0, NRINI(log_context_data_attributes.exclude), 0,
       NR_ATTRIBUTE_DESTINATION_LOG);
 
   nr_php_modify_attribute_destinations(config, 0, NRINI(attributes.include),

--- a/agent/tests/test_monolog.c
+++ b/agent/tests/test_monolog.c
@@ -319,9 +319,6 @@ static void test_convert_context_data_to_attributes_bad_params(TSRMLS_D) {
 }
 
 void test_main(void* p NRUNUSED) {
-#if defined(ZTS) && !defined(PHP7)
-  void*** tsrm_ls = NULL;
-#endif /* ZTS && !PHP7 */
 
   tlib_php_engine_create("");
 

--- a/agent/tests/test_monolog.c
+++ b/agent/tests/test_monolog.c
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "tlib_php.h"
+#include "tlib_datastore.h"
+
+#include "php_agent.h"
+#include "nr_attributes.h"
+#include "lib_monolog_private.h"
+
+tlib_parallel_info_t parallel_info
+    = {.suggested_nthreads = -1, .state_size = 0};
+
+static void test_convert_zval_to_attribute_obj(TSRMLS_D) {
+  zval* obj;
+  nrobj_t* nrobj;
+  nr_status_t err;
+
+  tlib_php_request_start();
+
+  /* test null zval */
+  obj = nr_php_zval_alloc();
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_null("NULL zval", nrobj);
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* test boolean */
+  obj = tlib_php_request_eval_expr("True;" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_not_null("Boolean converted", nrobj);
+  tlib_pass_if_equal("Boolean type correct", NR_OBJECT_BOOLEAN, nro_type(nrobj),
+                     int, "%d");
+  tlib_pass_if_true("Boolean value correct", nro_get_boolean(nrobj, &err),
+                    "expected true");
+  tlib_pass_if_equal("Boolean GET successful", NR_SUCCESS, err, int, "%d");
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* long */
+  obj = tlib_php_request_eval_expr("1234567;" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_not_null("Long converted", nrobj);
+  tlib_pass_if_equal("Long type correct", NR_OBJECT_LONG, nro_type(nrobj), int,
+                     "%d");
+  tlib_pass_if_equal("Long value correct", 1234567, nro_get_long(nrobj, &err),
+                     int, "%d");
+  tlib_pass_if_equal("Long GET successful", NR_SUCCESS, err, int, "%d");
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* double */
+  obj = tlib_php_request_eval_expr("1.234567;" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_not_null("Double converted", nrobj);
+  tlib_pass_if_equal("Double type correct", NR_OBJECT_DOUBLE, nro_type(nrobj),
+                     int, "%d");
+  tlib_pass_if_equal("Double value correct", 1.234567,
+                     nro_get_double(nrobj, &err), int, "%d");
+  tlib_pass_if_equal("Double GET successful", NR_SUCCESS, err, int, "%d");
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* string */
+  obj = tlib_php_request_eval_expr("\"A\";" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_not_null("String converted", nrobj);
+  tlib_pass_if_equal("String type correct", NR_OBJECT_STRING, nro_type(nrobj),
+                     int, "%d");
+  tlib_pass_if_str_equal("String value correct", "A",
+                         nro_get_string(nrobj, &err));
+  tlib_pass_if_equal("String GET successful", NR_SUCCESS, err, int, "%d");
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* constant boolean */
+  tlib_php_request_eval("define(\"CONSTANT_DEFINE_BOOLEAN\", True);" TSRMLS_CC);
+  obj = tlib_php_request_eval_expr("CONSTANT_DEFINE_BOOLEAN;" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_not_null("Constant Boolean converted", nrobj);
+  tlib_pass_if_equal("Constant Boolean type correct", NR_OBJECT_BOOLEAN,
+                     nro_type(nrobj), int, "%d");
+  tlib_pass_if_true("Constant Boolean value correct",
+                    nro_get_boolean(nrobj, &err), "expected true");
+  tlib_pass_if_equal("Constant Boolean GET successful", NR_SUCCESS, err, int,
+                     "%d");
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* constant long */
+  tlib_php_request_eval("define(\"CONSTANT_DEFINE_LONG\",1234567);" TSRMLS_CC);
+  obj = tlib_php_request_eval_expr("CONSTANT_DEFINE_LONG;" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_not_null("Constant Long converted", nrobj);
+  tlib_pass_if_equal("Constant Long type correct", NR_OBJECT_LONG,
+                     nro_type(nrobj), int, "%d");
+  tlib_pass_if_equal("Constant Long value correct", 1234567,
+                     nro_get_long(nrobj, &err), int, "%d");
+  tlib_pass_if_equal("Constant Long GET successful", NR_SUCCESS, err, int,
+                     "%d");
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* double */
+  tlib_php_request_eval(
+      "define(\"CONSTANT_DEFINE_DOUBLE\",1.234567);" TSRMLS_CC);
+  obj = tlib_php_request_eval_expr("CONSTANT_DEFINE_DOUBLE;" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_not_null("Constant Double converted", nrobj);
+  tlib_pass_if_equal("Constant Double type correct", NR_OBJECT_DOUBLE,
+                     nro_type(nrobj), int, "%d");
+  tlib_pass_if_equal("Constant Double value correct", 1.234567,
+                     nro_get_double(nrobj, &err), int, "%d");
+  tlib_pass_if_equal("Constant Double GET successful", NR_SUCCESS, err, int,
+                     "%d");
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* test constant string */
+  tlib_php_request_eval("define(\"CONSTANT_DEFINE_STRING\", \"A\");" TSRMLS_CC);
+  obj = tlib_php_request_eval_expr("CONSTANT_DEFINE_STRING;" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_not_null("Constant String converted", nrobj);
+  tlib_pass_if_equal("Constant tring type correct", NR_OBJECT_STRING,
+                     nro_type(nrobj), int, "%d");
+  tlib_pass_if_str_equal("Constant String value correct", "A",
+                         nro_get_string(nrobj, &err));
+  tlib_pass_if_equal("Constant String GET successful", NR_SUCCESS, err, int,
+                     "%d");
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* test array */
+  obj = tlib_php_request_eval_expr("array(1, 2, 3);" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_null("Array not converted", nrobj);
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  /* test object */
+  obj = tlib_php_request_eval_expr("new stdClass();" TSRMLS_CC);
+  nrobj = nr_monolog_context_data_zval_to_attribute_obj(obj);
+  tlib_pass_if_null("Object not converted", nrobj);
+  nr_php_zval_free(&obj);
+  nro_delete(nrobj);
+
+  tlib_php_request_end();
+}
+
+#define TEST_ATTRIBUTES_CREATION(CONTEXT_DATA, EXPECTED_JSON)                  \
+  do {                                                                         \
+    char* actual_json;                                                         \
+    nr_attributes_t* attributes                                                \
+        = nr_monolog_convert_context_data_to_attributes(context_data);         \
+                                                                               \
+    tlib_fail_if_null("attributes is not NULL", attributes);                   \
+                                                                               \
+    nrobj_t* log_attributes                                                    \
+        = nr_attributes_user_to_obj(attributes, NR_ATTRIBUTE_DESTINATION_LOG); \
+                                                                               \
+    tlib_fail_if_null("log_attributes is not NULL", log_attributes);           \
+    tlib_fail_if_bool_equal("At least one attribute created", 1,               \
+                            0 > nro_getsize(log_attributes));                  \
+                                                                               \
+    if (0 < nro_getsize(log_attributes)) {                                     \
+      actual_json = nro_to_json(log_attributes);                               \
+    }                                                                          \
+                                                                               \
+    tlib_pass_if_str_equal("Converted array", expected_json, actual_json);     \
+    nr_free(actual_json);                                                      \
+    nro_delete(log_attributes);                                                \
+    nr_attributes_destroy(&attributes);                                        \
+  } while (0)
+
+static void test_convert_context_data_to_json(TSRMLS_D) {
+  zval* context_data;
+
+  tlib_php_request_start();
+  nrtxn_t* txn = NRPRG(txn);
+
+  /* enable context data filtering */
+  nr_attribute_config_t* orig_config
+      = nr_attribute_config_copy(NRPRG(txn)->attribute_config);
+  txn->options.log_forwarding_context_data_enabled = 1;
+  nr_attribute_config_enable_destinations(txn->attribute_config,
+                                          NR_ATTRIBUTE_DESTINATION_LOG);
+
+  context_data = tlib_php_request_eval_expr(
+      "array(1=>\"one\","
+      "\"string_attr\"=>\"string_value\","
+      "\"double_attr\"=>3.1,"
+      "\"int_attr\"=>1234,"
+      "\"true_bool_attr\"=>True,"
+      "\"false_bool_attr\"=>False,"
+      "\"array_attr\"=>array(\"nested_string\"=>\"nested_string_value\"),"
+      "\"object_attr\"=>new StdClass())" TSRMLS_CC);
+
+  /* test without any filters and all attributes allowed */
+  char* expected_json
+      = "{"
+        "\"context.false_bool_attr\":false,"
+        "\"context.true_bool_attr\":true,"
+        "\"context.int_attr\":1234,"
+        "\"context.double_attr\":3.10000,"
+        "\"context.string_attr\":\"string_value\""
+        "}";
+
+  TEST_ATTRIBUTES_CREATION(context_data, expected_json);
+
+  /* add filtering rules and try again */
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.string_attr",
+                                          NR_ATTRIBUTE_DESTINATION_LOG, 0);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.i*",
+                                          NR_ATTRIBUTE_DESTINATION_LOG, 0);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.f*", 0,
+                                          NR_ATTRIBUTE_DESTINATION_LOG);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.t*", 0,
+                                          NR_ATTRIBUTE_DESTINATION_LOG);
+  expected_json
+      = "{"
+        "\"context.int_attr\":1234,"
+        "\"context.double_attr\":3.10000,"
+        "\"context.string_attr\":\"string_value\""
+        "}";
+
+  TEST_ATTRIBUTES_CREATION(context_data, expected_json);
+
+  /* another case to add filtering rules and try again */
+  nr_attribute_config_destroy(&(NRPRG(txn)->attribute_config));
+  NRPRG(txn)->attribute_config = nr_attribute_config_copy(orig_config);
+  nr_attribute_config_enable_destinations(txn->attribute_config,
+                                          NR_ATTRIBUTE_DESTINATION_LOG);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.d*",
+                                          NR_ATTRIBUTE_DESTINATION_LOG, 0);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.i*",
+                                          NR_ATTRIBUTE_DESTINATION_LOG, 0);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.*", 0,
+                                          NR_ATTRIBUTE_DESTINATION_LOG);
+  expected_json
+      = "{"
+        "\"context.int_attr\":1234,"
+        "\"context.double_attr\":3.10000"
+        "}";
+
+  TEST_ATTRIBUTES_CREATION(context_data, expected_json);
+
+  /* test global and context_data include/exclude rules */
+  nr_attribute_config_destroy(&(NRPRG(txn)->attribute_config));
+  NRPRG(txn)->attribute_config = nr_attribute_config_copy(orig_config);
+  nr_attribute_config_enable_destinations(txn->attribute_config,
+                                          NR_ATTRIBUTE_DESTINATION_LOG);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.d*",
+                                          NR_ATTRIBUTE_DESTINATION_LOG, 0);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.i*",
+                                          NR_ATTRIBUTE_DESTINATION_LOG, 0);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.true_bool_attr",
+                                          NR_ATTRIBUTE_DESTINATION_LOG, 0);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.t*", 0,
+                                          NR_ATTRIBUTE_DESTINATION_ALL);
+  nr_attribute_config_modify_destinations(NRPRG(txn)->attribute_config,
+                                          "context.false_bool_attr", 0,
+                                          NR_ATTRIBUTE_DESTINATION_ALL);
+  expected_json
+      = "{"
+        "\"context.true_bool_attr\":true,"
+        "\"context.int_attr\":1234,"
+        "\"context.double_attr\":3.10000,"
+        "\"context.string_attr\":\"string_value\""
+        "}";
+
+  TEST_ATTRIBUTES_CREATION(context_data, expected_json);
+
+  nr_attribute_config_destroy(&orig_config);
+  nr_php_zval_free(&context_data);
+
+  tlib_php_request_end();
+}
+
+void test_main(void* p NRUNUSED) {
+#if defined(ZTS) && !defined(PHP7)
+  void*** tsrm_ls = NULL;
+#endif /* ZTS && !PHP7 */
+
+  tlib_php_engine_create("");
+
+  test_convert_zval_to_attribute_obj();
+  test_convert_context_data_to_json();
+
+  tlib_php_engine_destroy(TSRMLS_C);
+}

--- a/axiom/nr_attributes.c
+++ b/axiom/nr_attributes.c
@@ -98,12 +98,12 @@ void nr_attribute_config_disable_destinations(nr_attribute_config_t* config,
 }
 
 void nr_attribute_config_enable_destinations(nr_attribute_config_t* config,
-                                             uint32_t disabled_destinations) {
+                                             uint32_t enabled_destinations) {
   if (0 == config) {
     return;
   }
 
-  config->disabled_destinations &= ~disabled_destinations;
+  config->disabled_destinations &= ~enaabled_destinations;
 }
 
 nr_attribute_destination_modifier_t* nr_attribute_destination_modifier_create(

--- a/axiom/nr_attributes.c
+++ b/axiom/nr_attributes.c
@@ -97,6 +97,15 @@ void nr_attribute_config_disable_destinations(nr_attribute_config_t* config,
   config->disabled_destinations |= disabled_destinations;
 }
 
+void nr_attribute_config_enable_destinations(nr_attribute_config_t* config,
+                                             uint32_t disabled_destinations) {
+  if (0 == config) {
+    return;
+  }
+
+  config->disabled_destinations &= ~disabled_destinations;
+}
+
 nr_attribute_destination_modifier_t* nr_attribute_destination_modifier_create(
     const char* match,
     uint32_t include_destinations,

--- a/axiom/nr_attributes.c
+++ b/axiom/nr_attributes.c
@@ -103,7 +103,7 @@ void nr_attribute_config_enable_destinations(nr_attribute_config_t* config,
     return;
   }
 
-  config->disabled_destinations &= ~enaabled_destinations;
+  config->disabled_destinations &= ~enabled_destinations;
 }
 
 nr_attribute_destination_modifier_t* nr_attribute_destination_modifier_create(

--- a/axiom/nr_attributes.h
+++ b/axiom/nr_attributes.h
@@ -38,10 +38,11 @@ typedef struct _nr_attributes_t nr_attributes_t;
 #define NR_ATTRIBUTE_DESTINATION_ERROR 4
 #define NR_ATTRIBUTE_DESTINATION_BROWSER 8
 #define NR_ATTRIBUTE_DESTINATION_SPAN 16
+#define NR_ATTRIBUTE_DESTINATION_LOG 32
 #define NR_ATTRIBUTE_DESTINATION_ALL                                       \
   (NR_ATTRIBUTE_DESTINATION_TXN_EVENT | NR_ATTRIBUTE_DESTINATION_TXN_TRACE \
    | NR_ATTRIBUTE_DESTINATION_ERROR | NR_ATTRIBUTE_DESTINATION_BROWSER     \
-   | NR_ATTRIBUTE_DESTINATION_SPAN)
+   | NR_ATTRIBUTE_DESTINATION_SPAN | NR_ATTRIBUTE_DESTINATION_LOG)
 
 /*
  * Attribute keys and value string lengths are limited.  If a string exceeds
@@ -96,6 +97,22 @@ extern nr_attribute_config_t* nr_attribute_config_create(void);
  *           will not be overriden:  They will instead be or-ed.
  */
 extern void nr_attribute_config_disable_destinations(
+    nr_attribute_config_t* config,
+    uint32_t disabled_destinations);
+
+/*
+ * Purpose : Enable attribute destinations.
+ *
+ * Params  : 1. The configuration to modify.
+ *           2. The set of destinations to enable.
+ *
+ * Note    : Destinations are enabled by default when a config
+ *           is created.  This function can be used to enable
+ *           a previously disabled destination.  Current
+ *           use is to enable destinationss disabled by default
+ *           for testing purposes.
+ */
+extern void nr_attribute_config_enable_destinations(
     nr_attribute_config_t* config,
     uint32_t disabled_destinations);
 

--- a/axiom/nr_attributes.h
+++ b/axiom/nr_attributes.h
@@ -114,7 +114,7 @@ extern void nr_attribute_config_disable_destinations(
  */
 extern void nr_attribute_config_enable_destinations(
     nr_attribute_config_t* config,
-    uint32_t disabled_destinations);
+    uint32_t enabled_destinations);
 
 /*
  * Purpose : Modify the destinations of a particular attribute, or all

--- a/axiom/nr_log_event.c
+++ b/axiom/nr_log_event.c
@@ -122,10 +122,6 @@ bool nr_log_event_to_json_buffer(const nr_log_event_t* event, nrbuf_t* buf) {
   add_log_field_to_buf(buf, "entity.name", event->entity_name, false, false,
                        true);
   add_log_field_to_buf(buf, "hostname", event->hostname, false, false, true);
-  /*
-  add_log_field_to_buf(buf, "attributes", context_json, false, false,
-  false);
-  */
 
   // timestamp always present
   nr_buffer_add(buf, NR_PSTR(",\"timestamp\":"));

--- a/axiom/nr_log_event.c
+++ b/axiom/nr_log_event.c
@@ -47,6 +47,8 @@ void nr_log_event_destroy(nr_log_event_t** ptr) {
  *           3. Value of the field (JSON value)
  *           4. Boolean indicating if this is the first field
  *           5. Boolean indicating if this field is required
+ *           6. Boolean indicating if this field should be quoted
+ *              (use false if including a JSON string, for example)
  *
  * Returns : True is data was added to buf.
  */

--- a/axiom/nr_log_event.h
+++ b/axiom/nr_log_event.h
@@ -8,6 +8,7 @@
 
 #include "util_buffer.h"
 #include "util_time.h"
+#include "nr_attributes.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -99,5 +100,7 @@ extern void nr_log_event_set_entity_name(nr_log_event_t* event,
 extern void nr_log_event_set_hostname(nr_log_event_t* event, const char* name);
 extern void nr_log_event_set_timestamp(nr_log_event_t* event, nrtime_t time);
 extern void nr_log_event_set_priority(nr_log_event_t* event, int priority);
-
+extern void nr_log_event_set_context_attributes(
+    nr_log_event_t* event,
+    nr_attributes_t* context_attributes);
 #endif /* NR_LOG_EVENT_HDR */

--- a/axiom/nr_log_event_private.h
+++ b/axiom/nr_log_event_private.h
@@ -6,12 +6,12 @@
 #ifndef NR_LOG_EVENT_PRIVATE_H
 #define NR_LOG_EVENT_PRIVATE_H
 
-#include "util_object.h"
-
+#include "nr_attributes.h"
 struct _nr_log_event_t {
   char* message;
   char* log_level;
   nrtime_t timestamp;
+  nr_attributes_t* context_attributes;
   char* trace_id;
   char* span_id;
   char* entity_guid;

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3276,6 +3276,18 @@ bool nr_txn_log_forwarding_enabled(nrtxn_t* txn) {
   return true;
 }
 
+bool nr_txn_log_forwarding_context_data_enabled(nrtxn_t* txn) {
+  if (!nr_txn_log_forwarding_enabled(txn)) {
+    return false;
+  }
+
+  if (!txn->options.log_forwarding_context_data_enabled) {
+    return false;
+  }
+
+  return true;
+}
+
 bool nr_txn_log_forwarding_log_level_verify(nrtxn_t* txn,
                                             const char* log_level_name) {
   int log_level;
@@ -3371,6 +3383,7 @@ static void log_event_set_linking_metadata(nr_log_event_t* e,
 static nr_log_event_t* log_event_create(const char* log_level_name,
                                         const char* log_message,
                                         nrtime_t timestamp,
+                                        nr_attributes_t* context_attributes,
                                         nrtxn_t* txn,
                                         nrapp_t* app) {
   nr_log_event_t* e = nr_log_event_create();
@@ -3380,6 +3393,7 @@ static nr_log_event_t* log_event_create(const char* log_level_name,
   nr_log_event_set_log_level(e, ENSURE_LOG_LEVEL_NAME(log_level_name));
   nr_log_event_set_message(e, log_message);
   nr_log_event_set_timestamp(e, timestamp);
+  nr_log_event_set_context_attributes(e, context_attributes);
 
   log_event_set_linking_metadata(e, txn, app);
 
@@ -3390,6 +3404,7 @@ static void nr_txn_add_log_event(nrtxn_t* txn,
                                  const char* log_level_name,
                                  const char* log_message,
                                  nrtime_t timestamp,
+                                 nr_attributes_t* context_attributes,
                                  nrapp_t* app) {
   nr_log_event_t* e = NULL;
   bool event_dropped = false;
@@ -3411,7 +3426,7 @@ static void nr_txn_add_log_event(nrtxn_t* txn,
     event_dropped = true;
   } else {
     /* event passed log level filter so add it */
-    e = log_event_create(log_level_name, log_message, timestamp, txn, app);
+    e = log_event_create(log_level_name, log_message, timestamp, context_attributes, txn, app);
     if (NULL == e) {
       nrl_debug(NRL_TXN, "%s: failed to create log event", __func__);
       event_dropped = true;
@@ -3444,16 +3459,26 @@ static void nr_txn_add_logging_metrics(nrtxn_t* txn, const char* level_name) {
   nr_free(metric_name);
 }
 
-void nr_txn_record_log_event(nrtxn_t* txn,
+void nr_txn_record_log_event_ex(nrtxn_t* txn,
                              const char* log_level_name,
                              const char* log_message,
                              nrtime_t timestamp,
+                             nr_attributes_t* context_attributes,
                              nrapp_t* app) {
   if (nrunlikely(NULL == txn)) {
     return;
   }
 
-  nr_txn_add_log_event(txn, log_level_name, log_message, timestamp, app);
+  nr_txn_add_log_event(txn, log_level_name, log_message, timestamp, context_attributes, app);
 
   nr_txn_add_logging_metrics(txn, log_level_name);
+}
+
+void nr_txn_record_log_event(nrtxn_t* txn,
+                             const char* log_level_name,
+                             const char* log_message,
+                             nrtime_t timestamp,
+                             nrapp_t* app) {
+
+  nr_txn_record_log_event_ex(txn, log_level_name, log_message, timestamp, NULL, app);
 }

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3459,7 +3459,7 @@ static void nr_txn_add_logging_metrics(nrtxn_t* txn, const char* level_name) {
   nr_free(metric_name);
 }
 
-void nr_txn_record_log_event_ex(nrtxn_t* txn,
+void nr_txn_record_log_event(nrtxn_t* txn,
                              const char* log_level_name,
                              const char* log_message,
                              nrtime_t timestamp,
@@ -3469,16 +3469,8 @@ void nr_txn_record_log_event_ex(nrtxn_t* txn,
     return;
   }
 
-  nr_txn_add_log_event(txn, log_level_name, log_message, timestamp, context_attributes, app);
+  nr_txn_add_log_event(txn, log_level_name, log_message, timestamp,
+                       context_attributes, app);
 
   nr_txn_add_logging_metrics(txn, log_level_name);
-}
-
-void nr_txn_record_log_event(nrtxn_t* txn,
-                             const char* log_level_name,
-                             const char* log_message,
-                             nrtime_t timestamp,
-                             nrapp_t* app) {
-
-  nr_txn_record_log_event_ex(txn, log_level_name, log_message, timestamp, NULL, app);
 }

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -41,7 +41,7 @@
 #include "util_string_pool.h"
 
 #define NR_TXN_REQUEST_PARAMETER_ATTRIBUTE_PREFIX "request.parameters."
-
+#define NR_TXN_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX "context."
 typedef enum _nr_tt_recordsql_t {
   NR_SQL_NONE = 0,
   NR_SQL_RAW = 1,
@@ -122,6 +122,7 @@ typedef struct _nrtxnopt_t {
                            application logging features */
   bool log_decorating_enabled;  /* Whether log decorating is enabled */
   bool log_forwarding_enabled;  /* Whether log forwarding is enabled */
+  bool log_forwarding_context_data_enabled; /* Whether context data is forwarded with logs */
   int log_forwarding_log_level; /* minimum log level to forward to the collector
                                  */
   size_t log_events_max_samples_stored; /* The maximum number of log events per
@@ -629,6 +630,11 @@ extern void nr_txn_record_custom_event(nrtxn_t* txn,
 extern bool nr_txn_log_forwarding_enabled(nrtxn_t* txn);
 
 /*
+ * Purpose : Check log forwarding context data configuration
+ */
+extern bool nr_txn_log_forwarding_context_data_enabled(nrtxn_t* txn);
+
+/*
  * Purpose : Check log forwarding log level configuration
  */
 extern bool nr_txn_log_forwarding_log_level_verify(nrtxn_t* txn,
@@ -651,9 +657,17 @@ extern bool nr_txn_log_decorating_enabled(nrtxn_t* txn);
  *           2. Log record level name
  *           3. Log record message
  *           4. Log record timestamp
- *           5. The application (to get linking meta data)
+ *           5. Attribute data for Monolog context data (can be NULL)
+ *           6. The application (to get linking meta data)
  *
  */
+extern void nr_txn_record_log_event_ex(nrtxn_t* txn,
+                                    const char* level_name,
+                                    const char* message,
+                                    nrtime_t timestamp,
+                                    nr_attributes_t* context_attributes,
+                                    nrapp_t* app);
+
 extern void nr_txn_record_log_event(nrtxn_t* txn,
                                     const char* level_name,
                                     const char* message,

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -41,7 +41,6 @@
 #include "util_string_pool.h"
 
 #define NR_TXN_REQUEST_PARAMETER_ATTRIBUTE_PREFIX "request.parameters."
-#define NR_TXN_LOG_CONTEXT_DATA_ATTRIBUTE_PREFIX "context."
 typedef enum _nr_tt_recordsql_t {
   NR_SQL_NONE = 0,
   NR_SQL_RAW = 1,

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -661,17 +661,11 @@ extern bool nr_txn_log_decorating_enabled(nrtxn_t* txn);
  *           6. The application (to get linking meta data)
  *
  */
-extern void nr_txn_record_log_event_ex(nrtxn_t* txn,
-                                    const char* level_name,
-                                    const char* message,
-                                    nrtime_t timestamp,
-                                    nr_attributes_t* context_attributes,
-                                    nrapp_t* app);
-
 extern void nr_txn_record_log_event(nrtxn_t* txn,
                                     const char* level_name,
                                     const char* message,
                                     nrtime_t timestamp,
+                                    nr_attributes_t* context_attributes,
                                     nrapp_t* app);
 
 /*

--- a/axiom/tests/test_attributes.c
+++ b/axiom/tests/test_attributes.c
@@ -268,7 +268,7 @@ static void test_config_modify_destinations(void) {
   uint32_t trace = NR_ATTRIBUTE_DESTINATION_TXN_TRACE;
   uint32_t error = NR_ATTRIBUTE_DESTINATION_ERROR;
   uint32_t browser = NR_ATTRIBUTE_DESTINATION_BROWSER;
-
+  uint32_t log = NR_ATTRIBUTE_DESTINATION_LOG;
   /* NULL config: Don't blow up! */
   nr_attribute_config_modify_destinations(0, "alpha", event, error);
 
@@ -283,6 +283,10 @@ static void test_config_modify_destinations(void) {
   nr_attribute_config_modify_destinations(config, "beta.*", 0, trace);
 
   nr_attribute_config_modify_destinations(config, "beta.alpha", 0, browser);
+  nr_attribute_config_modify_destinations(config, "beta.al*", 0, log);
+
+  nr_attribute_config_modify_destinations(config, "beta.alp", log, 0);
+  nr_attribute_config_modify_destinations(config, "beta.alph", 0, browser);
 
   test_config_as_json("modifiers created and in correct order", config,
                       "{"
@@ -314,12 +318,36 @@ static void test_config_modify_destinations(void) {
                       "\"exclude_destinations\":0"
                       "},"
                       "{"
+                      "\"has_wildcard_suffix\":true,"
+                      "\"match\":\"beta.al\","
+                      "\"match_len\":7,"
+                      "\"match_hash\":3041978671,"
+                      "\"include_destinations\":0,"
+                      "\"exclude_destinations\":32"
+                      "},"
+                      "{"
                       "\"has_wildcard_suffix\":false,"
                       "\"match\":\"beta.al\","
                       "\"match_len\":7,"
                       "\"match_hash\":3041978671,"
                       "\"include_destinations\":0,"
                       "\"exclude_destinations\":5"
+                      "},"
+                      "{"
+                      "\"has_wildcard_suffix\":false,"
+                      "\"match\":\"beta.alp\","
+                      "\"match_len\":8,"
+                      "\"match_hash\":4236011699,"
+                      "\"include_destinations\":32,"
+                      "\"exclude_destinations\":0"
+                      "},"
+                      "{"
+                      "\"has_wildcard_suffix\":false,"
+                      "\"match\":\"beta.alph\","
+                      "\"match_len\":9,"
+                      "\"match_hash\":2625680436,"
+                      "\"include_destinations\":0,"
+                      "\"exclude_destinations\":8"
                       "},"
                       "{"
                       "\"has_wildcard_suffix\":false,"
@@ -344,6 +372,7 @@ static void test_config_copy(void) {
   uint32_t trace = NR_ATTRIBUTE_DESTINATION_TXN_TRACE;
   uint32_t error = NR_ATTRIBUTE_DESTINATION_ERROR;
   uint32_t browser = NR_ATTRIBUTE_DESTINATION_BROWSER;
+  uint32_t log = NR_ATTRIBUTE_DESTINATION_LOG;
 
   config_copy = nr_attribute_config_copy(0);
   tlib_pass_if_true("copy NULL config", 0 == config_copy, "config_copy=%p",
@@ -374,6 +403,9 @@ static void test_config_copy(void) {
   nr_attribute_config_modify_destinations(config, "beta.", browser, 0);
   nr_attribute_config_modify_destinations(config, "beta.*", 0, trace);
 
+  nr_attribute_config_modify_destinations(config, "gamma.", log, 0);
+  nr_attribute_config_modify_destinations(config, "gamma.*", 0, trace);
+
   config_copy = nr_attribute_config_copy(config);
   config_copy_json = nr_attribute_config_to_json(config_copy);
   config_json = nr_attribute_config_to_json(config);
@@ -394,6 +426,7 @@ static void test_config_apply(void) {
   uint32_t trace = NR_ATTRIBUTE_DESTINATION_TXN_TRACE;
   uint32_t error = NR_ATTRIBUTE_DESTINATION_ERROR;
   uint32_t browser = NR_ATTRIBUTE_DESTINATION_BROWSER;
+  uint32_t log = NR_ATTRIBUTE_DESTINATION_LOG;
 
   config = nr_attribute_config_create();
 
@@ -414,9 +447,10 @@ static void test_config_apply(void) {
   /*
    * Test that the destination modifier are applied in the correct order.
    */
-  nr_attribute_config_modify_destinations(config, "alpha.*", browser | trace,
+  nr_attribute_config_modify_destinations(config, "alpha.*", browser | trace | log,
                                           0);
   nr_attribute_config_modify_destinations(config, "alpha.beta", error, browser);
+  nr_attribute_config_modify_destinations(config, "alpha.b*", 0, log);
 
   destinations = nr_attribute_config_apply(config, "alpha.beta",
                                            nr_mkhash("alpha.beta", 0), event);
@@ -568,6 +602,7 @@ static void test_add(void) {
   uint32_t trace = NR_ATTRIBUTE_DESTINATION_TXN_TRACE;
   uint32_t error = NR_ATTRIBUTE_DESTINATION_ERROR;
   uint32_t browser = NR_ATTRIBUTE_DESTINATION_BROWSER;
+  uint32_t log = NR_ATTRIBUTE_DESTINATION_LOG;
   uint32_t all = NR_ATTRIBUTE_DESTINATION_ALL;
   nr_status_t st;
   nrobj_t* obj;
@@ -605,6 +640,8 @@ static void test_add(void) {
   tlib_pass_if_true("add success", NR_SUCCESS == st, "st=%d", (int)st);
   st = nr_attributes_user_add_string(attributes, error, "gamma", "789");
   tlib_pass_if_true("add success", NR_SUCCESS == st, "st=%d", (int)st);
+  st = nr_attributes_user_add_string(attributes, log, "delta", "abc");
+  tlib_pass_if_true("add success", NR_SUCCESS == st, "st=%d", (int)st);
 
   st = nr_attributes_agent_add_long(attributes, browser | event, "psi", 123);
   tlib_pass_if_true("add success", NR_SUCCESS == st, "st=%d", (int)st);
@@ -612,6 +649,8 @@ static void test_add(void) {
   tlib_pass_if_true("add success", NR_SUCCESS == st, "st=%d", (int)st);
   st = nr_attributes_agent_add_string(attributes, browser | error, "theta",
                                       "789");
+  tlib_pass_if_true("add success", NR_SUCCESS == st, "st=%d", (int)st);
+  st = nr_attributes_agent_add_string(attributes, log, "chi", "abc");
   tlib_pass_if_true("add success", NR_SUCCESS == st, "st=%d", (int)st);
 
   st = nr_attributes_agent_add_string(attributes, 0,
@@ -625,10 +664,10 @@ static void test_add(void) {
 
   test_user_attributes_as_json(
       "user attributes: all", attributes, all,
-      "{\"gamma\":\"789\",\"beta\":456,\"alpha\":123}");
+      "{\"delta\":\"abc\",\"gamma\":\"789\",\"beta\":456,\"alpha\":123}");
   test_agent_attributes_as_json(
       "agent attributes: all", attributes, all,
-      "{\"theta\":\"789\",\"omega\":456,\"psi\":123}");
+      "{\"chi\":\"abc\",\"theta\":\"789\",\"omega\":456,\"psi\":123}");
 
   test_user_attributes_as_json("user attributes: event", attributes, event,
                                "{\"alpha\":123}");

--- a/axiom/tests/test_log_event.c
+++ b/axiom/tests/test_log_event.c
@@ -386,6 +386,9 @@ static void test_log_event_context_attributes(void) {
   // Test: Setting a NULL context data ptr should not crash
   nr_log_event_set_context_attributes(event, NULL);
 
+  // Test: All NULL parameters should not crash
+  nr_log_event_set_context_attributes(NULL, NULL);
+
   nr_log_event_destroy(&event);
 }
 

--- a/axiom/tests/test_log_event.c
+++ b/axiom/tests/test_log_event.c
@@ -377,7 +377,7 @@ static void test_log_event_context_attributes(void) {
   // Test : Get context attributes with a NULL event
   tlib_pass_if_null("Initialize event should have NULL context",
                     event->context_attributes);
-  
+
   // Test: Setting context data on NULL event ptr should not crash
   attributes = nr_attributes_create(NULL);
   nr_log_event_set_context_attributes(NULL, attributes);
@@ -387,7 +387,6 @@ static void test_log_event_context_attributes(void) {
   nr_log_event_set_context_attributes(event, NULL);
 
   nr_log_event_destroy(&event);
-
 }
 
 tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};

--- a/axiom/tests/test_log_event.c
+++ b/axiom/tests/test_log_event.c
@@ -370,6 +370,24 @@ static void test_log_event_priority(void) {
   nr_log_event_set_priority(NULL, 0xFFFF);
 }
 
+static void test_log_event_context_attributes(void) {
+  nr_log_event_t* event = nr_log_event_create();
+  nr_attributes_t* attributes = NULL;
+
+  // Test : Get context attributes with a NULL event
+  tlib_pass_if_null("Initialize event should have NULL context",
+                    event->context_attributes);
+  nr_log_event_destroy(&event);
+
+  // Test: Setting context data on NULL event ptr should not crash
+  attributes = nr_attributes_create(NULL);
+  nr_log_event_set_context_attributes(NULL, attributes);
+  nr_attributes_destroy(&attributes);
+
+  // Test: Setting a NULL context data ptr should not crash
+  nr_log_event_set_context_attributes(event, NULL);
+}
+
 tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};
 
 void test_main(void* p NRUNUSED) {
@@ -385,4 +403,5 @@ void test_main(void* p NRUNUSED) {
   test_log_event_timestamp();
   test_log_event_priority();
   test_log_event_span_id();
+  test_log_event_context_attributes();
 }

--- a/axiom/tests/test_log_event.c
+++ b/axiom/tests/test_log_event.c
@@ -377,8 +377,7 @@ static void test_log_event_context_attributes(void) {
   // Test : Get context attributes with a NULL event
   tlib_pass_if_null("Initialize event should have NULL context",
                     event->context_attributes);
-  nr_log_event_destroy(&event);
-
+  
   // Test: Setting context data on NULL event ptr should not crash
   attributes = nr_attributes_create(NULL);
   nr_log_event_set_context_attributes(NULL, attributes);
@@ -386,6 +385,9 @@ static void test_log_event_context_attributes(void) {
 
   // Test: Setting a NULL context data ptr should not crash
   nr_log_event_set_context_attributes(event, NULL);
+
+  nr_log_event_destroy(&event);
+
 }
 
 tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8303,7 +8303,7 @@ static void test_record_log_event(void) {
   /* fill up events pool to force sampling */
   for (int i = 0, max_events = nr_log_events_max_events(txn->log_events);
        i < max_events; i++) {
-    nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, &appv);
+    nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, NULL, &appv);
   }
   /* force sampling */
   nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, NULL, &appv);

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8180,7 +8180,7 @@ static void test_record_log_event(void) {
    */
 
   txn = new_txn_for_record_log_event_test(APP_ENTITY_NAME);
-  nr_txn_record_log_event(NULL, NULL, NULL, 0, NULL);
+  nr_txn_record_log_event(NULL, NULL, NULL, 0, NULL, NULL);
   tlib_pass_if_int_equal("all params null, no crash, event not recorded", 0,
                          nr_log_events_number_seen(txn->log_events));
   tlib_pass_if_int_equal("all params null, no crash, event not recorded", 0,
@@ -8188,7 +8188,7 @@ static void test_record_log_event(void) {
   nr_txn_destroy(&txn);
 
   txn = new_txn_for_record_log_event_test(APP_ENTITY_NAME);
-  nr_txn_record_log_event(NULL, LOG_EVENT_PARAMS, NULL);
+  nr_txn_record_log_event(NULL, LOG_EVENT_PARAMS, NULL, NULL);
   tlib_pass_if_int_equal("null txn, no crash, event not recorded", 0,
                          nr_log_events_number_seen(txn->log_events));
   tlib_pass_if_int_equal("null txn, no crash, event not recorded", 0,
@@ -8200,7 +8200,7 @@ static void test_record_log_event(void) {
    * don't blow up!
    */
   txn = new_txn_for_record_log_event_test(APP_ENTITY_NAME);
-  nr_txn_record_log_event(txn, NULL, NULL, 0, NULL);
+  nr_txn_record_log_event(txn, NULL, NULL, 0, NULL, NULL);
   tlib_pass_if_int_equal("null log params, event not recorded", 0,
                          nr_log_events_number_seen(txn->log_events));
   tlib_pass_if_int_equal("null log params, event not recorded", 0,
@@ -8214,7 +8214,7 @@ static void test_record_log_event(void) {
   nr_txn_destroy(&txn);
 
   txn = new_txn_for_record_log_event_test(APP_ENTITY_NAME);
-  nr_txn_record_log_event(txn, NULL, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, NULL, LOG_MESSAGE, 0, NULL, NULL);
   tlib_pass_if_int_equal("null log level, event seen", 1,
                          nr_log_events_number_seen(txn->log_events));
   tlib_pass_if_int_equal("null log level, event saved", 1,
@@ -8253,7 +8253,7 @@ static void test_record_log_event(void) {
 
   /* Happy path - everything initialized: record! */
   txn = new_txn_for_record_log_event_test(APP_ENTITY_NAME);
-  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, &appv);
+  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, NULL, &appv);
   tlib_pass_if_int_equal("happy path, event seen", 1,
                          nr_log_events_number_seen(txn->log_events));
   tlib_pass_if_int_equal("happy path, event saved", 1,
@@ -8306,8 +8306,8 @@ static void test_record_log_event(void) {
     nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, &appv);
   }
   /* force sampling */
-  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, &appv);
-  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, &appv);
+  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, NULL, &appv);
+  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, NULL, &appv);
   test_txn_metric_is("happy path with sampling, events recorded and dropped",
                      txn->unscoped_metrics, MET_FORCED,
                      "Logging/Forwarding/Dropped", 2, 0, 0, 0, 0, 0);
@@ -8321,8 +8321,8 @@ static void test_record_log_event(void) {
   tlib_pass_if_not_null("empty log events pool created", txn->log_events);
   tlib_pass_if_int_equal("empty log events pool stores 0 events", 0,
                          nr_log_events_max_events(txn->log_events));
-  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, &appv);
-  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, &appv);
+  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, NULL, &appv);
+  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, NULL, &appv);
   /* Events are seen because log forwarding is enabled
      and txn->options.log_events_max_samples_stored > 0 */
   tlib_pass_if_int_equal("happy path, event seen", 2,
@@ -8337,7 +8337,7 @@ static void test_record_log_event(void) {
   /* High_security */
   txn = new_txn_for_record_log_event_test(APP_ENTITY_NAME);
   txn->high_security = 1;
-  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, &appv);
+  nr_txn_record_log_event(txn, LOG_EVENT_PARAMS, NULL, &appv);
   tlib_pass_if_int_equal("happy path, hsm, event seen", 0,
                          nr_log_events_number_seen(txn->log_events));
   tlib_pass_if_int_equal("happy path, hsm, event saved", 0,
@@ -8355,17 +8355,17 @@ static void test_record_log_event(void) {
 
   /* default filter log level is LOG_LEVEL_WARNING */
   /* these messages should be accepted */
-  nr_txn_record_log_event(txn, LL_ALER_STR, LOG_MESSAGE, 0, NULL);
-  nr_txn_record_log_event(txn, LL_CRIT_STR, LOG_MESSAGE, 0, NULL);
-  nr_txn_record_log_event(txn, LL_WARN_STR, LOG_MESSAGE, 0, NULL);
-  nr_txn_record_log_event(txn, LL_EMER_STR, LOG_MESSAGE, 0, NULL);
-  nr_txn_record_log_event(txn, LL_UNKN_STR, LOG_MESSAGE, 0, NULL);
-  nr_txn_record_log_event(txn, "APPLES", LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, LL_ALER_STR, LOG_MESSAGE, 0, NULL, NULL);
+  nr_txn_record_log_event(txn, LL_CRIT_STR, LOG_MESSAGE, 0, NULL, NULL);
+  nr_txn_record_log_event(txn, LL_WARN_STR, LOG_MESSAGE, 0, NULL, NULL);
+  nr_txn_record_log_event(txn, LL_EMER_STR, LOG_MESSAGE, 0, NULL, NULL);
+  nr_txn_record_log_event(txn, LL_UNKN_STR, LOG_MESSAGE, 0, NULL, NULL);
+  nr_txn_record_log_event(txn, "APPLES", LOG_MESSAGE, 0, NULL, NULL);
 
   /* these messages will be dropped */
-  nr_txn_record_log_event(txn, LL_INFO_STR, LOG_MESSAGE, 0, NULL);
-  nr_txn_record_log_event(txn, LL_DEBU_STR, LOG_MESSAGE, 0, NULL);
-  nr_txn_record_log_event(txn, LL_NOTI_STR, LOG_MESSAGE, 0, NULL);
+  nr_txn_record_log_event(txn, LL_INFO_STR, LOG_MESSAGE, 0, NULL, NULL);
+  nr_txn_record_log_event(txn, LL_DEBU_STR, LOG_MESSAGE, 0, NULL, NULL);
+  nr_txn_record_log_event(txn, LL_NOTI_STR, LOG_MESSAGE, 0, NULL, NULL);
 
   /* events seen and saved are both 6 because the filtering occurs before
    * log forwarding handles the messages.


### PR DESCRIPTION
- Adds a log destination for attributes.  Log attributes are created on log events for context data passed to logging library.
- Adds code to capture the context data for the Monolog library and convert it to attributes on the log event.
- Adds a unit test to exercise conversion of context data to attributes as well as the log destination for attributes.
- Note this commit does not contain code to convert log attributes to JSON for sending to the daemon/collector.