### PR TITLE
refactor(agent): improve magic file recognition performance

### DIFF
--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -671,6 +671,11 @@ nr_php_op_array_file_name(const zend_op_array* op_array) {
 #endif
 }
 
+static inline nr_string_len_t NRPURE
+nr_php_op_array_file_name_len(const zend_op_array* op_array) {
+  return op_array->filename ? op_array->filename->len : 0;
+}
+
 static inline const char* NRPURE
 nr_php_op_array_function_name(const zend_op_array* op_array) {
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -802,6 +802,8 @@ static void nr_execute_handle_framework(const nr_framework_table_t frameworks[],
   }
 }
 
+#define STR_AND_LEN(v) v, v##_len
+
 /*
  * Attempt to detect a framework.
  * Call the appropriate enable function if we find the framework.
@@ -816,8 +818,8 @@ static nrframework_t nr_try_detect_framework(
   size_t i;
 
   for (i = 0; i < num_frameworks; i++) {
-    if (nr_striendswith(filename, filename_len, frameworks[i].file_to_check,
-                        frameworks[i].file_to_check_len)) {
+    if (nr_striendswith(STR_AND_LEN(filename),
+                        STR_AND_LEN(frameworks[i].file_to_check))) {
       /*
        * If we have a special check function and it tells us to ignore
        * the file name because some other condition wasn't met, continue
@@ -884,8 +886,8 @@ static void nr_execute_handle_library(const char* filename,
   size_t i;
 
   for (i = 0; i < num_libraries; i++) {
-    if (nr_striendswith(filename, filename_len, libraries[i].file_to_check,
-                        libraries[i].file_to_check_len)) {
+    if (nr_striendswith(STR_AND_LEN(filename),
+                        STR_AND_LEN(libraries[i].file_to_check))) {
       nrl_debug(NRL_INSTRUMENT, "detected library=%s",
                 libraries[i].library_name);
 
@@ -906,9 +908,8 @@ static void nr_execute_handle_logging_framework(const char* filename,
   size_t i;
 
   for (i = 0; i < num_logging_frameworks; i++) {
-    if (nr_striendswith(filename, filename_len,
-                        logging_frameworks[i].file_to_check,
-                        logging_frameworks[i].file_to_check_len)) {
+    if (nr_striendswith(STR_AND_LEN(filename),
+                        STR_AND_LEN(logging_frameworks[i].file_to_check))) {
       nrl_debug(NRL_INSTRUMENT, "detected library=%s",
                 logging_frameworks[i].library_name);
 
@@ -924,6 +925,8 @@ static void nr_execute_handle_logging_framework(const char* filename,
     }
   }
 }
+
+#undef STR_AND_LEN
 
 /*
  * Purpose : Detect library and framework usage from a PHP file.

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -813,19 +813,11 @@ static nrframework_t nr_try_detect_framework(
     const char* filename,
     const size_t filename_len TSRMLS_DC) {
   nrframework_t detected = NR_FW_UNSET;
-  const char* filename_suffix;
   size_t i;
 
   for (i = 0; i < num_frameworks; i++) {
-    size_t file_to_check_len = frameworks[i].file_to_check_len;
-    if (filename_len < file_to_check_len) {
-      /* No point in checking if checked filename is shorter than 'magic' file
-       * pattern */
-      continue;
-    }
-    /* Check if filename ends with the desired pattern */
-    filename_suffix = filename_lower + (filename_len - file_to_check_len);
-    if (nr_stricmp(filename_suffix, frameworks[i].file_to_check) == 0) {
+    if (nr_striendswith(filename, filename_len, frameworks[i].file_to_check,
+                        frameworks[i].file_to_check_len)) {
       /*
        * If we have a special check function and it tells us to ignore
        * the file name because some other condition wasn't met, continue
@@ -889,19 +881,11 @@ static nrframework_t nr_try_force_framework(
 
 static void nr_execute_handle_library(const char* filename,
                                       const size_t filename_len TSRMLS_DC) {
-  const char* filename_suffix;
   size_t i;
 
   for (i = 0; i < num_libraries; i++) {
-    size_t file_to_check_len = libraries[i].file_to_check_len;
-    if (filename_len < file_to_check_len) {
-      /* No point in checking if checked filename is shorter than 'magic' file
-       * pattern */
-      continue;
-    }
-    /* Check if filename ends with the desired pattern */
-    filename_suffix = filename_lower + (filename_len - file_to_check_len);
-    if (nr_stricmp(filename_suffix, libraries[i].file_to_check) == 0) {
+    if (nr_striendswith(filename, filename_len, libraries[i].file_to_check,
+                        libraries[i].file_to_check_len)) {
       nrl_debug(NRL_INSTRUMENT, "detected library=%s",
                 libraries[i].library_name);
 
@@ -918,21 +902,13 @@ static void nr_execute_handle_library(const char* filename,
 static void nr_execute_handle_logging_framework(const char* filename,
                                                 const size_t filename_len
                                                     TSRMLS_DC) {
-  const char* filename_suffix;
   bool is_enabled = false;
   size_t i;
 
   for (i = 0; i < num_logging_frameworks; i++) {
-    size_t file_to_check_len = logging_frameworks[i].file_to_check_len;
-    if (filename_len < file_to_check_len) {
-      /* No point in checking if checked filename is shorter than 'magic' file
-       * pattern */
-      continue;
-    }
-
-    /* Check if filename ends with the desired pattern */
-    filename_suffix = filename_lower + (filename_len - file_to_check_len);
-    if (nr_stricmp(filename_suffix, logging_frameworks[i].file_to_check) == 0) {
+    if (nr_striendswith(filename, filename_len,
+                        logging_frameworks[i].file_to_check,
+                        logging_frameworks[i].file_to_check_len)) {
       nrl_debug(NRL_INSTRUMENT, "detected library=%s",
                 logging_frameworks[i].library_name);
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -330,9 +330,9 @@ static const nr_framework_table_t all_frameworks[] = {
      *   cake1.2 and cake1.3 use a subdirectory named 'cake' (lower case)
      *   cake2.0 and on use a subdirectory named 'Cake' (upper case file name)
      */
-    {"CakePHP", "cakephp", NR_PSTR ("cake/libs/object.php"), nr_cakephp_special_1,
+    {"CakePHP", "cakephp", NR_PSTR("cake/libs/object.php"), nr_cakephp_special_1,
      nr_cakephp_enable_1, NR_FW_CAKEPHP},
-    {"CakePHP", "cakephp", NR_PSTR ("cake/core/app.php"), nr_cakephp_special_2,
+    {"CakePHP", "cakephp", NR_PSTR("cake/core/app.php"), nr_cakephp_special_2,
      nr_cakephp_enable_2, NR_FW_CAKEPHP},
 
     /*
@@ -342,85 +342,85 @@ static const nr_framework_table_t all_frameworks[] = {
      * specifically a problem for Expression Engine (look for expression_engine,
      * below.)
      */
-    {"CodeIgniter", "codeigniter", NR_PSTR ("codeigniter.php"), 0, nr_codeigniter_enable,
+    {"CodeIgniter", "codeigniter", NR_PSTR("codeigniter.php"), 0, nr_codeigniter_enable,
      NR_FW_CODEIGNITER},
 
-    {"Drupal8", "drupal8", NR_PSTR ("core/includes/bootstrap.inc"), 0, nr_drupal8_enable,
+    {"Drupal8", "drupal8", NR_PSTR("core/includes/bootstrap.inc"), 0, nr_drupal8_enable,
      NR_FW_DRUPAL8},
-    {"Drupal", "drupal", NR_PSTR ("includes/common.inc"), 0, nr_drupal_enable,
+    {"Drupal", "drupal", NR_PSTR("includes/common.inc"), 0, nr_drupal_enable,
      NR_FW_DRUPAL},
 
-    {"Joomla", "joomla", NR_PSTR ("joomla/import.php"), 0, nr_joomla_enable,
+    {"Joomla", "joomla", NR_PSTR("joomla/import.php"), 0, nr_joomla_enable,
      NR_FW_JOOMLA}, /* <= Joomla 1.5 */
-    {"Joomla", "joomla", NR_PSTR ("libraries/joomla/factory.php"), 0, nr_joomla_enable,
+    {"Joomla", "joomla", NR_PSTR("libraries/joomla/factory.php"), 0, nr_joomla_enable,
      NR_FW_JOOMLA}, /* >= Joomla 1.6, including 2.5 and 3.2 */
 
-    {"Kohana", "kohana", NR_PSTR ("kohana/core.php"), 0, nr_kohana_enable, NR_FW_KOHANA},
-    {"Kohana", "kohana", NR_PSTR ("kohana/core.php"), 0, nr_kohana_enable, NR_FW_KOHANA},
+    {"Kohana", "kohana", NR_PSTR("kohana/core.php"), 0, nr_kohana_enable, NR_FW_KOHANA},
+    {"Kohana", "kohana", NR_PSTR("kohana/core.php"), 0, nr_kohana_enable, NR_FW_KOHANA},
 
     /* See below: Zend, the legacy project of Laminas, which shares much
        of the instrumentation implementation with Laminas */
-    {"Laminas3", "laminas3", NR_PSTR ("laminas/mvc/application.php"), 0,
+    {"Laminas3", "laminas3", NR_PSTR("laminas/mvc/application.php"), 0,
      nr_laminas3_enable, NR_FW_LAMINAS3},
-    {"Laminas3", "laminas3", NR_PSTR ("laminas-mvc/src/application.php"), 0,
+    {"Laminas3", "laminas3", NR_PSTR("laminas-mvc/src/application.php"), 0,
      nr_laminas3_enable, NR_FW_LAMINAS3},
 
-    {"Laravel", "laravel", NR_PSTR ("illuminate/foundation/application.php"), 0,
+    {"Laravel", "laravel", NR_PSTR("illuminate/foundation/application.php"), 0,
      nr_laravel_enable, NR_FW_LARAVEL},
-    {"Laravel", "laravel", NR_PSTR ("bootstrap/compiled.php"), 0, nr_laravel_enable,
+    {"Laravel", "laravel", NR_PSTR("bootstrap/compiled.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 4.x */
-    {"Laravel", "laravel", NR_PSTR ("storage/framework/compiled.php"), 0,
+    {"Laravel", "laravel", NR_PSTR("storage/framework/compiled.php"), 0,
      nr_laravel_enable, NR_FW_LARAVEL}, /* 5.0.0-14 */
-    {"Laravel", "laravel", NR_PSTR ("vendor/compiled.php"), 0, nr_laravel_enable,
+    {"Laravel", "laravel", NR_PSTR("vendor/compiled.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 5.0.15-5.0.x */
-    {"Laravel", "laravel", NR_PSTR ("bootstrap/cache/compiled.php"), 0, nr_laravel_enable,
+    {"Laravel", "laravel", NR_PSTR("bootstrap/cache/compiled.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 5.1.0-x */
-    {"Laravel", "laravel", NR_PSTR ("bootstrap/app.php"), 0, nr_laravel_enable,
+    {"Laravel", "laravel", NR_PSTR("bootstrap/app.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 8+ */
 
-    {"Lumen", "lumen", NR_PSTR ("lumen-framework/src/helpers.php"), 0, nr_lumen_enable,
+    {"Lumen", "lumen", NR_PSTR("lumen-framework/src/helpers.php"), 0, nr_lumen_enable,
      NR_FW_LUMEN},
 
-    {"Magento", "magento", NR_PSTR ("app/mage.php"), 0, nr_magento1_enable,
+    {"Magento", "magento", NR_PSTR("app/mage.php"), 0, nr_magento1_enable,
      NR_FW_MAGENTO1},
-    {"Magento2", "magento2", NR_PSTR ("magento/framework/app/bootstrap.php"), 0,
+    {"Magento2", "magento2", NR_PSTR("magento/framework/app/bootstrap.php"), 0,
      nr_magento2_enable, NR_FW_MAGENTO2},
 
-    {"MediaWiki", "mediawiki", NR_PSTR ("includes/webstart.php"), 0, nr_mediawiki_enable,
+    {"MediaWiki", "mediawiki", NR_PSTR("includes/webstart.php"), 0, nr_mediawiki_enable,
      NR_FW_MEDIAWIKI},
 
-    {"Silex", "silex", NR_PSTR ("silex/application.php"), 0, nr_silex_enable,
+    {"Silex", "silex", NR_PSTR("silex/application.php"), 0, nr_silex_enable,
      NR_FW_SILEX},
 
-    {"Slim", "slim", NR_PSTR ("slim/slim/app.php"), 0, nr_slim_enable,
+    {"Slim", "slim", NR_PSTR("slim/slim/app.php"), 0, nr_slim_enable,
      NR_FW_SLIM}, /* 3.x */
-    {"Slim", "slim", NR_PSTR ("slim/slim/slim.php"), 0, nr_slim_enable,
+    {"Slim", "slim", NR_PSTR("slim/slim/slim.php"), 0, nr_slim_enable,
      NR_FW_SLIM}, /* 2.x */
 
-    {"Symfony", "symfony1", NR_PSTR ("sfcontext.class.php"), 0, nr_symfony1_enable,
+    {"Symfony", "symfony1", NR_PSTR("sfcontext.class.php"), 0, nr_symfony1_enable,
      NR_FW_SYMFONY1},
-    {"Symfony", "symfony1", NR_PSTR ("sfconfig.class.php"), 0, nr_symfony1_enable,
+    {"Symfony", "symfony1", NR_PSTR("sfconfig.class.php"), 0, nr_symfony1_enable,
      NR_FW_SYMFONY1},
-    {"Symfony2", "symfony2", NR_PSTR ("bootstrap.php.cache"), 0, nr_symfony2_enable,
+    {"Symfony2", "symfony2", NR_PSTR("bootstrap.php.cache"), 0, nr_symfony2_enable,
      NR_FW_SYMFONY2}, /* also Symfony 3 */
     {"Symfony2", "symfony2",
-     NR_PSTR ("symfony/bundle/frameworkbundle/frameworkbundle.php"), 0,
+     NR_PSTR("symfony/bundle/frameworkbundle/frameworkbundle.php"), 0,
      nr_symfony2_enable, NR_FW_SYMFONY2}, /* also Symfony 3 */
-    {"Symfony4", "symfony4", NR_PSTR ("http-kernel/httpkernel.php"), 0,
+    {"Symfony4", "symfony4", NR_PSTR("http-kernel/httpkernel.php"), 0,
      nr_symfony4_enable, NR_FW_SYMFONY4}, /* also Symfony 5 */
 
-    {"WordPress", "wordpress", NR_PSTR ("wp-config.php"), 0, nr_wordpress_enable,
+    {"WordPress", "wordpress", NR_PSTR("wp-config.php"), 0, nr_wordpress_enable,
      NR_FW_WORDPRESS},
 
-    {"Yii", "yii", NR_PSTR ("framework/yii.php"), 0, nr_yii_enable, NR_FW_YII},
-    {"Yii", "yii", NR_PSTR ("framework/yiilite.php"), 0, nr_yii_enable, NR_FW_YII},
+    {"Yii", "yii", NR_PSTR("framework/yii.php"), 0, nr_yii_enable, NR_FW_YII},
+    {"Yii", "yii", NR_PSTR("framework/yiilite.php"), 0, nr_yii_enable, NR_FW_YII},
 
     /* See above: Laminas, the successor to Zend, which shares much
        of the instrumentation implementation with Zend */
-    {"Zend", "zend", NR_PSTR ("zend/loader.php"), 0, nr_zend_enable, NR_FW_ZEND},
-    {"Zend2", "zend2", NR_PSTR ("zend/mvc/application.php"), 0, nr_fw_zend2_enable,
+    {"Zend", "zend", NR_PSTR("zend/loader.php"), 0, nr_zend_enable, NR_FW_ZEND},
+    {"Zend2", "zend2", NR_PSTR("zend/mvc/application.php"), 0, nr_fw_zend2_enable,
      NR_FW_ZEND2},
-    {"Zend2", "zend2", NR_PSTR ("zend-mvc/src/application.php"), 0, nr_fw_zend2_enable,
+    {"Zend2", "zend2", NR_PSTR("zend-mvc/src/application.php"), 0, nr_fw_zend2_enable,
      NR_FW_ZEND2},
 };
 // clang-format: on
@@ -479,23 +479,23 @@ typedef struct _nr_library_table_t {
  */
 // clang-format: off
 static nr_library_table_t libraries[] = {
-    {"Doctrine 2", NR_PSTR ("doctrine/orm/query.php"), nr_doctrine2_enable},
-    {"Guzzle 3", NR_PSTR ("guzzle/http/client.php"), nr_guzzle3_enable},
-    {"Guzzle 4-5", NR_PSTR ("hasemitterinterface.php"), nr_guzzle4_enable},
-    {"Guzzle 6", NR_PSTR ("guzzle/src/functions_include.php"), nr_guzzle6_enable},
+    {"Doctrine 2", NR_PSTR("doctrine/orm/query.php"), nr_doctrine2_enable},
+    {"Guzzle 3", NR_PSTR("guzzle/http/client.php"), nr_guzzle3_enable},
+    {"Guzzle 4-5", NR_PSTR("hasemitterinterface.php"), nr_guzzle4_enable},
+    {"Guzzle 6", NR_PSTR("guzzle/src/functions_include.php"), nr_guzzle6_enable},
 
-    {"MongoDB", NR_PSTR ("mongodb/src/client.php"), nr_mongodb_enable},
+    {"MongoDB", NR_PSTR("mongodb/src/client.php"), nr_mongodb_enable},
 
     /*
      * The first path is for Composer installs, the second is for
      * /usr/local/bin. While BaseTestRunner isn't the very first file to load,
      * it contains the test status constants and loads before tests can run.
      */
-    {"PHPUnit", NR_PSTR ("phpunit/src/runner/basetestrunner.php"), nr_phpunit_enable},
-    {"PHPUnit", NR_PSTR ("phpunit/runner/basetestrunner.php"), nr_phpunit_enable},
+    {"PHPUnit", NR_PSTR("phpunit/src/runner/basetestrunner.php"), nr_phpunit_enable},
+    {"PHPUnit", NR_PSTR("phpunit/runner/basetestrunner.php"), nr_phpunit_enable},
 
-    {"Predis", NR_PSTR ("predis/src/client.php"), nr_predis_enable},
-    {"Predis", NR_PSTR ("predis/client.php"), nr_predis_enable},
+    {"Predis", NR_PSTR("predis/src/client.php"), nr_predis_enable},
+    {"Predis", NR_PSTR("predis/client.php"), nr_predis_enable},
 
     /*
      * Allow Zend Framework 1.x to be detected as a library as well as a
@@ -503,14 +503,14 @@ static nr_library_table_t libraries[] = {
      * with other frameworks or even without a framework at all. This is
      * necessary for Magento in particular, which is built on ZF1.
      */
-    {"Zend_Http", NR_PSTR ("zend/http/client.php"), nr_zend_http_enable},
+    {"Zend_Http", NR_PSTR("zend/http/client.php"), nr_zend_http_enable},
 
     /*
      * Allow Laminas Framework 3.x to be detected as a library as well as a
      * framework. This allows Laminas_Http_Client to be instrumented when used
      * with other frameworks or even without a framework at all.
      */
-    {"Laminas_Http", NR_PSTR ("laminas-http/src/client.php"), nr_laminas_http_enable},
+    {"Laminas_Http", NR_PSTR("laminas-http/src/client.php"), nr_laminas_http_enable},
 
     /*
      * Other frameworks, detected only, but not specifically
@@ -518,54 +518,54 @@ static nr_library_table_t libraries[] = {
      * detection of a supported framework or library later (since a transaction
      * can only have one framework).
      */
-    {"Aura1", NR_PSTR ("aura/framework/system.php"), NULL},
-    {"Aura2", NR_PSTR ("aura/di/src/containerinterface.php"), NULL},
-    {"Aura3", NR_PSTR ("aura/di/src/containerconfiginterface.php"), NULL},
-    {"CakePHP3", NR_PSTR ("cakephp/src/core/functions.php"), NULL},
-    {"Fuel", NR_PSTR ("fuel/core/classes/fuel.php"), NULL},
-    {"Lithium", NR_PSTR ("lithium/core/libraries.php"), NULL},
-    {"Phpbb", NR_PSTR ("phpbb/request/request.php"), NULL},
-    {"Phpixie2", NR_PSTR ("phpixie/core/classes/phpixie/pixie.php"), NULL},
-    {"Phpixie3", NR_PSTR ("phpixie/framework.php"), NULL},
-    {"React", NR_PSTR ("react/event-loop/src/loopinterface.php"), NULL},
-    {"SilverStripe", NR_PSTR ("injector/silverstripeinjectioncreator.php"), NULL},
-    {"SilverStripe4", NR_PSTR ("silverstripeserviceconfigurationlocator.php"), NULL},
-    {"Typo3", NR_PSTR ("classes/typo3/flow/core/bootstrap.php"), NULL},
-    {"Typo3", NR_PSTR ("typo3/sysext/core/classes/core/bootstrap.php"), NULL},
-    {"Yii2", NR_PSTR ("yii2/baseyii.php"), NULL},
+    {"Aura1", NR_PSTR("aura/framework/system.php"), NULL},
+    {"Aura2", NR_PSTR("aura/di/src/containerinterface.php"), NULL},
+    {"Aura3", NR_PSTR("aura/di/src/containerconfiginterface.php"), NULL},
+    {"CakePHP3", NR_PSTR("cakephp/src/core/functions.php"), NULL},
+    {"Fuel", NR_PSTR("fuel/core/classes/fuel.php"), NULL},
+    {"Lithium", NR_PSTR("lithium/core/libraries.php"), NULL},
+    {"Phpbb", NR_PSTR("phpbb/request/request.php"), NULL},
+    {"Phpixie2", NR_PSTR("phpixie/core/classes/phpixie/pixie.php"), NULL},
+    {"Phpixie3", NR_PSTR("phpixie/framework.php"), NULL},
+    {"React", NR_PSTR("react/event-loop/src/loopinterface.php"), NULL},
+    {"SilverStripe", NR_PSTR("injector/silverstripeinjectioncreator.php"), NULL},
+    {"SilverStripe4", NR_PSTR("silverstripeserviceconfigurationlocator.php"), NULL},
+    {"Typo3", NR_PSTR("classes/typo3/flow/core/bootstrap.php"), NULL},
+    {"Typo3", NR_PSTR("typo3/sysext/core/classes/core/bootstrap.php"), NULL},
+    {"Yii2", NR_PSTR("yii2/baseyii.php"), NULL},
 
     /*
      * Other CMS (content management systems), detected only, but
      * not specifically instrumented.
      */
-    {"Moodle", NR_PSTR ("moodlelib.php"), NULL},
+    {"Moodle", NR_PSTR("moodlelib.php"), NULL},
     /*
      * It is likely that this will never be found, since the CodeIgniter.php
      * will get loaded first, and as such mark this transaction as belonging to
      * CodeIgniter, and not Expession Engine.
      */
-    {"ExpressionEngine", NR_PSTR ("system/expressionengine/config/config.php"), NULL},
+    {"ExpressionEngine", NR_PSTR("system/expressionengine/config/config.php"), NULL},
     /*
      * ExpressionEngine 5, however, has a very obvious file we can look for.
      */
-    {"ExpressionEngine5", NR_PSTR ("expressionengine/boot/boot.php"), NULL},
+    {"ExpressionEngine5", NR_PSTR("expressionengine/boot/boot.php"), NULL},
     /*
      * DokuWiki uses doku.php as an entry point, but has other files that are
      * loaded directly that this won't pick up. That's probably OK for
      * supportability metrics, but we'll add the most common name for the
      * configuration file as well just in case.
      */
-    {"DokuWiki", NR_PSTR ("doku.php"), NULL},
-    {"DokuWiki", NR_PSTR ("conf/dokuwiki.php"), NULL},
+    {"DokuWiki", NR_PSTR("doku.php"), NULL},
+    {"DokuWiki", NR_PSTR("conf/dokuwiki.php"), NULL},
 
     /*
      * SugarCRM no longer has a community edition, so this likely only works
      * with older versions.
      */
-    {"SugarCRM", NR_PSTR ("sugarobjects/sugarconfig.php"), NULL},
+    {"SugarCRM", NR_PSTR("sugarobjects/sugarconfig.php"), NULL},
 
-    {"Xoops", NR_PSTR ("class/xoopsload.php"), NULL},
-    {"E107", NR_PSTR ("e107_handlers/e107_class.php"), NULL},
+    {"Xoops", NR_PSTR("class/xoopsload.php"), NULL},
+    {"E107", NR_PSTR("e107_handlers/e107_class.php"), NULL},
 };
 // clang-format: on
 
@@ -574,15 +574,15 @@ static size_t num_libraries = sizeof(libraries) / sizeof(nr_library_table_t);
 // clang-format: off
 static nr_library_table_t logging_frameworks[] = {
     /* Monolog - Logging for PHP */
-    {"Monolog", NR_PSTR ("monolog/logger.php"), nr_monolog_enable},
+    {"Monolog", NR_PSTR("monolog/logger.php"), nr_monolog_enable},
     /* Consolidation/Log - Logging for PHP */
-    {"Consolidation/Log", NR_PSTR ("consolidation/log/src/logger.php"), NULL},
+    {"Consolidation/Log", NR_PSTR("consolidation/log/src/logger.php"), NULL},
     /* laminas-log - Logging for PHP */
-    {"laminas-log", NR_PSTR ("laminas-log/src/logger.php"), NULL},
+    {"laminas-log", NR_PSTR("laminas-log/src/logger.php"), NULL},
     /* cakephp-log - Logging for PHP */
-    {"cakephp-log", NR_PSTR ("cakephp/log/log.php"), NULL},
+    {"cakephp-log", NR_PSTR("cakephp/log/log.php"), NULL},
     /* Analog - Logging for PHP */
-    {"Analog", NR_PSTR ("analog/analog.php"), NULL},
+    {"Analog", NR_PSTR("analog/analog.php"), NULL},
 };
 // clang-format: on
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -470,30 +470,32 @@ nrframework_t nr_php_framework_from_config(const char* config_name) {
 typedef struct _nr_library_table_t {
   const char* library_name;
   const char* file_to_check;
+  size_t file_to_check_len;
   nr_library_enable_fn_t enable;
 } nr_library_table_t;
 
 /*
  * Note that all paths should be in lowercase.
  */
+// clang-format: off
 static nr_library_table_t libraries[] = {
-    {"Doctrine 2", "doctrine/orm/query.php", nr_doctrine2_enable},
-    {"Guzzle 3", "guzzle/http/client.php", nr_guzzle3_enable},
-    {"Guzzle 4-5", "hasemitterinterface.php", nr_guzzle4_enable},
-    {"Guzzle 6", "guzzle/src/functions_include.php", nr_guzzle6_enable},
+    {"Doctrine 2", NR_PSTR ("doctrine/orm/query.php"), nr_doctrine2_enable},
+    {"Guzzle 3", NR_PSTR ("guzzle/http/client.php"), nr_guzzle3_enable},
+    {"Guzzle 4-5", NR_PSTR ("hasemitterinterface.php"), nr_guzzle4_enable},
+    {"Guzzle 6", NR_PSTR ("guzzle/src/functions_include.php"), nr_guzzle6_enable},
 
-    {"MongoDB", "mongodb/src/client.php", nr_mongodb_enable},
+    {"MongoDB", NR_PSTR ("mongodb/src/client.php"), nr_mongodb_enable},
 
     /*
      * The first path is for Composer installs, the second is for
      * /usr/local/bin. While BaseTestRunner isn't the very first file to load,
      * it contains the test status constants and loads before tests can run.
      */
-    {"PHPUnit", "phpunit/src/runner/basetestrunner.php", nr_phpunit_enable},
-    {"PHPUnit", "phpunit/runner/basetestrunner.php", nr_phpunit_enable},
+    {"PHPUnit", NR_PSTR ("phpunit/src/runner/basetestrunner.php"), nr_phpunit_enable},
+    {"PHPUnit", NR_PSTR ("phpunit/runner/basetestrunner.php"), nr_phpunit_enable},
 
-    {"Predis", "predis/src/client.php", nr_predis_enable},
-    {"Predis", "predis/client.php", nr_predis_enable},
+    {"Predis", NR_PSTR ("predis/src/client.php"), nr_predis_enable},
+    {"Predis", NR_PSTR ("predis/client.php"), nr_predis_enable},
 
     /*
      * Allow Zend Framework 1.x to be detected as a library as well as a
@@ -501,14 +503,14 @@ static nr_library_table_t libraries[] = {
      * with other frameworks or even without a framework at all. This is
      * necessary for Magento in particular, which is built on ZF1.
      */
-    {"Zend_Http", "zend/http/client.php", nr_zend_http_enable},
+    {"Zend_Http", NR_PSTR ("zend/http/client.php"), nr_zend_http_enable},
 
     /*
      * Allow Laminas Framework 3.x to be detected as a library as well as a
      * framework. This allows Laminas_Http_Client to be instrumented when used
      * with other frameworks or even without a framework at all.
      */
-    {"Laminas_Http", "laminas-http/src/client.php", nr_laminas_http_enable},
+    {"Laminas_Http", NR_PSTR ("laminas-http/src/client.php"), nr_laminas_http_enable},
 
     /*
      * Other frameworks, detected only, but not specifically
@@ -516,70 +518,73 @@ static nr_library_table_t libraries[] = {
      * detection of a supported framework or library later (since a transaction
      * can only have one framework).
      */
-    {"Aura1", "aura/framework/system.php", NULL},
-    {"Aura2", "aura/di/src/containerinterface.php", NULL},
-    {"Aura3", "aura/di/src/containerconfiginterface.php", NULL},
-    {"CakePHP3", "cakephp/src/core/functions.php", NULL},
-    {"Fuel", "fuel/core/classes/fuel.php", NULL},
-    {"Lithium", "lithium/core/libraries.php", NULL},
-    {"Phpbb", "phpbb/request/request.php", NULL},
-    {"Phpixie2", "phpixie/core/classes/phpixie/pixie.php", NULL},
-    {"Phpixie3", "phpixie/framework.php", NULL},
-    {"React", "react/event-loop/src/loopinterface.php", NULL},
-    {"SilverStripe", "injector/silverstripeinjectioncreator.php", NULL},
-    {"SilverStripe4", "silverstripeserviceconfigurationlocator.php", NULL},
-    {"Typo3", "classes/typo3/flow/core/bootstrap.php", NULL},
-    {"Typo3", "typo3/sysext/core/classes/core/bootstrap.php", NULL},
-    {"Yii2", "yii2/baseyii.php", NULL},
+    {"Aura1", NR_PSTR ("aura/framework/system.php"), NULL},
+    {"Aura2", NR_PSTR ("aura/di/src/containerinterface.php"), NULL},
+    {"Aura3", NR_PSTR ("aura/di/src/containerconfiginterface.php"), NULL},
+    {"CakePHP3", NR_PSTR ("cakephp/src/core/functions.php"), NULL},
+    {"Fuel", NR_PSTR ("fuel/core/classes/fuel.php"), NULL},
+    {"Lithium", NR_PSTR ("lithium/core/libraries.php"), NULL},
+    {"Phpbb", NR_PSTR ("phpbb/request/request.php"), NULL},
+    {"Phpixie2", NR_PSTR ("phpixie/core/classes/phpixie/pixie.php"), NULL},
+    {"Phpixie3", NR_PSTR ("phpixie/framework.php"), NULL},
+    {"React", NR_PSTR ("react/event-loop/src/loopinterface.php"), NULL},
+    {"SilverStripe", NR_PSTR ("injector/silverstripeinjectioncreator.php"), NULL},
+    {"SilverStripe4", NR_PSTR ("silverstripeserviceconfigurationlocator.php"), NULL},
+    {"Typo3", NR_PSTR ("classes/typo3/flow/core/bootstrap.php"), NULL},
+    {"Typo3", NR_PSTR ("typo3/sysext/core/classes/core/bootstrap.php"), NULL},
+    {"Yii2", NR_PSTR ("yii2/baseyii.php"), NULL},
 
     /*
      * Other CMS (content management systems), detected only, but
      * not specifically instrumented.
      */
-    {"Moodle", "moodlelib.php", NULL},
+    {"Moodle", NR_PSTR ("moodlelib.php"), NULL},
     /*
      * It is likely that this will never be found, since the CodeIgniter.php
      * will get loaded first, and as such mark this transaction as belonging to
      * CodeIgniter, and not Expession Engine.
      */
-    {"ExpressionEngine", "system/expressionengine/config/config.php", NULL},
+    {"ExpressionEngine", NR_PSTR ("system/expressionengine/config/config.php"), NULL},
     /*
      * ExpressionEngine 5, however, has a very obvious file we can look for.
      */
-    {"ExpressionEngine5", "expressionengine/boot/boot.php", NULL},
+    {"ExpressionEngine5", NR_PSTR ("expressionengine/boot/boot.php"), NULL},
     /*
      * DokuWiki uses doku.php as an entry point, but has other files that are
      * loaded directly that this won't pick up. That's probably OK for
      * supportability metrics, but we'll add the most common name for the
      * configuration file as well just in case.
      */
-    {"DokuWiki", "doku.php", NULL},
-    {"DokuWiki", "conf/dokuwiki.php", NULL},
+    {"DokuWiki", NR_PSTR ("doku.php"), NULL},
+    {"DokuWiki", NR_PSTR ("conf/dokuwiki.php"), NULL},
 
     /*
      * SugarCRM no longer has a community edition, so this likely only works
      * with older versions.
      */
-    {"SugarCRM", "sugarobjects/sugarconfig.php", NULL},
+    {"SugarCRM", NR_PSTR ("sugarobjects/sugarconfig.php"), NULL},
 
-    {"Xoops", "class/xoopsload.php", NULL},
-    {"E107", "e107_handlers/e107_class.php", NULL},
+    {"Xoops", NR_PSTR ("class/xoopsload.php"), NULL},
+    {"E107", NR_PSTR ("e107_handlers/e107_class.php"), NULL},
 };
+// clang-format: on
 
 static size_t num_libraries = sizeof(libraries) / sizeof(nr_library_table_t);
 
+// clang-format: off
 static nr_library_table_t logging_frameworks[] = {
     /* Monolog - Logging for PHP */
-    {"Monolog", "monolog/logger.php", nr_monolog_enable},
+    {"Monolog", NR_PSTR ("monolog/logger.php"), nr_monolog_enable},
     /* Consolidation/Log - Logging for PHP */
-    {"Consolidation/Log", "consolidation/log/src/logger.php", NULL},
+    {"Consolidation/Log", NR_PSTR ("consolidation/log/src/logger.php"), NULL},
     /* laminas-log - Logging for PHP */
-    {"laminas-log", "laminas-log/src/logger.php", NULL},
+    {"laminas-log", NR_PSTR ("laminas-log/src/logger.php"), NULL},
     /* cakephp-log - Logging for PHP */
-    {"cakephp-log", "cakephp/log/log.php", NULL},
+    {"cakephp-log", NR_PSTR ("cakephp/log/log.php"), NULL},
     /* Analog - Logging for PHP */
-    {"Analog", "analog/analog.php", NULL},
+    {"Analog", NR_PSTR ("analog/analog.php"), NULL},
 };
+// clang-format: on
 
 static size_t num_logging_frameworks
     = sizeof(logging_frameworks) / sizeof(nr_library_table_t);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -310,6 +310,7 @@ typedef struct _nr_framework_table_t {
   const char* framework_name;
   const char* config_name;
   const char* file_to_check;
+  size_t file_to_check_len;
   nr_framework_special_fn_t special;
   nr_framework_enable_fn_t enable;
   nrframework_t detected;
@@ -322,15 +323,16 @@ typedef struct _nr_framework_table_t {
  *
  * Note that all paths should be in lowercase.
  */
+// clang-format: off
 static const nr_framework_table_t all_frameworks[] = {
     /*
      * Watch out:
      *   cake1.2 and cake1.3 use a subdirectory named 'cake' (lower case)
      *   cake2.0 and on use a subdirectory named 'Cake' (upper case file name)
      */
-    {"CakePHP", "cakephp", "cake/libs/object.php", nr_cakephp_special_1,
+    {"CakePHP", "cakephp", NR_PSTR ("cake/libs/object.php"), nr_cakephp_special_1,
      nr_cakephp_enable_1, NR_FW_CAKEPHP},
-    {"CakePHP", "cakephp", "cake/core/app.php", nr_cakephp_special_2,
+    {"CakePHP", "cakephp", NR_PSTR ("cake/core/app.php"), nr_cakephp_special_2,
      nr_cakephp_enable_2, NR_FW_CAKEPHP},
 
     /*
@@ -340,87 +342,88 @@ static const nr_framework_table_t all_frameworks[] = {
      * specifically a problem for Expression Engine (look for expression_engine,
      * below.)
      */
-    {"CodeIgniter", "codeigniter", "codeigniter.php", 0, nr_codeigniter_enable,
+    {"CodeIgniter", "codeigniter", NR_PSTR ("codeigniter.php"), 0, nr_codeigniter_enable,
      NR_FW_CODEIGNITER},
 
-    {"Drupal8", "drupal8", "core/includes/bootstrap.inc", 0, nr_drupal8_enable,
+    {"Drupal8", "drupal8", NR_PSTR ("core/includes/bootstrap.inc"), 0, nr_drupal8_enable,
      NR_FW_DRUPAL8},
-    {"Drupal", "drupal", "includes/common.inc", 0, nr_drupal_enable,
+    {"Drupal", "drupal", NR_PSTR ("includes/common.inc"), 0, nr_drupal_enable,
      NR_FW_DRUPAL},
 
-    {"Joomla", "joomla", "joomla/import.php", 0, nr_joomla_enable,
+    {"Joomla", "joomla", NR_PSTR ("joomla/import.php"), 0, nr_joomla_enable,
      NR_FW_JOOMLA}, /* <= Joomla 1.5 */
-    {"Joomla", "joomla", "libraries/joomla/factory.php", 0, nr_joomla_enable,
+    {"Joomla", "joomla", NR_PSTR ("libraries/joomla/factory.php"), 0, nr_joomla_enable,
      NR_FW_JOOMLA}, /* >= Joomla 1.6, including 2.5 and 3.2 */
 
-    {"Kohana", "kohana", "kohana/core.php", 0, nr_kohana_enable, NR_FW_KOHANA},
-    {"Kohana", "kohana", "kohana/core.php", 0, nr_kohana_enable, NR_FW_KOHANA},
+    {"Kohana", "kohana", NR_PSTR ("kohana/core.php"), 0, nr_kohana_enable, NR_FW_KOHANA},
+    {"Kohana", "kohana", NR_PSTR ("kohana/core.php"), 0, nr_kohana_enable, NR_FW_KOHANA},
 
     /* See below: Zend, the legacy project of Laminas, which shares much
        of the instrumentation implementation with Laminas */
-    {"Laminas3", "laminas3", "laminas/mvc/application.php", 0,
+    {"Laminas3", "laminas3", NR_PSTR ("laminas/mvc/application.php"), 0,
      nr_laminas3_enable, NR_FW_LAMINAS3},
-    {"Laminas3", "laminas3", "laminas-mvc/src/application.php", 0,
+    {"Laminas3", "laminas3", NR_PSTR ("laminas-mvc/src/application.php"), 0,
      nr_laminas3_enable, NR_FW_LAMINAS3},
 
-    {"Laravel", "laravel", "illuminate/foundation/application.php", 0,
+    {"Laravel", "laravel", NR_PSTR ("illuminate/foundation/application.php"), 0,
      nr_laravel_enable, NR_FW_LARAVEL},
-    {"Laravel", "laravel", "bootstrap/compiled.php", 0, nr_laravel_enable,
+    {"Laravel", "laravel", NR_PSTR ("bootstrap/compiled.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 4.x */
-    {"Laravel", "laravel", "storage/framework/compiled.php", 0,
+    {"Laravel", "laravel", NR_PSTR ("storage/framework/compiled.php"), 0,
      nr_laravel_enable, NR_FW_LARAVEL}, /* 5.0.0-14 */
-    {"Laravel", "laravel", "vendor/compiled.php", 0, nr_laravel_enable,
+    {"Laravel", "laravel", NR_PSTR ("vendor/compiled.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 5.0.15-5.0.x */
-    {"Laravel", "laravel", "bootstrap/cache/compiled.php", 0, nr_laravel_enable,
+    {"Laravel", "laravel", NR_PSTR ("bootstrap/cache/compiled.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 5.1.0-x */
-    {"Laravel", "laravel", "bootstrap/app.php", 0, nr_laravel_enable,
+    {"Laravel", "laravel", NR_PSTR ("bootstrap/app.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 8+ */
 
-    {"Lumen", "lumen", "lumen-framework/src/helpers.php", 0, nr_lumen_enable,
+    {"Lumen", "lumen", NR_PSTR ("lumen-framework/src/helpers.php"), 0, nr_lumen_enable,
      NR_FW_LUMEN},
 
-    {"Magento", "magento", "app/mage.php", 0, nr_magento1_enable,
+    {"Magento", "magento", NR_PSTR ("app/mage.php"), 0, nr_magento1_enable,
      NR_FW_MAGENTO1},
-    {"Magento2", "magento2", "magento/framework/app/bootstrap.php", 0,
+    {"Magento2", "magento2", NR_PSTR ("magento/framework/app/bootstrap.php"), 0,
      nr_magento2_enable, NR_FW_MAGENTO2},
 
-    {"MediaWiki", "mediawiki", "includes/webstart.php", 0, nr_mediawiki_enable,
+    {"MediaWiki", "mediawiki", NR_PSTR ("includes/webstart.php"), 0, nr_mediawiki_enable,
      NR_FW_MEDIAWIKI},
 
-    {"Silex", "silex", "silex/application.php", 0, nr_silex_enable,
+    {"Silex", "silex", NR_PSTR ("silex/application.php"), 0, nr_silex_enable,
      NR_FW_SILEX},
 
-    {"Slim", "slim", "slim/slim/app.php", 0, nr_slim_enable,
+    {"Slim", "slim", NR_PSTR ("slim/slim/app.php"), 0, nr_slim_enable,
      NR_FW_SLIM}, /* 3.x */
-    {"Slim", "slim", "slim/slim/slim.php", 0, nr_slim_enable,
+    {"Slim", "slim", NR_PSTR ("slim/slim/slim.php"), 0, nr_slim_enable,
      NR_FW_SLIM}, /* 2.x */
 
-    {"Symfony", "symfony1", "sfcontext.class.php", 0, nr_symfony1_enable,
+    {"Symfony", "symfony1", NR_PSTR ("sfcontext.class.php"), 0, nr_symfony1_enable,
      NR_FW_SYMFONY1},
-    {"Symfony", "symfony1", "sfconfig.class.php", 0, nr_symfony1_enable,
+    {"Symfony", "symfony1", NR_PSTR ("sfconfig.class.php"), 0, nr_symfony1_enable,
      NR_FW_SYMFONY1},
-    {"Symfony2", "symfony2", "bootstrap.php.cache", 0, nr_symfony2_enable,
+    {"Symfony2", "symfony2", NR_PSTR ("bootstrap.php.cache"), 0, nr_symfony2_enable,
      NR_FW_SYMFONY2}, /* also Symfony 3 */
     {"Symfony2", "symfony2",
-     "symfony/bundle/frameworkbundle/frameworkbundle.php", 0,
+     NR_PSTR ("symfony/bundle/frameworkbundle/frameworkbundle.php"), 0,
      nr_symfony2_enable, NR_FW_SYMFONY2}, /* also Symfony 3 */
-    {"Symfony4", "symfony4", "http-kernel/httpkernel.php", 0,
+    {"Symfony4", "symfony4", NR_PSTR ("http-kernel/httpkernel.php"), 0,
      nr_symfony4_enable, NR_FW_SYMFONY4}, /* also Symfony 5 */
 
-    {"WordPress", "wordpress", "wp-config.php", 0, nr_wordpress_enable,
+    {"WordPress", "wordpress", NR_PSTR ("wp-config.php"), 0, nr_wordpress_enable,
      NR_FW_WORDPRESS},
 
-    {"Yii", "yii", "framework/yii.php", 0, nr_yii_enable, NR_FW_YII},
-    {"Yii", "yii", "framework/yiilite.php", 0, nr_yii_enable, NR_FW_YII},
+    {"Yii", "yii", NR_PSTR ("framework/yii.php"), 0, nr_yii_enable, NR_FW_YII},
+    {"Yii", "yii", NR_PSTR ("framework/yiilite.php"), 0, nr_yii_enable, NR_FW_YII},
 
     /* See above: Laminas, the successor to Zend, which shares much
        of the instrumentation implementation with Zend */
-    {"Zend", "zend", "zend/loader.php", 0, nr_zend_enable, NR_FW_ZEND},
-    {"Zend2", "zend2", "zend/mvc/application.php", 0, nr_fw_zend2_enable,
+    {"Zend", "zend", NR_PSTR ("zend/loader.php"), 0, nr_zend_enable, NR_FW_ZEND},
+    {"Zend2", "zend2", NR_PSTR ("zend/mvc/application.php"), 0, nr_fw_zend2_enable,
      NR_FW_ZEND2},
-    {"Zend2", "zend2", "zend-mvc/src/application.php", 0, nr_fw_zend2_enable,
+    {"Zend2", "zend2", NR_PSTR ("zend-mvc/src/application.php"), 0, nr_fw_zend2_enable,
      NR_FW_ZEND2},
 };
+// clang-format: on
 static const int num_all_frameworks
     = sizeof(all_frameworks) / sizeof(nr_framework_table_t);
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -813,7 +813,6 @@ static nrframework_t nr_try_detect_framework(
     const char* filename,
     const size_t filename_len TSRMLS_DC) {
   nrframework_t detected = NR_FW_UNSET;
-  char* filename_lower = nr_string_to_lowercase(filename);
   const char* filename_suffix;
   size_t i;
 
@@ -826,7 +825,7 @@ static nrframework_t nr_try_detect_framework(
     }
     /* Check if filename ends with the desired pattern */
     filename_suffix = filename_lower + (filename_len - file_to_check_len);
-    if (nr_stridx(filename_suffix, frameworks[i].file_to_check) >= 0) {
+    if (nr_stricmp(filename_suffix, frameworks[i].file_to_check) == 0) {
       /*
        * If we have a special check function and it tells us to ignore
        * the file name because some other condition wasn't met, continue
@@ -850,7 +849,6 @@ static nrframework_t nr_try_detect_framework(
   }
 
 end:
-  nr_free(filename_lower);
   return detected;
 }
 
@@ -891,7 +889,6 @@ static nrframework_t nr_try_force_framework(
 
 static void nr_execute_handle_library(const char* filename,
                                       const size_t filename_len TSRMLS_DC) {
-  char* filename_lower = nr_string_to_lowercase(filename);
   const char* filename_suffix;
   size_t i;
 
@@ -904,7 +901,7 @@ static void nr_execute_handle_library(const char* filename,
     }
     /* Check if filename ends with the desired pattern */
     filename_suffix = filename_lower + (filename_len - file_to_check_len);
-    if (nr_stridx(filename_suffix, libraries[i].file_to_check) >= 0) {
+    if (nr_stricmp(filename_suffix, libraries[i].file_to_check) == 0) {
       nrl_debug(NRL_INSTRUMENT, "detected library=%s",
                 libraries[i].library_name);
 
@@ -916,14 +913,11 @@ static void nr_execute_handle_library(const char* filename,
       }
     }
   }
-
-  nr_free(filename_lower);
 }
 
 static void nr_execute_handle_logging_framework(const char* filename,
                                                 const size_t filename_len
                                                     TSRMLS_DC) {
-  char* filename_lower = nr_string_to_lowercase(filename);
   const char* filename_suffix;
   bool is_enabled = false;
   size_t i;
@@ -938,7 +932,7 @@ static void nr_execute_handle_logging_framework(const char* filename,
 
     /* Check if filename ends with the desired pattern */
     filename_suffix = filename_lower + (filename_len - file_to_check_len);
-    if (nr_stridx(filename_suffix, logging_frameworks[i].file_to_check) >= 0) {
+    if (nr_stricmp(filename_suffix, logging_frameworks[i].file_to_check) == 0) {
       nrl_debug(NRL_INSTRUMENT, "detected library=%s",
                 logging_frameworks[i].library_name);
 
@@ -953,8 +947,6 @@ static void nr_execute_handle_logging_framework(const char* filename,
           NRPRG(txn), logging_frameworks[i].library_name, is_enabled);
     }
   }
-
-  nr_free(filename_lower);
 }
 
 /*

--- a/axiom/tests/test_strings.c
+++ b/axiom/tests/test_strings.c
@@ -1228,6 +1228,29 @@ static void test_str_append(void) {
   nr_free(str);
 }
 
+static void test_iendswith(void) {
+  tlib_pass_if_bool_equal("input is NULL", false,
+                          nr_striendswith(NULL, 4, NR_PSTR("bar")));
+
+  tlib_pass_if_bool_equal("input is empty", false,
+                          nr_striendswith(NR_PSTR(""), NR_PSTR("bar")));
+
+  tlib_pass_if_bool_equal("input is too short", false,
+                          nr_striendswith(NR_PSTR("ar"), NR_PSTR("bar")));
+
+  tlib_pass_if_bool_equal(
+      "no match", false, nr_striendswith(NR_PSTR("foobarbaz"), NR_PSTR("bar")));
+
+  tlib_pass_if_bool_equal("not quite match", false,
+                          nr_striendswith(NR_PSTR("foobarr"), NR_PSTR("bar")));
+
+  tlib_pass_if_bool_equal("suffix match", true,
+                          nr_striendswith(NR_PSTR("foobar"), NR_PSTR("bar")));
+
+  tlib_pass_if_bool_equal("exact match", true,
+                          nr_striendswith(NR_PSTR("bar"), NR_PSTR("bar")));
+}
+
 tlib_parallel_info_t parallel_info = {.suggested_nthreads = 2, .state_size = 0};
 
 void test_main(void* p NRUNUSED) {
@@ -1265,6 +1288,7 @@ void test_main(void* p NRUNUSED) {
   test_formatf();
   test_strsplit();
   test_str_append();
+  test_iendswith();
 
   /*
    * character tests

--- a/axiom/tests/test_strings.c
+++ b/axiom/tests/test_strings.c
@@ -1232,8 +1232,14 @@ static void test_iendswith(void) {
   tlib_pass_if_bool_equal("input is NULL", false,
                           nr_striendswith(NULL, 4, NR_PSTR("bar")));
 
+  tlib_pass_if_bool_equal("pattern is NULL", false,
+                          nr_striendswith(NR_PSTR("foo"), NULL, 0));
+
   tlib_pass_if_bool_equal("input is empty", false,
                           nr_striendswith(NR_PSTR(""), NR_PSTR("bar")));
+
+  tlib_pass_if_bool_equal("pattern is empty", true,
+                          nr_striendswith(NR_PSTR("foo"), NR_PSTR("")));
 
   tlib_pass_if_bool_equal("input is too short", false,
                           nr_striendswith(NR_PSTR("ar"), NR_PSTR("bar")));

--- a/axiom/util_strings.h
+++ b/axiom/util_strings.h
@@ -16,6 +16,7 @@
 
 #include "nr_axiom.h"
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "util_object.h"
@@ -436,6 +437,33 @@ static inline int nr_toupper(int c) {
     return c & 0xdf;
   }
   return c;
+}
+
+/*
+ * Purpose : Checks whether a string ends with the specified pattern. Note that
+ * nr_striendswith is case-insensitive.
+ *
+ * Params  : 1. The input string to examine.
+ *           2. The input string length.
+ *           3. The pattern to look for at the end of the string.
+ *           4. The pattern length.
+ *
+ * Returns : The true if input string ends with the pattern or false otherwise.
+ */
+static inline bool nr_striendswith(const char* s,
+                                   const size_t slen,
+                                   const char* pattern,
+                                   const size_t pattern_len) {
+  const char* suffix;
+
+  if (slen < pattern_len) {
+    /* input shorter than pattern */
+    return false;
+  }
+
+  /* compare input's suffix with the pattern and return result */
+  suffix = s + (slen - pattern_len);
+  return 0 == nr_stricmp(suffix, pattern);
 }
 
 #endif /* UTIL_STRINGS_HDR */

--- a/axiom/util_strings.h
+++ b/axiom/util_strings.h
@@ -461,6 +461,11 @@ static inline bool nr_striendswith(const char* s,
     return false;
   }
 
+  if (NULL == s) {
+    /* invalid input */
+    return false;
+  }
+
   /* compare input's suffix with the pattern and return result */
   suffix = s + (slen - pattern_len);
   return 0 == nr_stricmp(suffix, pattern);


### PR DESCRIPTION
Speed up speed library/framework detection by performing a suffix match on the 'magic' file pattern with case insensitive string comparison instead of a substring search within a lowercased filename. This is possible because all of the 'magic' file search patterns patterns are right anchored.