### PR TITLE
refactor: compile wordpress hook regex at minit

### DIFF
--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -21,6 +21,8 @@
 #define NR_WORDPRESS_HOOK_PREFIX "Framework/WordPress/Hook/"
 #define NR_WORDPRESS_PLUGIN_PREFIX "Framework/WordPress/Plugin/"
 
+static nr_regex_t* wordpress_hook_regex;
+
 static size_t zval_len_without_trailing_slash(const zval* zstr) {
   nr_string_len_t len = Z_STRLEN_P(zstr);
   const char* str = Z_STRVAL_P(zstr);
@@ -428,7 +430,7 @@ static char* nr_wordpress_clean_tag(const zval* tag TSRMLS_DC) {
     return NULL;
   }
 
-  regex = NRPRG(wordpress_hook_regex);
+  regex = wordpress_hook_regex;
   if (NULL == regex) {
     return NULL;
   }
@@ -593,4 +595,14 @@ void nr_wordpress_enable(TSRMLS_D) {
 
   nr_php_add_call_user_func_array_pre_callback(
       nr_wordpress_call_user_func_array TSRMLS_CC);
+}
+
+void nr_wordpress_minit(void) {
+  wordpress_hook_regex = nr_regex_create(
+      "(^([a-z_-]+[_-])([0-9a-f_.]+[0-9][0-9a-f.]+)(_{0,1}.*)$|(.*))",
+      NR_REGEX_CASELESS, 0);
+}
+
+void nr_wordpress_mshutdown(void) {
+  nr_regex_destroy(&wordpress_hook_regex);
 }

--- a/agent/fw_wordpress.h
+++ b/agent/fw_wordpress.h
@@ -29,4 +29,7 @@ char* nr_php_wordpress_core_match_regex(const char* filename TSRMLS_DC);
  */
 char* nr_php_wordpress_plugin_match_regex(const char* filename TSRMLS_DC);
 
+extern void nr_wordpress_minit(void);
+extern void nr_wordpress_mshutdown(void);
+
 #endif /* FW_WORDPRESS_HDR */

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -22,6 +22,7 @@
 #include "php_vm.h"
 #include "php_wrapper.h"
 #include "fw_laravel.h"
+#include "fw_wordpress.h"
 #include "lib_guzzle4.h"
 #include "lib_guzzle6.h"
 #include "nr_agent.h"
@@ -34,9 +35,6 @@
 #include "util_strings.h"
 #include "util_syscalls.h"
 #include "util_threads.h"
-
-#include "fw_laravel.h"
-#include "lib_guzzle4.h"
 
 static void php_newrelic_init_globals(zend_newrelic_globals* nrg) {
   if (nrunlikely(NULL == nrg)) {
@@ -709,6 +707,7 @@ PHP_MINIT_FUNCTION(newrelic) {
   nr_guzzle4_minit(TSRMLS_C);
   nr_guzzle6_minit(TSRMLS_C);
   nr_laravel_minit(TSRMLS_C);
+  nr_wordpress_minit();
   nr_php_set_opcode_handlers();
 
   nrl_debug(NRL_INIT, "MINIT processing done");

--- a/agent/php_mshutdown.c
+++ b/agent/php_mshutdown.c
@@ -15,6 +15,7 @@
 #include "php_vm.h"
 #include "nr_agent.h"
 #include "util_logging.h"
+#include "fw_wordpress.h"
 
 #ifdef TAGS
 void zm_shutdown_newrelic(void); /* ctags landing pad only */
@@ -38,6 +39,8 @@ PHP_MSHUTDOWN_FUNCTION(newrelic) {
    * It is assumed that this MSHUTDOWN is only done once per PHP process.
    */
   nrl_debug(NRL_INIT, "MSHUTDOWN processing started");
+
+  nr_wordpress_mshutdown();
 
   /* restore header handler */
   sapi_module.header_handler = NR_PHP_PROCESS_GLOBALS(orig_header_handler);

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -379,7 +379,6 @@ int symfony1_in_error404; /* Whether we are currently within a
                              sfError404Exception::printStackTrace() frame */
 
 char* wordpress_tag;                   /* The current WordPress tag */
-nr_regex_t* wordpress_hook_regex;      /* Regex to sanitize hook names */
 nr_regex_t* wordpress_plugin_regex;    /* Regex for plugin filenames */
 nr_regex_t* wordpress_theme_regex;     /* Regex for theme filenames */
 nr_regex_t* wordpress_core_regex;      /* Regex for plugin filenames */

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -89,14 +89,6 @@ PHP_RINIT_FUNCTION(newrelic) {
     nr_php_extension_instrument_rescan(NRPRG(extensions) TSRMLS_CC);
   }
 
-  /*
-   * Compile regex for WordPress: includes logic for
-   * hook sanitization regex.
-   */
-  NRPRG(wordpress_hook_regex) = nr_regex_create(
-      "(^([a-z_-]+[_-])([0-9a-f_.]+[0-9][0-9a-f.]+)(_{0,1}.*)$|(.*))",
-      NR_REGEX_CASELESS, 0);
-
   NRPRG(mysql_last_conn) = NULL;
   NRPRG(pgsql_last_conn) = NULL;
   NRPRG(datastore_connections) = nr_hashmap_create(

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -98,7 +98,6 @@ int nr_php_post_deactivate(void) {
   nr_php_exception_filters_destroy(&NRPRG(exception_filters));
   nr_regex_destroy(&NRPRG(wordpress_plugin_regex));
   nr_regex_destroy(&NRPRG(wordpress_core_regex));
-  nr_regex_destroy(&NRPRG(wordpress_hook_regex));
   nr_regex_destroy(&NRPRG(wordpress_theme_regex));
   nr_hashmap_destroy(&NRPRG(wordpress_file_metadata));
 


### PR DESCRIPTION
Improve agent's performance by compiling `wordpress_hook_regex` once per process at MINIT rather than on every request at RINIT, (and be clean up at MSHUTDOWN rather than RSHUTDOWN).