### PR TITLE
fix: remove warning message for `NULL` Docker ID

### DIFF
--- a/agent/php_environment.c
+++ b/agent/php_environment.c
@@ -608,9 +608,6 @@ void nr_php_gather_v2_docker_id() {
   if (NULL != dockerId) {
     NR_PHP_PROCESS_GLOBALS(docker_id) = dockerId;
     nrl_verbosedebug(NRL_AGENT, "%s: Docker v2 ID: %s", __func__, dockerId);
-  } else {
-    nrl_warning(NRL_AGENT, "%s: Unable to read docker v2 container id",
-                __func__);
   }
 }
 


### PR DESCRIPTION
Agent should not emit a warning message if the Docker ID was not detected in `/proc/self/mountinfo`. 
Non-dockerized and Non-docker V2 applications will not have this value.