### PR TITLE
refactor: improve performance of wrap_generic_callable

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -124,11 +124,11 @@ typedef void (*nr_library_enable_fn_t)(TSRMLS_D);
     avail = avail - 3;                        \
   }
 
-static int nr_format_zval_for_debug(zval* arg,
-                                    char* pbuf,
-                                    size_t pos,
-                                    size_t avail,
-                                    size_t depth TSRMLS_DC) {
+int nr_format_zval_for_debug(zval* arg,
+                             char* pbuf,
+                             size_t pos,
+                             size_t avail,
+                             size_t depth TSRMLS_DC) {
   nr_string_len_t len;
   nr_string_len_t i;
   char* str;

--- a/agent/php_user_instrument.h
+++ b/agent/php_user_instrument.h
@@ -27,10 +27,6 @@ typedef struct nrspecialfn_return_t (*nrspecialfn_t)(
 
 typedef void (*nruserfn_declared_t)(TSRMLS_D);
 
-typedef enum {
-  NR_WRAPREC_NOT_TRANSIENT = 0,
-  NR_WRAPREC_IS_TRANSIENT = 1
-} nr_transience_t;
 /*
  * An equivalent data structure for user functions.
  *
@@ -79,7 +75,7 @@ typedef struct _nruserfn_t {
                                */
   int is_names_wt_simple;     /* True if this function "names" its enclosing WT;
                                  the first such function does the naming */
-  nr_transience_t transience; /* Wraprecs that are transient are destroyed
+  bool is_transient;          /* Wraprecs that are transient are destroyed
                                  after each request. Wraprecs that are
                                  non-transient are kept until module shutdown.
                                  Currently, while all wraprecs are stored
@@ -161,8 +157,7 @@ extern void nr_php_add_custom_tracer(const char* namestr,
 extern nruserfn_t* nr_php_add_custom_tracer_callable(
     zend_function* func TSRMLS_DC);
 extern nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
-                                                  size_t namestrlen,
-                                                  nr_transience_t transience TSRMLS_DC);
+                                                  size_t namestrlen);
 extern void nr_php_reset_user_instrumentation(void);
 extern void nr_php_remove_transient_user_instrumentation(void);
 extern void nr_php_add_user_instrumentation(TSRMLS_D);

--- a/agent/php_wrapper.c
+++ b/agent/php_wrapper.c
@@ -47,16 +47,7 @@ static char* Z_TYPE_STR(zval* zv) {
 nruserfn_t* nr_php_wrap_user_function(const char* name,
                                       size_t namelen,
                                       nrspecialfn_t callback TSRMLS_DC) {
-  return nr_php_wrap_user_function_with_transience(name, namelen, callback,
-                                                   NR_WRAPREC_NOT_TRANSIENT TSRMLS_CC);
-}
-
-nruserfn_t* nr_php_wrap_user_function_with_transience(const char* name,
-                                                 size_t namelen,
-                                                 nrspecialfn_t callback,
-                                                 nr_transience_t transience TSRMLS_DC) {
-  nruserfn_t* wraprec = nr_php_add_custom_tracer_named(name, namelen,
-                                                       transience TSRMLS_CC);
+  nruserfn_t* wraprec = nr_php_add_custom_tracer_named(name, namelen);
 
   if (wraprec && callback) {
     if ((NULL != wraprec->special_instrumentation)

--- a/agent/php_wrapper.h
+++ b/agent/php_wrapper.h
@@ -89,11 +89,6 @@ extern nruserfn_t* nr_php_wrap_user_function(const char* name,
                                              size_t namelen,
                                              nrspecialfn_t callback TSRMLS_DC);
 
-extern nruserfn_t* nr_php_wrap_user_function_with_transience(const char* name,
-                                                             size_t namelen,
-                                                             nrspecialfn_t callback,
-                                                             nr_transience_t TSRMLS_DC);
-
 extern nruserfn_t* nr_php_wrap_user_function_extra(const char* name,
                                                    size_t namelen,
                                                    nrspecialfn_t callback,

--- a/agent/php_zval.h
+++ b/agent/php_zval.h
@@ -417,4 +417,14 @@ static inline zval* nr_php_zval_real_value(zval* zv) {
 
 /* }}} */
 
+/* {{{ Debugging functions */
+
+extern int nr_format_zval_for_debug(zval* arg,
+                                    char* pbuf,
+                                    size_t pos,
+                                    size_t avail,
+                                    size_t depth TSRMLS_DC);
+
+/* }}} */
+
 #endif /* PHP_ZVAL_HDR */

--- a/agent/tests/test_user_instrument.c
+++ b/agent/tests/test_user_instrument.c
@@ -97,7 +97,7 @@ static void test_hashmap_wraprec() {
 
   /* instrument user function */
   user_func1_wraprec = nr_php_add_custom_tracer_named(
-      user_func1_name, nr_strlen(user_func1_name), NR_WRAPREC_NOT_TRANSIENT );
+      user_func1_name, nr_strlen(user_func1_name));
   wraprec_found = nr_php_get_wraprec(user_func1_zf);
   tlib_pass_if_ptr_equal("lookup instrumented user function succeeds",
                          wraprec_found, user_func1_wraprec);

--- a/tests/integration/frameworks/drupal/skipif.inc
+++ b/tests/integration/frameworks/drupal/skipif.inc
@@ -1,0 +1,9 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+if (version_compare(PHP_VERSION, "8.2", ">=")) {
+  die("skip: PHP >= 8.2 not supported\n");
+}

--- a/tests/integration/frameworks/drupal/test_invoke_all_with.php
+++ b/tests/integration/frameworks/drupal/test_invoke_all_with.php
@@ -26,6 +26,7 @@ b2
 a3
 b4
 b4
+b2
 */
 
 /*EXPECT_METRICS
@@ -37,11 +38,11 @@ b4
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Framework/Drupal/Hook/hook_1"},                         [2, "??", "??", "??", "??", "??"]],
-    [{"name":"Framework/Drupal/Hook/hook_2"},                         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Hook/hook_2"},                         [2, "??", "??", "??", "??", "??"]],
     [{"name":"Framework/Drupal/Hook/hook_3"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Framework/Drupal/Hook/hook_4"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Framework/Drupal/Module/module_a"},                     [2, "??", "??", "??", "??", "??"]],
-    [{"name":"Framework/Drupal/Module/module_b"},                     [3, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Module/module_b"},                     [4, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/all"},                                 [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransaction/php__FILE__"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime"},                            [1, "??", "??", "??", "??", "??"]],
@@ -49,9 +50,12 @@ b4
     [{"name":"Supportability/framework/Drupal8/forced"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},        [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},           [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/api/add_custom_tracer"},                 [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/api/add_custom_tracer"},                 [2, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/invoke_callback_instrumented"},                  [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Custom/invoke_callback"},                               [1, "??", "??", "??", "??", "??"]],
     [{"name":"Custom/invoke_callback_instrumented",
+      "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Custom/invoke_callback",
       "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},  [1, "??", "??", "??", "??", "??"]]
   ]
@@ -127,5 +131,15 @@ $handler->invokeallwith("hook_4", [$page_cache, "get"]);
 /* At this point, module_b_hook_4 should NOT be instrumented */
 
 // test string callback; function already instrumented
+// This will reuse the existing wraprec and successfully
+// add instrumentation because the "before" callback is unset
 $func_name = "invoke_callback_instrumented";
 $handler->invokeallwith("hook_4", $func_name);
+
+// test non-transiently wrapping an already transiently instrumented function
+// This will overwrite the existing transient wrapper
+$func_name = "invoke_callback";
+newrelic_add_custom_tracer($func_name);
+// Now this test will function the same as above: adding special instrumentation
+// to an already existing wrapper
+$handler->invokeallwith("hook_2", $func_name);

--- a/tests/integration/frameworks/drupal/test_module_invoke_all.php
+++ b/tests/integration/frameworks/drupal/test_module_invoke_all.php
@@ -1,0 +1,87 @@
+<?php
+
+/*DESCRIPTION
+Tests Drupal 7 hook invoking methods
+*/
+
+// force the framework to avoid requiring the drupal detection file
+/*INI
+newrelic.framework = drupal
+newrelic.application_logging.enabled = false
+newrelic.application_logging.forwarding.enabled = false
+newrelic.application_logging.metrics.enabled = false
+*/
+
+/*SKIPIF
+require("skipif.inc");
+*/
+
+/*EXPECT
+module_hook_with_arg(arg=[arg_value])
+g
+h
+f
+h
+f
+*/
+
+/*EXPECT_METRICS
+[
+  "?? agent run id",
+  "?? timeframe start",
+  "?? timeframe stop",
+  [
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"},
+                                                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"},
+                                                                    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Forwarding/PHP/disabled"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/Logging/Metrics/PHP/disabled"},       [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Hook/hook_with_arg"},    [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Hook/f"},                [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Hook/g"},                [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Hook/h"},                [2, "??", "??", "??", "??", "??"]],
+    [{"name":"Framework/Drupal/Module/module"},         [5, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransaction/all"},                   [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransaction/php__FILE__"},           [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransactionTotalTime"},              [1, "??", "??", "??", "??", "??"]],
+    [{"name":"OtherTransactionTotalTime/php__FILE__"},  [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/framework/Drupal/forced"}, [1,    0,    0,    0,    0,    0]]
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+
+function module_invoke_all($f) {
+    $args = func_get_args();
+    unset($args[0]);
+    call_user_func_array("module_" . $f, $args);
+}
+
+function module_h() {
+    echo "h\n";
+    throw new Exception("Test Exception");
+}
+
+function module_f() {
+    try {
+        module_invoke_all("h");
+    } catch (Exception $e) {
+        echo "f\n";
+    }
+}
+
+function module_g() {
+    echo "g\n";
+    module_f();
+}
+
+function module_hook_with_arg($arg) {
+        echo "module_hook_with_arg(arg=[$arg])\n";
+}
+
+module_invoke_all("hook_with_arg", "arg_value");
+module_invoke_all("g");
+module_invoke_all("f");


### PR DESCRIPTION
`nr_php_wrap_generic_callable` is used to create transient wraprecs for callables which **_don't require to be named_**. This assumption makes it possible to stay DRY and reuse `nr_php_zval_to_function` in lieu of complex pattern matching for the type of callable. This reduces agent's performance overhead as it now uses `nr_php_wrap_callable` always instead of sometimes using `nr_php_wrap_user_function_with_transience(IS_TRANSIENT)`. This is an alternative to #665 which obsoletes and removes #679 and makes #770 no longer needed.

TL:DR; The agent's performance overhead when `nr_php_wrap_user_function_with_transience(IS_TRANSIENT)` is used comes from the need to walk the linked list of named wraprecs in `nr_php_add_custom_tracer_named` [here](https://github.com/newrelic/newrelic-php-agent/blob/5a1ef2bcd7ed1e5ffde87c9175cce8e41abb8268/agent/php_user_instrument.c#L413-L426).