### PR TITLE
feat(tests): Defaults to "null" for expected errors [DRAFT DO NOT MERGE]

### DIFF
--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -591,6 +591,12 @@ func (t *Test) Compare(harvest *newrelic.Harvest) {
 	// check for any "expected spans like"
 	t.compareSpanEventsLike(harvest)
 
+	// if expected error events and traced errors are undefined - default to "null"
+	if nil == t.errorEvents && nil == t.tracedErrors {
+		t.errorEvents = []byte("null")
+		t.tracedErrors = []byte("null")
+	}
+
 	// check remaining payloads
 	t.comparePayload(t.analyticEvents, harvest.TxnEvents, false)
 	t.comparePayload(t.customEvents, harvest.CustomEvents, false)


### PR DESCRIPTION
If neither EXPECT_TRACED_ERRORS or EXPECT_ERROR_EVENTS defined then default to "null" for both.  This will guarantee there is an explicit expectation for an error if it expected for a test or else it will fail.