### PR TITLE
feat(agent): Adds JSON for log attributes

### DIFF
--- a/axiom/nr_attributes.c
+++ b/axiom/nr_attributes.c
@@ -723,6 +723,9 @@ static char* nr_attribute_debug_json(const nr_attribute_t* attribute) {
   if (NR_ATTRIBUTE_DESTINATION_BROWSER & attribute->destinations) {
     nro_set_array_string(dests, 0, "browser");
   }
+  if (NR_ATTRIBUTE_DESTINATION_LOG & attribute->destinations) {
+    nro_set_array_string(dests, 0, "log");
+  }
 
   nro_set_hash(obj, "dests", dests);
   nro_delete(dests);

--- a/axiom/nr_log_event.c
+++ b/axiom/nr_log_event.c
@@ -33,7 +33,9 @@ void nr_log_event_destroy(nr_log_event_t** ptr) {
   nr_free(event->entity_guid);
   nr_free(event->entity_name);
   nr_free(event->hostname);
-  nr_attributes_destroy(&(event->context_attributes));
+  if (NULL != event->context_attributes) {
+    nr_attributes_destroy(&(event->context_attributes));
+  }
 
   nr_realfree((void**)ptr);
 }
@@ -105,6 +107,9 @@ char* nr_log_event_to_json(const nr_log_event_t* event) {
 }
 
 bool nr_log_event_to_json_buffer(const nr_log_event_t* event, nrbuf_t* buf) {
+  char* json = NULL;
+  nrobj_t* log_attributes = NULL;
+
   if (NULL == event || NULL == buf) {
     return false;
   }
@@ -126,6 +131,19 @@ bool nr_log_event_to_json_buffer(const nr_log_event_t* event, nrbuf_t* buf) {
   // timestamp always present
   nr_buffer_add(buf, NR_PSTR(",\"timestamp\":"));
   nr_buffer_write_uint64_t_as_text(buf, event->timestamp);
+
+  // add attributes if present
+  if (NULL != event->context_attributes) {
+    log_attributes = nr_attributes_user_to_obj(event->context_attributes,
+                                              NR_ATTRIBUTE_DESTINATION_LOG);
+    if (0 < nro_getsize(log_attributes)) {
+      json = nro_to_json(log_attributes);
+      add_log_field_to_buf(buf, "attributes", json, false, false, false);
+      nr_free(json);
+    }
+
+    nro_delete(log_attributes);
+  }
 
   nr_buffer_add(buf, NR_PSTR("}"));
 
@@ -161,9 +179,8 @@ void nr_log_event_set_timestamp(nr_log_event_t* event, const nrtime_t time) {
   event->timestamp = time / NR_TIME_DIVISOR_MS;
 }
 
-void nr_log_event_set_context_attributes(
-    nr_log_event_t* event,
-    nr_attributes_t* context_attributes) {
+void nr_log_event_set_context_attributes(nr_log_event_t* event,
+                                         nr_attributes_t* context_attributes) {
   if (NULL == event) {
     return;
   }

--- a/axiom/tests/test_log_event.c
+++ b/axiom/tests/test_log_event.c
@@ -29,6 +29,8 @@ static void test_log_event_create_destroy(void) {
 static void test_log_event_to_json(void) {
   char* json;
   nr_log_event_t* log;
+  nr_attributes_t* attributes = NULL;
+  nr_attribute_config_t* config = NULL;
 
   /*
    * Test : Bad parameters.
@@ -99,6 +101,14 @@ static void test_log_event_to_json(void) {
   nr_log_event_set_guid(log, "test id 3");
   nr_log_event_set_entity_name(log, "entity name here");
   nr_log_event_set_hostname(log, "host name here");
+  config = nr_attribute_config_create();
+  attributes = nr_attributes_create(config);
+  nr_attribute_config_destroy(&config);
+  nr_attributes_user_add_string(attributes, NR_ATTRIBUTE_DESTINATION_LOG,
+                                "string_attr", "string_attr_value");
+  nr_attributes_user_add_long(attributes, NR_ATTRIBUTE_DESTINATION_LOG,
+                              "long_attr", 12345);
+  nr_log_event_set_context_attributes(log, attributes);
   json = nr_log_event_to_json(log);
   tlib_pass_if_str_equal(
       "requires escaping for JSON event",
@@ -110,7 +120,11 @@ static void test_log_event_to_json(void) {
       "\"entity.guid\":\"test id 3\","
       "\"entity.name\":\"entity name here\","
       "\"hostname\":\"host name here\","
-      "\"timestamp\":12345"
+      "\"timestamp\":12345,"
+      "\"attributes\":{"
+      "\"long_attr\":12345,"
+      "\"string_attr\":\"string_attr_value\""
+      "}"
       "}",
       json);
   nr_free(json);
@@ -120,6 +134,8 @@ static void test_log_event_to_json(void) {
 static void test_log_event_to_json_buffer(void) {
   nrbuf_t* buf = nr_buffer_create(0, 0);
   nr_log_event_t* log;
+  nr_attributes_t* attributes = NULL;
+  nr_attribute_config_t* config = NULL;
 
   /*
    * Test : Bad parameters.
@@ -163,6 +179,14 @@ static void test_log_event_to_json_buffer(void) {
   nr_log_event_set_guid(log, "test id 3");
   nr_log_event_set_entity_name(log, "entity name here");
   nr_log_event_set_hostname(log, "host name here");
+  config = nr_attribute_config_create();
+  attributes = nr_attributes_create(config);
+  nr_attribute_config_destroy(&config);
+  nr_attributes_user_add_string(attributes, NR_ATTRIBUTE_DESTINATION_LOG,
+                                "string_attr", "string_attr_value");
+  nr_attributes_user_add_long(attributes, NR_ATTRIBUTE_DESTINATION_LOG,
+                              "long_attr", 12345);
+  nr_log_event_set_context_attributes(log, attributes);
   tlib_pass_if_bool_equal("full log event", true,
                           nr_log_event_to_json_buffer(log, buf));
   nr_buffer_add(buf, NR_PSTR("\0"));
@@ -175,7 +199,11 @@ static void test_log_event_to_json_buffer(void) {
                          "\"entity.guid\":\"test id 3\","
                          "\"entity.name\":\"entity name here\","
                          "\"hostname\":\"host name here\","
-                         "\"timestamp\":12345"
+                         "\"timestamp\":12345,"
+                         "\"attributes\":{"
+                         "\"long_attr\":12345,"
+                         "\"string_attr\":\"string_attr_value\""
+                         "}"
                          "}",
                          nr_buffer_cptr(buf));
   nr_log_event_destroy(&log);

--- a/tests/integration/logging/monolog2/test_monolog_context_default.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_default.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data default
+behavior is to not convert to attributes.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+*/
+
+/*EXPECT
+monolog2.DEBUG: None converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "None converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??"
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("None converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_exception.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_exception.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation does not convert an exception
+object into log context attributes
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog2.ALERT: context is nested array {"exception":"[object] (RuntimeException(code: 0): Foo at /usr/local/src/newrelic-php-agent/tests/integration/logging/monolog2/test_monolog_context_exception.php:100)"}
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+  {
+    "common": {
+      "attributes": {}
+    },
+    "logs": [
+      {
+        "message": "context is nested array",
+        "level": "ALERT",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      }
+    ]
+  }
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog2');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+  $context = ['exception' => new \RuntimeException('Foo')];
+  $logger->alert("context is nested array", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_1.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_1.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+only an exclusion rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = "context.A"
+*/
+
+/*EXPECT
+monolog2.DEBUG: B C converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "B C converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.C": "C value",
+            "context.B": "B value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("B C converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_10.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_10.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+general and specific.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.attributes.include = "context.AB"
+newrelic.application_logging.forwarding.context_data.exclude = "context.A*"
+*/
+
+/*EXPECT
+monolog2.DEBUG: AB converted {"AA":"AA value","AB":"AB value","AC":"AC value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "AB converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.AB": "AB value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("AA" => "AA value", "AB" => "AB value", "AC" => "AC value");
+    $logger->debug("AB converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_11.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_11.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+general and specific.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.attributes.include = "context.A*"
+newrelic.application_logging.forwarding.context_data.exclude = "context.AB"
+*/
+
+/*EXPECT
+monolog2.DEBUG: AA AC converted {"AA":"AA value","AB":"AB value","AC":"AC value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "AA AC converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.AC": "AC value",
+            "context.AA": "AA value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("AA" => "AA value", "AB" => "AB value", "AC" => "AC value");
+    $logger->debug("AA AC converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_2.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_2.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+only an inclusion rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.A, context.B"
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog2.DEBUG: A B C converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A B C converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.C": "C value",
+            "context.B": "B value",
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A B C converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_3.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_3.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+only an inclusion and exclusion rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.A, context.B"
+newrelic.application_logging.forwarding.context_data.exclude = "context.C"
+*/
+
+/*EXPECT
+monolog2.DEBUG: A B converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A B converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.B": "B value",
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A B converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_4.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_4.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+exclusion wildcard rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.A"
+newrelic.application_logging.forwarding.context_data.exclude = "context.*"
+*/
+
+/*EXPECT
+monolog2.DEBUG: A converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_5.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_5.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+inclusion wildcard rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.*"
+newrelic.application_logging.forwarding.context_data.exclude = "context.B, context.C"
+*/
+
+/*EXPECT
+monolog2.DEBUG: A converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_6.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_6.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+only exclusion wildcard given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = "context.B"
+*/
+
+/*EXPECT
+monolog2.DEBUG: A C converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A C converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.C": "C value",
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A C converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_7.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_7.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+inclusion and exclusion rules the same.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.B"
+newrelic.application_logging.forwarding.context_data.exclude = "context.B"
+*/
+
+/*EXPECT
+monolog2.DEBUG: A C converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A C converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.C": "C value",
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A C converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_8.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_8.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+inclusion and exclusion overlap.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.AB"
+newrelic.application_logging.forwarding.context_data.exclude = "context.A*"
+*/
+
+/*EXPECT
+monolog2.DEBUG: AB converted {"AA":"AA value","AB":"AB value","AC":"AC value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "AB converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.AB": "AB value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("AA" => "AA value", "AB" => "AB value", "AC" => "AC value");
+    $logger->debug("AB converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_filter_9.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_filter_9.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation filters context data when
+inclusion and exclusion overlap.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.A*"
+newrelic.application_logging.forwarding.context_data.exclude = "context.AB*"
+*/
+
+/*EXPECT
+monolog2.DEBUG: AA AC converted {"AA":"AA value","AB":"AB value","AC":"AC value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "AA AC converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.AC": "AC value",
+            "context.AA": "AA value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("AA" => "AA value", "AB" => "AB value", "AC" => "AC value");
+    $logger->debug("AA AC converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_hsm_disable_forwarding.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_hsm_disable_forwarding.php
@@ -1,0 +1,136 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation converts context data to attributes
+properly.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+newrelic.high_security = true
+*/
+
+/*EXPECT
+monolog2.DEBUG: key is string converted {"testkey_string":"value"}
+monolog2.INFO: key is int not converted {"1":"value"}
+monolog2.NOTICE: int value converted {"int":1}
+monolog2.WARNING: dbl value converted {"dbl":3.1415926}
+monolog2.ERROR: TRUE value converted {"TRUE":true}
+monolog2.CRITICAL: FALSE value converted {"FALSE":false}
+monolog2.ALERT: array value not converted {"array":{"foo":"bar","baz":"long"}}
+monolog2.EMERGENCY: object value not converted {"object":{"Monolog\\Logger":[]}}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/CRITICAL"},                                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/EMERGENCY"},                                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ERROR"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/INFO"},                                              [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/NOTICE"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/WARNING"},                                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+null
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog2');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+
+  // insert delays between log messages to allow priority sampling
+  // to resolve that later messages have higher precedence
+  // since timestamps are only millisecond resolution
+  // without delays sometimes order in output will reflect
+  // all having the same timestamp.
+  $context = ["testkey_string" => "value"];
+  $logger->debug("key is string converted", $context);
+  usleep(10000);
+
+  $context = [1 => "value"];
+  $logger->info("key is int not converted", $context);
+  usleep(10000);
+
+  $context = ["int" => 1];
+  $logger->notice("int value converted", $context);
+  usleep(10000);
+
+  $context = ["dbl" => 3.1415926];
+  $logger->warning("dbl value converted", $context);
+  usleep(10000);
+
+  $context = ["TRUE" => TRUE];
+  $logger->error("TRUE value converted", $context);
+  usleep(10000);
+
+  $context = array("FALSE" => FALSE);
+  $logger->critical("FALSE value converted", $context);
+  usleep(10000);
+
+  $context = ["array" => array('foo' => 'bar', 'baz' => 'long')];
+  $logger->alert("array value not converted", $context);
+  usleep(10000);
+
+  $context = ["object" => $logger];
+  $logger->emergency("object value not converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_limits_1.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_limits_1.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation drops context data when
+key length is greater than 255 butes
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+*/
+
+/*EXPECT
+monolog2.DEBUG: None converted
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "None converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??"
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $key = str_repeat("A", 300);
+    $context = array($key => "value");
+    $logger->debug("None converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_limits_2.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_limits_2.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation drops context data when
+value length is greater than 255 butes
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+*/
+
+/*EXPECT
+monolog2.DEBUG: Value truncated
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "Value truncated",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog2__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog2');
+
+    $logfmt = "%channel%.%level_name%: %message%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $value = str_repeat("A", 300);
+    $context = array("key" => $value);
+    $logger->debug("Value truncated", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_precedence_1.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_precedence_1.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation obeys specific enable over general
+when disabled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.attributes.enabled = 1
+newrelic.application_logging.forwarding.context_data.enabled = 0
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog2.DEBUG: key is string converted {"testkey_string":"value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+  {
+    "common": {
+      "attributes": {}
+    },
+    "logs": [
+      {
+        "message": "key is string converted",
+        "level": "DEBUG",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      }
+    ]
+  }
+]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog2');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+  $context = ["testkey_string" => "value"];
+  $logger->debug("key is string converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_precedence_2.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_precedence_2.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation obeys general enable over specific
+when enabled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.attributes.enabled = 0
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog2.DEBUG: key is string converted {"testkey_string":"value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+  {
+    "common": {
+      "attributes": {}
+    },
+    "logs": [
+      {
+        "message": "key is string converted",
+        "level": "DEBUG",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      }
+    ]
+  }
+]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog2');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+  $context = ["testkey_string" => "value"];
+  $logger->debug("key is string converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog2/test_monolog_context_simple.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_simple.php
@@ -1,0 +1,238 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog2 instrumentation converts context data to attributes
+properly.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog2.DEBUG: key is string converted {"testkey_string":"value"}
+monolog2.INFO: key is int not converted {"1":"value"}
+monolog2.NOTICE: int value converted {"int":1}
+monolog2.WARNING: dbl value converted {"dbl":3.1415926}
+monolog2.ERROR: TRUE value converted {"TRUE":true}
+monolog2.CRITICAL: FALSE value converted {"FALSE":false}
+monolog2.ALERT: array value not converted {"array":{"foo":"bar","baz":"long"}}
+monolog2.EMERGENCY: object value not converted {"object":{"Monolog\\Logger":[]}}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/CRITICAL"},                                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/EMERGENCY"},                                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ERROR"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/INFO"},                                              [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/NOTICE"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/WARNING"},                                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+  {
+    "common": {
+      "attributes": {}
+    },
+    "logs": [
+      {
+        "message": "TRUE value converted",
+        "level": "ERROR",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.TRUE": true
+        }
+      },
+      {
+        "message": "FALSE value converted",
+        "level": "CRITICAL",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.FALSE": false
+        }
+      },
+      {
+        "message": "int value converted",
+        "level": "NOTICE",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.int": 1
+        }
+      },
+      {
+        "message": "dbl value converted",
+        "level": "WARNING",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.dbl": 3.14159
+        }
+      },
+      {
+        "message": "key is int not converted",
+        "level": "INFO",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      },
+      {
+        "message": "array value not converted",
+        "level": "ALERT",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      },
+      {
+        "message": "object value not converted",
+        "level": "EMERGENCY",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      },
+      {
+        "message": "key is string converted",
+        "level": "DEBUG",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog2__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.testkey_string": "value"
+        }
+      }
+    ]
+  }
+]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(2);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog2');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+
+  // insert delays between log messages to allow priority sampling
+  // to resolve that later messages have higher precedence
+  // since timestamps are only millisecond resolution
+  // without delays sometimes order in output will reflect
+  // all having the same timestamp.
+  $context = ["testkey_string" => "value"];
+  $logger->debug("key is string converted", $context);
+  usleep(10000);
+
+  $context = [1 => "value"];
+  $logger->info("key is int not converted", $context);
+  usleep(10000);
+
+  $context = ["int" => 1];
+  $logger->notice("int value converted", $context);
+  usleep(10000);
+
+  $context = ["dbl" => 3.1415926];
+  $logger->warning("dbl value converted", $context);
+  usleep(10000);
+
+  $context = ["TRUE" => TRUE];
+  $logger->error("TRUE value converted", $context);
+  usleep(10000);
+
+  $context = array("FALSE" => FALSE);
+  $logger->critical("FALSE value converted", $context);
+  usleep(10000);
+
+  $context = ["array" => array('foo' => 'bar', 'baz' => 'long')];
+  $logger->alert("array value not converted", $context);
+  usleep(10000);
+
+  $context = ["object" => $logger];
+  $logger->emergency("object value not converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_default.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_default.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data default
+behavior is to not convert to attributes.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+*/
+
+/*EXPECT
+monolog3.DEBUG: None converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "None converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??"
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("None converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_exception.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_exception.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation does not convert an exception
+object into log context attributes
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog3.ALERT: context is nested array {"exception":"[object] (RuntimeException(code: 0): Foo at /usr/local/src/newrelic-php-agent/tests/integration/logging/monolog3/test_monolog_context_exception.php:100)"}
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+  {
+    "common": {
+      "attributes": {}
+    },
+    "logs": [
+      {
+        "message": "context is nested array",
+        "level": "ALERT",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      }
+    ]
+  }
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog3');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+  $context = ['exception' => new \RuntimeException('Foo')];
+  $logger->alert("context is nested array", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_1.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_1.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+only an exclusion rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = "context.A"
+*/
+
+/*EXPECT
+monolog3.DEBUG: B C converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "B C converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.C": "C value",
+            "context.B": "B value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("B C converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_10.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_10.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+general and specific.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.attributes.include = "context.AB"
+newrelic.application_logging.forwarding.context_data.exclude = "context.A*"
+*/
+
+/*EXPECT
+monolog3.DEBUG: AB converted {"AA":"AA value","AB":"AB value","AC":"AC value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "AB converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.AB": "AB value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("AA" => "AA value", "AB" => "AB value", "AC" => "AC value");
+    $logger->debug("AB converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_11.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_11.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+general and specific.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.attributes.include = "context.A*"
+newrelic.application_logging.forwarding.context_data.exclude = "context.AB"
+*/
+
+/*EXPECT
+monolog3.DEBUG: AA AC converted {"AA":"AA value","AB":"AB value","AC":"AC value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "AA AC converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.AC": "AC value",
+            "context.AA": "AA value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("AA" => "AA value", "AB" => "AB value", "AC" => "AC value");
+    $logger->debug("AA AC converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_2.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_2.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+only an inclusion rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.A, context.B"
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog3.DEBUG: A B C converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A B C converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.C": "C value",
+            "context.B": "B value",
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A B C converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_3.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_3.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+only an inclusion and exclusion rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.A, context.B"
+newrelic.application_logging.forwarding.context_data.exclude = "context.C"
+*/
+
+/*EXPECT
+monolog3.DEBUG: A B converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A B converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.B": "B value",
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A B converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_4.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_4.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+exclusion wildcard rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.A"
+newrelic.application_logging.forwarding.context_data.exclude = "context.*"
+*/
+
+/*EXPECT
+monolog3.DEBUG: A converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_5.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_5.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+inclusion wildcard rule is given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.*"
+newrelic.application_logging.forwarding.context_data.exclude = "context.B, context.C"
+*/
+
+/*EXPECT
+monolog3.DEBUG: A converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "attributes": {
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_6.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_6.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+only exclusion wildcard given.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = "context.B"
+*/
+
+/*EXPECT
+monolog3.DEBUG: A C converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A C converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.C": "C value",
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A C converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_7.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_7.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+inclusion and exclusion rules the same.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.B"
+newrelic.application_logging.forwarding.context_data.exclude = "context.B"
+*/
+
+/*EXPECT
+monolog3.DEBUG: A C converted {"A":"A value","B":"B value","C":"C value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "A C converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.C": "C value",
+            "context.A": "A value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("A" => "A value", "B" => "B value", "C" => "C value");
+    $logger->debug("A C converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_8.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_8.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+inclusion and exclusion overlap.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.AB"
+newrelic.application_logging.forwarding.context_data.exclude = "context.A*"
+*/
+
+/*EXPECT
+monolog3.DEBUG: AB converted {"AA":"AA value","AB":"AB value","AC":"AC value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "AB converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.AB": "AB value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("AA" => "AA value", "AB" => "AB value", "AC" => "AC value");
+    $logger->debug("AB converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_filter_9.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_filter_9.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation filters context data when
+inclusion and exclusion overlap.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = "context.A*"
+newrelic.application_logging.forwarding.context_data.exclude = "context.AB*"
+*/
+
+/*EXPECT
+monolog3.DEBUG: AA AC converted {"AA":"AA value","AB":"AB value","AC":"AC value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "AA AC converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.AC": "AC value",
+            "context.AA": "AA value"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message% %context%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $context = array("AA" => "AA value", "AB" => "AB value", "AC" => "AC value");
+    $logger->debug("AA AC converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_hsm_disable_forwarding.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_hsm_disable_forwarding.php
@@ -1,0 +1,136 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation converts context data to attributes
+properly.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+newrelic.high_security = true
+*/
+
+/*EXPECT
+monolog3.DEBUG: key is string converted {"testkey_string":"value"}
+monolog3.INFO: key is int not converted {"1":"value"}
+monolog3.NOTICE: int value converted {"int":1}
+monolog3.WARNING: dbl value converted {"dbl":3.1415926}
+monolog3.ERROR: TRUE value converted {"TRUE":true}
+monolog3.CRITICAL: FALSE value converted {"FALSE":false}
+monolog3.ALERT: array value not converted {"array":{"foo":"bar","baz":"long"}}
+monolog3.EMERGENCY: object value not converted {"object":{"Monolog\\Logger":[]}}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/CRITICAL"},                                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/EMERGENCY"},                                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ERROR"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/INFO"},                                              [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/NOTICE"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/WARNING"},                                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+null
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog3');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+
+  // insert delays between log messages to allow priority sampling
+  // to resolve that later messages have higher precedence
+  // since timestamps are only millisecond resolution
+  // without delays sometimes order in output will reflect
+  // all having the same timestamp.
+  $context = ["testkey_string" => "value"];
+  $logger->debug("key is string converted", $context);
+  usleep(10000);
+
+  $context = [1 => "value"];
+  $logger->info("key is int not converted", $context);
+  usleep(10000);
+
+  $context = ["int" => 1];
+  $logger->notice("int value converted", $context);
+  usleep(10000);
+
+  $context = ["dbl" => 3.1415926];
+  $logger->warning("dbl value converted", $context);
+  usleep(10000);
+
+  $context = ["TRUE" => TRUE];
+  $logger->error("TRUE value converted", $context);
+  usleep(10000);
+
+  $context = array("FALSE" => FALSE);
+  $logger->critical("FALSE value converted", $context);
+  usleep(10000);
+
+  $context = ["array" => array('foo' => 'bar', 'baz' => 'long')];
+  $logger->alert("array value not converted", $context);
+  usleep(10000);
+
+  $context = ["object" => $logger];
+  $logger->emergency("object value not converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_limits_1.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_limits_1.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation drops context data when
+key length is greater than 255 butes
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+*/
+
+/*EXPECT
+monolog3.DEBUG: None converted
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "None converted",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??"
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $key = str_repeat("A", 300);
+    $context = array($key => "value");
+    $logger->debug("None converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_limits_2.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_limits_2.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation drops context data when
+value length is greater than 255 butes
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+*/
+
+/*EXPECT
+monolog3.DEBUG: Value truncated
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+    {
+      "common": {
+        "attributes": {}
+      },
+      "logs": [
+        {
+          "message": "Value truncated",
+          "level": "DEBUG",
+          "timestamp": "??",
+          "trace.id": "??",
+          "span.id": "??",
+          "entity.guid": "??",
+          "entity.name": "tests/integration/logging/monolog3__FILE__",
+          "hostname": "__HOST__",
+          "timestamp": "??",
+          "attributes": {
+            "context.key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        }
+      ]
+    }
+  ]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging() {
+    $logger = new Logger('monolog3');
+
+    $logfmt = "%channel%.%level_name%: %message%\n";
+    $formatter = new LineFormatter($logfmt);
+
+    $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $stdoutHandler->setFormatter($formatter);
+
+    $logger->pushHandler($stdoutHandler);
+
+    $value = str_repeat("A", 300);
+    $context = array("key" => $value);
+    $logger->debug("Value truncated", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_precedence_1.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_precedence_1.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation obeys specific enable over general
+when disabled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.attributes.enabled = 1
+newrelic.application_logging.forwarding.context_data.enabled = 0
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog3.DEBUG: key is string converted {"testkey_string":"value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+  {
+    "common": {
+      "attributes": {}
+    },
+    "logs": [
+      {
+        "message": "key is string converted",
+        "level": "DEBUG",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      }
+    ]
+  }
+]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog3');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+  $context = ["testkey_string" => "value"];
+  $logger->debug("key is string converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_precedence_2.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_precedence_2.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation obeys general enable over specific
+when enabled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.attributes.enabled = 0
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog3.DEBUG: key is string converted {"testkey_string":"value"}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+  {
+    "common": {
+      "attributes": {}
+    },
+    "logs": [
+      {
+        "message": "key is string converted",
+        "level": "DEBUG",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      }
+    ]
+  }
+]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog3');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+  $context = ["testkey_string" => "value"];
+  $logger->debug("key is string converted", $context);
+}
+
+test_logging();

--- a/tests/integration/logging/monolog3/test_monolog_context_simple.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_simple.php
@@ -1,0 +1,238 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that Monolog3 instrumentation converts context data to attributes
+properly.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.application_logging.enabled = true
+newrelic.application_logging.forwarding.enabled = true
+newrelic.application_logging.metrics.enabled = true
+newrelic.application_logging.forwarding.max_samples_stored = 10
+newrelic.application_logging.forwarding.log_level = DEBUG
+newrelic.application_logging.forwarding.context_data.enabled = 1
+newrelic.application_logging.forwarding.context_data.include = ""
+newrelic.application_logging.forwarding.context_data.exclude = ""
+*/
+
+/*EXPECT
+monolog3.DEBUG: key is string converted {"testkey_string":"value"}
+monolog3.INFO: key is int not converted {"1":"value"}
+monolog3.NOTICE: int value converted {"int":1}
+monolog3.WARNING: dbl value converted {"dbl":3.1415926}
+monolog3.ERROR: TRUE value converted {"TRUE":true}
+monolog3.CRITICAL: FALSE value converted {"FALSE":false}
+monolog3.ALERT: array value not converted {"array":{"foo":"bar","baz":"long"}}
+monolog3.EMERGENCY: object value not converted {"object":{"Monolog\\Logger":[]}}
+*/
+
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines"},                                                   [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ALERT"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/CRITICAL"},                                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/DEBUG"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/EMERGENCY"},                                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/ERROR"},                                             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/INFO"},                                              [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/NOTICE"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Logging/lines/WARNING"},                                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                            [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+
+/*EXPECT_LOG_EVENTS
+[
+  {
+    "common": {
+      "attributes": {}
+    },
+    "logs": [
+      {
+        "message": "TRUE value converted",
+        "level": "ERROR",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.TRUE": true
+        }
+      },
+      {
+        "message": "FALSE value converted",
+        "level": "CRITICAL",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.FALSE": false
+        }
+      },
+      {
+        "message": "int value converted",
+        "level": "NOTICE",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.int": 1
+        }
+      },
+      {
+        "message": "dbl value converted",
+        "level": "WARNING",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.dbl": 3.14159
+        }
+      },
+      {
+        "message": "key is int not converted",
+        "level": "INFO",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      },
+      {
+        "message": "array value not converted",
+        "level": "ALERT",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      },
+      {
+        "message": "object value not converted",
+        "level": "EMERGENCY",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??"
+      },
+      {
+        "message": "key is string converted",
+        "level": "DEBUG",
+        "trace.id": "??",
+        "span.id": "??",
+        "entity.guid": "??",
+        "entity.name": "tests\/integration\/logging\/monolog3__FILE__",
+        "hostname": "__HOST__",
+        "timestamp": "??",
+        "attributes": {
+          "context.testkey_string": "value"
+        }
+      }
+    ]
+  }
+]
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/monolog.php');
+require_monolog(3);
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+
+function test_logging()
+{
+  $logger = new Logger('monolog3');
+
+  $logfmt = "%channel%.%level_name%: %message% %context%\n";
+  $formatter = new LineFormatter($logfmt);
+
+  $stdoutHandler = new StreamHandler('php://stdout', Logger::DEBUG);
+  $stdoutHandler->setFormatter($formatter);
+
+  $logger->pushHandler($stdoutHandler);
+
+  // insert delays between log messages to allow priority sampling
+  // to resolve that later messages have higher precedence
+  // since timestamps are only millisecond resolution
+  // without delays sometimes order in output will reflect
+  // all having the same timestamp.
+  $context = ["testkey_string" => "value"];
+  $logger->debug("key is string converted", $context);
+  usleep(10000);
+
+  $context = [1 => "value"];
+  $logger->info("key is int not converted", $context);
+  usleep(10000);
+
+  $context = ["int" => 1];
+  $logger->notice("int value converted", $context);
+  usleep(10000);
+
+  $context = ["dbl" => 3.1415926];
+  $logger->warning("dbl value converted", $context);
+  usleep(10000);
+
+  $context = ["TRUE" => TRUE];
+  $logger->error("TRUE value converted", $context);
+  usleep(10000);
+
+  $context = array("FALSE" => FALSE);
+  $logger->critical("FALSE value converted", $context);
+  usleep(10000);
+
+  $context = ["array" => array('foo' => 'bar', 'baz' => 'long')];
+  $logger->alert("array value not converted", $context);
+  usleep(10000);
+
+  $context = ["object" => $logger];
+  $logger->emergency("object value not converted", $context);
+}
+
+test_logging();


### PR DESCRIPTION
Adds json conversion for log attributes associated with log events.

Unit tests added to test log event JSON conversion function and conversion of log events to JSON into the flatbuffer used to communicate with the daemon.

Integration tests added for Monolog2 and Monolog3 to exercise:
 - simple addition of context data
 - filtering rules (include/exclude) under various scenarios
 - precedence of global and specific enable INI settings
 - attributes are not sent if HSM is enabled