### PR TITLE
fix(oapi): delay adding a segment to the parent's children for perfor…

### DIFF
--- a/agent/php_api_datastore.c
+++ b/agent/php_api_datastore.c
@@ -208,6 +208,7 @@ PHP_FUNCTION(newrelic_record_datastore_segment) {
       nr_segment_t* child = nr_segment_children_get(&segment->children, i);
       nr_segment_discard(&child);
     }
+    nr_segment_children_deinit(&segment->children);
 #if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
     || defined OVERWRITE_ZEND_EXECUTE_DATA /* not OAPI */
     NRTXN(force_current_segment) = segment->parent;

--- a/agent/php_stacked_segment.c
+++ b/agent/php_stacked_segment.c
@@ -86,7 +86,7 @@ nr_segment_t* nr_php_stacked_segment_move_to_heap(
   }
 
   s->parent = NULL;
-  nr_segment_set_parent(s, stacked->parent);
+  nr_segment_set_parent_delayed_child(s, stacked->parent);
 
   NR_PHP_CURRENT_STACKED_POP(stacked);
 

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -660,6 +660,17 @@ bool nr_segment_set_name(nr_segment_t* segment, const char* name) {
 }
 
 bool nr_segment_set_parent(nr_segment_t* segment, nr_segment_t* parent) {
+  if (nr_segment_set_parent_delayed_child(segment, parent)) {
+    // parent can be NULL here if the segment's parent was already NULL
+    if (NULL != parent) {
+      nr_segment_children_add(&parent->children, segment);
+    }
+    return true;
+  }
+  return false;
+}
+
+bool nr_segment_set_parent_delayed_child(nr_segment_t* segment, nr_segment_t* parent) {
   nr_segment_t* ancestor = NULL;
 
   if (NULL == segment) {
@@ -695,7 +706,6 @@ bool nr_segment_set_parent(nr_segment_t* segment, nr_segment_t* parent) {
     nr_segment_children_remove(&segment->parent->children, segment);
   }
 
-  nr_segment_children_add(&parent->children, segment);
   segment->parent = parent;
 
   return true;

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -868,6 +868,17 @@ void nr_segment_destroy_tree(nr_segment_t* root) {
       root, (nr_segment_iter_t)nr_segment_destroy_children_callback, NULL);
 }
 
+void nr_segment_end_tree(nr_segment_t* curr, nr_segment_t* root) {
+  nr_segment_t* next;
+  if (NULL == curr || root == NULL) {return;}
+  next = curr->parent;
+  while (curr != root) {
+    nr_segment_end(&curr);
+    curr = next;
+    next = curr->parent;
+  }
+}
+
 bool nr_segment_discard(nr_segment_t** segment_ptr) {
   nr_segment_t* segment = NULL;
   nrtxn_t* txn = NULL;

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -570,6 +570,20 @@ extern void nr_segment_heap_to_set(nr_minmax_heap_t* heap, nr_set_t* set);
 extern void nr_segment_destroy_tree(nr_segment_t* root);
 
 /*
+ * Purpose : end all active segments
+ *
+ * Params  : 1. the current active segment on a tree
+ *           2. The root segment for that tree (may not be the root
+ *                segment of the transaction in an async context)
+ *
+ * WARNING : This should only be called during transaction destruction.
+ *           In non-testing scenarios, if this is ever called with
+ *           curr != root, something has gone wrong
+ *
+ */
+extern void nr_segment_end_tree(nr_segment_t* curr, nr_segment_t* root);
+
+/*
  * Purpose : Discard and free a single segment.
  *
  * Params  : 1. The address of a segment.

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -372,6 +372,19 @@ extern bool nr_segment_set_name(nr_segment_t* segment, const char* name);
 extern bool nr_segment_set_parent(nr_segment_t* segment, nr_segment_t* parent);
 
 /*
+ * Purpose : Set the parent of a segment. Does not add the segment to its
+ *           parent's children list.
+ *
+ * Params  : 1. The pointer to the segment to be parented.
+ *           2. The pointer to the segment to become the new parent.
+ *
+ * Returns : true if successful, false otherwise. If the target segment
+ *           is an ancestor of the target parent, the function will return
+ *           false to prevent a cycle from being created.
+ */
+extern bool nr_segment_set_parent_delayed_child(nr_segment_t* segment, nr_segment_t* parent);
+
+/*
  * Purpose : Set the timing of a segment.
  *
  * Params  : 1. The pointer to the segment to be retimed.

--- a/axiom/nr_segment_datastore.c
+++ b/axiom/nr_segment_datastore.c
@@ -118,6 +118,7 @@ bool nr_segment_datastore_end(nr_segment_t** segment_ptr,
       nr_segment_t* child = nr_segment_children_get(&segment->children, i);
       nr_segment_discard(&child);
     }
+    nr_segment_children_deinit(&segment->children);
   }
 
   if (nr_datastore_is_sql(params->datastore.type)) {

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -409,6 +409,15 @@ static void nr_segment_discard_wrapper(nr_segment_t* segment,
 
   txn = segment->txn;
 
+  if(segment->parent->async_context == segment->async_context) {
+    /*
+     * nr_segment_discard only removes the segment from its parent's
+     * children list if they are in separate async contexts. But at
+     * the point of call of this function, all segments have been
+     * added to their parent's children list.
+     */
+    nr_segment_children_remove(&segment->parent->children, segment);
+  }
   if (!nr_segment_discard(&segment)) {
     /*
      * Something must be seriously messed up if one ends up here.

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -1238,6 +1238,7 @@ void nr_txn_create_rollup_metrics(nrtxn_t* txn) {
 }
 
 void nr_txn_destroy_fields(nrtxn_t* txn) {
+  nr_segment_end_tree(nr_txn_get_current_segment(txn, NULL), txn->segment_root);
   nr_log_events_destroy(&txn->log_events);
   nr_analytics_events_destroy(&txn->custom_events);
   nr_attribute_config_destroy(&txn->attribute_config);

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -409,10 +409,10 @@ static void nr_segment_discard_wrapper(nr_segment_t* segment,
 
   txn = segment->txn;
 
-  if(segment->parent->async_context == segment->async_context) {
+  if(0 == segment->async_context) {
     /*
      * nr_segment_discard only removes the segment from its parent's
-     * children list if they are in separate async contexts. But at
+     * children list if they are in an async contexts. But at
      * the point of call of this function, all segments have been
      * added to their parent's children list.
      */

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -7802,13 +7802,9 @@ static void test_max_segments(void) {
    * Start a default and an async segment
    */
   s1 = nr_segment_start(txn, NULL, NULL);
-  s2 = nr_segment_start(txn, NULL, NULL);
-  s3 = nr_segment_start(txn, NULL, NULL);
-  s4 = nr_segment_start(txn, NULL, NULL);
-
-  nr_segment_set_parent(s2, s1);
-  nr_segment_set_parent(s3, s1);
-  nr_segment_set_parent(s4, s3);
+  s2 = nr_segment_start(txn, s1, NULL);
+  s3 = nr_segment_start(txn, s1, NULL);
+  s4 = nr_segment_start(txn, s3, NULL);
 
   nr_segment_set_timing(s1, 0, 10000);
   nr_segment_set_timing(s2, 2000, 10000);


### PR DESCRIPTION
…mance gains.

This seems to create some volatility in the test tests/integration/external/curl_multi_exec/test_span_sets_method.php, with the correct spans being created, but their order being non-deterministic. The integration runner is unable to properly match the spans due to the differences between them being in the metadata, so the runner has already matched the spans before seeing the differences in metadata

This is an alternative approach to https://github.com/newrelic/newrelic-php-agent/pull/801 and only 1 of the 2 should be merged.