### PR TITLE
fix(agent): Resolve mysqli deprecation warnings on PHP 8.1+

### DIFF
--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -645,19 +645,20 @@ NR_INNER_WRAPPER(mysqli_construct) {
 
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
   bool port_is_null = 1;
-  
+  const char *type_spec = "|s!s!s!s!l!s!";
   if (FAILURE
       == zend_parse_parameters_ex(
-          ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|s!s!s!s!l!s!", &host,
+          ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, type_spec, &host,
           &host_len, &username, &username_len, &password, &password_len,
           &database, &database_len, &port, &port_is_null, &socket, &socket_len)) {
     nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     return;
   }
 #else
+  const char *type_spec =  "|ssssls";
   if (FAILURE
       == zend_parse_parameters_ex(
-          ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|ssssls", &host,
+          ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, type_spec, &host,
           &host_len, &username, &username_len, &password, &password_len,
           &database, &database_len, &port, &socket, &socket_len)) {
     nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
@@ -808,28 +809,20 @@ NR_INNER_WRAPPER(mysqli_commit) {
   nr_string_len_t name_len = 0;
 
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
-  if (FAILURE
-      == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "o|ls!",
-                                  &mysqli_obj, &flags, &name, &name_len)) {
-    if (FAILURE
-        == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                    ZEND_NUM_ARGS() TSRMLS_CC, "|ls!", &flags,
-                                    &name, &name_len)) {
-      nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-      return;
-    } else {
-      mysqli_obj = NR_PHP_INTERNAL_FN_THIS();
-    }
-  }
+  const char *proc_type_spec = "o|ls!";
+  const char *oo_type_spec = "|ls!";
 #else
+  const char *proc_type_spec = "o|ls";
+  const char *oo_type_spec = "|ls";
+#endif
+
   if (FAILURE
       == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "o|ls",
+                                  ZEND_NUM_ARGS() TSRMLS_CC, proc_type_spec,
                                   &mysqli_obj, &flags, &name, &name_len)) {
     if (FAILURE
         == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                    ZEND_NUM_ARGS() TSRMLS_CC, "|ls", &flags,
+                                    ZEND_NUM_ARGS() TSRMLS_CC, oo_type_spec, &flags,
                                     &name, &name_len)) {
       nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
       return;
@@ -837,7 +830,7 @@ NR_INNER_WRAPPER(mysqli_commit) {
       mysqli_obj = NR_PHP_INTERNAL_FN_THIS();
     }
   }
-#endif
+
   nr_php_instrument_datastore_operation_call(nr_wrapper, NR_DATASTORE_MYSQL,
                                              "commit", instance,
                                              INTERNAL_FUNCTION_PARAM_PASSTHRU);
@@ -888,15 +881,17 @@ NR_INNER_WRAPPER(mysqli_real_connect) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
   bool port_is_null = 1;
+  const char *proc_type_spec = "o|s!s!s!s!l!s!l";
+  const char *oo_type_spec = "|s!s!s!s!l!s!l";
   if (FAILURE
       == zend_parse_parameters_ex(
-          ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "o|s!s!s!s!l!s!l",
+          ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, proc_type_spec,
           &mysqli_obj, &host, &host_len, &username, &username_len, &password,
           &password_len, &database, &database_len, &port, &port_is_null, &socket, &socket_len,
           &flags)) {
     if (FAILURE
         == zend_parse_parameters_ex(
-            ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|s!s!s!s!l!s!l",
+            ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, oo_type_spec,
             &host, &host_len, &username, &username_len, &password,
             &password_len, &database, &database_len, &port, &port_is_null, &socket,
             &socket_len, &flags)) {
@@ -907,15 +902,17 @@ NR_INNER_WRAPPER(mysqli_real_connect) {
     }
   }
 #else
+  const char *proc_type_spec = "o|sssslsl";
+  const char *oo_type_spec = "|sssslsl";
   if (FAILURE
       == zend_parse_parameters_ex(
-          ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "o|sssslsl",
+          ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, proc_type_spec,
           &mysqli_obj, &host, &host_len, &username, &username_len, &password,
           &password_len, &database, &database_len, &port, &socket, &socket_len,
           &flags)) {
     if (FAILURE
         == zend_parse_parameters_ex(
-            ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|sssslsl",
+            ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, oo_type_spec,
             &host, &host_len, &username, &username_len, &password,
             &password_len, &database, &database_len, &port, &socket,
             &socket_len, &flags)) {
@@ -1399,22 +1396,17 @@ NR_INNER_WRAPPER(mysqli_stmt_construct) {
   nr_string_len_t sqlstrlen = 0;
 
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
-  if (FAILURE
-      == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "o|s!", &mysqli_obj,
-                                  &sqlstr, &sqlstrlen)) {
-    nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-    return;
-  }
+  const char *type_spec = "o|s!";
 #else
+  const char *type_spec = "o|s";
+#endif
   if (FAILURE
       == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "o|s", &mysqli_obj,
+                                  ZEND_NUM_ARGS() TSRMLS_CC, type_spec, &mysqli_obj,
                                   &sqlstr, &sqlstrlen)) {
     nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     return;
   }
-#endif
 
   nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -642,9 +642,10 @@ NR_INNER_WRAPPER(mysqli_construct) {
   zend_long port = 0;
   zval* mysqli_obj = NULL;
   int zcaught = 0;
-  bool port_is_null = 1;
 
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+  bool port_is_null = 1;
+  
   if (FAILURE
       == zend_parse_parameters_ex(
           ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|s!s!s!s!l!s!", &host,

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -1281,31 +1281,21 @@ end:
 
 /*
  * Handle
- *   resource mysqli_stmt_execute ( object $link, ?array $params = null )
- *   resource mysqli_stmt::execute( ?array $params = null)
+ *   resource mysqli_stmt_execute ( object $link )
+ *   resource mysqli_stmt::execute()
  */
 NR_INNER_WRAPPER(mysqli_stmt_execute) {
   zval* stmt_obj = NULL;
-  zval* param_array = NULL;
   const char* sqlstr = NULL;
   int sqlstrlen;
   int zcaught = 0;
   nr_segment_t* segment = NULL;
 
-#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
   if (FAILURE
       == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "o|a!", &stmt_obj, &param_array)) {
+                                  ZEND_NUM_ARGS() TSRMLS_CC, "o", &stmt_obj)) {
     stmt_obj = NR_PHP_INTERNAL_FN_THIS();
   }
-#else
-  if (FAILURE
-      == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
-                                  ZEND_NUM_ARGS() TSRMLS_CC, "o|a", &stmt_obj, &param_array)) {
-    stmt_obj = NR_PHP_INTERNAL_FN_THIS();
-  }
-#endif
-
   sqlstr = nr_php_prepared_statement_find(stmt_obj, "mysqli" TSRMLS_CC);
   sqlstrlen = nr_strlen(sqlstr);
 

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -642,13 +642,14 @@ NR_INNER_WRAPPER(mysqli_construct) {
   zend_long port = 0;
   zval* mysqli_obj = NULL;
   int zcaught = 0;
+  bool port_is_null = 1;
 
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
   if (FAILURE
       == zend_parse_parameters_ex(
           ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|s!s!s!s!l!s!", &host,
           &host_len, &username, &username_len, &password, &password_len,
-          &database, &database_len, &port, &socket, &socket_len)) {
+          &database, &database_len, &port, &port_is_null, &socket, &socket_len)) {
     nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     return;
   }

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -887,17 +887,18 @@ NR_INNER_WRAPPER(mysqli_real_connect) {
    * to minimize any chances of introducing new problems.
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+  bool port_is_null = 1;
   if (FAILURE
       == zend_parse_parameters_ex(
           ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "o|s!s!s!s!l!s!l",
           &mysqli_obj, &host, &host_len, &username, &username_len, &password,
-          &password_len, &database, &database_len, &port, &socket, &socket_len,
+          &password_len, &database, &database_len, &port, &port_is_null, &socket, &socket_len,
           &flags)) {
     if (FAILURE
         == zend_parse_parameters_ex(
             ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|s!s!s!s!l!s!l",
             &host, &host_len, &username, &username_len, &password,
-            &password_len, &database, &database_len, &port, &socket,
+            &password_len, &database, &database_len, &port, &port_is_null, &socket,
             &socket_len, &flags)) {
       nr_wrapper->oldhandler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
       return;

--- a/tests/integration/mysqli/test_null_connect_proc.php
+++ b/tests/integration/mysqli/test_null_connect_proc.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should not cause a deprecation warning to be thrown when passing null
+to optional arguments for mysqli_connect on PHP 8.1+
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: Deprecation warning PHP 8.1+ specific\n");
+}
+*/
+
+/*INI
+error_reporting = E_DEPRECATION
+*/
+
+/*EXPECT
+*/
+
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/config.php');
+
+$link = mysqli_connect(null, null, null, null, null, null);
+
+if (mysqli_connect_errno()) {
+  echo mysqli_connect_error() . "\n";
+  exit(1);
+}
+
+mysqli_close($link);

--- a/tests/integration/mysqli/test_null_construct_oo.php
+++ b/tests/integration/mysqli/test_null_construct_oo.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should not cause a deprecation warning to be thrown when passing null
+to optional arguments for mysqli::__construct on PHP 8.1+
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: Deprecation warning PHP 8.1+ specific\n");
+}
+*/
+
+/*INI
+error_reporting = E_DEPRECATION
+*/
+
+/*EXPECT
+*/
+
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/config.php');
+
+$link = new mysqli(null, null, null, null, null, null);
+
+if (mysqli_connect_errno()) {
+  echo mysqli_connect_error() . "\n";
+  exit(1);
+}
+
+mysqli_close($link);

--- a/tests/integration/mysqli/test_null_rc_oo.php
+++ b/tests/integration/mysqli/test_null_rc_oo.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should not cause a deprecation warning to be thrown when passing null
+to optional arguments for mysqli::real_connect on PHP 8.1+
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: Deprecation warning PHP 8.1+ specific\n");
+}
+*/
+
+/*INI
+error_reporting = E_DEPRECATION
+*/
+
+/*EXPECT
+*/
+
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/config.php');
+
+$link = mysqli_init();
+$link->options(MYSQLI_OPT_CONNECT_TIMEOUT, 10);
+$link->real_connect(null, null, null, null, null, null);
+
+if (mysqli_connect_errno()) {
+  echo mysqli_connect_error() . "\n";
+  exit(1);
+}
+
+mysqli_close($link);

--- a/tests/integration/mysqli/test_null_rc_proc.php
+++ b/tests/integration/mysqli/test_null_rc_proc.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should not cause a deprecation warning to be thrown when passing null
+to optional arguments for mysqli_real_connect on PHP 8.1+
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: Deprecation warning PHP 8.1+ specific\n");
+}
+*/
+
+/*INI
+error_reporting = E_DEPRECATION
+*/
+
+/*EXPECT
+*/
+
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/config.php');
+
+$link = mysqli_init();
+mysqli_options($link, MYSQLI_OPT_CONNECT_TIMEOUT, 10);
+
+mysqli_real_connect($link, null, null, null, null, null, null);
+
+if (mysqli_connect_errno()) {
+  echo mysqli_connect_error() . "\n";
+  exit(1);
+}
+
+mysqli_close($link);

--- a/tests/integration/mysqli/test_null_stmt_construct.php
+++ b/tests/integration/mysqli/test_null_stmt_construct.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should not cause a deprecation warning to be thrown when passing null
+to optional arguments for mysqli_stmt:__construct on PHP 8.1+
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: Deprecation warning PHP 8.1+ specific\n");
+}
+*/
+
+/*INI
+error_reporting = E_ALL
+*/
+
+/*EXPECT
+STATISTICS
+*/
+
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/config.php');
+
+function test_stmt_prepare($link)
+{
+  $stmt = new mysqli_stmt($link, null);
+  $name = 'STATISTICS';
+
+  $query = "SELECT TABLE_NAME FROM information_schema.tables WHERE table_name=?";
+  if (FALSE === $stmt->prepare($query) ||
+      FALSE === $stmt->bind_param('s', $name) ||
+      FALSE === $stmt->execute() ||
+      FALSE === $stmt->bind_result($name)) {
+    echo mysqli_stmt_error($stmt) . "\n";
+    mysqli_stmt_close($stmt);
+    return;
+  }
+
+  while (mysqli_stmt_fetch($stmt)) {
+    echo $name . "\n";
+  }
+
+  mysqli_stmt_close($stmt);
+}
+
+$link = mysqli_connect($MYSQL_HOST, $MYSQL_USER, $MYSQL_PASSWD, $MYSQL_DB, $MYSQL_PORT, $MYSQL_SOCKET);
+if (mysqli_connect_errno()) {
+  echo mysqli_connect_error() . "\n";
+  exit(1);
+}
+
+test_stmt_prepare($link);
+mysqli_close($link);
+


### PR DESCRIPTION
Certain wrapped mysqli functions allow null values to be passed for optional values on PHP 8.1+. 
This PR fixes the issue of the agent not properly expecting these null values in zpp resulting in deprecation warnings being thrown.