### PR TITLE
tests: fix guzzle integration tests

### DIFF
--- a/tests/integration/external/guzzle5/test_spans_external.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php
@@ -20,7 +20,7 @@ if (version_compare(PHP_VERSION, "7.0", "<")) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 1
+newrelic.transaction_tracer.detail = 0
 */
 
 /*EXPECT_RESPONSE_HEADERS

--- a/tests/integration/external/guzzle5/test_spans_external.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php
@@ -20,7 +20,7 @@ if (version_compare(PHP_VERSION, "7.0", "<")) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 0
+newrelic.transaction_tracer.detail = 1
 */
 
 /*EXPECT_RESPONSE_HEADERS

--- a/tests/integration/external/guzzle5/test_spans_external.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php
@@ -28,7 +28,6 @@ newrelic.transaction_tracer.detail = 0
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [
-  [
     [
       {
         "traceId": "??",
@@ -93,7 +92,6 @@ newrelic.transaction_tracer.detail = 0
         "http.statusCode": 200
       }
     ]
-  ]
 ]
 */
 

--- a/tests/integration/external/guzzle5/test_spans_external.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php
@@ -26,13 +26,8 @@ newrelic.transaction_tracer.detail = 1
 /*EXPECT_RESPONSE_HEADERS
 */
 
-/*EXPECT_SPAN_EVENTS
+/*EXPECT_SPAN_EVENTS_LIKE
 [
-  "?? agent run id",
-  {
-    "reservoir_size": 10000,
-    "events_seen": 4
-  },
   [
     [
       {
@@ -51,28 +46,6 @@ newrelic.transaction_tracer.detail = 1
       },
       {},
       {}
-    ],
-    [
-      {
-        "traceId": "??",
-        "duration": "??",
-        "transactionId": "??",
-        "name": "Custom\/GuzzleHttp\\Client::__construct",
-        "guid": "??",
-        "type": "Span",
-        "category": "generic",
-        "priority": "??",
-        "sampled": true,
-        "parentId": "??",
-        "timestamp": "??"
-      },
-      {},
-      {
-        "code.lineno": "??",
-        "code.namespace": "GuzzleHttp\\Client",
-        "code.filepath": "??",
-        "code.function": "__construct"
-      }
     ],
     [
       {

--- a/tests/integration/external/guzzle5/test_spans_external.php5.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php5.php
@@ -16,7 +16,7 @@ require('skipif.inc');
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 1
+newrelic.transaction_tracer.detail = 0
 newrelic.code_level_metrics.enabled=false
 */
 

--- a/tests/integration/external/guzzle5/test_spans_external.php5.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php5.php
@@ -23,13 +23,8 @@ newrelic.code_level_metrics.enabled=false
 /*EXPECT_RESPONSE_HEADERS
 */
 
-/*EXPECT_SPAN_EVENTS
+/*EXPECT_SPAN_EVENTS_LIKE
 [
-  "?? agent run id",
-  {
-    "reservoir_size": 10000,
-    "events_seen": 4
-  },
   [
     [
       {
@@ -45,23 +40,6 @@ newrelic.code_level_metrics.enabled=false
         "nr.entryPoint": true,
         "timestamp": "??",
         "transaction.name": "OtherTransaction\/php__FILE__"
-      },
-      {},
-      {}
-    ],
-    [
-      {
-        "traceId": "??",
-        "duration": "??",
-        "transactionId": "??",
-        "name": "Custom\/GuzzleHttp\\Client::__construct",
-        "guid": "??",
-        "type": "Span",
-        "category": "generic",
-        "priority": "??",
-        "sampled": true,
-        "parentId": "??",
-        "timestamp": "??"
       },
       {},
       {}

--- a/tests/integration/external/guzzle5/test_spans_external.php5.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php5.php
@@ -25,7 +25,6 @@ newrelic.code_level_metrics.enabled=false
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [
-  [
     [
       {
         "traceId": "??",
@@ -90,7 +89,6 @@ newrelic.code_level_metrics.enabled=false
         "http.statusCode": 200
       }
     ]
-  ]
 ]
 */
 

--- a/tests/integration/external/guzzle5/test_spans_external.php5.php
+++ b/tests/integration/external/guzzle5/test_spans_external.php5.php
@@ -16,7 +16,7 @@ require('skipif.inc');
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 0
+newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled=false
 */
 

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
@@ -24,13 +24,8 @@ newrelic.transaction_tracer.detail = 1
 */
 
 
-/*EXPECT_SPAN_EVENTS
+/*EXPECT_SPAN_EVENTS_LIKE
 [
-  "?? agent run id",
-  {
-    "reservoir_size": 10000,
-    "events_seen": 3
-  },
   [
     [
       {
@@ -49,28 +44,6 @@ newrelic.transaction_tracer.detail = 1
       },
       {},
       {}
-    ],
-    [
-      {
-        "traceId": "??",
-        "duration": "??",
-        "transactionId": "??",
-        "name": "Custom\/GuzzleHttp\\Client::__construct",
-        "guid": "??",
-        "type": "Span",
-        "category": "generic",
-        "priority": "??",
-        "sampled": true,
-        "parentId": "??",
-        "timestamp": "??"
-      },
-      {},
-      {
-        "code.lineno": "??",
-        "code.namespace": "GuzzleHttp\\Client",
-        "code.filepath": "??",
-        "code.function": "__construct"
-      }
     ],
     [
       {

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
@@ -20,7 +20,7 @@ if (version_compare(PHP_VERSION, "7.0", "<")) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 0
+newrelic.transaction_tracer.detail = 1
 */
 
 

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
@@ -20,7 +20,7 @@ if (version_compare(PHP_VERSION, "7.0", "<")) {
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 1
+newrelic.transaction_tracer.detail = 0
 */
 
 

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php
@@ -26,7 +26,6 @@ newrelic.transaction_tracer.detail = 0
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [
-  [
     [
       {
         "traceId": "??",
@@ -68,7 +67,6 @@ newrelic.transaction_tracer.detail = 0
         "http.statusCode": 200
       }
     ]
-  ]
 ]
 */
 

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php5.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php5.php
@@ -23,7 +23,6 @@ newrelic.code_level_metrics.enabled=false
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [
-  [
     [
       {
         "traceId": "??",
@@ -65,7 +64,6 @@ newrelic.code_level_metrics.enabled=false
         "http.statusCode": 200
       }
     ]
-  ]
 ]
 */
 

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php5.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php5.php
@@ -21,13 +21,8 @@ newrelic.code_level_metrics.enabled=false
 */
 
 
-/*EXPECT_SPAN_EVENTS
+/*EXPECT_SPAN_EVENTS_LIKE
 [
-  "?? agent run id",
-  {
-    "reservoir_size": 10000,
-    "events_seen": 3
-  },
   [
     [
       {
@@ -43,23 +38,6 @@ newrelic.code_level_metrics.enabled=false
         "nr.entryPoint": true,
         "timestamp": "??",
         "transaction.name": "OtherTransaction\/php__FILE__"
-      },
-      {},
-      {}
-    ],
-    [
-      {
-        "traceId": "??",
-        "duration": "??",
-        "transactionId": "??",
-        "name": "Custom\/GuzzleHttp\\Client::__construct",
-        "guid": "??",
-        "type": "Span",
-        "category": "generic",
-        "priority": "??",
-        "sampled": true,
-        "parentId": "??",
-        "timestamp": "??"
       },
       {},
       {}

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php5.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php5.php
@@ -16,7 +16,7 @@ require('skipif.inc');
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 1
+newrelic.transaction_tracer.detail = 0
 newrelic.code_level_metrics.enabled=false
 */
 

--- a/tests/integration/external/guzzle6/test_spans_are_created_correctly.php5.php
+++ b/tests/integration/external/guzzle6/test_spans_are_created_correctly.php5.php
@@ -16,7 +16,7 @@ require('skipif.inc');
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 0
+newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled=false
 */
 

--- a/tests/integration/external/guzzle7/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle7/test_spans_are_created_correctly.php
@@ -16,7 +16,7 @@ require("skipif.inc");
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 0
+newrelic.transaction_tracer.detail = 1
 */
 
 

--- a/tests/integration/external/guzzle7/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle7/test_spans_are_created_correctly.php
@@ -20,13 +20,8 @@ newrelic.transaction_tracer.detail = 1
 */
 
 
-/*EXPECT_SPAN_EVENTS
+/*EXPECT_SPAN_EVENTS_LIKE
 [
-  "?? agent run id",
-  {
-    "reservoir_size": 10000,
-    "events_seen": 3
-  },
   [
     [
       {
@@ -45,28 +40,6 @@ newrelic.transaction_tracer.detail = 1
       },
       {},
       {}
-    ],
-    [
-      {
-        "traceId": "??",
-        "duration": "??",
-        "transactionId": "??",
-        "name": "Custom\/GuzzleHttp\\Client::__construct",
-        "guid": "??",
-        "type": "Span",
-        "category": "generic",
-        "priority": "??",
-        "sampled": true,
-        "parentId": "??",
-        "timestamp": "??"
-      },
-      {},
-      {
-        "code.lineno": "??",
-        "code.namespace": "GuzzleHttp\\Client",
-        "code.filepath": "??",
-        "code.function": "__construct"
-      }
     ],
     [
       {

--- a/tests/integration/external/guzzle7/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle7/test_spans_are_created_correctly.php
@@ -22,7 +22,6 @@ newrelic.transaction_tracer.detail = 0
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [
-  [
     [
       {
         "traceId": "??",
@@ -64,7 +63,6 @@ newrelic.transaction_tracer.detail = 0
         "http.statusCode": 200
       }
     ]
-  ]
 ]
 */
 

--- a/tests/integration/external/guzzle7/test_spans_are_created_correctly.php
+++ b/tests/integration/external/guzzle7/test_spans_are_created_correctly.php
@@ -16,7 +16,7 @@ require("skipif.inc");
 /*INI
 newrelic.distributed_tracing_enabled = true
 newrelic.transaction_tracer.threshold = 0
-newrelic.transaction_tracer.detail = 1
+newrelic.transaction_tracer.detail = 0
 */
 
 


### PR DESCRIPTION
guzzle integration tests are flaky - they expect span for a call to `new Client();`
however when `transaction_tracer.detail` is set to 0, the agent sometimes drops it.
On the other hand when `transaction_tracer.detail` is set to 1, the agent
generates many more spans. Take advantage of `EXPECT_SPAN_EVENTS_LIKE` and only look
for limited number of spans: root and external.