### PR TITLE
tests: add `EXPECT_METRICS_EXIST` to integration tests

### DIFF
--- a/src/newrelic/integration/parse.go
+++ b/src/newrelic/integration/parse.go
@@ -32,6 +32,7 @@ var (
 		"EXPECT_SPAN_EVENTS_LIKE": parseSpanEventsLike,
 		"EXPECT_LOG_EVENTS":       parseLogEvents,
 		"EXPECT_METRICS":          parseMetrics,
+		"EXPECT_METRICS_EXIST":    parseMetricsExist,
 		"EXPECT":                  parseExpect,
 		"EXPECT_REGEX":            parseExpectRegex,
 		"EXPECT_SCRUBBED":         parseExpectScrubbed,
@@ -222,6 +223,10 @@ func parseLogEvents(test *Test, content []byte) error {
 }
 func parseMetrics(test *Test, content []byte) error {
 	test.metrics = content
+	return nil
+}
+func parseMetricsExist(test *Test, content []byte) error {
+	test.metricsExist = content
 	return nil
 }
 func parseSlowSQLs(test *Test, content []byte) error {

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -36,6 +36,7 @@ type Test struct {
 	spanEventsLike []byte
 	logEvents      []byte
 	metrics        []byte
+	metricsExist   []byte
 	slowSQLs       []byte
 	tracedErrors   []byte
 	txnTraces      []byte
@@ -555,6 +556,15 @@ func (t *Test) Compare(harvest *newrelic.Harvest) {
 	if nil == harvest && t.GetExpectHarvest() {
 		t.Fatal(errors.New("no harvest received"))
 		return
+	}
+
+	if nil != t.metricsExist {
+		for _, name := range strings.Split(strings.TrimSpace(string(t.metricsExist)), "\n") {
+			name = strings.TrimSpace(name)
+			if !harvest.Metrics.Has(name) {
+				t.Fail(fmt.Errorf("metric does not exist: %s\n\nactual metric table: %s", name, harvest.Metrics.DebugJSON()))
+			}
+		}
 	}
 
 	// if we expect a harvest and these is not, then we run our tests as per normal

--- a/src/newrelic/metrics.go
+++ b/src/newrelic/metrics.go
@@ -340,6 +340,13 @@ func (mt *MetricTable) Empty() bool {
 	return 0 == mt.count
 }
 
+// Has returns true if the given metric exists in the metric table (regardless
+// of scope).
+func (mt *MetricTable) Has(name string) bool {
+	_, ok := mt.metrics[name]
+	return ok
+}
+
 // Data marshals the collection to JSON according to the schema expected
 // by the collector.
 func (mt *MetricTable) Data(id AgentRunID, harvestStart time.Time) ([]byte,

--- a/src/newrelic/metrics_test.go
+++ b/src/newrelic/metrics_test.go
@@ -301,3 +301,21 @@ func BenchmarkMetricTableCollectorJSON(b *testing.B) {
 		mt.CollectorJSON(AgentRunID("12345"), now)
 	}
 }
+
+func TestMetricTableHas(t *testing.T) {
+	mt := NewMetricTable(20, start)
+	mt.AddCount("foo", "", 1, 0)
+	mt.AddCount("bar", "quux", 1, 0)
+
+	if mt.Has("quux") {
+		t.Fatal("non-existent metric is reported as existing")
+	}
+
+	if !mt.Has("foo") {
+		t.Fatal("unscoped metric is reported as missing")
+	}
+
+	if !mt.Has("bar") {
+		t.Fatal("scoped metric is reported as missing")
+	}
+}

--- a/tests/integration/logging/analog/test_supportability_metric.php
+++ b/tests/integration/logging/analog/test_supportability_metric.php
@@ -16,25 +16,9 @@ were installed by composer. The library itself is a mock.
 newrelic.application_logging.enabled = true
 */
 
-/*EXPECT_METRICS
-[
-  "?? agent run id",
-  "?? timeframe start",
-  "?? timeframe stop",
-  [
-    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransaction/all"},                                             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransaction/php__FILE__"},                                     [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime"},                                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime/php__FILE__"},                            [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/PHP/Analog/disabled"},                       [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Analog/detected"},                           [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},                    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},                       [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},              [1, "??", "??", "??", "??", "??"]]
-  ]
-]
+/*EXPECT_METRICS_EXIST
+Supportability/library/Analog/detected
+Supportability/Logging/PHP/Analog/disabled
 */
 
 

--- a/tests/integration/logging/cakephp-log/test_supportability_metric.php
+++ b/tests/integration/logging/cakephp-log/test_supportability_metric.php
@@ -16,26 +16,9 @@ were installed by composer. The library itself is a mock.
 newrelic.application_logging.enabled = true
 */
 
-/*EXPECT_METRICS
-[
-  "?? agent run id",
-  "?? timeframe start",
-  "?? timeframe stop",
-  [
-    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransaction/all"},                                             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransaction/php__FILE__"},                                     [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime"},                                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime/php__FILE__"},                            [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/PHP/cakephp-log/disabled"},                  [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/cakephp-log/detected"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},                    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},                       [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},              [1, "??", "??", "??", "??", "??"]]
-  ]
-]
+/*EXPECT_METRICS_EXIST
+Supportability/library/cakephp-log/detected
+Supportability/Logging/PHP/cakephp-log/disabled
 */
-
 
 require_once(realpath(dirname(__FILE__)) . '/vendor/cakephp/log/Log.php');

--- a/tests/integration/logging/consolidation-log/test_supportability_metric.php
+++ b/tests/integration/logging/consolidation-log/test_supportability_metric.php
@@ -16,26 +16,9 @@ were installed by composer. The library itself is a mock.
 newrelic.application_logging.enabled = true
 */
 
-/*EXPECT_METRICS
-[
-  "?? agent run id",
-  "?? timeframe start",
-  "?? timeframe stop",
-  [
-    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransaction/all"},                                             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransaction/php__FILE__"},                                     [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime"},                                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime/php__FILE__"},                            [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/PHP/Consolidation/Log/disabled"},            [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Consolidation/Log/detected"},                [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},                    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},                       [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},              [1, "??", "??", "??", "??", "??"]]
-  ]
-]
+/*EXPECT_METRICS_EXIST
+Supportability/library/Consolidation/Log/detected
+Supportability/Logging/PHP/Consolidation/Log/disabled
 */
-
 
 require_once(realpath(dirname(__FILE__)) . '/vendor/consolidation/log/src/Logger.php');

--- a/tests/integration/logging/laminas-log/test_supportability_metric.php
+++ b/tests/integration/logging/laminas-log/test_supportability_metric.php
@@ -16,26 +16,9 @@ were installed by composer. The library itself is a mock.
 newrelic.application_logging.enabled = true
 */
 
-/*EXPECT_METRICS
-[
-  "?? agent run id",
-  "?? timeframe start",
-  "?? timeframe stop",
-  [
-    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransaction/all"},                                             [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransaction/php__FILE__"},                                     [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime"},                                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"OtherTransactionTotalTime/php__FILE__"},                            [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/PHP/laminas-log/disabled"},                  [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/laminas-log/detected"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},                    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/Metrics/PHP/enabled"},                       [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},              [1, "??", "??", "??", "??", "??"]]
-  ]
-]
+/*EXPECT_METRICS_EXIST
+Supportability/library/laminas-log/detected
+Supportability/Logging/PHP/laminas-log/disabled
 */
-
 
 require_once(realpath(dirname(__FILE__)) . '/vendor/laminas/laminas-log/src/Logger.php');


### PR DESCRIPTION
Integration tests sometimes don't care about the exact set of metrics that are being sent (particularly around things like datastore metrics); what is really interesting is that the framework is detected, the transaction is named correctly, and that there aren't errors. This adds a new `EXPECT_METRICS_EXIST` section which is simply a newline separated list of metric names that will be searched for: if any don't exist, the test will fail.

For example:

```php
<?php

/*EXPECT_METRICS_EXIST
Supportability/framework/WordPress/detected
*/
?>
```

This asserts that the test will generate
`Supportability/framework/WordPress/detected` metric, but doesn't assert anything else about the metric table.

---------