### PR TITLE
chore(docs): use https for docs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Before submitting an Issue, please search for similar ones in the
 
 1. Please open the pull request against the `dev` branch.  This is the development branch where all changes are tested before merging to main.
 2. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
-3. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+3. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](https://semver.org/).
 4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ## Contributor License Agreement

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ If you would like to [contribute](https://github.com/newrelic/newrelic-php-agent
 To all [contributors](https://github.com/newrelic/newrelic-php-agent/graphs/contributors), we thank you! Without your contribution, this project would not be what it is today. We also host a community project page dedicated to the [New Relic PHP agent](https://opensource.newrelic.com/projects/newrelic/newrelic-php-agent).
 
 ## License
-The PHP agent is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License and also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.
+The PHP agent is licensed under the [Apache 2.0](https://apache.org/licenses/LICENSE-2.0.txt) License and also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -132,7 +132,7 @@ _"This does not contain everything, but what it contains is true"._
    ```
 
 0. Format code with
-   [clang-format 3.8](http://releases.llvm.org/3.8.0/tools/clang/docs/ClangFormat.html) 
+   [clang-format 3.8](https://releases.llvm.org/3.8.0/tools/clang/docs/ClangFormat.html) 
    or later using our [style configuration file](.clang-format).
 
 0. Disregard directives from this list when other approaches are more

--- a/agent/README.txt
+++ b/agent/README.txt
@@ -6,4 +6,4 @@ and API descriptions please see the online FAQ at:
 
 For license and copyright, see LICENSE.
 
-For support, contact us at http://support.newrelic.com for assistance.
+For support, contact us at https://support.newrelic.com for assistance.

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -355,7 +355,7 @@ The New Relic installation directory is incomplete. The files or
 directories listed above could not be found. This usually means that
 you have a corrupt installation archive. Please re-download your New
 Relic software and try again. If the problem persists, please contact
-${bold}http://support.newrelic.com${rmso} and report the issue. Be sure
+${bold}https://support.newrelic.com${rmso} and report the issue. Be sure
 to include all the above output in your bug report. We apologize for the
 inconvenience.
 
@@ -494,7 +494,7 @@ fatal() {
   echo "FATAL: $@" >&2
   cat >&2 <<EOF
 FATAL: New Relic agent installation failed.
-       Please contact ${bold}http://support.newrelic.com${rmso}
+       Please contact ${bold}https://support.newrelic.com${rmso}
        and report the above error. We have also created a tar file with
        log files and other system info that can help solve the problem.
        If the file $logtar exists please attach it to your bug report.
@@ -742,7 +742,7 @@ accompany each PHP install. Sometimes, these require that you install
 the "dev" package for PHP or the "cli" version. We need one or the
 other.
 
-Please visit ${bold}http://newrelic.com/docs/php${rmso} and review the
+Please visit ${bold}https://newrelic.com/docs/php${rmso} and review the
 installation documentation for ways in which you can customize this
 script to look for PHP in non-standard locations or to do a manual
 install.
@@ -1832,8 +1832,8 @@ EOF
 
 The New Relic Proxy Daemon is installed, but the agent
 is not. Please point your favorite web browser at
-${bold}http://newrelic.com/docs/php${rmso} for how to install the agent
-by hand.
+${bold}https://docs.newrelic.com/docs/apm/agents/php-agent/installation/php-agent-installation-overview/${rmso} 
+for how to install the agent by hand.
 
 EOF
       fi
@@ -1860,7 +1860,7 @@ EOF
 2. Restart your web server. This will fix most reporting issues and
    load the agent's new features and bug fixes.
 
-If you have questions or comments, go to http://support.newrelic.com.
+If you have questions or comments, go to https://support.newrelic.com.
 
 EOF
     fi
@@ -1991,7 +1991,7 @@ distribution. All existing configuration files that were modified
 have been left in place. If you wish to permanently remove ${bold}New
 Relic${rmso}, you may wish to invoke this script with the 'purge'
 option to completely remove ${bold}New Relic${rmso}. If so, please take
-a moment to mail ${bold}http://support.newrelic.com${rmso} telling us
+a moment to mail ${bold}https://support.newrelic.com${rmso} telling us
 why you are leaving us and what we can do to help you or improve your
 experience. Thank you in advance.
 
@@ -2021,7 +2021,7 @@ do_purge() {
 
 We are sorry to see you go! If there is anything we can do
 to improve your experience with the product, please mail
-${bold}http://support.newrelic.com${rmso} and we will do our very best
+${bold}https://support.newrelic.com${rmso} and we will do our very best
 to help you or to improve the product to meet your expectations. Thank
 you in advance. -- The ${bold}New Relic${rmso} ${agent} Team
 

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -465,7 +465,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          newrelic.error_collector.ignore_errors = 3
 ;
 ;          The list of constants are available at:
-;          http://php.net/manual/en/errorfunc.constants.php
+;          https://php.net/manual/en/errorfunc.constants.php
 ;
 ;          Please note that this setting does not apply to errors recorded
 ;          using the newrelic_notice_error API.

--- a/axiom/tests/cross_agent_tests/sql_obfuscation/README.md
+++ b/axiom/tests/cross_agent_tests/sql_obfuscation/README.md
@@ -25,12 +25,12 @@ Test cases may also contain the following properties:
 
 The following database documentation may be helpful in understanding these test
 cases:
-* [MySQL String Literals](http://dev.mysql.com/doc/refman/5.5/en/string-literals.html)
-* [PostgreSQL String Constants](http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS)
+* [MySQL String Literals](https://dev.mysql.com/doc/refman/5.5/en/string-literals.html)
+* [PostgreSQL String Constants](https://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS)
 
 SQL Syntax Documentation:
-* [MySQL](http://dev.mysql.com/doc/refman/5.5/en/language-structure.html)
-* [PostgreSQL](http://www.postgresql.org/docs/8.4/static/sql-syntax.html)
-* [Cassandra](http://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_lexicon_c.html)
-* [Oracle](http://docs.oracle.com/cd/B28359_01/appdev.111/b28370/langelems.htm)
+* [MySQL](https://dev.mysql.com/doc/refman/5.5/en/language-structure.html)
+* [PostgreSQL](https://www.postgresql.org/docs/8.4/static/sql-syntax.html)
+* [Cassandra](https://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_lexicon_c.html)
+* [Oracle](https://docs.oracle.com/cd/B28359_01/appdev.111/b28370/langelems.htm)
 * [SQLite](https://www.sqlite.org/lang.html)


### PR DESCRIPTION
Change user-facing documentation links to use `https` instead of `http`