### PR TITLE
feat(agent): Add INI option that determines if package detection should be enabled

### DIFF
--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -602,5 +602,9 @@ void nr_drupal8_enable(TSRMLS_D) {
     nr_php_wrap_user_function(NR_PSTR("Drupal\\views\\ViewExecutable::execute"),
                               nr_drupal8_wrap_view_execute TSRMLS_CC);
   }
-  nr_txn_add_php_package(NRPRG(txn), "drupal/core", PHP_PACKAGE_VERSION_UNKNOWN);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "drupal/core",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/fw_joomla.c
+++ b/agent/fw_joomla.c
@@ -167,4 +167,9 @@ void nr_joomla_enable(TSRMLS_D) {
    */
   nr_php_wrap_user_function(NR_PSTR("JControllerLegacy::execute"),
                             nr_joomla3_name_the_wt TSRMLS_CC);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "joomla",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/fw_laminas3.c
+++ b/agent/fw_laminas3.c
@@ -153,5 +153,9 @@ void nr_laminas3_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Laminas\\Mvc\\Console\\Router\\RouteMatch::setMatchedRouteName"),
       nr_laminas3_name_the_wt TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "laminas/laminas-mvc", PHP_PACKAGE_VERSION_UNKNOWN);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "laminas/laminas-mvc",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -913,10 +913,16 @@ NR_PHP_WRAPPER(nr_laravel_application_construct) {
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
 
+  /*
+   * Retrieving the version is not included in the INI check below because it is
+   * needed for Laravel's instrumentation.
+   */
   version = nr_php_get_object_constant(this_var, "VERSION");
 
-  // Add php package to transaction
-  nr_txn_add_php_package(NRPRG(txn), "laravel/framework", version);
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    // Add php package to transaction
+    nr_txn_add_php_package(NRPRG(txn), "laravel/framework", version);
+  }
 
   if (version) {
     nrl_debug(NRL_FRAMEWORK, "Laravel version is " NRP_FMT, NRP_PHP(version));

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -208,5 +208,9 @@ void nr_lumen_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Laravel\\Lumen\\Application::sendExceptionToHandler"),
       nr_lumen_exception TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "laravel/lumen-framework", PHP_PACKAGE_VERSION_UNKNOWN);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "laravel/lumen-framework",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/fw_magento2.c
+++ b/agent/fw_magento2.c
@@ -449,4 +449,9 @@ void nr_magento2_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("Magento\\Ui\\Controller\\Adminhtml\\Index\\Render::execute"),
       nr_magento2_ui_controller_execute TSRMLS_CC);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "magento",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/fw_mediawiki.c
+++ b/agent/fw_mediawiki.c
@@ -232,4 +232,9 @@ void nr_mediawiki_enable(TSRMLS_D) {
                             nr_mediawiki_getaction TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("ApiMain::setupExecuteAction"),
                             nr_mediawiki_apimain_setupexecuteaction TSRMLS_CC);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "mediawiki",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -127,11 +127,13 @@ void nr_slim_enable(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("Slim\\Routing\\Route::run"),
                             nr_slim3_4_route_run TSRMLS_CC);
 
-  /* Slim 2 does not have the same path as Slim 3/4 which is why
-     we need to separate these*/
-  nr_php_wrap_user_function(NR_PSTR("Slim\\Slim::__construct"),
-                            nr_slim_application_construct);
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    /* Slim 2 does not have the same path as Slim 3/4 which is why
+      we need to separate these*/
+    nr_php_wrap_user_function(NR_PSTR("Slim\\Slim::__construct"),
+                              nr_slim_application_construct);
 
-  nr_php_wrap_user_function(NR_PSTR("Slim\\App::__construct"),
-                            nr_slim_application_construct);
+    nr_php_wrap_user_function(NR_PSTR("Slim\\App::__construct"),
+                              nr_slim_application_construct);
+  }
 }

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -250,5 +250,9 @@ void nr_symfony4_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
         NR_PSTR("Symfony\\Component\\Console\\Command\\Command::run"),
      nr_symfony4_console_application_run TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "symfony/http-kernel", PHP_PACKAGE_VERSION_UNKNOWN);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "symfony/http-kernel",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -585,7 +585,10 @@ void nr_wordpress_enable(TSRMLS_D) {
         nr_wordpress_call_user_func_array TSRMLS_CC);
   }
 
-  nr_txn_add_php_package(NRPRG(txn), "wordpress", PHP_PACKAGE_VERSION_UNKNOWN);
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "wordpress",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }
 
 void nr_wordpress_minit(void) {

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -76,5 +76,9 @@ nr_slowsqls_labelled_query_t* nr_doctrine2_lookup_input_query(TSRMLS_D) {
 void nr_doctrine2_enable(TSRMLS_D) {
   nr_php_wrap_user_function(NR_PSTR("Doctrine\\ORM\\Query::_doExecute"),
                             nr_doctrine2_cache_dql TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "doctrine/orm", PHP_PACKAGE_VERSION_UNKNOWN);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "doctrine/orm",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/lib_guzzle4.c
+++ b/agent/lib_guzzle4.c
@@ -518,7 +518,11 @@ void nr_guzzle4_enable(TSRMLS_D) {
    */
   nr_php_wrap_user_function(NR_PSTR("GuzzleHttp\\Client::__construct"),
                             nr_guzzle_client_construct TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", PHP_PACKAGE_VERSION_UNKNOWN);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }
 
 void nr_guzzle4_minit(TSRMLS_D) {

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -343,7 +343,6 @@ const zend_function_entry nr_guzzle6_requesthandler_functions[]
 /* }}} */
 
 NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
-  char* version;
   zval* config;
   zend_class_entry* guzzle_client_ce;
   zval* handler_stack;
@@ -351,10 +350,12 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   zval* retval;
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
 
-  version = nr_php_get_object_constant(this_var, "VERSION");
-  
-  // Add php package to transaction
-  nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", version);
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    char* version = nr_php_get_object_constant(this_var, "VERSION");
+    // Add php package to transaction
+    nr_txn_add_php_package(NRPRG(txn), "guzzlehttp/guzzle", version);
+    nr_free(version);
+  }
 
   (void)wraprec;
   NR_UNUSED_SPECIALFN;
@@ -407,7 +408,6 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   retval = nr_php_call(handler_stack, "push", middleware);
 
   nr_php_zval_free(&retval);
-  nr_free(version);
 
 end:
   nr_php_zval_free(&middleware);

--- a/agent/lib_mongodb.c
+++ b/agent/lib_mongodb.c
@@ -264,5 +264,9 @@ void nr_mongodb_enable(TSRMLS_D) {
   nr_php_wrap_user_function_extra(
       NR_PSTR("MongoDB\\Operation\\DatabaseCommand::execute"),
       nr_mongodb_operation, "databaseCommand" TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "mongodb/mongodb", PHP_PACKAGE_VERSION_UNKNOWN);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "mongodb/mongodb",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -511,5 +511,9 @@ void nr_monolog_enable(TSRMLS_D) {
                             nr_monolog_logger_pushhandler TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("Monolog\\Logger::addRecord"),
                             nr_monolog_logger_addrecord TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "monolog/monolog", "10.0.1.1");
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "monolog/monolog",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -511,5 +511,5 @@ void nr_monolog_enable(TSRMLS_D) {
                             nr_monolog_logger_pushhandler TSRMLS_CC);
   nr_php_wrap_user_function(NR_PSTR("Monolog\\Logger::addRecord"),
                             nr_monolog_logger_addrecord TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "monolog/monolog", PHP_PACKAGE_VERSION_UNKNOWN);
+  nr_txn_add_php_package(NRPRG(txn), "monolog/monolog", "10.0.1.1");
 }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -711,6 +711,7 @@ void nr_phpunit_enable(TSRMLS_D) {
       nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
 
   if (NRINI(vulnerability_management_package_detection_enabled)) {
-    nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit",
+                           PHP_PACKAGE_VERSION_UNKNOWN);
   }
 }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -709,5 +709,8 @@ void nr_phpunit_enable(TSRMLS_D) {
   nr_php_wrap_user_function(
       NR_PSTR("PHPUnit\\Framework\\TestResult::addError"),
       nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
-  nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", PHP_PACKAGE_VERSION_UNKNOWN);
+
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", PHP_PACKAGE_VERSION_UNKNOWN);
+  }
 }

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -633,7 +633,6 @@ NR_PHP_WRAPPER(nr_predis_aggregateconnection_getConnection) {
 NR_PHP_WRAPPER_END
 
 NR_PHP_WRAPPER(nr_predis_client_construct) {
-  char* version;
   zval* conn = NULL;
   zval* params = nr_php_arg_get(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   zval* scope = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
@@ -641,10 +640,12 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   (void)wraprec;
 
   NR_PHP_WRAPPER_CALL;
-  version = nr_php_get_object_constant(scope, "VERSION");
-  
-  // Add php package to transaction
-  nr_txn_add_php_package(NRPRG(txn), "predis/predis", version);
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    char* version = nr_php_get_object_constant(scope, "VERSION");
+    // Add php package to transaction
+    nr_txn_add_php_package(NRPRG(txn), "predis/predis", version);
+    nr_free(version);
+  }
 
   /*
    * Grab the connection object from the client, since we actually instrument
@@ -685,7 +686,6 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   nr_php_zval_free(&conn);
   nr_php_arg_release(&params);
   nr_php_scope_release(&scope);
-  nr_free(version);
 }
 NR_PHP_WRAPPER_END
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -994,7 +994,9 @@ static void nr_php_user_instrumentation_from_file(const char* filename,
                               filename_len TSRMLS_CC);
   nr_execute_handle_library(filename, filename_len TSRMLS_CC);
   nr_execute_handle_logging_framework(filename, filename_len TSRMLS_CC);
-  nr_execute_handle_package(filename);
+  if (NRINI(vulnerability_management_package_detection_enabled)) {
+    nr_execute_handle_package(filename);
+  }
 }
 
 /*

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -503,6 +503,13 @@ nriniuint_t
 nrinibool_t
     code_level_metrics_enabled; /* newrelic.code_level_metrics.enabled */
 
+/*
+ * Configuration option to enable or disable package detection for vulnerability management
+ */
+nrinibool_t
+    vulnerability_management_package_detection_enabled; /* newrelic.vulnerability_management.package_detection.enabled
+                                                         */
+
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
 /*
  * pid and user_function_wrappers are used to store user function wrappers.

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -3009,6 +3009,18 @@ STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.context_data.exclu
                      newrelic_globals,
                      0)
 
+/*
+ * Vulnerability Management
+ */
+STD_PHP_INI_ENTRY_EX("newrelic.vulnerability_management.package_detection.enabled",
+                     "1",
+                     NR_PHP_REQUEST,
+                     nr_boolean_mh,
+                     vulnerability_management_package_detection_enabled,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     nr_enabled_disabled_dh)
+
 PHP_INI_END() /* } */
 
 void nr_php_register_ini_entries(int module_number TSRMLS_DC) {

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1299,3 +1299,11 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;newrelic.code_level_metrics.enabled = true
 
+; Setting: newrelic.vulnerability_management.package_detection.enabled
+; Type   : boolean
+; Scope  : per-directory
+; Default: true
+; Info   : Toggles whether the agent provides package detection information
+;          for vulnerability management.
+;
+;newrelic.vulnerability_management.package_detection.enabled = true

--- a/axiom/cmd_txndata_transmit.c
+++ b/axiom/cmd_txndata_transmit.c
@@ -573,8 +573,6 @@ static uint32_t nr_txndata_prepend_php_packages(nr_flatbuffer_t* fb,
     return 0;
   }
 
-  nrl_verbosedebug(NRL_DEBUG, "php packages json = |%s|", json);
-
   data = nr_flatbuffers_prepend_string(fb, json);
   nr_free(json);
 


### PR DESCRIPTION
This PR does the following:

- Adds a `newrelic.vulnerability_management.package_detection.enabled` INI option, which disables or enables package detection for vulnerability management. This is set to on by default.  
- Adds INI check before adding a package to a transaction to ensure the option is enabled. 
- Adds package information to transaction for Joomla, Mediawiki, and Magento. The version is sent as an empty string because the version is unknown.