### PR TITLE
refactor: reduce # of wp plugin/theme name calculation

### DIFF
--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -91,6 +91,9 @@ typedef struct _nruserfn_t {
   nr_string_len_t drupal_module_len;
   char* drupal_hook;
   nr_string_len_t drupal_hook_len;
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO
+  char* wordpress_plugin_theme;
+#endif
 } nruserfn_t;
 
 extern nruserfn_t* nr_wrapped_user_functions; /* a singly linked list */


### PR DESCRIPTION
Improve agent's performance by figuring out the plugin/theme name at the point an action or filter is added and store it in the wraprec rather than doing it at runtime (which is slow, even with memoization in `wordpress_file_metadata` hashmap).