### PR TITLE
feat(agent): Add Yii v2 framework instrumentation

### DIFF
--- a/agent/fw_hooks.h
+++ b/agent/fw_hooks.h
@@ -39,7 +39,8 @@ extern void nr_symfony4_enable(TSRMLS_D);
 extern void nr_silex_enable(TSRMLS_D);
 extern void nr_slim_enable(TSRMLS_D);
 extern void nr_wordpress_enable(TSRMLS_D);
-extern void nr_yii_enable(TSRMLS_D);
+extern void nr_yii1_enable(TSRMLS_D);
+extern void nr_yii2_enable(TSRMLS_D);
 extern void nr_zend_enable(TSRMLS_D);
 extern void nr_fw_zend2_enable(TSRMLS_D);
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -412,8 +412,9 @@ static const nr_framework_table_t all_frameworks[] = {
     {"WordPress", "wordpress", NR_PSTR("wp-config.php"), 0, nr_wordpress_enable,
      NR_FW_WORDPRESS},
 
-    {"Yii", "yii", NR_PSTR("framework/yii.php"), 0, nr_yii_enable, NR_FW_YII},
-    {"Yii", "yii", NR_PSTR("framework/yiilite.php"), 0, nr_yii_enable, NR_FW_YII},
+    {"Yii", "yii", NR_PSTR("framework/yii.php"), 0, nr_yii1_enable, NR_FW_YII},
+    {"Yii", "yii", NR_PSTR("framework/yiilite.php"), 0, nr_yii1_enable, NR_FW_YII},
+    {"Yii2", "yii2", NR_PSTR("yii2/baseyii.php"), 0, nr_yii2_enable, NR_FW_YII},
 
     /* See above: Laminas, the successor to Zend, which shares much
        of the instrumentation implementation with Zend */
@@ -532,7 +533,6 @@ static nr_library_table_t libraries[] = {
     {"SilverStripe4", NR_PSTR("silverstripeserviceconfigurationlocator.php"), NULL},
     {"Typo3", NR_PSTR("classes/typo3/flow/core/bootstrap.php"), NULL},
     {"Typo3", NR_PSTR("typo3/sysext/core/classes/core/bootstrap.php"), NULL},
-    {"Yii2", NR_PSTR("yii2/baseyii.php"), NULL},
 
     /*
      * Other CMS (content management systems), detected only, but

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -639,7 +639,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          Must be one of the following values:
 ;          cakephp, codeigniter, drupal, drupal8, joomla, kohana, laravel,
 ;          magento, magento2, mediawiki, slim, symfony2, symfony4,
-;          wordpress, yii, zend, zend2, no_framework
+;          wordpress, yii, yii2, zend, zend2, no_framework
 ;
 ;          Note that "drupal" covers only Drupal 6 and 7 and "symfony2"
 ;          now only supports Symfony 3.x.


### PR DESCRIPTION
- [x] Implement Yii v2 instrumentation for auto transaction naming
- [x] Implement non-web transactions (yiic CLI) — works out-of-the-box
- [x] Update documentation
- [x] Implement wrapper for [Yii2 ErrorHandler](https://www.yiiframework.com/doc/api/2.0/yii-web-errorhandler) (currently NewRelic is blind because of the custom PHP error_handler of the framework)
- [ ] Add integration tests (needed?)

Fixes #821

I've recompiled the agent locally with those changes and transaction names correctly show up now:

![Screenshot 2024-01-31 at 07 23 53](https://github.com/newrelic/newrelic-php-agent/assets/4599319/ce01be96-e102-45f0-8721-05c505556ae3)

![Screenshot 2024-01-31 at 11 32 02](https://github.com/newrelic/newrelic-php-agent/assets/4599319/350f73b5-1b88-430c-bd1e-808d7f529fc0)

CLI uses the same hook method:

![Screenshot 2024-01-31 at 11 16 34](https://github.com/newrelic/newrelic-php-agent/assets/4599319/9505ff44-cab9-4eec-aa23-3855ae438480)
