### PR TITLE
refactor: cache wordpress clean tag values

### DIFF
--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -410,6 +410,10 @@ static void nr_wordpress_call_user_func_array(zend_function* func,
   nr_php_wrap_callable(func, nr_wordpress_wrap_hook TSRMLS_CC);
 }
 
+static void free_tag(void* tag) {
+  nr_free(tag);
+}
+
 /*
  * Some plugins generate transient tag names. We can detect these by checking
  * the substrings returned from our regex rule. If the tag is transient, we
@@ -418,8 +422,7 @@ static void nr_wordpress_call_user_func_array(zend_function* func,
  * Example: (old) add_option__transient_timeout_twccr_382402301f44c883bc0137_cat
  *          (new) add_option__transient_timeout_twccr_*_cat
  */
-static char* nr_wordpress_clean_tag(const zval* tag TSRMLS_DC) {
-  char* orig_tag = NULL;
+static char* nr_wordpress_clean_tag(const zval* tag) {
   char* clean_tag = NULL;
   nr_regex_t* regex = NULL;
   nr_regex_substrings_t* ss = NULL;
@@ -433,8 +436,16 @@ static char* nr_wordpress_clean_tag(const zval* tag TSRMLS_DC) {
     return NULL;
   }
 
-  orig_tag = nr_strndup(Z_STRVAL_P(tag), Z_STRLEN_P(tag));
-  ss = nr_regex_match_capture(regex, orig_tag, nr_strlen(orig_tag));
+  if (NULL == NRPRG(wordpress_clean_tag_cache)) {
+    NRPRG(wordpress_clean_tag_cache) = nr_hashmap_create(free_tag);
+  }
+
+  if (nr_hashmap_get_into(NRPRG(wordpress_clean_tag_cache), Z_STRVAL_P(tag),
+                          Z_STRLEN_P(tag), (void**)&clean_tag)) {
+    return clean_tag;
+  }
+
+  ss = nr_regex_match_capture(regex, Z_STRVAL_P(tag), Z_STRLEN_P(tag));
   clean_tag = nr_regex_substrings_get(ss, 5);
 
   /*
@@ -455,7 +466,9 @@ static char* nr_wordpress_clean_tag(const zval* tag TSRMLS_DC) {
   }
 
   nr_regex_substrings_destroy(&ss);
-  nr_free(orig_tag);
+
+  nr_hashmap_set(NRPRG(wordpress_clean_tag_cache), Z_STRVAL_P(tag),
+                 Z_STRLEN_P(tag), clean_tag);
 
   return clean_tag;
 }
@@ -479,9 +492,8 @@ NR_PHP_WRAPPER(nr_wordpress_exec_handle_tag) {
      */
     char* old_tag = NRPRG(wordpress_tag);
 
-    NRPRG(wordpress_tag) = nr_wordpress_clean_tag(tag TSRMLS_CC);
+    NRPRG(wordpress_tag) = nr_wordpress_clean_tag(tag);
     NR_PHP_WRAPPER_CALL;
-    nr_free(NRPRG(wordpress_tag));
     NRPRG(wordpress_tag) = old_tag;
   } else {
     NR_PHP_WRAPPER_CALL;
@@ -561,9 +573,8 @@ NR_PHP_WRAPPER(nr_wordpress_apply_filters) {
        */
       char* old_tag = NRPRG(wordpress_tag);
 
-      NRPRG(wordpress_tag) = nr_wordpress_clean_tag(tag TSRMLS_CC);
+      NRPRG(wordpress_tag) = nr_wordpress_clean_tag(tag);
       NR_PHP_WRAPPER_CALL;
-      nr_free(NRPRG(wordpress_tag));
       NRPRG(wordpress_tag) = old_tag;
     } else {
       NR_PHP_WRAPPER_CALL;

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -385,6 +385,7 @@ nr_regex_t* wordpress_theme_regex;     /* Regex for theme filenames */
 nr_regex_t* wordpress_core_regex;      /* Regex for plugin filenames */
 nr_hashmap_t* wordpress_file_metadata; /* Metadata for plugin and theme names
                                           given a filename */
+nr_hashmap_t* wordpress_clean_tag_cache; /* Cached clean tags */
 
 char* doctrine_dql; /* The current Doctrine DQL. Only non-NULL while a Doctrine
                        object is on the stack. */

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -101,6 +101,7 @@ int nr_php_post_deactivate(void) {
   nr_regex_destroy(&NRPRG(wordpress_hook_regex));
   nr_regex_destroy(&NRPRG(wordpress_theme_regex));
   nr_hashmap_destroy(&NRPRG(wordpress_file_metadata));
+  nr_hashmap_destroy(&NRPRG(wordpress_clean_tag_cache));
 
   nr_free(NRPRG(mysql_last_conn));
   nr_free(NRPRG(pgsql_last_conn));


### PR DESCRIPTION
Improve agent's performance by caching WordPress 'clean_tag' values of transient tags (hooks) rather than cleaning them with regex matching each time they are encountered in a request.