### PR TITLE
tests: fix deprecated redis function tests

### DIFF
--- a/tests/integration/redis/test_instance_list.php
+++ b/tests/integration/redis/test_instance_list.php
@@ -89,8 +89,7 @@ function test_redis() {
   tap_equal(2, $redis->rPush($key, 'C'), 'append C');
   tap_equal(3, $redis->lPush($key, 'A'), 'prepend A');
 
-  /* Redis->lGet is deprecated, but use it once to verify it works */
-  tap_equal('A', @$redis->lGet($key, 0), 'retrieve element 0');
+  tap_equal('A', $redis->lIndex($key, 0), 'retrieve element 0');
   tap_equal('B', $redis->lIndex($key, 1), 'retrieve element 1');
   tap_equal('C', $redis->lIndex($key, 2), 'retrieve element 2');
   tap_equal('C', $redis->lIndex($key, -1), 'retrieve last element');
@@ -119,8 +118,7 @@ function test_redis() {
 
   tap_equal(4, $redis->rpush($key, 'A', 'B', 'B', 'C'), 'add new elements');
 
-  /* Redis->lRemove is depreacted, but use it once to verity it works */
-  tap_equal(1, @$redis->lRemove($key, 'B', 1), 'remove first occurence of B');
+  tap_equal(1, @$redis->lRem($key, 'B', 1), 'remove first occurence of B');
   tap_equal(['A', 'B', 'C'], $redis->lrange($key, 0, -1), 'verify list elements');
   tap_equal(0, $redis->lRem($key, 'NOT_IN_LIST', 1), 'remove missing element');
 
@@ -146,7 +144,6 @@ redis_trace_nodes_match($txn, [
   'Datastore/operation/Redis/del',
   'Datastore/operation/Redis/exists',
   'Datastore/operation/Redis/expire',
-  'Datastore/operation/Redis/lget',
   'Datastore/operation/Redis/lindex',
   'Datastore/operation/Redis/linsert',
   'Datastore/operation/Redis/llen',
@@ -155,7 +152,6 @@ redis_trace_nodes_match($txn, [
   'Datastore/operation/Redis/lpushx',
   'Datastore/operation/Redis/lrange',
   'Datastore/operation/Redis/lrem',
-  'Datastore/operation/Redis/lremove',
   'Datastore/operation/Redis/lset',
   'Datastore/operation/Redis/ltrim',
   'Datastore/operation/Redis/rpop',

--- a/tests/integration/redis/test_lget.php
+++ b/tests/integration/redis/test_lget.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Redis metrics including instance information for Redis
+list operations.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(phpversion('redis'), '5.3.7', '>')) {
+  die("skip: Redis <= 5.3.7 required\n");
+}
+
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 1
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+*/
+
+/*EXPECT
+ok - append B
+ok - append C
+ok - prepend A
+ok - retrieve element 0
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/operation/Redis/lGet
+*/
+
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/helpers.php');
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/integration.php');
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/tap.php');
+require_once(realpath (dirname ( __FILE__ )) . '/redis.inc');
+
+function test_redis() {
+  global $REDIS_HOST, $REDIS_PORT;
+
+  $redis = new Redis();
+  $redis->connect($REDIS_HOST, $REDIS_PORT);
+
+  /* generate unique key names to use for this test run */
+  $key = randstr(16);
+  $key2 = "{$key}_b";
+  if ($redis->exists([$key, $key2])) {
+    die("skip: key(s) already exist: $key, $key2\n");
+  }
+
+  /* Ensure the keys don't persist (too much) longer than the test. */
+  $redis->expire($key, 30 /* seconds */);
+  $redis->expire($key2, 30 /* seconds */);
+
+  tap_equal(1, $redis->rPush($key, 'B'), 'append B');
+  tap_equal(2, $redis->rPush($key, 'C'), 'append C');
+  tap_equal(3, $redis->lPush($key, 'A'), 'prepend A');
+
+  /* Redis->lGet is deprecated, but use it once to verify it works */
+  tap_equal('A', @$redis->lGet($key, 0), 'retrieve element 0');
+}

--- a/tests/integration/redis/test_lget.php
+++ b/tests/integration/redis/test_lget.php
@@ -31,7 +31,7 @@ ok - retrieve element 0
 */
 
 /*EXPECT_METRICS_EXIST
-Datastore/operation/Redis/lGet
+Datastore/operation/Redis/lget
 */
 
 require_once(realpath (dirname ( __FILE__ )) . '/../../include/helpers.php');

--- a/tests/integration/redis/test_lget.php
+++ b/tests/integration/redis/test_lget.php
@@ -63,3 +63,5 @@ function test_redis() {
   /* Redis->lGet is deprecated, but use it once to verify it works */
   tap_equal('A', @$redis->lGet($key, 0), 'retrieve element 0');
 }
+
+test_redis();

--- a/tests/integration/redis/test_list.php
+++ b/tests/integration/redis/test_list.php
@@ -82,12 +82,9 @@ ok - rpushx to a list that does not exist
     [{"name":"Datastore/operation/Redis/expire"},                     [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/expire",
       "scope":"OtherTransaction/php__FILE__"},                        [2, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lget"},                       [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lget",
-      "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lindex"},                     [8, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/operation/Redis/lindex"},                     [9, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lindex",
-      "scope":"OtherTransaction/php__FILE__"},                        [8, "??", "??", "??", "??", "??"]],
+      "scope":"OtherTransaction/php__FILE__"},                        [9, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/linsert"},                    [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/linsert",
       "scope":"OtherTransaction/php__FILE__"},                        [2, "??", "??", "??", "??", "??"]],
@@ -106,12 +103,9 @@ ok - rpushx to a list that does not exist
     [{"name":"Datastore/operation/Redis/lrange"},                     [4, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lrange",
       "scope":"OtherTransaction/php__FILE__"},                        [4, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lrem"},                       [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/operation/Redis/lrem"},                       [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lrem",
-      "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lremove"},                    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lremove",
-      "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
+      "scope":"OtherTransaction/php__FILE__"},                        [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lset"},                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lset",
       "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
@@ -141,9 +135,6 @@ ok - rpushx to a list that does not exist
 ]
 */
 
-
-
-
 require_once(realpath (dirname ( __FILE__ )) . '/../../include/helpers.php');
 require_once(realpath (dirname ( __FILE__ )) . '/../../include/tap.php');
 require_once(realpath (dirname ( __FILE__ )) . '/redis.inc');
@@ -169,8 +160,7 @@ function test_redis() {
   tap_equal(2, $redis->rPush($key, 'C'), 'append C');
   tap_equal(3, $redis->lPush($key, 'A'), 'prepend A');
 
-  /* Redis->lGet is deprecated, but use it once to verify it works */
-  tap_equal('A', @$redis->lGet($key, 0), 'retrieve element 0');
+  tap_equal('A', $redis->lIndex($key, 0), 'retrieve element 0');
   tap_equal('B', $redis->lIndex($key, 1), 'retrieve element 1');
   tap_equal('C', $redis->lIndex($key, 2), 'retrieve element 2');
   tap_equal('C', $redis->lIndex($key, -1), 'retrieve last element');
@@ -199,8 +189,7 @@ function test_redis() {
 
   tap_equal(4, $redis->rpush($key, 'A', 'B', 'B', 'C'), 'add new elements');
 
-  /* Redis->lRemove is depreacted, but use it once to verity it works */
-  tap_equal(1, @$redis->lRemove($key, 'B', 1), 'remove first occurence of B');
+  tap_equal(1, @$redis->lRem($key, 'B', 1), 'remove first occurence of B');
   tap_equal(['A', 'B', 'C'], $redis->lrange($key, 0, -1), 'verify list elements');
   tap_equal(0, $redis->lRem($key, 'NOT_IN_LIST', 1), 'remove missing element');
 

--- a/tests/integration/redis/test_list_logging_off.php
+++ b/tests/integration/redis/test_list_logging_off.php
@@ -85,12 +85,9 @@ ok - rpushx to a list that does not exist
     [{"name":"Datastore/operation/Redis/expire"},                     [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/expire",
       "scope":"OtherTransaction/php__FILE__"},                        [2, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lget"},                       [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lget",
-      "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lindex"},                     [8, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/operation/Redis/lindex"},                     [9, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lindex",
-      "scope":"OtherTransaction/php__FILE__"},                        [8, "??", "??", "??", "??", "??"]],
+      "scope":"OtherTransaction/php__FILE__"},                        [9, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/linsert"},                    [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/linsert",
       "scope":"OtherTransaction/php__FILE__"},                        [2, "??", "??", "??", "??", "??"]],
@@ -109,12 +106,9 @@ ok - rpushx to a list that does not exist
     [{"name":"Datastore/operation/Redis/lrange"},                     [4, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lrange",
       "scope":"OtherTransaction/php__FILE__"},                        [4, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lrem"},                       [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Datastore/operation/Redis/lrem"},                       [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lrem",
-      "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lremove"},                    [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Datastore/operation/Redis/lremove",
-      "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
+      "scope":"OtherTransaction/php__FILE__"},                        [2, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lset"},                       [1, "??", "??", "??", "??", "??"]],
     [{"name":"Datastore/operation/Redis/lset",
       "scope":"OtherTransaction/php__FILE__"},                        [1, "??", "??", "??", "??", "??"]],
@@ -144,9 +138,6 @@ ok - rpushx to a list that does not exist
 ]
 */
 
-
-
-
 require_once(realpath (dirname ( __FILE__ )) . '/../../include/helpers.php');
 require_once(realpath (dirname ( __FILE__ )) . '/../../include/tap.php');
 require_once(realpath (dirname ( __FILE__ )) . '/redis.inc');
@@ -172,8 +163,7 @@ function test_redis() {
   tap_equal(2, $redis->rPush($key, 'C'), 'append C');
   tap_equal(3, $redis->lPush($key, 'A'), 'prepend A');
 
-  /* Redis->lGet is deprecated, but use it once to verify it works */
-  tap_equal('A', @$redis->lGet($key, 0), 'retrieve element 0');
+  tap_equal('A', $redis->lIndex($key, 0), 'retrieve element 0');
   tap_equal('B', $redis->lIndex($key, 1), 'retrieve element 1');
   tap_equal('C', $redis->lIndex($key, 2), 'retrieve element 2');
   tap_equal('C', $redis->lIndex($key, -1), 'retrieve last element');
@@ -202,8 +192,7 @@ function test_redis() {
 
   tap_equal(4, $redis->rpush($key, 'A', 'B', 'B', 'C'), 'add new elements');
 
-  /* Redis->lRemove is depreacted, but use it once to verity it works */
-  tap_equal(1, @$redis->lRemove($key, 'B', 1), 'remove first occurence of B');
+  tap_equal(1, @$redis->lRem($key, 'B', 1), 'remove first occurence of B');
   tap_equal(['A', 'B', 'C'], $redis->lrange($key, 0, -1), 'verify list elements');
   tap_equal(0, $redis->lRem($key, 'NOT_IN_LIST', 1), 'remove missing element');
 

--- a/tests/integration/redis/test_lrem.php
+++ b/tests/integration/redis/test_lrem.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Redis metrics including instance information for Redis
+list operations.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(phpversion('redis'), '5.3.7', '>')) {
+  die("skip: Redis <= 5.3.7 required\n");
+}
+
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 1
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+*/
+
+/*EXPECT
+ok - add new elements
+ok - remove first occurence of B
+ok - verify list elements
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/operation/Redis/lRem
+*/
+
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/helpers.php');
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/integration.php');
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/tap.php');
+require_once(realpath (dirname ( __FILE__ )) . '/redis.inc');
+
+function test_redis() {
+  global $REDIS_HOST, $REDIS_PORT;
+
+  $redis = new Redis();
+  $redis->connect($REDIS_HOST, $REDIS_PORT);
+
+  /* generate unique key names to use for this test run */
+  $key = randstr(16);
+  $key2 = "{$key}_b";
+  if ($redis->exists([$key, $key2])) {
+    die("skip: key(s) already exist: $key, $key2\n");
+  }
+
+  /* Ensure the keys don't persist (too much) longer than the test. */
+  $redis->expire($key, 30 /* seconds */);
+  $redis->expire($key2, 30 /* seconds */);
+
+  tap_equal(4, $redis->rpush($key, 'A', 'B', 'B', 'C'), 'add new elements');
+
+  /* Redis->lRemove is depreacted, but use it once to verity it works */
+  tap_equal(1, @$redis->lRemove($key, 'B', 1), 'remove first occurence of B');
+  tap_equal(['A', 'B', 'C'], $redis->lrange($key, 0, -1), 'verify list elements');
+}

--- a/tests/integration/redis/test_lrem.php
+++ b/tests/integration/redis/test_lrem.php
@@ -61,3 +61,4 @@ function test_redis() {
   tap_equal(1, @$redis->lRemove($key, 'B', 1), 'remove first occurence of B');
   tap_equal(['A', 'B', 'C'], $redis->lrange($key, 0, -1), 'verify list elements');
 }
+test_redis();

--- a/tests/integration/redis/test_lrem.php
+++ b/tests/integration/redis/test_lrem.php
@@ -30,7 +30,7 @@ ok - verify list elements
 */
 
 /*EXPECT_METRICS_EXIST
-Datastore/operation/Redis/lRem
+Datastore/operation/Redis/lrem
 */
 
 require_once(realpath (dirname ( __FILE__ )) . '/../../include/helpers.php');

--- a/tests/integration/redis/test_lremove.php
+++ b/tests/integration/redis/test_lremove.php
@@ -30,7 +30,7 @@ ok - verify list elements
 */
 
 /*EXPECT_METRICS_EXIST
-Datastore/operation/Redis/lrem
+Datastore/operation/Redis/lremove
 */
 
 require_once(realpath (dirname ( __FILE__ )) . '/../../include/helpers.php');


### PR DESCRIPTION
`lGet` and `lRemove` are deprecated functions that no longer run on later versions of the Redis extension. Pin the tests to the last known working version and gate via SKIPIF.