### PR TITLE
ci: update GitHub Actions to use Node 20

### DIFF
--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -55,7 +55,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon_test
       - name: Save integration_runner for integration tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin/integration_runner
@@ -124,19 +124,19 @@ jobs:
           -e ENABLE_COVERAGE=${{matrix.codecov}}
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-check
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs/*.gc*
@@ -161,24 +161,24 @@ jobs:
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Get integration_runner
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs

--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -32,13 +32,13 @@ jobs:
         arch: [amd64]
     steps:
       - name: Checkout newrelic-php-agent code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon_test
       - name: Save integration_runner for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin/integration_runner
@@ -77,13 +77,13 @@ jobs:
             codecov: 1
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -124,19 +124,19 @@ jobs:
           -e ENABLE_COVERAGE=${{matrix.codecov}}
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-check
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs/*.gc*
@@ -155,30 +155,30 @@ jobs:
             codecov: 1
     steps:
       - name: Checkout integration tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Get integration_runner
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs
@@ -187,7 +187,7 @@ jobs:
           chmod 755 php-agent/bin/integration_runner
           chmod 755 php-agent/agent/modules/newrelic.so
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -250,7 +250,7 @@ jobs:
           echo "COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.codecov == 1 }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           working-directory: ./php-agent

--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -62,7 +62,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so

--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -35,19 +35,19 @@ jobs:
         php: ['8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Enable arm64 emulation
         if: ${{ inputs.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
           platforms: arm64
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so

--- a/.github/workflows/make-for-platform-on-arch.yml
+++ b/.github/workflows/make-for-platform-on-arch.yml
@@ -78,7 +78,7 @@ jobs:
           -e APP_supportability=${{secrets.APP_SUPPORTABILITY}}
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION ${{inputs.make-target}}
       - name: Save ${{inputs.make-target}} artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}
           path: php-agent/${{ inputs.artifact-pattern }}

--- a/.github/workflows/make-for-platform-on-arch.yml
+++ b/.github/workflows/make-for-platform-on-arch.yml
@@ -54,19 +54,19 @@ jobs:
         platform: [gnu, musl]
     steps:
       - name: Checkout newrelic-php-agent code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Enable arm64 emulation
         if: ${{ inputs.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
           platforms: arm64
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
           -e APP_supportability=${{secrets.APP_SUPPORTABILITY}}
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION ${{inputs.make-target}}
       - name: Save ${{inputs.make-target}} artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}
           path: php-agent/${{ inputs.artifact-pattern }}

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -37,18 +37,18 @@ jobs:
         php: ['8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout integration tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Get integration_runner
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: integration_runner-${{matrix.platform}}-${{inputs.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
           path: php-agent/agent/modules
@@ -58,12 +58,12 @@ jobs:
           chmod 755 php-agent/agent/modules/newrelic.so
       - name: Enable arm64 emulation
         if: ${{ inputs.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
           platforms: arm64
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -43,12 +43,12 @@ jobs:
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Get integration_runner
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: integration_runner-${{matrix.platform}}-${{inputs.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
           path: php-agent/agent/modules

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -52,7 +52,7 @@ jobs:
           -e BUILD_NUMBER=${{inputs.build-number}}
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION release-daemon
       - name: Save build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: newrelic-php-agent/releases
           name: release-from-gha
@@ -87,7 +87,7 @@ jobs:
           -e BUILD_NUMBER=${{inputs.build-number}}
           $IMAGE_NAME:agent-builder-php${{matrix.php_ver}}-${{matrix.platform}}-$IMAGE_VERSION release-${{matrix.php_ver}}-gha
       - name: Save build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: newrelic-php-agent/releases
           name: release-from-gha

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -35,12 +35,12 @@ jobs:
         arch: [amd64]
     steps:
       - name: Checkout newrelic-php-agent code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref }}
           path: newrelic-php-agent
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
           -e BUILD_NUMBER=${{inputs.build-number}}
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION release-daemon
       - name: Save build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
           name: release-from-gha
@@ -69,12 +69,12 @@ jobs:
         arch: [amd64]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref }}
           path: newrelic-php-agent
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -87,7 +87,7 @@ jobs:
           -e BUILD_NUMBER=${{inputs.build-number}}
           $IMAGE_NAME:agent-builder-php${{matrix.php_ver}}-${{matrix.platform}}-$IMAGE_VERSION release-${{matrix.php_ver}}-gha
       - name: Save build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
           name: release-from-gha

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -18,14 +18,14 @@ jobs:
     steps:
       - name: Test Default Branch
         id: default-branch
-        uses: actions/github-script@v2
+        uses: actions/github-script@v7
         with:
           script: |
             const data = await github.repos.get(context.repo)
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const data = await github.repos.get(context.repo)
+            const data = await github.rest.repos.get(context.repo)
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -58,7 +58,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon_test
       - name: Save integration_runner for integration tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin/integration_runner
@@ -159,19 +159,19 @@ jobs:
           -e ENABLE_COVERAGE=${{matrix.codecov}}
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-${{ steps.get-check-variant.outputs.AGENT_CHECK_VARIANT }}
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs/*.gc*
@@ -206,24 +206,24 @@ jobs:
         with:
           path: php-agent
       - name: Get integration_runner
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -31,17 +31,17 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Checkout newrelic-php-agent code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
       - name: Enable arm64 emulation
         if: ${{ matrix.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
           platforms: arm64
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon_test
       - name: Save integration_runner for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin/integration_runner
@@ -91,17 +91,17 @@ jobs:
             codecov: 1
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
       - name: Enable arm64 emulation
         if: ${{ matrix.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
           platforms: arm64
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -159,19 +159,19 @@ jobs:
           -e ENABLE_COVERAGE=${{matrix.codecov}}
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-${{ steps.get-check-variant.outputs.AGENT_CHECK_VARIANT }}
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs/*.gc*
@@ -202,28 +202,28 @@ jobs:
             codecov: 1
     steps:
       - name: Checkout integration tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: php-agent
       - name: Get integration_runner
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs
@@ -233,12 +233,12 @@ jobs:
           chmod 755 php-agent/agent/modules/newrelic.so
       - name: Enable arm64 emulation
         if: ${{ matrix.arch == 'arm64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
           platforms: arm64
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -296,7 +296,7 @@ jobs:
           nr-php make gcov
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.codecov == 1 }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           working-directory: ./php-agent


### PR DESCRIPTION
Ensure that workflows use the versions of actions that are running on Node 20. Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), and GitHub [announced](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) its deprecation in GitHub Actions.

Actions upgraded:
- actions/checkout@v3 -> v4: https://github.com/actions/checkout/releases/tag/v4.0.0
  * CHANGELOG: https://github.com/actions/checkout/blob/main/CHANGELOG.md
- docker/login-action@v2 -> v3: https://github.com/docker/login-action/releases/tag/v3.0.0
- docker/setup-qemu-action@v2 -> v3: https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0
- codecov/codecov-action@v3 -> v3.1.5: https://github.com/codecov/codecov-action/releases/tag/v3.1.5
- actions/github-script@v2 -> v7: https://github.com/actions/github-script/releases/tag/v7.0.0
  * Breaking changes by version: https://github.com/actions/github-script?tab=readme-ov-file#breaking-changes
  * Required updating the `github` REST call to use `rest` context