### PR TITLE
tests: simplify EXPECTED_PHP_PACKAGES "null" value processing

### DIFF
--- a/src/newrelic/integration/parse.go
+++ b/src/newrelic/integration/parse.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"unicode"
 )
@@ -286,8 +285,7 @@ func parseConfig(test *Test, content []byte) error {
 
 func parsePhpPackages(test *Test, content []byte) error {
 	// clean up provided string data if it is "null"
-	nullRE := regexp.MustCompile(`^\s*null\s*`)
-	if nullRE.Match(content) {
+	if "null" == strings.TrimSpace(string(content)) {
 		test.phpPackagesConfig = []byte("null")
 		return nil
 	}

--- a/src/newrelic/integration/parse.go
+++ b/src/newrelic/integration/parse.go
@@ -288,7 +288,7 @@ func parsePhpPackages(test *Test, content []byte) error {
 	// clean up provided string data if it is "null"
 	nullRE := regexp.MustCompile(`^\s*null\s*`)
 	if nullRE.Match(content) {
-		test.phpPackagesConfig = "null"
+		test.phpPackagesConfig = []byte("null")
 		return nil
 	}
 

--- a/src/newrelic/integration/parse.go
+++ b/src/newrelic/integration/parse.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"unicode"
 )
@@ -284,6 +285,13 @@ func parseConfig(test *Test, content []byte) error {
 }
 
 func parsePhpPackages(test *Test, content []byte) error {
+	// clean up provided string data if it is "null"
+	nullRE := regexp.MustCompile(`^\s*null\s*`)
+	if nullRE.Match(content) {
+		test.phpPackagesConfig = "null"
+		return nil
+	}
+
 	test.phpPackagesConfig = content
 	return nil
 }

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -513,16 +513,16 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 	var test_package_name_only bool = false
 
 	if nil != t.phpPackagesConfig {
-		expectedPkgsCollection, err := NewPhpPackagesCollection(t.Path, t.phpPackagesConfig)
-		if nil != err {
-			t.Fatal(err)
-			return
-		}
 
 		expect_null_pkgs := "null" == string(t.phpPackagesConfig)
 		if expect_null_pkgs {
 			expectedPackages = nil
 		} else {
+			expectedPkgsCollection, err := NewPhpPackagesCollection(t.Path, t.phpPackagesConfig)
+			if nil != err {
+				t.Fatal(err)
+				return
+			}
 			test_package_name_only = expectedPkgsCollection.config.package_name_only
 			if test_package_name_only {
 				t.AddNote("Tested package name only")

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -518,21 +518,27 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 			t.Fatal(err)
 			return
 		}
-		test_package_name_only = expectedPkgsCollection.config.package_name_only
-		if test_package_name_only {
-			t.AddNote("Tested package name only")
+
+		expect_null_pkgs := "null" == string(t.phpPackagesConfig)
+		if expect_null_pkgs {
+			expectedPackages = nil
+		} else {
+			test_package_name_only = expectedPkgsCollection.config.package_name_only
+			if test_package_name_only {
+				t.AddNote("Tested package name only")
+			}
+			expectedPackages, err = expectedPkgsCollection.GatherInstalledPackages()
+			if nil != err {
+				t.Fatal(err)
+				return
+			}
 		}
-		expectedPackages, err = expectedPkgsCollection.GatherInstalledPackages()
-		if nil != err {
-			t.Fatal(err)
-			return
-		}
-		if nil == expectedPackages || 0 == len(expectedPackages) {
+		if !expect_null_pkgs && (nil == expectedPackages || 0 == len(expectedPackages)) {
 			t.Fatal(fmt.Errorf("EXPECTED_PHP_PACKAGES used but no packaged detected in environment!"))
 		}
 	} else {
-               // no configuration given for package (no EXPECT_PHP_PACKAGES in test case) so don't run test
-               return
+		// no configuration given for package (no EXPECT_PHP_PACKAGES in test case) so don't run test
+		return
 	}
 
 	audit, err := newrelic.IntegrationData(harvest.PhpPackages, newrelic.AgentRunID("?? agent run id"), time.Now())

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -514,8 +514,8 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 
 	if nil != t.phpPackagesConfig {
 
-		expect_null_pkgs := "null" == string(t.phpPackagesConfig)
-		if expect_null_pkgs {
+		expectNullPkgs := "null" == string(t.phpPackagesConfig)
+		if expectNullPkgs {
 			expectedPackages = nil
 		} else {
 			expectedPkgsCollection, err := NewPhpPackagesCollection(t.Path, t.phpPackagesConfig)
@@ -533,7 +533,7 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 				return
 			}
 		}
-		if !expect_null_pkgs && (nil == expectedPackages || 0 == len(expectedPackages)) {
+		if !expectNullPkgs && (nil == expectedPackages || 0 == len(expectedPackages)) {
 			t.Fatal(fmt.Errorf("EXPECTED_PHP_PACKAGES used but no packaged detected in environment!"))
 		}
 	} else {


### PR DESCRIPTION
This change determines if the string "null" (with leading and trailing whitespace) was given as the `EXPECT_PHP_PACKAGES` stanza body and if so sets it to "null" to simplify later processing.

Changes needed to test PR #818. 