### PR TITLE
fix(agent): port the functionality to bypass wordpress cufa calls by wrapping add_filter

### DIFF
--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -578,6 +578,63 @@ NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
 }
 NR_PHP_WRAPPER_END
 
+/*
+ * Wrap the wordpress function add_filter
+ * 
+ * function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 )
+ *
+ * @param string   $hook_name     The name of the filter to add the callback to.
+* @param callable $callback      The callback to be run when the filter is applied.
+* @param int      $priority      Optional. Used to specify the order in which the functions
+*                                associated with a particular filter are executed.
+*                                Lower numbers correspond with earlier execution,
+*                                and functions with the same priority are executed
+*                                in the order in which they were added to the filter. Default 10.
+* @param int      $accepted_args Optional. The number of arguments the function accepts. Default 1.
+* @return true Always returns true.
+ */
+
+NR_PHP_WRAPPER(nr_wordpress_add_filter) {
+  /* Wordpress's add_action() is just a wrapper around add_filter(),
+   * so we only need to instrument this function */
+  NR_UNUSED_SPECIALFN;
+  (void)wraprec;
+  const char* filename = NULL;
+  bool wrap_hook = true;
+
+  NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_WORDPRESS);
+
+  /*
+   * We only want to hook the function being called if this is a WordPress
+   * function, we're instrumenting hooks, and WordPress is currently executing
+   * hooks (denoted by the wordpress_tag being set).
+   */
+  if ((NR_FW_WORDPRESS != NRPRG(current_framework))
+      || (0 == NRINI(wordpress_hooks))) {
+    wrap_hook = false;
+  }
+
+  if (NRINI(wordpress_hooks_skip_filename)
+      && 0 != nr_strlen(NRINI(wordpress_hooks_skip_filename))) {
+    filename = nr_php_op_array_file_name(NR_OP_ARRAY);
+
+    if (nr_strstr(filename, NRINI(wordpress_hooks_skip_filename))) {
+      nrl_verbosedebug(NRL_FRAMEWORK, "skipping hooks for function from %s",
+                       filename);
+      wrap_hook = false;
+    }
+  }
+
+  if (true == wrap_hook) {
+    zval* callback = nr_php_arg_get(2, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+    /* the callback here can be any PHP callable. nr_php_wrap_generic_callable
+   * checks that a valid callable is passed */
+    nr_php_wrap_generic_callable(callback, nr_wordpress_wrap_hook);
+    nr_php_arg_release(&callback);
+  }
+}
+NR_PHP_WRAPPER_END
+
 void nr_wordpress_enable(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("apply_filters"),
                             nr_wordpress_apply_filters TSRMLS_CC);
@@ -590,7 +647,7 @@ void nr_wordpress_enable(TSRMLS_D) {
 
   nr_php_wrap_user_function(NR_PSTR("do_action_ref_array"),
                             nr_wordpress_exec_handle_tag TSRMLS_CC);
+  nr_php_wrap_user_function(NR_PSTR("add_filter"),
+                            nr_wordpress_add_filter);
 
-  nr_php_add_call_user_func_array_pre_callback(
-      nr_wordpress_call_user_func_array TSRMLS_CC);
 }

--- a/tests/integration/frameworks/wordpress/mock_hooks.php
+++ b/tests/integration/frameworks/wordpress/mock_hooks.php
@@ -1,0 +1,27 @@
+<?php
+
+// Simple mock of wordpress's do_action, apply_filter, add_filter, add_action
+// In a real Wordpress app, the $tag is not what is eventually
+// called by the call_user_func_array. We do this for test simplicity
+function do_action($tag, ...$args) {
+    call_user_func_array($tag, $args);
+}
+function apply_filters($tag, ...$args) {
+    call_user_func_array($tag, $args);
+}
+
+function add_filter($tag, $callback) {
+    echo "add filter\n";
+}
+
+// WP's add_action wraps add_filter
+function add_action($tag, $callback) {
+    add_filter($tag, $callback);
+}
+
+//Simple mock of wordpress's get_theme_roots
+function get_theme_roots() {
+}
+
+// Noop to prevent PHP 8.2 empty file optimization
+sleep(0);

--- a/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should properly instrument Wordpress apply_filters hooks.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "5.6", "<")) {
+  die("skip: PHP < 5.6 argument unpacking not supported\n");
+}
+*/
+
+/*INI
+newrelic.framework = wordpress
+*/
+
+/*EXPECT
+add filter
+add filter
+add filter
+f: string1
+add filter
+h: string3
+g: string2
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? start time",
+  "?? stop time",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Framework/WordPress/Hook/f"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Framework/WordPress/Hook/g"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Framework/WordPress/Hook/h"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},               [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},          [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/framework/WordPress/forced"},           [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+require_once __DIR__.'/mock_hooks.php';
+
+function h($str) {
+    echo "h: ";
+    echo $str;
+    echo "\n";
+    throw new Exception("Test Exception");
+}
+
+function g($str) {
+    echo "g: ";
+    echo $str;
+    echo "\n";
+}
+
+function f($str) {
+    echo "f: ";
+    echo $str;
+    echo "\n";
+    // For OAPI: attempt to overwrite the currently executing transient wrapper
+    add_filter("hook", "f");
+    try {
+        apply_filters("h", "string3");
+    } catch (Exception $e) {
+        apply_filters("g", "string2");
+    }
+}
+
+// Due to the mock simplification described above, the hook
+// is not used in this test, and the callback is treated as the hook
+add_filter("hook", "f");
+add_filter("hook", "g");
+add_filter("hook", "h");
+apply_filters("f", "string1");

--- a/tests/integration/frameworks/wordpress/test_wordpress_do_action.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_do_action.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should properly instrument Wordpress do_action hooks.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "5.6", "<")) {
+  die("skip: PHP < 5.6 argument unpacking not supported\n");
+}
+*/
+
+/*INI
+newrelic.framework = wordpress
+*/
+
+/*EXPECT
+add filter
+add filter
+add filter
+g
+f
+h
+g
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? start time",
+  "?? stop time",
+  [
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},      [1, "??", "??", "??", "??", "??"]],
+    [{"name": "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Framework/WordPress/Hook/f"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Framework/WordPress/Hook/g"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Framework/WordPress/Hook/h"},                          [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/all"},                                [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime"},                           [1, "??", "??", "??", "??", "??"]],
+    [{"name": "OtherTransactionTotalTime/php__FILE__"},               [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/enabled"},          [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/framework/WordPress/forced"},           [1, "??", "??", "??", "??", "??"]]
+  ]
+]
+*/
+
+require_once __DIR__.'/mock_hooks.php';
+
+function h() {
+    echo "h\n";
+    throw new Exception("Test Exception");
+}
+
+function g() {
+    echo "g\n";
+}
+
+function f() {
+    echo "f\n";
+    try {
+        do_action("h");
+    } catch (Exception $e){
+        do_action("g");
+    }
+}
+
+// Due to the mock simplification described above, the hook
+// is not used in this test, and the callback is treated as the hook
+add_action("hook", "f");
+add_action("hook", "g");
+add_action("hook", "h");
+/* 
+ * pre-OAPI: Initiates a non-flattened call stack of internal->user_code
+ * to ensure that cufa instrumentation properly handles skipping
+ * opline lookups of internal functions
+ *
+ * OAPI: Initiates a call to an added action outside
+ * the context of do_action, to ensure we only instrument
+ * with an active hook
+ */
+$function = new ReflectionFunction('g');
+$function->invoke();
+
+do_action("f");


### PR DESCRIPTION
Port the work previously done here: reference: https://github.com/newrelic/newrelic-php-agent/pull/731

Bypass the need to check for cufa calls during do_action/filter by instrumenting add_action/filter and wrapping the desired calls at hook time, rather than call time. Substantially improves performance and stability.