### PR TITLE
tests: make tests deterministic

### DIFF
--- a/tests/include/helpers.php
+++ b/tests/include/helpers.php
@@ -31,8 +31,8 @@ function force_error() {
  * A user function has to be called to force a transaction trace. PHP 7.1
  * includes dead code elimination, which means that we have to actually do
  * something that can't be eliminated: re-setting the error reporting level to
- * what it already is will do the job.
+ * what it already is will do the job. Additionally force non-zero duration for the segment not to be dropped.
  */
 function force_transaction_trace() {
-  error_reporting(error_reporting());
+  error_reporting(error_reporting()); time_nanosleep(0, 50000); // 50usec should be enough
 }

--- a/tests/integration/ini/test_transaction_tracer_max_segments.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments.php
@@ -82,7 +82,7 @@ newrelic.distributed_tracing_enabled=0
 
 
 function my_function(){
-    printf('');
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped, 50usec should be enough
 }
 
 newrelic_add_custom_tracer("my_function");

--- a/tests/integration/ini/test_transaction_tracer_max_segments_nested.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_nested.php
@@ -177,7 +177,7 @@ newrelic.distributed_tracing_enabled=0
 
 
 function my_function() {
-    printf('');
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped, 50usec should be enough
 }
 function grandmother(){
     for ($i = 0; $i < 1000; $i++) {

--- a/tests/integration/ini/test_transaction_tracer_max_segments_nested.php5.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_nested.php5.php
@@ -126,7 +126,7 @@ newrelic.code_level_metrics.enabled=false
 
 
 function my_function() {
-    printf('');
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped, 50usec should be enough
 }
 function grandmother(){
     for ($i = 0; $i < 1000; $i++) {

--- a/tests/integration/ini/test_transaction_tracer_max_segments_no_cap.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_no_cap.php
@@ -82,7 +82,7 @@ newrelic.distributed_tracing_enabled=0
 
 
 function my_function(){
-    printf('');
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped, 50usec should be enough
 }
 
 newrelic_add_custom_tracer("my_function");

--- a/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php
@@ -123,7 +123,7 @@ newrelic.distributed_tracing_enabled=0
 
 
 function my_function(){
-    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped, 50usec should be enough
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped; duration needs to be shorter than datastore segment
 }
 
 newrelic_add_custom_tracer("my_function");
@@ -133,7 +133,7 @@ my_function();
 my_function();
 
 newrelic_record_datastore_segment(function () {
-    return 42;
+    time_nanosleep(0, 70000); return 42; // force non-zero duration for the segment not to be dropped; duration needs to be longer than user func segment
 }, array(
     'product'       => 'mysql',
     'collection'    => 'table',

--- a/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php
@@ -123,7 +123,7 @@ newrelic.distributed_tracing_enabled=0
 
 
 function my_function(){
-  printf('');
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped, 50usec should be enough
 }
 
 newrelic_add_custom_tracer("my_function");

--- a/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php5.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php5.php
@@ -112,7 +112,7 @@ newrelic.code_level_metrics.enabled=false
 
 
 function my_function(){
-  printf('');
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped, 50usec should be enough
 }
 
 newrelic_add_custom_tracer("my_function");

--- a/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php5.php
+++ b/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php5.php
@@ -112,7 +112,7 @@ newrelic.code_level_metrics.enabled=false
 
 
 function my_function(){
-    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped, 50usec should be enough
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped; duration needs to be shorter than datastore segment
 }
 
 newrelic_add_custom_tracer("my_function");
@@ -122,7 +122,7 @@ my_function();
 my_function();
 
 newrelic_record_datastore_segment(function () {
-    return 42;
+    time_nanosleep(0, 70000); return 42; // force non-zero duration for the segment not to be dropped; duration needs to be longer than user func segment
 }, array(
     'product'       => 'mysql',
     'collection'    => 'table',


### PR DESCRIPTION
1. [Force non-zero duration of helper user function](https://github.com/newrelic/newrelic-php-agent/pull/781/commits/3b30afde42664a5fb00408a9e0f1d43e4770cbae)
When tests execute fast enough, the helper function's segment start time and end time are equal and this causes the segment to be dropped (see [here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/axiom/nr_segment_traces.c#L371-L378)). However, some integration tests have inconsistent test expectation in expected transaction traces (all tests that use `force_transaction_trace`, defined in `tests/include/helpers.php`, e.g. many tests in `tests/integration/attributes`). On one hand, wildcard match is used for trace details (e.g. [here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/tests/integration/attributes/test_enabled.php#L86)) but on the other hand segment names are expected to match exactly (e.g. [here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/tests/integration/attributes/test_enabled.php#L95-L98)). On faster hardware this discrepancy will cause such tests to fail. To address this test instability, non-zero duration is forced on test helper user function `force_transaction_trace`.

2. [Adjust forced duration to ensure expected sampling](https://github.com/newrelic/newrelic-php-agent/pull/781/commits/9e54713f99cf020f2dfd9ca5dd6e9132cdd2f030)
`tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php` expects datastore segment, created with `newrelic_record_datastore_segment`, to have longer duration than the at least one execution of custom instrumented user function `my_function`, and therefore appear in the transaction trace [here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php#L77). There is, however, absolutely no apparent reason for that to happen.  `tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php` test limits the number of recorded segments to 3 with this ini setting: `newrelic.transaction_tracer.max_segments_cli=3`. 
This has direct impact on the size of the heap of segments kept, created [here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/axiom/nr_txn.c#L588-L594). The test creates more than 3 segments - 3 for custom traced my_function ([here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php#L131-L133)) and 1 datastore segment ([here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/tests/integration/ini/test_transaction_tracer_max_segments_with_datastore.php#L135-L145)). However neither of the segments have a well defined, deterministic duration. Duration is used to determine which segment gets kept and which one gets dropped at the time the segment gets ended [here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/axiom/nr_segment.c#L732). Note [here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/axiom/nr_txn.c#L588-L594), when the heap of segments kept heap is created, `nr_segment_wrapped_span_priority_comparator` is set to determine min and max values of elements in the heap. However, in this particular test, both segments have the same, default priority of 0 (priorities are defined [here](https://github.com/newrelic/newrelic-php-agent/blob/1563e8045968fe0c6ee228c566ca080afceba6c1/axiom/nr_segment.h#L70-L92)). They’re neither root segments, neither segment’s id is used in distributed trace, nor any of the segments has logs or user attributes associated with it. This causes `nr_segment_wrapped_span_priority_comparator` to fall back to `nr_segment_wrapped_duration_comparator`, which leaves things to being more or less random as sometimes the execution of `my_function` is shorter than execution of `newrelic_record_datastore_segment` but other times it is the other way around.
