### PR TITLE
feat(oapi): use segment pool instead of stacked segments

### DIFF
--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -259,7 +259,13 @@ NR_PHP_WRAPPER(nr_drupal_http_request_before) {
      * after function properly
      */
     NRPRG(drupal_http_request_segment)
-        = nr_segment_start(NRPRG(txn), NRTXN(segment_root), NULL);
+        = nr_segment_start(NRPRG(txn), NULL, NULL);
+    /*
+     * The new segment needs to have the wraprec data attached, so that
+     * fcall_end is able to properly dispatch to the after wrapper, as
+     * this new segment is now at the top of the segment stack.
+     */
+    NRPRG(drupal_http_request_segment)->wraprec = auto_segment->wraprec;
   }
 }
 NR_PHP_WRAPPER_END

--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -253,8 +253,13 @@ NR_PHP_WRAPPER(nr_drupal_http_request_before) {
    * checking a counter.
    */
   if (1 == NRPRG(drupal_http_request_depth)) {
+    /*
+     * Parent this segment to the txn root so as to not interfere with
+     * the OAPI default segment stack, which is used to dispatch to the
+     * after function properly
+     */
     NRPRG(drupal_http_request_segment)
-        = nr_segment_start(NRPRG(txn), NULL, NULL);
+        = nr_segment_start(NRPRG(txn), NRTXN(segment_root), NULL);
   }
 }
 NR_PHP_WRAPPER_END

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -2069,6 +2069,12 @@ static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
     return;
   }
 
+  /*
+   * Reassign segment to the current segment, as some before/after wraprecs
+   * start and then stop a segment. If that happened, we want to ensure we
+   * get the now-current segment
+   */
+  segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
   nr_php_execute_metadata_init(&metadata, NR_OP_ARRAY);
   nr_php_execute_segment_end(segment, &metadata, create_metric);
   nr_php_execute_metadata_release(&metadata);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1892,7 +1892,7 @@ static void nr_php_instrument_func_begin(NR_EXECUTE_PROTO) {
   segment = nr_segment_start(NRPRG(txn), NULL, NULL);
 
   if (nrunlikely(NULL == segment)) {
-    nrl_verbosedebug(NRL_AGENT, "Error initializing stacked segment.");
+    nrl_verbosedebug(NRL_AGENT, "Error starting segment.");
     return;
   }
 

--- a/agent/php_stacked_segment.c
+++ b/agent/php_stacked_segment.c
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
-    || defined OVERWRITE_ZEND_EXECUTE_DATA /* not OAPI */
 #include "php_stacked_segment.h"
 #include "util_logging.h"
 #include "php_execute.h"
 #include "php_error.h"
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA /* not OAPI */
 
 /*
  * Purpose : Add a stacked segment to the stacked segment stack. The top

--- a/agent/php_stacked_segment.h
+++ b/agent/php_stacked_segment.h
@@ -5,8 +5,6 @@
 
 #ifndef PHP_STACKED_SEGMENT_HDR
 #define PHP_STACKED_SEGMENT_HDR
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
-    || defined OVERWRITE_ZEND_EXECUTE_DATA /* not OAPI */
 
 #include "nr_segment.h"
 
@@ -258,6 +256,8 @@
 // clang-format on
 
 #include "php_agent.h"
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA /* not OAPI */
 
 /*
  * Purpose : Initialize a stacked segment.

--- a/agent/php_stacked_segment.h
+++ b/agent/php_stacked_segment.h
@@ -165,93 +165,9 @@
  * Stacked segments cannot be used to model async segments.
  */
 
-// clang-format off
 /*
- * Observer API paradigm.
- *
- *
- * The workflow of using stacked segments in connection with regular
- * segments is complicated. It's best illustrated by a short ASCII
- * cartoon.
- *
- *  root <                      root                      root
- *                               |                         |
- *                               *A <                      *A
- *                                                         |
- *                                                         *B
- *
- * We start out with a root segment, OAPI calls nr_php_observer_fcall_begin for
- * A, and it starts stacked segment *A and then nr_php_observer_fcall_begin(B)
- * starts stacked segment *B as a child of *A.
- *
- *  root                        root                       root
- *   |                           |                          |
- *   *A <                        *A                         *A <
- *                               |
- *                               *C <
- *
- * *nr_php_observer_fcall_end(B) decides to discard *B, and *A is the current
- * segment again. nr_php_observer_fcall_begin(C) starts *C gets started as child
- * of *A and when nr_php_observer_fcall_end(C) is called, *C gets discarded too.
- * Note that up to this point, no segment except the root segment ever was
- * allocated via the slab; however, stacked segments are being calloced in
- * stacked_segment_init.
- *
- *   root                        root                       root
- *    |                           |                          |
- *    *A <                        *A                         *A
- *                                |                          |
- *                                *D <                       *D
- *                                                           |
- *                                                           *E <
- *
- * In a next exciting step, nr_php_observer_fcall_begin(D) starts stacked
- * segment *D as child of *A and nr_php_observer_fcall_begin(E) *E is started as
- * child of *D.
- *
- *   root                        root
- *    |                           |
- *    *A                          *A <
- *    |                           |
- *    *D <                        e
- *    |
- *    e
- *
- * Now something new happens. nr_php_observer_fcall_end(E) decides to keep the
- * stacked segment *E. We copy the contents of the stacked segment *E into a
- * segment e we obtained from the slab allocator, and we make e a child of the
- * stacked segment *D. nr_php_observer_fcall_end(D) discards stacked segment *D
- * and its child e is made a child of *D's parent *A.
- *
- *   root                        root                       root
- *    |                           |                          |
- *    *A                          *A <                       *A
- *   / \                          |                         / \
- *  e   *F <                      e                        e   *G <
- *
- * More of the same. nr_php_observer_fcall_begin(F) creates a stacked segment *F
- * as child of A and nr_php_observer_fcall_end(F) eventually discards it.
- * nr_php_observer_fcall_begin(G) then creates a stacked segment *G.
- *
- *   root                        root <                     root
- *    |                           |                         / \
- *    *A <                        a                        a   *H
- *   / \                         / \                      / \
- *  e   g                       e   g                    e   g
- *
- * Finally nr_php_observer_fcall_end(G) also decides to keep *G. Again, it is
- * turned into a regular segment g and made a child of *A. Then we decide to
- * keep *A, turning it into regular segment a and making it a child of the root
- * segment. Afterward a nr_php_observer_fcall_begin(H) starts stacked segment *H
- * as child of the root segment.
- *
- * Note that with this workflow, we went through the
- * nr_segment_start/nr_segment_discard cycle for only 3 times,
- * although we used 8 different segments. For the remaining 5 segments, we
- * went through the stacked segment cycle.
- *
- * Also note that this only works with segments on the default parent stack.
- * Stacked segments cannot be used to model async segments.
+ * Observer API paradigm: OAPI cannot make use of stacked segments and
+ * therefore uses the txn segment stack API.
  */
 // clang-format on
 

--- a/agent/php_stacked_segment.h
+++ b/agent/php_stacked_segment.h
@@ -5,6 +5,8 @@
 
 #ifndef PHP_STACKED_SEGMENT_HDR
 #define PHP_STACKED_SEGMENT_HDR
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA /* not OAPI */
 
 #include "nr_segment.h"
 
@@ -315,4 +317,5 @@ extern void nr_php_stacked_segment_unwind(TSRMLS_D);
 extern nr_segment_t* nr_php_stacked_segment_move_to_heap(
     nr_segment_t* stacked TSRMLS_DC);
 
+#endif /* not OAPI */
 #endif /* PHP_STACKED_SEGMENT_HDR */

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1072,10 +1072,10 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  for (nr_segment_t* segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
-       segment != NULL && segment != NRTXN(segment_root);
-       segment = nr_txn_get_current_segment(NRPRG(txn), NULL)) {
+  nr_segment_t* segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
+  while(NULL != segment && segment != NRTXN(segment_root)) {
     nr_segment_end(&segment);
+    segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
   }
 #else
   nr_php_stacked_segment_unwind(TSRMLS_C);

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -844,11 +844,14 @@ nr_status_t nr_php_txn_begin(const char* appnames,
 
   nr_php_txn_send_metrics_once(NRPRG(txn) TSRMLS_CC);
 
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA /* not OAPI */
   /*
    * Disable automated parenting for the default parent context. See
    * php_stacked_segment.h for further details.
    */
   nr_txn_force_current_segment(NRPRG(txn), NRTXN(segment_root));
+#endif
 
   nr_php_collect_x_request_start(TSRMLS_C);
   nr_php_set_initial_path(NRPRG(txn) TSRMLS_CC);
@@ -1067,7 +1070,16 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
    * by calling newrelic_end_transaction inside nested function scopes)
    * the stack of stacked segments has to be cleaned up.
    */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
+  for (nr_segment_t* segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
+       segment != NULL && segment != NRTXN(segment_root);
+       segment = nr_txn_get_current_segment(NRPRG(txn), NULL)) {
+    nr_segment_end(&segment);
+  }
+#else
   nr_php_stacked_segment_unwind(TSRMLS_C);
+#endif
 
   nrl_verbosedebug(NRL_TXN, "%s: Ending the transaction and stack depth = %d",
                    __func__, NRPRG(php_cur_stack_depth));

--- a/agent/tests/test_php_stacked_segment.c
+++ b/agent/tests/test_php_stacked_segment.c
@@ -15,110 +15,8 @@
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = -1, .state_size = 0};
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
-    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
-static void test_start_end_discard(TSRMLS_D) {
-  nr_segment_t* stacked = NULL;
-  nr_segment_t* segment;
-
-  tlib_php_request_start();
-
-  /*
-   * Initial state: current segment forced to root
-   */
-  tlib_pass_if_ptr_equal("current stacked segment forced to root",
-                         NRTXN(segment_root), NRTXN(force_current_segment));
-
-  /*
-   * Add a stacked segment.
-   */
-  stacked = nr_php_stacked_segment_init(stacked);
-
-  tlib_pass_if_not_null("current stacked forced to stacked should not be null",
-                        stacked);
-  tlib_pass_if_ptr_equal("current stacked segment has txn", stacked->txn,
-                         NRPRG(txn));
-  tlib_pass_if_ptr_equal("current stacked forced to stacked", stacked,
-                         NRTXN(force_current_segment));
-
-  /*
-   * Discard a stacked segment.
-   */
-  nr_php_stacked_segment_deinit(stacked);
-
-  tlib_pass_if_ptr_equal("current stacked segment forced to root",
-                         NRTXN(segment_root), NRTXN(force_current_segment));
-  tlib_pass_if_size_t_equal(
-      "no segment created", 0,
-      nr_segment_children_size(&NRTXN(segment_root)->children));
-
-  /*
-   * Add another stacked segment.
-   */
-  stacked = nr_php_stacked_segment_init(stacked TSRMLS_CC);
-
-  tlib_pass_if_ptr_equal("current stacked segment has txn", stacked->txn,
-                         NRPRG(txn));
-  tlib_pass_if_ptr_equal("current stacked forced to stacked", stacked,
-                         NRTXN(force_current_segment));
-
-  /*
-   * End a stacked segment.
-   */
-  segment = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
-  nr_segment_end(&segment);
-
-  tlib_pass_if_true("moved segment is different from stacked segment",
-                    segment != stacked, "%p!=%p", segment, stacked);
-  tlib_pass_if_ptr_equal("current stacked segment forced to root",
-                         NRTXN(segment_root), NRTXN(force_current_segment));
-  tlib_pass_if_size_t_equal(
-      "no segment created", 1,
-      nr_segment_children_size(&NRTXN(segment_root)->children));
-
-  tlib_php_request_end();
-}
-
-static void test_unwind(TSRMLS_D) {
-  nr_segment_t* stacked_1 = NULL;
-  nr_segment_t* stacked_2 = NULL;
-  nr_segment_t* stacked_3 = NULL;
-  nr_segment_t* segment;
-
-  tlib_php_request_start();
-
-  /*
-   * Add stacked segments.
-   */
-  stacked_1 = nr_php_stacked_segment_init(stacked_1 TSRMLS_CC);
-  stacked_2 = nr_php_stacked_segment_init(stacked_2 TSRMLS_CC);
-  stacked_3 = nr_php_stacked_segment_init(stacked_3 TSRMLS_CC);
-
-  /*
-   * Add a regular segment.
-   */
-  segment = nr_segment_start(NRPRG(txn), NULL, NULL);
-  nr_segment_end(&segment);
-
-  /*
-   * Sleep; otherwise, unwind will dump the short segments and fail.
-   */
-  nr_msleep(500);
-
-  /*
-   * Unwind the stacked segment stack.
-   */
-  nr_php_stacked_segment_unwind(TSRMLS_C);
-
-  tlib_pass_if_size_t_equal(
-      "one child segment of root", 1,
-      nr_segment_children_size(&NRTXN(segment_root)->children));
-
-  tlib_pass_if_size_t_equal("4 segments in total ", 4, NRTXN(segment_count));
-
-  tlib_php_request_end();
-}
-#else
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
+    || defined OVERWRITE_ZEND_EXECUTE_DATA /* not OAPI */
 static void test_start_end_discard(TSRMLS_D) {
   nr_segment_t stacked = {0};
   nr_segment_t* segment;
@@ -218,8 +116,6 @@ static void test_unwind(TSRMLS_D) {
 
   tlib_php_request_end();
 }
-#endif
-
 void test_main(void* p NRUNUSED) {
 #if defined(ZTS) && !defined(PHP7)
   void*** tsrm_ls = NULL;
@@ -229,3 +125,7 @@ void test_main(void* p NRUNUSED) {
   test_unwind(TSRMLS_C);
   tlib_php_engine_destroy(TSRMLS_C);
 }
+#else
+void test_main(void* p NRUNUSED) {
+}
+#endif /* not OAPI */


### PR DESCRIPTION
Because OAPI doesn't create a nice callstack that replicates the PHP callstack, stacked segments make little/no sense in its context. Instead, we want to utilize the segment pool available in txn's.

force_current_segment was how stacked segments were able to maintain their context in a txn while not being on the segment stack. For OAPI, there is no reason to use this field, as the current segment will just be the top of the txn's segment stack.