### PR TITLE
feat(tests): Enable opcache by default for the integration runner.

### DIFF
--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -347,14 +347,14 @@ func main() {
 		ctx.Settings["newrelic.loglevel"] = *flagLoglevel
 	}
 
-    if false == *flagOpcacheOff {
-        // PHP Modules common to all tests
-        ctx.Settings["zend_extension"] = "opcache.so"
+	if false == *flagOpcacheOff {
+		// PHP Modules common to all tests
+		ctx.Settings["zend_extension"] = "opcache.so"
 
-        // PHP INI values common to all tests
-        // These settings can be overwritten by adding new values to the INI block
-        ctx.Settings["opcache.enable"] = "1"
-        ctx.Settings["opcache.enable_cli"] = "1"
+		// PHP INI values common to all tests
+		// These settings can be overwritten by adding new values to the INI block
+		ctx.Settings["opcache.enable"] = "1"
+		ctx.Settings["opcache.enable_cli"] = "1"
 	}
 
 	// If the user provided a custom agent extension, use it.

--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -50,6 +50,7 @@ var (
 	flagTime            = flag.Bool("time", false, "time each test")
 	flagMaxCustomEvents = flag.Int("max_custom_events", 30000, "value for newrelic.custom_events.max_samples_stored")
 	flagWarnIsFail      = flag.Bool("warnisfail", false, "warn result is treated as a fail")
+	flagOpcacheOff      = flag.Bool("opcacheoff", false, "run without opcache. Some tests are intended to fail when run this way")
 
 	// externalPort is the port on which we start a server to handle
 	// external calls.
@@ -346,6 +347,7 @@ func main() {
 		ctx.Settings["newrelic.loglevel"] = *flagLoglevel
 	}
 
+    if false == *flagOpcacheOff {
         // PHP Modules common to all tests
         ctx.Settings["zend_extension"] = "opcache.so"
 
@@ -353,6 +355,7 @@ func main() {
         // These settings can be overwritten by adding new values to the INI block
         ctx.Settings["opcache.enable"] = "1"
         ctx.Settings["opcache.enable_cli"] = "1"
+	}
 
 	// If the user provided a custom agent extension, use it.
 	if len(*flagAgent) > 0 {

--- a/src/integration_runner/main.go
+++ b/src/integration_runner/main.go
@@ -346,6 +346,14 @@ func main() {
 		ctx.Settings["newrelic.loglevel"] = *flagLoglevel
 	}
 
+        // PHP Modules common to all tests
+        ctx.Settings["zend_extension"] = "opcache.so"
+
+        // PHP INI values common to all tests
+        // These settings can be overwritten by adding new values to the INI block
+        ctx.Settings["opcache.enable"] = "1"
+        ctx.Settings["opcache.enable_cli"] = "1"
+
 	// If the user provided a custom agent extension, use it.
 	if len(*flagAgent) > 0 {
 		ctx.Settings["extension"], _ = filepath.Abs(*flagAgent)

--- a/tests/integration/opcache/disabled/opcache_test.inc
+++ b/tests/integration/opcache/disabled/opcache_test.inc
@@ -1,0 +1,12 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Test should not run with opache */
+if (extension_loaded('Zend OPcache')) {
+  if (false != opcache_get_status()) {
+    die("fail: Zend OPcache extension required to be not loaded\n");
+  }
+}

--- a/tests/integration/opcache/disabled/opcache_test.inc
+++ b/tests/integration/opcache/disabled/opcache_test.inc
@@ -7,6 +7,6 @@
 /* Test should not run with opache */
 if (extension_loaded('Zend OPcache')) {
   if (false != opcache_get_status()) {
-    die("fail: Zend OPcache extension required to be not loaded\n");
+    die("fail: OPcache enabled but needs to be disabled\n");
   }
 }

--- a/tests/integration/opcache/disabled/skipif.inc
+++ b/tests/integration/opcache/disabled/skipif.inc
@@ -11,5 +11,5 @@ if (version_compare(PHP_VERSION, "7.1", "<")) {
 
 /* Test should not run with opache */
 if (extension_loaded('Zend OPcache')) {
-  die("warn: Zend OPcache extension required\n");
+  die("warn: Zend OPcache extension required to be not loaded\n");
 }

--- a/tests/integration/opcache/disabled/skipif.inc
+++ b/tests/integration/opcache/disabled/skipif.inc
@@ -8,8 +8,3 @@
 if (version_compare(PHP_VERSION, "7.1", "<")) {
   die("skip: PHP < 7.1 not supported\n");
 }
-
-/* Test should not run with opache */
-if (extension_loaded('Zend OPcache')) {
-  die("warn: Zend OPcache extension required to be not loaded\n");
-}

--- a/tests/integration/opcache/disabled/skipif.inc
+++ b/tests/integration/opcache/disabled/skipif.inc
@@ -1,0 +1,15 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Opcache only supported with PHP 7+ */
+if (version_compare(PHP_VERSION, "7.0", "<")) {
+  die("skip: PHP < 7.0.0 not supported\n");
+}
+
+/* Test should not run with opache */
+if (extension_loaded('Zend OPcache')) {
+  die("warn: Zend OPcache extension required\n");
+}

--- a/tests/integration/opcache/disabled/skipif.inc
+++ b/tests/integration/opcache/disabled/skipif.inc
@@ -5,8 +5,8 @@
  */
 
 /* Opcache only supported with PHP 7+ */
-if (version_compare(PHP_VERSION, "7.0", "<")) {
-  die("skip: PHP < 7.0.0 not supported\n");
+if (version_compare(PHP_VERSION, "7.1", "<")) {
+  die("skip: PHP < 7.1 not supported\n");
 }
 
 /* Test should not run with opache */

--- a/tests/integration/opcache/disabled/test_computations.php
+++ b/tests/integration/opcache/disabled/test_computations.php
@@ -58,6 +58,7 @@ opcache.jit=function
 /*EXPECT
 Hello
 */
+require('opcache_test.inc');
 
 newrelic_add_custom_tracer('computation');
 

--- a/tests/integration/opcache/disabled/test_computations.php
+++ b/tests/integration/opcache/disabled/test_computations.php
@@ -26,10 +26,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ANALYTICS_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_computations.php
+++ b/tests/integration/opcache/disabled/test_computations.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Transaction event created and no errors despite creating spans
+for a HUGE number of calls.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 50,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "timestamp": "??",
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "priority": "??",
+        "sampled": true,
+        "totalTime": "??",
+        "error": false
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT
+Hello
+*/
+
+newrelic_add_custom_tracer('computation');
+
+function computation(float $a): int
+{
+
+    $b = intval($a) % (2 ** 32);
+    return $b;
+}
+
+for ($i = 0; $i < 500; ++$i) {
+    computation(2**64);
+}
+echo 'Hello';

--- a/tests/integration/opcache/disabled/test_even_odd_count.php
+++ b/tests/integration/opcache/disabled/test_even_odd_count.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Transaction event generated with JIT enabled even when doing lots of loops.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS null */
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 50,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "timestamp": "??",
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "priority": "??", 
+        "sampled": true,
+        "totalTime": "??",
+        "error": false
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+5000
+*/
+
+
+function even(int $a): bool {
+    if ($a == 1)  {
+        return false;
+    } else if (($a % 2) == 0) {
+            return true;
+        }
+    return false;
+}
+
+$count = 0;
+for ($i = 1; $i <= 10000; $i++)
+{
+        if (even($i)) $count++;
+}
+echo "$count";
+

--- a/tests/integration/opcache/disabled/test_even_odd_count.php
+++ b/tests/integration/opcache/disabled/test_even_odd_count.php
@@ -27,10 +27,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS null */
 
 /*EXPECT_ANALYTICS_EVENTS

--- a/tests/integration/opcache/disabled/test_even_odd_count.php
+++ b/tests/integration/opcache/disabled/test_even_odd_count.php
@@ -60,6 +60,7 @@ opcache.jit=function
 /*EXPECT
 5000
 */
+require('opcache_test.inc');
 
 
 function even(int $a): bool {

--- a/tests/integration/opcache/disabled/test_recursion_no_segfault.php
+++ b/tests/integration/opcache/disabled/test_recursion_no_segfault.php
@@ -36,6 +36,7 @@ null
 /*EXPECT
 89
 */
+require('opcache_test.inc');
 
 newrelic_add_custom_tracer('fibonacci'); 
 

--- a/tests/integration/opcache/disabled/test_recursion_no_segfault.php
+++ b/tests/integration/opcache/disabled/test_recursion_no_segfault.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+JIT enabled, should still instrument without crashing.
+Previous tests would invariably cause a segfault when
+recursively finding the 10th fibonacci number.
+ */
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+error_reporting = E_ALL
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT
+89
+*/
+
+newrelic_add_custom_tracer('fibonacci'); 
+
+
+function fibonacci($n){
+    return(($n < 2) ? 1 : fibonacci($n - 2) + fibonacci($n - 1));
+}
+
+$n = 10; /* Get the nth Fibonacci number. */
+
+$fibonacci = fibonacci($n);
+echo $fibonacci;
+

--- a/tests/integration/opcache/disabled/test_recursion_no_segfault.php
+++ b/tests/integration/opcache/disabled/test_recursion_no_segfault.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 null
 */

--- a/tests/integration/opcache/disabled/test_span_class_function.php
+++ b/tests/integration/opcache/disabled/test_span_class_function.php
@@ -1,0 +1,278 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+With JIT, span events should show properly.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 9
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/main",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/main",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/main",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/Classname::functionName",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.namespace": "Classname",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/Classname::functionName",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.namespace": "Classname",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/Classname::functionName",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.namespace": "Classname",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/Classname::functionName",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.namespace": "Classname",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/Classname::functionName",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.namespace": "Classname",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+HelloHelloHellofunctionNamefunctionNamefunctionNamefunctionNamefunctionNameOK
+*/
+
+newrelic_add_custom_tracer('main');
+newrelic_add_custom_tracer('Classname::functionName');
+function main()
+{
+  echo 'Hello';
+}
+main();
+main();
+main();
+
+abstract class Classname{
+
+        protected function functionName() : void {
+                echo 'functionName';
+                for($i = 0; $i < 500; ++$i) {
+                /* Spin wheels. */
+                $x = 10 + 10;
+                }
+        }
+
+        final public function __destruct(){
+
+        }
+
+}
+
+class LittleClass extends Classname{
+        public function __construct(){
+                $this->functionName();
+        }
+}
+
+for($i = 0; $i < 5; ++$i){
+        new LittleClass;
+}
+echo "OK\n";

--- a/tests/integration/opcache/disabled/test_span_class_function.php
+++ b/tests/integration/opcache/disabled/test_span_class_function.php
@@ -239,6 +239,7 @@ zend_extension=opcache.so
 /*EXPECT
 HelloHelloHellofunctionNamefunctionNamefunctionNamefunctionNamefunctionNameOK
 */
+require('opcache_test.inc');
 
 newrelic_add_custom_tracer('main');
 newrelic_add_custom_tracer('Classname::functionName');

--- a/tests/integration/opcache/disabled/test_span_events_are_created_from_segments.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_from_segments.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that span events are correctly created from any eligible segment.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ]
+  ]
+]
+*/
+
+function a() {
+  time_nanosleep(0, 100000000);
+}
+
+a();
+newrelic_record_datastore_segment(function () {
+  time_nanosleep(0, 100000000);
+}, array(
+  'product' => 'FakeDB',
+));

--- a/tests/integration/opcache/disabled/test_span_events_are_created_from_segments.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_from_segments.php
@@ -101,6 +101,7 @@ opcache.jit=function
   ]
 ]
 */
+require('opcache_test.inc');
 
 function a() {
   time_nanosleep(0, 100000000);

--- a/tests/integration/opcache/disabled/test_span_events_are_created_from_segments.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_from_segments.php
@@ -28,10 +28,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_SPAN_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php
@@ -33,9 +33,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php
@@ -165,6 +165,7 @@ opcache.jit=function
 /*EXPECT_REGEX
 ^\s*(PHP )?Fatal error:\s*foo in .*? on line [0-9]+\s*$
 */
+require('opcache_test.inc');
 
 set_error_handler(
     function (int $errno, string $errstr) {

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php
@@ -1,0 +1,194 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that span events are correctly created from any eligible segment, even
+when an error is generated and handled by user error handler. The span that
+generated the error should have error attributes. Additionally error events
+should be created.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+display_errors=1
+log_errors=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 100,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "E_USER_ERROR",
+        "error.message": "foo",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "databaseDuration": "??",
+        "databaseCallCount": 1,
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 4
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "foo",
+        "error.class": "E_USER_ERROR",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/{closure}",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*(PHP )?Fatal error:\s*foo in .*? on line [0-9]+\s*$
+*/
+
+set_error_handler(
+    function (int $errno, string $errstr) {
+        time_nanosleep(0, 100000000);
+        return false;
+    }
+);
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    trigger_error('foo', E_USER_ERROR);
+}
+
+newrelic_record_datastore_segment(
+    function () {
+        time_nanosleep(0, 100000000);
+    }, array(
+        'product' => 'FakeDB',
+    )
+);
+a();
+
+echo 'this should never be printed';

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_exit.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_exit.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_SPAN_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_exit.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_exit.php
@@ -102,6 +102,7 @@ opcache.jit=function
   ]
 ]
 */
+require('opcache_test.inc');
 
 function a()
 {

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_exit.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_exit.php
@@ -1,0 +1,123 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that span events are correctly created from any eligible segment, even
+when exit() is called.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    exit(0);
+}
+
+newrelic_record_datastore_segment(
+    function () {
+        time_nanosleep(0, 100000000);
+    }, array(
+    'product' => 'FakeDB',
+    )
+);
+a();

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php
@@ -31,10 +31,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_SPAN_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php
@@ -110,6 +110,7 @@ opcache.jit=function
 /*EXPECT_REGEX
 ^\s*(PHP )?Fatal error:\s*foo in .*? on line [0-9]+\s*$
 */
+require('opcache_test.inc');
 
 function a()
 {

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php
@@ -1,0 +1,133 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that span events are correctly created from any eligible segment, even
+when an error is generated and left to the default error handler.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+display_errors=1
+log_errors=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "foo",
+        "error.class": "E_USER_ERROR",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*(PHP )?Fatal error:\s*foo in .*? on line [0-9]+\s*$
+*/
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    trigger_error('foo', E_USER_ERROR);
+}
+
+newrelic_record_datastore_segment(
+    function () {
+        time_nanosleep(0, 100000000);
+    }, array(
+        'product' => 'FakeDB',
+    )
+);
+a();
+
+echo 'this should never be printed';

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
@@ -8,11 +8,15 @@
 Test that span events are correctly created from any eligible segment, even
 when an uncaught exception is handled by the user exception handler. The
 span that generated the exception should have error attributes. Additionally
-error events should be created.
+error events should be created for PHP 8+ and OAPI.
 */
 
 /*SKIPIF
 <?php
+
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 7.0.0 not supported\n");
+}
 
 require('skipif.inc');
 

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
@@ -37,11 +37,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
@@ -169,6 +169,7 @@ opcache.jit=function
 
 /*EXPECT
 */
+require('opcache_test.inc');
 
 set_exception_handler(
     function (Throwable $exception) {

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
@@ -1,0 +1,196 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+/*DESCRIPTION
+Test that span events are correctly created from any eligible segment, even
+when an uncaught exception is handled by the user exception handler. The
+span that generated the exception should have error attributes. Additionally
+error events should be created.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+display_errors=1
+log_errors=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "databaseDuration": "??",
+        "databaseCallCount": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 4
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "a"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/{closure}",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "{closure}"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+*/
+
+set_exception_handler(
+    function (Throwable $exception) {
+        time_nanosleep(0, 100000000);
+        exit(0); 
+    }
+);
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    throw new RuntimeException('oops');
+}
+
+newrelic_record_datastore_segment(
+    function () {
+        time_nanosleep(0, 100000000);
+    }, array(
+        'product' => 'FakeDB',
+    )
+);
+a();
+
+echo 'this should never be printed';

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php7.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php7.php
@@ -140,6 +140,7 @@ null
 
 /*EXPECT
 */
+require('opcache_test.inc');
 
 set_exception_handler(
     function (Throwable $exception) {

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php7.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php7.php
@@ -36,11 +36,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 null
 */

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception_invalid_handler.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception_invalid_handler.php
@@ -1,0 +1,210 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+/*DESCRIPTION
+Test that span events are correctly created from any eligible segment, even
+when an uncaught exception is handled by the user exception handler. The
+span that generated the exception should have error attributes. Additionally
+error events should be created.
+
+Caveat: This test uses invalid PHP code which causes undefined behavior. The
+test is left only to demonstrate this undefined behavior of an agent. When
+user exception handler is defined without explicitly accepting one parameter
+(which violates user exception handler's callback contract defined here:
+https://www.php.net/manual/en/function.set-exception-handler), when opcache
+is enabled, the oapi agent generated error events for PHPs: 8.0 and 8.1, but
+didn't generate error events PHP 8.2+ (hence PHPs 8.2+ are excluded from this
+test).
+*/
+
+/*SKIPIF
+<?php
+
+if (version_compare(PHP_VERSION, "8.2", ">=")) {
+  die("skip: PHP > 8.1 not supported\n");
+}
+
+require('skipif.inc');
+
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+display_errors=1
+log_errors=0
+error_reporting = E_ALL
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "databaseDuration": "??",
+        "databaseCallCount": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 4
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "a"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/{closure}",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "{closure}"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+*/
+
+set_exception_handler(
+    function () {
+        time_nanosleep(0, 100000000);
+        exit(0); 
+    }
+);
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    throw new RuntimeException('oops');
+}
+
+newrelic_record_datastore_segment(
+    function () {
+        time_nanosleep(0, 100000000);
+    }, array(
+        'product' => 'FakeDB',
+    )
+);
+a();
+
+echo 'this should never be printed';

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_unhandled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_unhandled_exception.php
@@ -33,10 +33,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_unhandled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_unhandled_exception.php
@@ -147,6 +147,7 @@ opcache.jit=function
 /*EXPECT_REGEX
 ^\s*(PHP )?Fatal error: Uncaught.*RuntimeException.*oops.*
 */
+require('opcache_test.inc');
 
 function a()
 {

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_unhandled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_unhandled_exception.php
@@ -1,0 +1,170 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*DESCRIPTION
+Test that span events are correctly created from any eligible segment, even
+when an uncaught exception is thrown and handling is left to the agent's default
+exception handler. The span that generated the exception and the root span should
+have error attributes. Additionally error events should be created.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+display_errors=1
+log_errors=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 100,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "databaseDuration": "??",
+        "databaseCallCount": 1,
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*(PHP )?Fatal error: Uncaught.*RuntimeException.*oops.*
+*/
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    throw new RuntimeException('oops');
+}
+
+newrelic_record_datastore_segment(
+    function () {
+        time_nanosleep(0, 100000000);
+    }, array(
+        'product' => 'FakeDB',
+    )
+);
+a();
+
+echo 'this should never be printed';

--- a/tests/integration/opcache/disabled/test_span_events_error_collector_disabled.php
+++ b/tests/integration/opcache/disabled/test_span_events_error_collector_disabled.php
@@ -31,9 +31,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
 /*EXPECT_ERROR_EVENTS
 null
 */

--- a/tests/integration/opcache/disabled/test_span_events_error_collector_disabled.php
+++ b/tests/integration/opcache/disabled/test_span_events_error_collector_disabled.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that no span events error attributes are captured when error_collector is disabled. No error events should be generated either.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.error_collector.enabled = false
+display_errors=1
+log_errors=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    trigger_error('foo', E_USER_ERROR);
+}
+
+newrelic_record_datastore_segment(
+    function () {
+        time_nanosleep(0, 100000000);
+    }, array(
+        'product' => 'FakeDB',
+    )
+);
+a();
+
+echo 'this should never be printed';

--- a/tests/integration/opcache/disabled/test_span_events_error_collector_disabled.php
+++ b/tests/integration/opcache/disabled/test_span_events_error_collector_disabled.php
@@ -108,6 +108,7 @@ null
   ]
 ]
 */
+require('opcache_test.inc');
 
 function a()
 {

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_nested.php
@@ -1,0 +1,217 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that a caught exception that originated from a child span is 
+correctly handled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+Caught exception: Division by zero
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+};
+
+a();
+b();

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_nested.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 null
 */

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_nested.php
@@ -177,6 +177,7 @@ Hello
 0.2
 Caught exception: Division by zero
 */
+require('opcache_test.inc');
 
 function c()
 {

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_nested_rethrown.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_nested_rethrown.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_nested_rethrown.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_nested_rethrown.php
@@ -1,0 +1,196 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that a caught exception that originated from a child span that 
+is "rethrown" is correctly handled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Rethrown caught exception: Division by zero' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 4
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Rethrown caught exception: Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Rethrown caught exception: Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+       "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*(PHP )?Fatal error:.*Uncaught.*Exception.*Rethrown caught exception: Division by zero.*
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        throw new RuntimeException('Rethrown caught exception: '. $e->getMessage());
+    }
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+b();

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_nested_rethrown.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_nested_rethrown.php
@@ -164,6 +164,7 @@ opcache.jit=function
 /*EXPECT_REGEX
 ^\s*(PHP )?Fatal error:.*Uncaught.*Exception.*Rethrown caught exception: Division by zero.*
 */
+require('opcache_test.inc');
 
 function c()
 {

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error.php
@@ -1,0 +1,169 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that a caught exception is correctly handled when a notice error is also
+called.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "Exception",
+        "error.message": "Noticed exception 'Exception' with message 'Notice me' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Noticed exception 'Exception' with message 'Notice me' in __FILE__:??",
+        "error.class": "Exception",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+Caught exception: Division by zero
+*/
+
+
+function fraction()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        $x = 0;
+        if (!$x) {
+          throw new RuntimeException('Division by zero');
+    }
+        echo 1/$x . "\n";
+    
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_notice_error(new Exception('Notice me'));
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+};
+
+a();
+fraction();

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error.php
@@ -137,6 +137,7 @@ opcache.jit=function
 Hello
 Caught exception: Division by zero
 */
+require('opcache_test.inc');
 
 
 function fraction()

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error_nested.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error_nested.php
@@ -1,0 +1,245 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that a caught exception that originated from a child span is correctly
+handled when a notice error is also called.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "Exception",
+        "error.message": "Noticed exception 'Exception' with message 'Notice me' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Noticed exception 'Exception' with message 'Notice me' in __FILE__:??",
+        "error.class": "Exception",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+0.2
+Caught exception: Division by zero
+*/
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    echo fraction(5) . "\n";
+    echo fraction(0) . "\n";
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo ("Caught exception: " . $e->getMessage() . "\n");
+    }
+    newrelic_notice_error(new Exception('Notice me'));
+}
+
+function fraction($x) {
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    return 1/$x;
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+};
+
+a();
+b();

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_notice_error_nested.php
@@ -204,6 +204,7 @@ Hello
 0.2
 Caught exception: Division by zero
 */
+require('opcache_test.inc');
 
 function c()
 {

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_same_span.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_same_span.php
@@ -28,10 +28,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 null
 */

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_same_span.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_same_span.php
@@ -108,6 +108,7 @@ null
 Hello
 Caught exception: Division by zero
 */
+require('opcache_test.inc');
 
 
 function fraction()

--- a/tests/integration/opcache/disabled/test_span_events_exception_caught_same_span.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_caught_same_span.php
@@ -1,0 +1,139 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that a caught exception is correctly handled in the same span.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+Caught exception: Division by zero
+*/
+
+
+function fraction()
+{
+    time_nanosleep(0, 100000000);
+    try {
+        $x = 0;
+        if (!$x) {
+          throw new RuntimeException('Division by zero');
+    }
+        echo 1/$x . "\n";
+    
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+};
+
+a();
+fraction();

--- a/tests/integration/opcache/disabled/test_span_events_exception_uncaught_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_uncaught_nested.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_exception_uncaught_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_uncaught_nested.php
@@ -189,6 +189,7 @@ opcache.jit=function
 /*EXPECT_REGEX
 ^\s*(PHP )?Fatal error: Uncaught.*RuntimeException.*oops.*
 */
+require('opcache_test.inc');
 
 function a()
 {

--- a/tests/integration/opcache/disabled/test_span_events_exception_uncaught_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_uncaught_nested.php
@@ -1,0 +1,224 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Test that an uncaught exception that originated from a child span is correctly handled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+display_errors=1
+log_errors=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "RuntimeException",
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "databaseDuration": "??",
+        "databaseCallCount": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Datastore\/statement\/FakeDB\/other\/other",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "datastore",
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "FakeDB"
+      },
+      {},
+      {
+        "db.instance": "unknown",
+        "peer.hostname": "unknown",
+        "peer.address": "unknown:unknown"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*(PHP )?Fatal error: Uncaught.*RuntimeException.*oops.*
+*/
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    b();
+}
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    c();
+}
+
+function c()
+{
+    time_nanosleep(0, 100000000);
+    throw new RuntimeException('oops');
+}
+
+newrelic_record_datastore_segment(
+    function () {
+        time_nanosleep(0, 100000000);
+    }, array(
+        'product' => 'FakeDB',
+    )
+);
+a();
+
+echo 'this should never be printed';

--- a/tests/integration/opcache/disabled/test_span_events_exist_when_no_segments.php
+++ b/tests/integration/opcache/disabled/test_span_events_exist_when_no_segments.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that a span event is created for transactions that create no segments.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+phpinfo();

--- a/tests/integration/opcache/disabled/test_span_events_exist_when_no_segments.php
+++ b/tests/integration/opcache/disabled/test_span_events_exist_when_no_segments.php
@@ -28,10 +28,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_SPAN_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_exist_when_no_segments.php
+++ b/tests/integration/opcache/disabled/test_span_events_exist_when_no_segments.php
@@ -57,5 +57,6 @@ opcache.jit=function
   ]
 ]
 */
+require('opcache_test.inc');
 
 phpinfo();

--- a/tests/integration/opcache/disabled/test_span_events_hsm_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_hsm_error.php
@@ -121,6 +121,7 @@ opcache.jit=function
 /*EXPECT_REGEX
 ^\s*(PHP )?Fatal error: Uncaught.*RuntimeException.*oops.*
 */
+require('opcache_test.inc');
 
 function a()
 {

--- a/tests/integration/opcache/disabled/test_span_events_hsm_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_hsm_error.php
@@ -32,10 +32,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_hsm_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_hsm_error.php
@@ -1,0 +1,137 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that span events error attributes conform to high security mode.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.high_security=true
+display_errors=1
+newrelic.high_security = true
+log_errors=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.message": "Message removed by New Relic high_security setting",
+        "error.class": "RuntimeException",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "error.message": "Message removed by New Relic high_security setting",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Message removed by New Relic high_security setting",
+        "error.class": "RuntimeException",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*(PHP )?Fatal error: Uncaught.*RuntimeException.*oops.*
+*/
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    throw new RuntimeException('oops');
+}
+
+a();
+
+echo 'this should never be printed';

--- a/tests/integration/opcache/disabled/test_span_events_notice_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_notice_error.php
@@ -135,6 +135,7 @@ opcache.jit=function
 /*EXPECT
 Hello
 */
+require('opcache_test.inc');
 
 
 function b()

--- a/tests/integration/opcache/disabled/test_span_events_notice_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_notice_error.php
@@ -28,10 +28,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_ERROR_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/disabled/test_span_events_notice_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_notice_error.php
@@ -1,0 +1,157 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that notice error is correctly handled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "Exception",
+        "error.message": "Noticed exception 'Exception' with message 'Notice me' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "??",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "??"
+      },
+      {},
+      {
+        "error.message": "Noticed exception 'Exception' with message 'Notice me' in __FILE__:??",
+        "error.class": "Exception",
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Hello
+*/
+
+
+function b()
+{
+    time_nanosleep(0, 100000000);
+    newrelic_notice_error(new Exception('Notice me'));
+}
+
+function a()
+{
+    time_nanosleep(0, 100000000);
+    echo "Hello\n";
+};
+
+a();
+b();

--- a/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_off.php
+++ b/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_off.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_SPAN_EVENTS
 null
 */

--- a/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_off.php
+++ b/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_off.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Span events should not be sent when distributed tracing is
+disabled, regardless of span events being enabled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled = 1
+newrelic.cross_application_tracer.enabled = false
+newrelic.distributed_tracing_enabled=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_SPAN_EVENTS
+null
+*/
+
+/*EXPECT
+Hello
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  echo 'Hello';
+}
+main();
+

--- a/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_off.php
+++ b/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_off.php
@@ -36,6 +36,7 @@ null
 /*EXPECT
 Hello
 */
+require('opcache_test.inc');
 
 newrelic_add_custom_tracer('main');
 function main()

--- a/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_on.php
+++ b/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_on.php
@@ -29,10 +29,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=function
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_SPAN_EVENTS
 null
 */

--- a/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_on.php
+++ b/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_on.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Span events should not be sent when distributed tracing is
+disabled, regardless of span events being enabled.
+*/
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled = 1
+newrelic.cross_application_tracer.enabled = true
+newrelic.distributed_tracing_enabled=0
+error_reporting = E_ALL
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_SPAN_EVENTS
+null
+*/
+
+/*EXPECT
+Hello
+*/
+
+newrelic_add_custom_tracer('main');
+function main()
+{
+  echo 'Hello';
+}
+main();
+

--- a/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_on.php
+++ b/tests/integration/opcache/disabled/test_span_events_on_dt_off_cat_on.php
@@ -36,6 +36,7 @@ null
 /*EXPECT
 Hello
 */
+require('opcache_test.inc');
 
 newrelic_add_custom_tracer('main');
 function main()

--- a/tests/integration/opcache/disabled/test_span_events_root_parent.php
+++ b/tests/integration/opcache/disabled/test_span_events_root_parent.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+JIT enabled, should still instrument.
+ */
+
+/*SKIPIF
+<?php
+
+require('skipif.inc');
+
+*/
+
+/*INI
+error_reporting = E_ALL
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.cross_application_tracer.enabled = false
+opcache.enable=0
+opcache.enable_cli=0
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=tracing
+*/
+
+/*PHPMODULES
+zend_extension=opcache.so
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 4
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??", 
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??", 
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/main",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/main",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "Custom\/main",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "parentId": "??",
+        "sampled": true,
+        "timestamp": "??"
+      },
+      {},
+      {
+        "code.lineno": "??",
+        "code.filepath": "__FILE__",
+        "code.function": "??"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+HelloHelloHello
+*/
+
+newrelic_add_custom_tracer('main'); 
+
+function main()
+{
+  sleep(1);
+  echo 'Hello';
+}
+main();
+main();
+main();

--- a/tests/integration/opcache/disabled/test_span_events_root_parent.php
+++ b/tests/integration/opcache/disabled/test_span_events_root_parent.php
@@ -123,6 +123,7 @@ opcache.jit=tracing
 /*EXPECT
 HelloHelloHello
 */
+require('opcache_test.inc');
 
 newrelic_add_custom_tracer('main'); 
 

--- a/tests/integration/opcache/disabled/test_span_events_root_parent.php
+++ b/tests/integration/opcache/disabled/test_span_events_root_parent.php
@@ -27,10 +27,6 @@ opcache.jit_buffer_size=32M
 opcache.jit=tracing
 */
 
-/*PHPMODULES
-zend_extension=opcache.so
-*/
-
 /*EXPECT_SPAN_EVENTS
 [
   "?? agent run id",

--- a/tests/integration/opcache/enabled/test_opcache.php
+++ b/tests/integration/opcache/enabled/test_opcache.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+This test exists to ensure that our test suites run with opcache
+enabled, thus it will FAIL (instead of skip) if opcache is not
+enabled. Our tests running with opcache on by default is
+important because that is the expected mode of operation by
+our customers.
+
+Transaction event created and no errors despite creating spans
+for a HUGE number of calls.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "7.4", "<")) {
+  die("skip: PHP < 7.4 not supported\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+error_reporting = E_ALL
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=function
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 50,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "timestamp": "??",
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "??",
+        "priority": "??",
+        "sampled": true,
+        "totalTime": "??",
+        "error": false
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+
+/*EXPECT
+Hello
+*/
+
+if (!extension_loaded('Zend OPcache')) {
+  die("fail: opcache not loaded");
+}
+if (!opcache_get_status()) {
+    die("fail: opcache disabled");
+}
+
+newrelic_add_custom_tracer('computation');
+
+function computation(float $a): int
+{
+
+    $b = intval($a) % (2 ** 32);
+    return $b;
+}
+
+for ($i = 0; $i < 500; ++$i) {
+    computation(2**64);
+}
+echo 'Hello';
+


### PR DESCRIPTION
* Enable the opcache.so extension by default in the integration_runner
* Ensure the opcache INI settings in the integration_runner environment are enabled (these can be overwritten in the test case INI section if needing to test without opcache)
* Added few tests to ensure compatibility with opcache disabled and to demonstrate how to overwrite the value.