### PR TITLE
feat(agent): extract version for php packages

### DIFF
--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -538,10 +538,11 @@ void nr_drupal_version() {
   zval retval;
   int result
       = zend_eval_string(string, &retval, "Retrieve Drupal Version");
+  
+  // Add php package to transaction
   if (result == SUCCESS) {
     if (Z_TYPE(retval) == IS_STRING) {
       char* version = Z_STRVAL(retval);
-      // Add php package to transaction
       nr_txn_add_php_package(NRPRG(txn), "drupal/core", version);
       zval_dtor(&retval);
     }

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -533,6 +533,21 @@ end:
 }
 NR_PHP_WRAPPER_END
 
+void nr_drupal_version(TSRMLS_D) {
+  char* string = "Drupal::VERSION;";
+  zval retval;
+  int result
+      = zend_eval_string(string, &retval, "Retrieve Drupal Version" TSRMLS_CC);
+  if (result == SUCCESS) {
+    if (Z_TYPE(retval) == IS_STRING) {
+      char* version = Z_STRVAL(retval);
+      // Add php package to transaction
+      nr_txn_add_php_package(NRPRG(txn), "drupal/core", version);
+      zval_dtor(&retval);
+    }
+  }
+}
+
 void nr_drupal8_enable(TSRMLS_D) {
   /*
    * Obtain a transation name if a page was cached.
@@ -585,19 +600,5 @@ void nr_drupal8_enable(TSRMLS_D) {
      */
     nr_php_wrap_user_function(NR_PSTR("Drupal\\views\\ViewExecutable::execute"),
                               nr_drupal8_wrap_view_execute TSRMLS_CC);
-  }
-
-  char* string = "Drupal::VERSION;";
-  zval retval;
-  int result
-      = zend_eval_string(string, &retval, "Retrieve Drupal Version" TSRMLS_CC);
-
-  if (result == SUCCESS) {
-    if (Z_TYPE(retval) == IS_STRING) {
-      char* version = Z_STRVAL(retval);
-      // Add php package to transaction
-      nr_txn_add_php_package(NRPRG(txn), "drupal/core", version);
-      zval_dtor(&retval);
-    }
   }
 }

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -533,11 +533,11 @@ end:
 }
 NR_PHP_WRAPPER_END
 
-void nr_drupal_version(TSRMLS_D) {
+void nr_drupal_version() {
   char* string = "Drupal::VERSION;";
   zval retval;
   int result
-      = zend_eval_string(string, &retval, "Retrieve Drupal Version" TSRMLS_CC);
+      = zend_eval_string(string, &retval, "Retrieve Drupal Version");
   if (result == SUCCESS) {
     if (Z_TYPE(retval) == IS_STRING) {
       char* version = Z_STRVAL(retval);

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -601,4 +601,5 @@ void nr_drupal8_enable(TSRMLS_D) {
     nr_php_wrap_user_function(NR_PSTR("Drupal\\views\\ViewExecutable::execute"),
                               nr_drupal8_wrap_view_execute TSRMLS_CC);
   }
+  nr_txn_add_php_package(NRPRG(txn), "drupal/core", " ");
 }

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -534,7 +534,7 @@ end:
 NR_PHP_WRAPPER_END
 
 void nr_drupal_version() {
-  const char* string = "Drupal::VERSION;";
+  char* string = "Drupal::VERSION;";
   zval retval;
   int result
       = zend_eval_string(string, &retval, "Retrieve Drupal Version");

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -13,6 +13,7 @@
 #include "fw_hooks.h"
 #include "fw_support.h"
 #include "fw_symfony_common.h"
+#include "nr_txn.h"
 #include "util_logging.h"
 #include "util_memory.h"
 #include "util_strings.h"
@@ -584,5 +585,19 @@ void nr_drupal8_enable(TSRMLS_D) {
      */
     nr_php_wrap_user_function(NR_PSTR("Drupal\\views\\ViewExecutable::execute"),
                               nr_drupal8_wrap_view_execute TSRMLS_CC);
+  }
+
+  char* string = "Drupal::VERSION;";
+  zval retval;
+  int result
+      = zend_eval_string(string, &retval, "Retrieve Drupal Version" TSRMLS_CC);
+
+  if (result == SUCCESS) {
+    if (Z_TYPE(retval) == IS_STRING) {
+      char* version = Z_STRVAL(retval);
+      // Add php package to transaction
+      nr_txn_add_php_package(NRPRG(txn), "drupal/core", version);
+      zval_dtor(&retval);
+    }
   }
 }

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -534,7 +534,7 @@ end:
 NR_PHP_WRAPPER_END
 
 void nr_drupal_version() {
-  char* string = "Drupal::VERSION;";
+  const char* string = "Drupal::VERSION;";
   zval retval;
   int result
       = zend_eval_string(string, &retval, "Retrieve Drupal Version");

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -544,8 +544,8 @@ void nr_drupal_version() {
     if (Z_TYPE(retval) == IS_STRING) {
       char* version = Z_STRVAL(retval);
       nr_txn_add_php_package(NRPRG(txn), "drupal/core", version);
-      zval_dtor(&retval);
     }
+    zval_dtor(&retval);
   }
 }
 

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -602,5 +602,5 @@ void nr_drupal8_enable(TSRMLS_D) {
     nr_php_wrap_user_function(NR_PSTR("Drupal\\views\\ViewExecutable::execute"),
                               nr_drupal8_wrap_view_execute TSRMLS_CC);
   }
-  nr_txn_add_php_package(NRPRG(txn), "drupal/core", " ");
+  nr_txn_add_php_package(NRPRG(txn), "drupal/core", PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_hooks.h
+++ b/agent/fw_hooks.h
@@ -55,4 +55,9 @@ extern void nr_predis_enable(TSRMLS_D);
 extern void nr_zend_http_enable(TSRMLS_D);
 extern void nr_monolog_enable(TSRMLS_D);
 
+/* Vulnerability Management Packages */
+extern void nr_drupal_version(TSRMLS_D);
+extern void nr_wordpress_version(TSRMLS_D);
+extern void nr_phpunit_version(TSRMLS_D);
+
 #endif /* FW_HOOKS_HDR */

--- a/agent/fw_hooks.h
+++ b/agent/fw_hooks.h
@@ -56,8 +56,8 @@ extern void nr_zend_http_enable(TSRMLS_D);
 extern void nr_monolog_enable(TSRMLS_D);
 
 /* Vulnerability Management Packages */
-extern void nr_drupal_version(TSRMLS_D);
-extern void nr_wordpress_version(TSRMLS_D);
-extern void nr_phpunit_version(TSRMLS_D);
+extern void nr_drupal_version(void);
+extern void nr_wordpress_version(void);
+extern void nr_phpunit_version(void);
 
 #endif /* FW_HOOKS_HDR */

--- a/agent/fw_laminas3.c
+++ b/agent/fw_laminas3.c
@@ -153,4 +153,5 @@ void nr_laminas3_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Laminas\\Mvc\\Console\\Router\\RouteMatch::setMatchedRouteName"),
       nr_laminas3_name_the_wt TSRMLS_CC);
+  nr_txn_add_php_package(NRPRG(txn), "laminas/laminas-mvc", " ");
 }

--- a/agent/fw_laminas3.c
+++ b/agent/fw_laminas3.c
@@ -153,5 +153,5 @@ void nr_laminas3_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Laminas\\Mvc\\Console\\Router\\RouteMatch::setMatchedRouteName"),
       nr_laminas3_name_the_wt TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "laminas/laminas-mvc", " ");
+  nr_txn_add_php_package(NRPRG(txn), "laminas/laminas-mvc", PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -477,52 +477,6 @@ leave:
 }
 
 /*
- * Purpose : Return a copy of Illuminate\Foundation\Application::VERSION.
- *           The caller is responsible for freeing the string.
- *
- * Params  : 1. An instance of Illuminate\Foundation\Application.
- *
- * Returns : The Laravel version number as a string or NULL if the version
- *           cannot be determined.
- */
-static char* nr_laravel_version(zval* app TSRMLS_DC) {
-  char* retval = NULL;
-  zval* version = NULL;
-  zend_class_entry* ce = NULL;
-
-  if (0 == nr_php_is_zval_valid_object(app)) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
-                     __func__);
-    return NULL;
-  }
-
-  ce = Z_OBJCE_P(app);
-  if (NULL == ce) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
-                     __func__);
-    return NULL;
-  }
-
-  version = nr_php_get_class_constant(ce, "VERSION");
-  if (NULL == version) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
-                     __func__);
-    return NULL;
-  }
-
-  if (nr_php_is_zval_valid_string(version)) {
-    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
-  } else {
-    nrl_verbosedebug(NRL_FRAMEWORK,
-                     "%s: expected VERSION be a valid string, got type %d",
-                     __func__, Z_TYPE_P(version));
-  }
-
-  nr_php_zval_free(&version);
-  return retval;
-}
-
-/*
  * We hook the application's exception handler to name transactions
  * when unhandled exceptions occur during request processing. Such
  * exceptions are caught by the framework's
@@ -959,7 +913,7 @@ NR_PHP_WRAPPER(nr_laravel_application_construct) {
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
 
-  version = nr_laravel_version(this_var TSRMLS_CC);
+  version = nr_php_get_object_constant(this_var, "VERSION");
 
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "laravel/framework", version);

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -962,7 +962,7 @@ NR_PHP_WRAPPER(nr_laravel_application_construct) {
   version = nr_laravel_version(this_var TSRMLS_CC);
 
   // Add php package to transaction
-  nr_txn_add_php_package(NRPRG(txn), "Laravel", version);
+  nr_txn_add_php_package(NRPRG(txn), "laravel/framework", version);
 
   if (version) {
     nrl_debug(NRL_FRAMEWORK, "Laravel version is " NRP_FMT, NRP_PHP(version));

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -208,5 +208,5 @@ void nr_lumen_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Laravel\\Lumen\\Application::sendExceptionToHandler"),
       nr_lumen_exception TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "laravel/lumen-framework", " ");
+  nr_txn_add_php_package(NRPRG(txn), "laravel/lumen-framework", PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -208,4 +208,5 @@ void nr_lumen_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Laravel\\Lumen\\Application::sendExceptionToHandler"),
       nr_lumen_exception TSRMLS_CC);
+  nr_txn_add_php_package(NRPRG(txn), "laravel/lumen-framework", " ");
 }

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -143,6 +143,7 @@ NR_PHP_WRAPPER(nr_slim_application_construct) {
   (void)wraprec;
 
   version = nr_slim_version(this_var);
+  
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "slim/slim", version);
 

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -98,43 +98,6 @@ NR_PHP_WRAPPER(nr_slim3_4_route_run) {
 }
 NR_PHP_WRAPPER_END
 
-static char* nr_slim_version(zval* app) {
-  char* retval = NULL;
-  zval* version = NULL;
-  zend_class_entry* ce = NULL;
-
-  if (0 == nr_php_is_zval_valid_object(app)) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
-                     __func__);
-    return NULL;
-  }
-
-  ce = Z_OBJCE_P(app);
-  if (NULL == ce) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
-                     __func__);
-    return NULL;
-  }
-
-  version = nr_php_get_class_constant(ce, "VERSION");
-  if (NULL == version) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
-                     __func__);
-    return NULL;
-  }
-
-  if (nr_php_is_zval_valid_string(version)) {
-    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
-  } else {
-    nrl_verbosedebug(NRL_FRAMEWORK,
-                     "%s: expected VERSION be a valid string, got type %d",
-                     __func__, Z_TYPE_P(version));
-  }
-
-  nr_php_zval_free(&version);
-  return retval;
-}
-
 NR_PHP_WRAPPER(nr_slim_application_construct) {
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
   char* version = NULL;
@@ -142,7 +105,7 @@ NR_PHP_WRAPPER(nr_slim_application_construct) {
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
 
-  version = nr_slim_version(this_var);
+  version = nr_php_get_object_constant(this_var, "VERSION");
   
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "slim/slim", version);

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -98,7 +98,7 @@ NR_PHP_WRAPPER(nr_slim3_4_route_run) {
 }
 NR_PHP_WRAPPER_END
 
-static char* nr_slim_version(zval* app TSRMLS_DC) {
+static char* nr_slim_version(zval* app) {
   char* retval = NULL;
   zval* version = NULL;
   zend_class_entry* ce = NULL;
@@ -136,13 +136,13 @@ static char* nr_slim_version(zval* app TSRMLS_DC) {
 }
 
 NR_PHP_WRAPPER(nr_slim_application_construct) {
-  zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
   char* version = NULL;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
 
-  version = nr_slim_version(this_var TSRMLS_CC);
+  version = nr_slim_version(this_var);
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "slim/slim", version);
 
@@ -166,8 +166,8 @@ void nr_slim_enable(TSRMLS_D) {
   /* Slim 2 does not have the same path as Slim 3/4 which is why
      we need to separate these*/
   nr_php_wrap_user_function(NR_PSTR("Slim\\Slim::__construct"),
-                            nr_slim_application_construct TSRMLS_CC);
+                            nr_slim_application_construct);
 
   nr_php_wrap_user_function(NR_PSTR("Slim\\App::__construct"),
-                            nr_slim_application_construct TSRMLS_CC);
+                            nr_slim_application_construct);
 }

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -250,5 +250,5 @@ void nr_symfony4_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
         NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),
      nr_symfony4_console_application_run TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "symfony/http-kernel", " ");
+  nr_txn_add_php_package(NRPRG(txn), "symfony/http-kernel", PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -2,6 +2,7 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "nr_txn.h"
 #include "php_agent.h"
 #include "php_call.h"
 #include "php_error.h"

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -197,6 +197,59 @@ end:
 }
 NR_PHP_WRAPPER_END
 
+static char* nr_symfony_version(zval* app TSRMLS_DC) {
+  char* retval = NULL;
+  zval* version = NULL;
+  zend_class_entry* ce = NULL;
+
+  if (0 == nr_php_is_zval_valid_object(app)) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
+                     __func__);
+    return NULL;
+  }
+
+  ce = Z_OBJCE_P(app);
+  if (NULL == ce) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
+                     __func__);
+    return NULL;
+  }
+
+  version = nr_php_get_class_constant(ce, "VERSION");
+  if (NULL == version) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
+                     __func__);
+    return NULL;
+  }
+
+  if (nr_php_is_zval_valid_string(version)) {
+    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
+  } else {
+    nrl_verbosedebug(NRL_FRAMEWORK,
+                     "%s: expected VERSION be a valid string, got type %d",
+                     __func__, Z_TYPE_P(version));
+  }
+
+  nr_php_zval_free(&version);
+  return retval;
+}
+
+NR_PHP_WRAPPER(nr_symfony_application_construct) {
+  zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  char* version = NULL;
+
+  NR_UNUSED_SPECIALFN;
+  (void)wraprec;
+
+  version = nr_symfony_version(this_var TSRMLS_CC);
+  // Add php package to transaction
+  nr_txn_add_php_package(NRPRG(txn), "symfony/symfony", version);
+
+  nr_free(version);
+  nr_php_scope_release(&this_var);
+}
+NR_PHP_WRAPPER_END
+
 void nr_symfony4_enable(TSRMLS_D) {
   /*
    * We set the path to 'unknown' to prevent having to name routing errors.
@@ -250,4 +303,7 @@ void nr_symfony4_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
         NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),
      nr_symfony4_console_application_run TSRMLS_CC);
+
+  nr_php_wrap_user_function(NR_PSTR("App\\Kernel::__construct"),
+                            nr_symfony_application_construct TSRMLS_CC);
 }

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -2,7 +2,6 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "nr_txn.h"
 #include "php_agent.h"
 #include "php_call.h"
 #include "php_error.h"
@@ -198,16 +197,6 @@ end:
 }
 NR_PHP_WRAPPER_END
 
-NR_PHP_WRAPPER(nr_symfony_application_construct) {
-  zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-
-  NR_UNUSED_SPECIALFN;
-  (void)wraprec;
-
-  nr_php_scope_release(&this_var);
-}
-NR_PHP_WRAPPER_END
-
 void nr_symfony4_enable(TSRMLS_D) {
   /*
    * We set the path to 'unknown' to prevent having to name routing errors.
@@ -261,7 +250,4 @@ void nr_symfony4_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
         NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),
      nr_symfony4_console_application_run TSRMLS_CC);
-
-  nr_php_wrap_user_function(NR_PSTR("App\\Kernel::__construct"),
-                            nr_symfony_application_construct TSRMLS_CC);
 }

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -198,55 +198,12 @@ end:
 }
 NR_PHP_WRAPPER_END
 
-static char* nr_symfony_version(zval* app TSRMLS_DC) {
-  char* retval = NULL;
-  zval* version = NULL;
-  zend_class_entry* ce = NULL;
-
-  if (0 == nr_php_is_zval_valid_object(app)) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
-                     __func__);
-    return NULL;
-  }
-
-  ce = Z_OBJCE_P(app);
-  if (NULL == ce) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
-                     __func__);
-    return NULL;
-  }
-
-  version = nr_php_get_class_constant(ce, "VERSION");
-  if (NULL == version) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
-                     __func__);
-    return NULL;
-  }
-
-  if (nr_php_is_zval_valid_string(version)) {
-    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
-  } else {
-    nrl_verbosedebug(NRL_FRAMEWORK,
-                     "%s: expected VERSION be a valid string, got type %d",
-                     __func__, Z_TYPE_P(version));
-  }
-
-  nr_php_zval_free(&version);
-  return retval;
-}
-
 NR_PHP_WRAPPER(nr_symfony_application_construct) {
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  char* version = NULL;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
 
-  version = nr_symfony_version(this_var TSRMLS_CC);
-  // Add php package to transaction
-  nr_txn_add_php_package(NRPRG(txn), "symfony/symfony", version);
-
-  nr_free(version);
   nr_php_scope_release(&this_var);
 }
 NR_PHP_WRAPPER_END

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -250,4 +250,5 @@ void nr_symfony4_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
         NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),
      nr_symfony4_console_application_run TSRMLS_CC);
+  nr_txn_add_php_package(NRPRG(txn), "symfony/http-kernel", " ");
 }

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -583,6 +583,8 @@ void nr_wordpress_enable(TSRMLS_D) {
     nr_php_add_call_user_func_array_pre_callback(
         nr_wordpress_call_user_func_array TSRMLS_CC);
   }
+
+  nr_txn_add_php_package(NRPRG(txn), "wordpress", " ");
 }
 
 void nr_wordpress_minit(void) {

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -552,7 +552,7 @@ NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
 NR_PHP_WRAPPER_END
 
 void nr_wordpress_version() {
-  const char* string = "$GLOBALS['wp_version'];";
+  char* string = "$GLOBALS['wp_version'];";
   zval retval;
   int result = zend_eval_string(string, &retval,
                                 "Retrieve Wordpress Version");

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -556,10 +556,11 @@ void nr_wordpress_version() {
   zval retval;
   int result = zend_eval_string(string, &retval,
                                 "Retrieve Wordpress Version");
+  
+  // Add php package to transaction
   if (result == SUCCESS) {
     if (Z_TYPE(retval) == IS_STRING) {
       char* version = Z_STRVAL(retval);
-      // Add php package to transaction
       nr_txn_add_php_package(NRPRG(txn), "wordpress", version);
       zval_dtor(&retval);
     }

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -585,7 +585,7 @@ void nr_wordpress_enable(TSRMLS_D) {
         nr_wordpress_call_user_func_array TSRMLS_CC);
   }
 
-  nr_txn_add_php_package(NRPRG(txn), "wordpress", " ");
+  nr_txn_add_php_package(NRPRG(txn), "wordpress", PHP_PACKAGE_VERSION_UNKNOWN);
 }
 
 void nr_wordpress_minit(void) {

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -551,6 +551,21 @@ NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
 }
 NR_PHP_WRAPPER_END
 
+void nr_wordpress_version(TSRMLS_D) {
+  char* string = "$GLOBALS['wp_version'];";
+  zval retval;
+  int result = zend_eval_string(string, &retval,
+                                "Retrieve Wordpress Version" TSRMLS_CC);
+  if (result == SUCCESS) {
+    if (Z_TYPE(retval) == IS_STRING) {
+      char* version = Z_STRVAL(retval);
+      // Add php package to transaction
+      nr_txn_add_php_package(NRPRG(txn), "wordpress", version);
+      zval_dtor(&retval);
+    }
+  }
+}
+
 void nr_wordpress_enable(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("apply_filters"),
                             nr_wordpress_apply_filters TSRMLS_CC);

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -551,11 +551,11 @@ NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
 }
 NR_PHP_WRAPPER_END
 
-void nr_wordpress_version(TSRMLS_D) {
+void nr_wordpress_version() {
   char* string = "$GLOBALS['wp_version'];";
   zval retval;
   int result = zend_eval_string(string, &retval,
-                                "Retrieve Wordpress Version" TSRMLS_CC);
+                                "Retrieve Wordpress Version");
   if (result == SUCCESS) {
     if (Z_TYPE(retval) == IS_STRING) {
       char* version = Z_STRVAL(retval);

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -562,8 +562,8 @@ void nr_wordpress_version() {
     if (Z_TYPE(retval) == IS_STRING) {
       char* version = Z_STRVAL(retval);
       nr_txn_add_php_package(NRPRG(txn), "wordpress", version);
-      zval_dtor(&retval);
     }
+    zval_dtor(&retval);
   }
 }
 

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -552,7 +552,7 @@ NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
 NR_PHP_WRAPPER_END
 
 void nr_wordpress_version() {
-  char* string = "$GLOBALS['wp_version'];";
+  const char* string = "$GLOBALS['wp_version'];";
   zval retval;
   int result = zend_eval_string(string, &retval,
                                 "Retrieve Wordpress Version");

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -76,5 +76,5 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 void nr_doctrine2_enable(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "doctrine/orm", " ");
+  nr_txn_add_php_package(NRPRG(txn), "doctrine/orm", PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -8,7 +8,6 @@
  *
  * Implemented according to the newrelic-internal SQL Input Query Spec.
  */
-#include "nr_txn.h"
 #include "php_agent.h"
 #include "php_wrapper.h"
 #include "fw_support.h"

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -76,4 +76,5 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 void nr_doctrine2_enable(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);
+  nr_txn_add_php_package(NRPRG(txn), "doctrine/orm", " ");
 }

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -8,6 +8,7 @@
  *
  * Implemented according to the newrelic-internal SQL Input Query Spec.
  */
+#include "nr_txn.h"
 #include "php_agent.h"
 #include "php_wrapper.h"
 #include "fw_support.h"

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -76,4 +76,18 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 void nr_doctrine2_enable(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);
+
+  char* string = "Doctrine\\ORM\\Version::VERSION;";
+  zval retval;
+  int result = zend_eval_string(string, &retval,
+                                "Retrieve Doctrine Version" TSRMLS_CC);
+
+  if (result == SUCCESS) {
+    if (Z_TYPE(retval) == IS_STRING) {
+      char* version = Z_STRVAL(retval);
+      // Add php package to transaction
+      nr_txn_add_php_package(NRPRG(txn), "doctrine/orm", version);
+      zval_dtor(&retval);
+    }
+  }
 }

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -77,18 +77,4 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 void nr_doctrine2_enable(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);
-
-  char* string = "Doctrine\\ORM\\Version::VERSION;";
-  zval retval;
-  int result = zend_eval_string(string, &retval,
-                                "Retrieve Doctrine Version" TSRMLS_CC);
-
-  if (result == SUCCESS) {
-    if (Z_TYPE(retval) == IS_STRING) {
-      char* version = Z_STRVAL(retval);
-      // Add php package to transaction
-      nr_txn_add_php_package(NRPRG(txn), "doctrine/orm", version);
-      zval_dtor(&retval);
-    }
-  }
 }

--- a/agent/lib_guzzle4.c
+++ b/agent/lib_guzzle4.c
@@ -518,6 +518,7 @@ void nr_guzzle4_enable(TSRMLS_D) {
    */
   nr_php_wrap_user_function(NR_PSTR("GuzzleHttp\\Client::__construct"),
                             nr_guzzle_client_construct TSRMLS_CC);
+  nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", " ");
 }
 
 void nr_guzzle4_minit(TSRMLS_D) {

--- a/agent/lib_guzzle4.c
+++ b/agent/lib_guzzle4.c
@@ -518,7 +518,7 @@ void nr_guzzle4_enable(TSRMLS_D) {
    */
   nr_php_wrap_user_function(NR_PSTR("GuzzleHttp\\Client::__construct"),
                             nr_guzzle_client_construct TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", " ");
+  nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", PHP_PACKAGE_VERSION_UNKNOWN);
 }
 
 void nr_guzzle4_minit(TSRMLS_D) {

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -361,10 +361,12 @@ static char* nr_guzzle_version(zval* app TSRMLS_DC) {
   }
 
   if (NULL == nr_php_get_class_constant(ce, "VERSION")) {
-    version = nr_php_get_class_constant(ce, "MAJOR_VERSION");
+    // If full version does not exist, then we will send empty string
+    return " ";
   } else {
     version = nr_php_get_class_constant(ce, "VERSION");
   }
+
   if (NULL == version) {
     nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
                      __func__);
@@ -373,10 +375,6 @@ static char* nr_guzzle_version(zval* app TSRMLS_DC) {
 
   if (nr_php_is_zval_valid_string(version)) {
     retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
-  } else if ((Z_TYPE_P(version) == IS_LONG)) {
-    zend_string* zstr = zend_long_to_str(Z_LVAL_P(version));
-    retval = strndup(ZSTR_VAL(zstr), ZSTR_LEN(zstr));
-    zend_string_release(zstr);
   } else {
     nrl_verbosedebug(NRL_FRAMEWORK,
                      "%s: expected VERSION be a valid string, got type %d",

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -445,6 +445,7 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   retval = nr_php_call(handler_stack, "push", middleware);
 
   nr_php_zval_free(&retval);
+  nr_free(version);
 
 end:
   nr_php_zval_free(&middleware);

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -360,12 +360,7 @@ static char* nr_guzzle_version(zval* app) {
     return NULL;
   }
 
-  if (NULL == nr_php_get_class_constant(ce, "VERSION")) {
-    // If full version does not exist, then we will send empty string
-    return " ";
-  } else {
-    version = nr_php_get_class_constant(ce, "VERSION");
-  }
+  version = nr_php_get_class_constant(ce, "VERSION");
 
   if (NULL == version) {
     nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -342,13 +342,63 @@ const zend_function_entry nr_guzzle6_requesthandler_functions[]
 
 /* }}} */
 
+static char* nr_guzzle_version(zval* app TSRMLS_DC) {
+  char* retval = NULL;
+  zval* version = NULL;
+  zend_class_entry* ce = NULL;
+
+  if (0 == nr_php_is_zval_valid_object(app)) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
+                     __func__);
+    return NULL;
+  }
+
+  ce = Z_OBJCE_P(app);
+  if (NULL == ce) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
+                     __func__);
+    return NULL;
+  }
+
+  if (NULL == nr_php_get_class_constant(ce, "VERSION")) {
+    version = nr_php_get_class_constant(ce, "MAJOR_VERSION");
+  } else {
+    version = nr_php_get_class_constant(ce, "VERSION");
+  }
+  if (NULL == version) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
+                     __func__);
+    return NULL;
+  }
+
+  if (nr_php_is_zval_valid_string(version)) {
+    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
+  } else if ((Z_TYPE_P(version) == IS_LONG)) {
+    zend_string* zstr = zend_long_to_str(Z_LVAL_P(version));
+    retval = strndup(ZSTR_VAL(zstr), ZSTR_LEN(zstr));
+    zend_string_release(zstr);
+  } else {
+    nrl_verbosedebug(NRL_FRAMEWORK,
+                     "%s: expected VERSION be a valid string, got type %d",
+                     __func__, Z_TYPE_P(version));
+  }
+
+  nr_php_zval_free(&version);
+  return retval;
+}
+
 NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
+  char* version;
   zval* config;
   zend_class_entry* guzzle_client_ce;
   zval* handler_stack;
   zval* middleware = NULL;
   zval* retval;
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+
+  version = nr_guzzle_version(this_var TSRMLS_CC);
+  // Add php package to transaction
+  nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", version);
 
   (void)wraprec;
   NR_UNUSED_SPECIALFN;

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -390,6 +390,7 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
 
   version = nr_guzzle_version(this_var TSRMLS_CC);
+  
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", version);
 

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -342,7 +342,7 @@ const zend_function_entry nr_guzzle6_requesthandler_functions[]
 
 /* }}} */
 
-static char* nr_guzzle_version(zval* app TSRMLS_DC) {
+static char* nr_guzzle_version(zval* app) {
   char* retval = NULL;
   zval* version = NULL;
   zend_class_entry* ce = NULL;
@@ -392,7 +392,7 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   zval* handler_stack;
   zval* middleware = NULL;
   zval* retval;
-  zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
+  zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
 
   version = nr_guzzle_version(this_var TSRMLS_CC);
   // Add php package to transaction

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -342,44 +342,6 @@ const zend_function_entry nr_guzzle6_requesthandler_functions[]
 
 /* }}} */
 
-static char* nr_guzzle_version(zval* app) {
-  char* retval = NULL;
-  zval* version = NULL;
-  zend_class_entry* ce = NULL;
-
-  if (0 == nr_php_is_zval_valid_object(app)) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
-                     __func__);
-    return NULL;
-  }
-
-  ce = Z_OBJCE_P(app);
-  if (NULL == ce) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
-                     __func__);
-    return NULL;
-  }
-
-  version = nr_php_get_class_constant(ce, "VERSION");
-
-  if (NULL == version) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
-                     __func__);
-    return NULL;
-  }
-
-  if (nr_php_is_zval_valid_string(version)) {
-    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
-  } else {
-    nrl_verbosedebug(NRL_FRAMEWORK,
-                     "%s: expected VERSION be a valid string, got type %d",
-                     __func__, Z_TYPE_P(version));
-  }
-
-  nr_php_zval_free(&version);
-  return retval;
-}
-
 NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   char* version;
   zval* config;
@@ -389,7 +351,7 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   zval* retval;
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
 
-  version = nr_guzzle_version(this_var TSRMLS_CC);
+  version = nr_php_get_object_constant(this_var, "VERSION");
   
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", version);

--- a/agent/lib_mongodb.c
+++ b/agent/lib_mongodb.c
@@ -264,5 +264,5 @@ void nr_mongodb_enable(TSRMLS_D) {
   nr_php_wrap_user_function_extra(
       NR_PSTR("MongoDB\\Operation\\DatabaseCommand::execute"),
       nr_mongodb_operation, "databaseCommand" TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "mongodb/mongodb", " ");
+  nr_txn_add_php_package(NRPRG(txn), "mongodb/mongodb", PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_mongodb.c
+++ b/agent/lib_mongodb.c
@@ -264,4 +264,5 @@ void nr_mongodb_enable(TSRMLS_D) {
   nr_php_wrap_user_function_extra(
       NR_PSTR("MongoDB\\Operation\\DatabaseCommand::execute"),
       nr_mongodb_operation, "databaseCommand" TSRMLS_CC);
+  nr_txn_add_php_package(NRPRG(txn), "mongodb/mongodb", " ");
 }

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -511,4 +511,5 @@ void nr_monolog_enable(TSRMLS_D) {
                             nr_monolog_logger_pushhandler TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("Monolog\\Logger::addRecord"),
                             nr_monolog_logger_addrecord TSRMLS_CC);
+  nr_txn_add_php_package(NRPRG(txn), "monolog/monolog", " ");
 }

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -511,5 +511,5 @@ void nr_monolog_enable(TSRMLS_D) {
                             nr_monolog_logger_pushhandler TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("Monolog\\Logger::addRecord"),
                             nr_monolog_logger_addrecord TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "monolog/monolog", " ");
+  nr_txn_add_php_package(NRPRG(txn), "monolog/monolog", PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -667,7 +667,7 @@ static int nr_phpunit_are_statuses_valid(TSRMLS_D) {
 }
 
 void nr_phpunit_version() {
-  char* string = "PHPUnit\\Runner\\Version::id();";
+  const char* string = "PHPUnit\\Runner\\Version::id();";
   zval retval;
   int result
       = zend_eval_string(string, &retval, "Retrieve PHPUnit Version");

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -692,4 +692,18 @@ void nr_phpunit_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("PHPUnit\\Framework\\TestResult::addError"),
       nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
+
+  char* string = "PHPUnit\\Runner\\Version::id();";
+  zval retval;
+  int result
+      = zend_eval_string(string, &retval, "Retrieve PHPUnit Version" TSRMLS_CC);
+
+  if (result == SUCCESS) {
+    if (Z_TYPE(retval) == IS_STRING) {
+      char* version = Z_STRVAL(retval);
+      // Add php package to transaction
+      nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", version);
+      zval_dtor(&retval);
+    }
+  }
 }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -2,6 +2,7 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "nr_txn.h"
 #include "php_agent.h"
 #include "php_call.h"
 #include "php_hash.h"

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -709,4 +709,5 @@ void nr_phpunit_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("PHPUnit\\Framework\\TestResult::addError"),
       nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
+  nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", " ");
 }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -666,11 +666,11 @@ static int nr_phpunit_are_statuses_valid(TSRMLS_D) {
   return 1;
 }
 
-void nr_phpunit_version(TSRMLS_D) {
+void nr_phpunit_version() {
   char* string = "PHPUnit\\Runner\\Version::id();";
   zval retval;
   int result
-      = zend_eval_string(string, &retval, "Retrieve PHPUnit Version" TSRMLS_CC);
+      = zend_eval_string(string, &retval, "Retrieve PHPUnit Version");
 
   if (result == SUCCESS) {
     if (Z_TYPE(retval) == IS_STRING) {

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -672,10 +672,10 @@ void nr_phpunit_version() {
   int result
       = zend_eval_string(string, &retval, "Retrieve PHPUnit Version");
 
+  // Add php package to transaction
   if (result == SUCCESS) {
     if (Z_TYPE(retval) == IS_STRING) {
       char* version = Z_STRVAL(retval);
-      // Add php package to transaction
       nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", version);
       zval_dtor(&retval);
     }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -709,5 +709,5 @@ void nr_phpunit_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("PHPUnit\\Framework\\TestResult::addError"),
       nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", " ");
+  nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -677,8 +677,8 @@ void nr_phpunit_version() {
     if (Z_TYPE(retval) == IS_STRING) {
       char* version = Z_STRVAL(retval);
       nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", version);
-      zval_dtor(&retval);
     }
+    zval_dtor(&retval);
   }
 }
 

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -666,6 +666,22 @@ static int nr_phpunit_are_statuses_valid(TSRMLS_D) {
   return 1;
 }
 
+void nr_phpunit_version(TSRMLS_D) {
+  char* string = "PHPUnit\\Runner\\Version::id();";
+  zval retval;
+  int result
+      = zend_eval_string(string, &retval, "Retrieve PHPUnit Version" TSRMLS_CC);
+
+  if (result == SUCCESS) {
+    if (Z_TYPE(retval) == IS_STRING) {
+      char* version = Z_STRVAL(retval);
+      // Add php package to transaction
+      nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", version);
+      zval_dtor(&retval);
+    }
+  }
+}
+
 void nr_phpunit_enable(TSRMLS_D) {
   if (!NRINI(phpunit_events_enabled)) {
     return;
@@ -693,18 +709,4 @@ void nr_phpunit_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("PHPUnit\\Framework\\TestResult::addError"),
       nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
-
-  char* string = "PHPUnit\\Runner\\Version::id();";
-  zval retval;
-  int result
-      = zend_eval_string(string, &retval, "Retrieve PHPUnit Version" TSRMLS_CC);
-
-  if (result == SUCCESS) {
-    if (Z_TYPE(retval) == IS_STRING) {
-      char* version = Z_STRVAL(retval);
-      // Add php package to transaction
-      nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", version);
-      zval_dtor(&retval);
-    }
-  }
 }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -667,7 +667,7 @@ static int nr_phpunit_are_statuses_valid(TSRMLS_D) {
 }
 
 void nr_phpunit_version() {
-  const char* string = "PHPUnit\\Runner\\Version::id();";
+  char* string = "PHPUnit\\Runner\\Version::id();";
   zval retval;
   int result
       = zend_eval_string(string, &retval, "Retrieve PHPUnit Version");

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -722,6 +722,7 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   nr_php_zval_free(&conn);
   nr_php_arg_release(&params);
   nr_php_scope_release(&scope);
+  nr_free(version);
 }
 NR_PHP_WRAPPER_END
 

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -679,6 +679,7 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
 
   NR_PHP_WRAPPER_CALL;
   version = nr_predis_version(scope);
+  
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "predis/predis", version);
 

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -632,43 +632,6 @@ NR_PHP_WRAPPER(nr_predis_aggregateconnection_getConnection) {
 }
 NR_PHP_WRAPPER_END
 
-static char* nr_predis_version(zval* app) {
-  char* retval = NULL;
-  zval* version = NULL;
-  zend_class_entry* ce = NULL;
-
-  if (0 == nr_php_is_zval_valid_object(app)) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
-                     __func__);
-    return NULL;
-  }
-
-  ce = Z_OBJCE_P(app);
-  if (NULL == ce) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
-                     __func__);
-    return NULL;
-  }
-
-  version = nr_php_get_class_constant(ce, "VERSION");
-  if (NULL == version) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
-                     __func__);
-    return NULL;
-  }
-
-  if (nr_php_is_zval_valid_string(version)) {
-    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
-  } else {
-    nrl_verbosedebug(NRL_FRAMEWORK,
-                     "%s: expected VERSION be a valid string, got type %d",
-                     __func__, Z_TYPE_P(version));
-  }
-
-  nr_php_zval_free(&version);
-  return retval;
-}
-
 NR_PHP_WRAPPER(nr_predis_client_construct) {
   char* version;
   zval* conn = NULL;
@@ -678,7 +641,7 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   (void)wraprec;
 
   NR_PHP_WRAPPER_CALL;
-  version = nr_predis_version(scope);
+  version = nr_php_get_object_constant(scope, "VERSION");
   
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "predis/predis", version);

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -632,7 +632,7 @@ NR_PHP_WRAPPER(nr_predis_aggregateconnection_getConnection) {
 }
 NR_PHP_WRAPPER_END
 
-static char* nr_predis_version(zval* app TSRMLS_DC) {
+static char* nr_predis_version(zval* app) {
   char* retval = NULL;
   zval* version = NULL;
   zend_class_entry* ce = NULL;
@@ -678,7 +678,7 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   (void)wraprec;
 
   NR_PHP_WRAPPER_CALL;
-  version = nr_predis_version(scope TSRMLS_CC);
+  version = nr_predis_version(scope);
   // Add php package to transaction
   nr_txn_add_php_package(NRPRG(txn), "predis/predis", version);
 

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -632,7 +632,45 @@ NR_PHP_WRAPPER(nr_predis_aggregateconnection_getConnection) {
 }
 NR_PHP_WRAPPER_END
 
+static char* nr_predis_version(zval* app TSRMLS_DC) {
+  char* retval = NULL;
+  zval* version = NULL;
+  zend_class_entry* ce = NULL;
+
+  if (0 == nr_php_is_zval_valid_object(app)) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
+                     __func__);
+    return NULL;
+  }
+
+  ce = Z_OBJCE_P(app);
+  if (NULL == ce) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
+                     __func__);
+    return NULL;
+  }
+
+  version = nr_php_get_class_constant(ce, "VERSION");
+  if (NULL == version) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have VERSION",
+                     __func__);
+    return NULL;
+  }
+
+  if (nr_php_is_zval_valid_string(version)) {
+    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
+  } else {
+    nrl_verbosedebug(NRL_FRAMEWORK,
+                     "%s: expected VERSION be a valid string, got type %d",
+                     __func__, Z_TYPE_P(version));
+  }
+
+  nr_php_zval_free(&version);
+  return retval;
+}
+
 NR_PHP_WRAPPER(nr_predis_client_construct) {
+  char* version;
   zval* conn = NULL;
   zval* params = nr_php_arg_get(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   zval* scope = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
@@ -640,6 +678,9 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   (void)wraprec;
 
   NR_PHP_WRAPPER_CALL;
+  version = nr_predis_version(scope TSRMLS_CC);
+  // Add php package to transaction
+  nr_txn_add_php_package(NRPRG(txn), "predis/predis", version);
 
   /*
    * Grab the connection object from the client, since we actually instrument

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -654,10 +654,16 @@ zval* nr_php_get_class_constant(const zend_class_entry* ce, const char* name) {
 #endif
 }
 
-char* nr_php_get_object_constant(zval* app, char* name) {
+char* nr_php_get_object_constant(zval* app, const char* name) {
   char* retval = NULL;
   zval* version = NULL;
   zend_class_entry* ce = NULL;
+
+  if (NULL == name || 0 >= nr_strlen(name)) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL object name",
+                     __func__);
+    return NULL;
+  }
 
   if (0 == nr_php_is_zval_valid_object(app)) {
     nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -654,6 +654,43 @@ zval* nr_php_get_class_constant(const zend_class_entry* ce, const char* name) {
 #endif
 }
 
+char* nr_php_get_object_constant(zval* app, char* name) {
+  char* retval = NULL;
+  zval* version = NULL;
+  zend_class_entry* ce = NULL;
+
+  if (0 == nr_php_is_zval_valid_object(app)) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application object is invalid",
+                     __func__);
+    return NULL;
+  }
+
+  ce = Z_OBJCE_P(app);
+  if (NULL == ce) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application has NULL class entry",
+                     __func__);
+    return NULL;
+  }
+
+  version = nr_php_get_class_constant(ce, name);
+  if (NULL == version) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: Application does not have %s",
+                     __func__, name);
+    return NULL;
+  }
+
+  if (nr_php_is_zval_valid_string(version)) {
+    retval = nr_strndup(Z_STRVAL_P(version), Z_STRLEN_P(version));
+  } else {
+    nrl_verbosedebug(NRL_FRAMEWORK,
+                     "%s: expected VERSION be a valid string, got type %d",
+                     __func__, Z_TYPE_P(version));
+  }
+
+  nr_php_zval_free(&version);
+  return retval;
+}
+
 int nr_php_is_zval_named_constant(const zval* zv, const char* name TSRMLS_DC) {
   int is_equal = 0;
   zval* constant;

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -484,7 +484,7 @@ extern zval* nr_php_get_class_constant(const zend_class_entry* ce,
  * Returns : A string that contains the value of the object constant. The caller
  *           is responsible for freeing the string after use.
  */
-extern char* nr_php_get_object_constant(zval* app, char* name);
+extern char* nr_php_get_object_constant(zval* app, const char* name);
 
 /*
  * Purpose : Determine if the given zval has the same value as the PHP constant

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -476,6 +476,17 @@ extern zval* nr_php_get_class_constant(const zend_class_entry* ce,
                                        const char* name);
 
 /*
+ * Purpose : Retrieve value for object constant
+ *
+ * Params  : 1. An instance of the application's class
+ *           2. The name of the object constant
+ *
+ * Returns : A string that contains the value of the object constant. The caller
+ *           is responsible for freeing the string after use.
+ */
+extern char* nr_php_get_object_constant(zval* app, char* name);
+
+/*
  * Purpose : Determine if the given zval has the same value as the PHP constant
  *           of the given name.
  *

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -609,7 +609,7 @@ static const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
     {"Wordpress", "wp-includes/version.php", nr_wordpress_version},
 };
 
-static size_t num_packages
+static const size_t num_packages
     = sizeof(vuln_mgmt_packages) / sizeof(nr_vuln_mgmt_table_t);
 
 /*
@@ -953,6 +953,11 @@ static void nr_execute_handle_logging_framework(const char* filename,
 #undef STR_AND_LEN
 
 static void nr_execute_handle_package(const char* filename) {
+  if (NULL == filename || 0 >= nr_strlen(filename)) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: The file name is NULL",
+                     __func__);
+    return;
+  }
   char* filename_lower = nr_string_to_lowercase(filename);
   size_t i = 0;
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -111,7 +111,7 @@ typedef void (*nr_library_enable_fn_t)(TSRMLS_D);
  * Purpose: Enable monitoring on specific functions for a detected vulnerability
  *          management package.
  */
-typedef void (*nr_vuln_mgmt_enable_fn_t)(TSRMLS_D);
+typedef void (*nr_vuln_mgmt_enable_fn_t)();
 
 /*
  * This code is used for function call debugging.
@@ -951,14 +951,14 @@ static void nr_execute_handle_logging_framework(
 
 #undef STR_AND_LEN
 
-static void nr_execute_handle_package(const char* filename TSRMLS_DC) {
+static void nr_execute_handle_package(const char* filename) {
   char* filename_lower = nr_string_to_lowercase(filename);
   size_t i = 0;
 
   for (i = 0; i < num_packages; i++) {
     if (nr_stridx(filename_lower, vuln_mgmt_packages[i].file_to_check) >= 0) {
       if (NULL != vuln_mgmt_packages[i].enable) {
-        vuln_mgmt_packages[i].enable(TSRMLS_C);
+        vuln_mgmt_packages[i].enable();
       }
     }
   }
@@ -988,7 +988,7 @@ static void nr_php_user_instrumentation_from_file(const char* filename,
                               filename_len TSRMLS_CC);
   nr_execute_handle_library(filename, filename_len TSRMLS_CC);
   nr_execute_handle_logging_framework(filename, filename_len TSRMLS_CC);
-  nr_execute_handle_package(filename TSRMLS_CC);
+  nr_execute_handle_package(filename);
 }
 
 /*

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -318,12 +318,13 @@ typedef struct _nr_vuln_mgmt_table_t {
 
 /* Note that all paths should be in lowercase. */
 static const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
-  {"Drupal", "core/lib/drupal.php", nr_drupal_version},
-  {"PHPUnit", "runner/version.php", nr_phpunit_version},
-  {"Wordpress", "wp-includes/version.php", nr_wordpress_version},
+    {"Drupal", "core/lib/drupal.php", nr_drupal_version},
+    {"PHPUnit", "runner/version.php", nr_phpunit_version},
+    {"Wordpress", "wp-includes/version.php", nr_wordpress_version},
 };
 
-static size_t num_packages = sizeof(vuln_mgmt_packages) / sizeof(nr_vuln_mgmt_table_t);
+static size_t num_packages
+    = sizeof(vuln_mgmt_packages) / sizeof(nr_vuln_mgmt_table_t);
 
 /*
  * Framework handling, definition and callbacks.
@@ -953,7 +954,7 @@ static void nr_execute_handle_logging_framework(
 static void nr_execute_handle_package(const char* filename TSRMLS_DC) {
   char* filename_lower = nr_string_to_lowercase(filename);
   size_t i = 0;
-  
+
   for (i = 0; i < num_packages; i++) {
     if (nr_stridx(filename_lower, vuln_mgmt_packages[i].file_to_check) >= 0) {
       if (NULL != vuln_mgmt_packages[i].enable) {

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -309,23 +309,6 @@ static void nr_show_execute_params(NR_EXECUTE_PROTO, char* pbuf TSRMLS_DC) {
   (void)pos;
 }
 
-/* Package handling for Vulnerability Management */
-typedef struct _nr_vuln_mgmt_table_t {
-  const char* package_name;
-  const char* file_to_check;
-  nr_vuln_mgmt_enable_fn_t enable;
-} nr_vuln_mgmt_table_t;
-
-/* Note that all paths should be in lowercase. */
-static const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
-    {"Drupal", "core/lib/drupal.php", nr_drupal_version},
-    {"PHPUnit", "runner/version.php", nr_phpunit_version},
-    {"Wordpress", "wp-includes/version.php", nr_wordpress_version},
-};
-
-static size_t num_packages
-    = sizeof(vuln_mgmt_packages) / sizeof(nr_vuln_mgmt_table_t);
-
 /*
  * Framework handling, definition and callbacks.
  */
@@ -611,6 +594,24 @@ static nr_library_table_t logging_frameworks[] = {
 
 static size_t num_logging_frameworks
     = sizeof(logging_frameworks) / sizeof(nr_library_table_t);
+
+/* Package handling for Vulnerability Management */
+typedef struct _nr_vuln_mgmt_table_t {
+  const char* package_name;
+  const char* file_to_check;
+  nr_vuln_mgmt_enable_fn_t enable;
+} nr_vuln_mgmt_table_t;
+
+/* Note that all paths should be in lowercase. */
+static const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
+    {"Drupal", "core/lib/drupal.php", nr_drupal_version},
+    {"PHPUnit", "runner/version.php", nr_phpunit_version},
+    {"Wordpress", "wp-includes/version.php", nr_wordpress_version},
+};
+
+static size_t num_packages
+    = sizeof(vuln_mgmt_packages) / sizeof(nr_vuln_mgmt_table_t);
+
 /*
  * This const char[] provides enough white space to indent functions to
  * (sizeof (nr_php_indentation_spaces) / NR_EXECUTE_INDENTATION_WIDTH) deep.

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -928,7 +928,6 @@ static void nr_execute_handle_library(const char* filename,
 static void nr_execute_handle_logging_framework(const char* filename,
                                                 const size_t filename_len
                                                     TSRMLS_DC) {
-  char* filename_lower = nr_string_to_lowercase(filename);
   bool is_enabled = false;
   size_t i;
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -925,8 +925,9 @@ static void nr_execute_handle_library(const char* filename,
   }
 }
 
-static void nr_execute_handle_logging_framework(
-  const char* filename TSRMLS_DC) {
+static void nr_execute_handle_logging_framework(const char* filename,
+                                                const size_t filename_len
+                                                    TSRMLS_DC) {
   char* filename_lower = nr_string_to_lowercase(filename);
   bool is_enabled = false;
   size_t i;

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -108,6 +108,12 @@ typedef void (*nr_framework_enable_fn_t)(TSRMLS_D);
 typedef void (*nr_library_enable_fn_t)(TSRMLS_D);
 
 /*
+ * Purpose: Enable monitoring on specific functions for a detected vulnerability
+ *          management package.
+ */
+typedef void (*nr_vuln_mgmt_enable_fn_t)(TSRMLS_D);
+
+/*
  * This code is used for function call debugging.
  */
 #define MAX_NR_EXECUTE_DEBUG_STRLEN (80)
@@ -302,6 +308,22 @@ static void nr_show_execute_params(NR_EXECUTE_PROTO, char* pbuf TSRMLS_DC) {
   (void)avail;
   (void)pos;
 }
+
+/* Package handling for Vulnerability Management */
+typedef struct _nr_vuln_mgmt_table_t {
+  const char* package_name;
+  const char* file_to_check;
+  nr_vuln_mgmt_enable_fn_t enable;
+} nr_vuln_mgmt_table_t;
+
+/* Note that all paths should be in lowercase. */
+static const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
+  {"Drupal", "core/lib/drupal.php", nr_drupal_version},
+  {"PHPUnit", "runner/version.php", nr_phpunit_version},
+  {"Wordpress", "wp-includes/version.php", nr_wordpress_version},
+};
+
+static size_t num_packages = sizeof(vuln_mgmt_packages) / sizeof(nr_vuln_mgmt_table_t);
 
 /*
  * Framework handling, definition and callbacks.
@@ -901,9 +923,9 @@ static void nr_execute_handle_library(const char* filename,
   }
 }
 
-static void nr_execute_handle_logging_framework(const char* filename,
-                                                const size_t filename_len
-                                                    TSRMLS_DC) {
+static void nr_execute_handle_logging_framework(
+  const char* filename TSRMLS_DC) {
+  char* filename_lower = nr_string_to_lowercase(filename);
   bool is_enabled = false;
   size_t i;
 
@@ -928,6 +950,21 @@ static void nr_execute_handle_logging_framework(const char* filename,
 
 #undef STR_AND_LEN
 
+static void nr_execute_handle_package(const char* filename TSRMLS_DC) {
+  char* filename_lower = nr_string_to_lowercase(filename);
+  size_t i = 0;
+  
+  for (i = 0; i < num_packages; i++) {
+    if (nr_stridx(filename_lower, vuln_mgmt_packages[i].file_to_check) >= 0) {
+      if (NULL != vuln_mgmt_packages[i].enable) {
+        vuln_mgmt_packages[i].enable(TSRMLS_C);
+      }
+    }
+  }
+
+  nr_free(filename_lower);
+}
+
 /*
  * Purpose : Detect library and framework usage from a PHP file.
  *
@@ -950,6 +987,7 @@ static void nr_php_user_instrumentation_from_file(const char* filename,
                               filename_len TSRMLS_CC);
   nr_execute_handle_library(filename, filename_len TSRMLS_CC);
   nr_execute_handle_logging_framework(filename, filename_len TSRMLS_CC);
+  nr_execute_handle_package(filename TSRMLS_CC);
 }
 
 /*

--- a/axiom/nr_php_packages.c
+++ b/axiom/nr_php_packages.c
@@ -39,9 +39,9 @@ nr_php_package_t* nr_php_package_create(char* name, char* version) {
   if (NULL != version) {
     p->package_version = nr_strdup(version);
   } else {
-    p->package_version
-        = nr_strdup(" ");  // if null, version is set to an empty
-                           // string with a space according to spec
+    p->package_version = nr_strdup(
+        PHP_PACKAGE_VERSION_UNKNOWN);  // if null, version is set to an empty
+                                       // string with a space according to spec
   }
 
   nrl_verbosedebug(NRL_INSTRUMENT, "Creating PHP Package '%s', version '%s'",

--- a/axiom/nr_php_packages.c
+++ b/axiom/nr_php_packages.c
@@ -15,6 +15,7 @@
 #include "util_vector.h"
 #include "util_hashmap.h"
 #include "util_hashmap_private.h"
+#include "util_logging.h"
 #include "util_strings.h"
 
 typedef struct {
@@ -43,6 +44,8 @@ nr_php_package_t* nr_php_package_create(char* name, char* version) {
                            // string with a space according to spec
   }
 
+  nrl_verbosedebug(NRL_INSTRUMENT, "Creating PHP Package '%s', version '%s'",
+                   p->package_name, p->package_version);
   return p;
 }
 

--- a/axiom/nr_php_packages.h
+++ b/axiom/nr_php_packages.h
@@ -11,6 +11,8 @@
 #include "util_vector.h"
 #include "util_hashmap.h"
 
+#define PHP_PACKAGE_VERSION_UNKNOWN " "
+
 typedef struct _nr_php_package_t {
   char* package_name;
   char* package_version;

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8545,6 +8545,8 @@ static void test_nr_txn_add_php_package(void) {
   char* package_version2 = "4.12.0";
   char* package_name3 = "Drupal";
   char* package_version3 = NULL;
+  char* package_name4 = "Wordpress";
+  char* package_version4 = PHP_PACKAGE_VERSION_UNKNOWN;
   nrtxn_t* txn = new_txn(0);
 
   /*
@@ -8559,11 +8561,13 @@ static void test_nr_txn_add_php_package(void) {
   nr_txn_add_php_package(txn, package_name1, package_version1);
   nr_txn_add_php_package(txn, package_name2, package_version2);
   nr_txn_add_php_package(txn, package_name3, package_version3);
+  nr_txn_add_php_package(txn, package_name4, package_version4);
   json = nr_php_packages_to_json(txn->php_packages);
 
   tlib_pass_if_str_equal("correct json",
                          "[[\"Laravel\",\"8.83.27\",{}],"
-                         "[\"Drupal\",\" \",{}],[\"Slim\",\"4.12.0\",{}]]",
+                         "[\"Drupal\",\" \",{}],[\"Wordpress\",\" \",{}],"
+                         "[\"Slim\",\"4.12.0\",{}]]",
                          json);
 
   nr_free(json);


### PR DESCRIPTION
This PR extracts the version for the following PHP packages and adds the package name and version to the transaction.
 
- Drupal 8, 9, 10 (`drupal/core`)
- Guzzle 6 (`guzzlehttp/guzzle`)
- Slim (`slim/slim`)
- PHPUnit (`phpunit/phpunit`)
- Predis (`predis/predis`)
- Wordpress 

In addition, this PR also sends information about the following PHP packages. For the packages that are being added without a version, an empty string will be sent as the version:

- Laminas without version information (`laminas/laminas-mvc`)
- Laravel with version information (`laravel/framework`)
- Lumen without version information (`laravel/lumen-framework`)
- Symfony without version information (`symfony/http-kernel`)
- Doctrine without version information (`doctrine/orm`)
- MongoDB without version information (`mongodb/mongodb`)
- Monolog without version information (`monolog/monolog`)
