### PR TITLE
refactor: suggestion to #765

### DIFF
--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -65,16 +65,6 @@ static nr_matcher_t* create_matcher_for_constant(const char* constant,
 static inline char* nr_wordpress_strip_php_suffix(char* filename, int filename_len) {
   char* retval = NULL;
 
-  if (NULL == filename || 0 >= filename_len) {
-    return NULL;
-  }
-
-  if (4 >= filename_len) {
-    /* if filename_len <= 4, there can't be a ".php" substring to remove. Assume
-     * the filename does not contain ".php" and return the original filename. */
-    return filename;
-  }
-
   if (!nr_striendswith(filename, filename_len, NR_PSTR(".php"))) {
     return filename;
   }

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -210,7 +210,7 @@ static char* nr_wordpress_plugin_from_function(zend_function* func TSRMLS_DC) {
                      NRP_PHP(NRPRG(wordpress_tag)));
     return NULL;
   }
-  filename_len = func->op_array.filename->len; // temp hack - should be nr_php_function_filename_len(func);
+  filename_len = nr_php_function_filename_len(func);
 
   if (NRPRG(wordpress_file_metadata)) {
     if (nr_hashmap_get_into(NRPRG(wordpress_file_metadata), filename,

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -702,6 +702,11 @@ nr_php_op_array_scope_name(const zend_op_array* op_array) {
   return NULL;
 }
 
+static inline nr_string_len_t NRPURE
+nr_php_function_filename_len(zend_function* func) {
+  return func ? nr_php_op_array_file_name_len(&func->op_array) : 0;
+}
+
 static inline const char* NRPURE
 nr_php_ini_entry_name(const zend_ini_entry* entry) {
 #if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */

--- a/axiom/tests/test_matcher.c
+++ b/axiom/tests/test_matcher.c
@@ -63,9 +63,49 @@ static void test_match_single(void) {
   nr_matcher_destroy(&matcher);
 }
 
+static void test_match_ex(void) {
+  char* found;
+  int len;
+  nr_matcher_t* matcher = nr_matcher_create();
+
+  nr_matcher_add_prefix(matcher, "/foo/bar");
+  found = nr_matcher_match_ex(matcher, NR_PSTR(""), &len);
+  tlib_pass_if_null("needle not matched", found);
+  tlib_pass_if_equal("needle match len", 0, len, int, "%d")
+  nr_free(found);
+
+  found = nr_matcher_match_ex(matcher, NR_PSTR("foo"), &len);
+  tlib_pass_if_null("needle not matched", found);
+  tlib_pass_if_equal("needle match len", 0, len, int, "%d")
+  nr_free(found);
+
+  found = nr_matcher_match_ex(matcher, NR_PSTR("/bar"), &len);
+  tlib_pass_if_null("needle not matched", found);
+  tlib_pass_if_equal("needle match len", 0, len, int, "%d")
+  nr_free(found);
+
+  found = nr_matcher_match_ex(matcher, NR_PSTR("/foo/bar/quux"), &len);
+  tlib_pass_if_str_equal("needle match", "quux", found);
+  tlib_pass_if_equal("needle match len", 4, len, int, "%d")
+  nr_free(found);
+
+  found = nr_matcher_match_ex(matcher, NR_PSTR("/foo/bar//quux"), &len);
+  tlib_pass_if_str_equal("needle match", "", found);
+  tlib_pass_if_equal("needle match len", 0, len, int, "%d")
+  nr_free(found);
+
+  found = nr_matcher_match_ex(matcher, NR_PSTR("/foo/bar/quux/baz"), &len);
+  tlib_pass_if_str_equal("needle match", "quux", found);
+  tlib_pass_if_equal("needle match len", 4, len, int, "%d")
+  nr_free(found);
+
+  nr_matcher_destroy(&matcher);
+}
+
 tlib_parallel_info_t parallel_info = {.suggested_nthreads = 2, .state_size = 0};
 
 void test_main(void* p NRUNUSED) {
   test_match_multiple();
   test_match_single();
+  test_match_ex();
 }

--- a/axiom/util_matcher.c
+++ b/axiom/util_matcher.c
@@ -52,8 +52,8 @@ bool nr_matcher_add_prefix(nr_matcher_t* matcher, const char* str) {
     prefix->len--;
   }
 
-  prefix->len += 1;
-  prefix->cp = nr_malloc(prefix->len+1);
+  prefix->len += 1; // +1 for the trailing '/'
+  prefix->cp = nr_malloc(prefix->len+1); // +1 for the '\0'
   for (i = 0; i < prefix->len; i++) {
     prefix->cp[i] = nr_tolower(str[i]);
   }

--- a/axiom/util_matcher.c
+++ b/axiom/util_matcher.c
@@ -46,14 +46,19 @@ bool nr_matcher_add_prefix(nr_matcher_t* matcher, const char* str) {
     return false;
   }
 
-  prefix = nr_calloc(1, sizeof(matcher_prefix));
+  if (NULL == (prefix = nr_calloc(1, sizeof(matcher_prefix)))) {
+    return false;
+  }
   prefix->len = nr_strlen(str);
   while (prefix->len > 0 && '/' == str[prefix->len - 1]) {
     prefix->len--;
   }
 
   prefix->len += 1; // +1 for the trailing '/'
-  prefix->cp = nr_malloc(prefix->len+1); // +1 for the '\0'
+  if (NULL == (prefix->cp = nr_malloc(prefix->len+1))) { // +1 for the '\0'
+    nr_matcher_prefix_dtor(prefix, NULL);
+    return false;
+  }
   for (i = 0; i < prefix->len; i++) {
     prefix->cp[i] = nr_tolower(str[i]);
   }

--- a/axiom/util_matcher.h
+++ b/axiom/util_matcher.h
@@ -16,8 +16,10 @@ extern void nr_matcher_destroy(nr_matcher_t** matcher_ptr);
 
 extern bool nr_matcher_add_prefix(nr_matcher_t* matcher, const char* prefix);
 
+extern char* nr_matcher_match_ex(nr_matcher_t* matcher, const char* input, int input_len, int* match_len);
 extern char* nr_matcher_match(nr_matcher_t* matcher, const char* input);
 
+extern char* nr_matcher_match_core_ex(nr_matcher_t* matcher, const char* input, int input_len, int* match_len);
 extern char* nr_matcher_match_core(nr_matcher_t* matcher, const char* input);
 
 #endif

--- a/axiom/util_strings.h
+++ b/axiom/util_strings.h
@@ -20,7 +20,6 @@
 #include <string.h>
 
 #include "util_object.h"
-#include "util_memory.h"
 
 /*
  * Purpose : Convert a string to lower case, following USASCII rules, returning
@@ -471,37 +470,6 @@ static inline bool nr_striendswith(const char* s,
   /* compare input's suffix with the pattern and return result */
   suffix = s + (slen - pattern_len);
   return 0 == nr_stricmp(suffix, pattern);
-}
-
-/*
- * Purpose : Strip the ".php" file extension from a file name
- *
- * Params  : 1. The string filename
- *           2. The filename length
- *
- * Returns : A newly allocated string stripped of the .php extension
- *
- */
-static inline char* nr_file_basename(char* filename, int filename_len) {
-  char* retval = NULL;
-
-  if (NULL == filename || 0 >= filename_len) {
-    return NULL;
-  }
-
-  if (4 >= filename_len) {
-    /* if filename_len <= 4, there can't be a ".php" substring to remove. Assume
-     * the filename does not contain ".php" and return the original filename. */
-    return filename;
-  }
-
-  if (!nr_striendswith(filename, filename_len, NR_PSTR(".php"))) {
-    return filename;
-  }
-
-  retval = nr_strndup(filename, filename_len - (sizeof(".php") - 1));
-  nr_free(filename);
-  return retval;
 }
 
 #endif /* UTIL_STRINGS_HDR */


### PR DESCRIPTION
A couple of suggestions to #765:
1. Save time by using pre-calculated string lengths vs calling strlen whenever possible
2. Move `nr_file_basename` as `nr_wordpress_strip_php_suffix` back to `fw_wordpress.c`