### PR TITLE
tests: improve EXPECT_PHP_PACKAGES processing

### DIFF
--- a/src/newrelic/integration/php_packages.go
+++ b/src/newrelic/integration/php_packages.go
@@ -148,7 +148,7 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 	// can detect and this is used to filter the auto-discovered packages (by integration_runner using "command")
 	supportedListFile, supportedOK = params["supported_packages"]
 
-	// or "expected_packages" which is specifies a fixed list of packages we expect to show up in this test
+	// or "expected_packages" which specifies a fixed list of packages we expect to show up in this test
 	expectedPackages, expectedOK = params["expected_packages"]
 	if expectedOK {
 		expectedPackagesArr, err = ParsePackagesList(expectedPackages)

--- a/src/newrelic/integration/php_packages.go
+++ b/src/newrelic/integration/php_packages.go
@@ -187,8 +187,6 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 			package_name_only:   package_name_only_map},
 	}
 
-	//fmt.Printf("PhpPackagesCollection: %+v\n", p)
-
 	return p, nil
 }
 
@@ -247,7 +245,6 @@ func (pkgs *PhpPackagesCollection) GatherInstalledPackages() ([]PhpPackage, erro
 		}
 	} else if 0 < len(pkgs.config.expected_packages) {
 		supported = pkgs.config.expected_packages
-		//fmt.Printf("expected_packages = +%v\n", supported)
 		if nil != err {
 			return nil, err
 		}

--- a/src/newrelic/integration/php_packages.go
+++ b/src/newrelic/integration/php_packages.go
@@ -136,8 +136,8 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 	var supported_list_file string
 	var expected_packages string
 	var package_name_only string
-	var expected_packages_map []string
-	var package_name_only_map []string
+	var expected_packages_arr []string
+	var package_name_only_arr []string
 	var command_ok, supported_ok, expected_ok bool
 	var ok bool
 	var err error
@@ -151,7 +151,7 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 	// or "expected_packages" which is specifies a fixed list of packages we expect to show up in this test
 	expected_packages, expected_ok = params["expected_packages"]
 	if expected_ok {
-		expected_packages_map, err = ParsePackagesList(expected_packages)
+		expected_packages_arr, err = ParsePackagesList(expected_packages)
 		if nil != err {
 			return nil, fmt.Errorf("Error parsing expected_packages list %s\n", err.Error())
 		}
@@ -172,7 +172,7 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 	// optional option to specify which packages will only have a name because agent cannot determine the version
 	package_name_only, ok = params["package_name_only"]
 	if ok {
-		package_name_only_map, err = ParsePackagesList(package_name_only)
+		package_name_only_arr, err = ParsePackagesList(package_name_only)
 		if nil != err {
 			return nil, fmt.Errorf("Error parsing package_name_only list %s\n", err.Error())
 		}
@@ -183,8 +183,8 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 			command:             command,
 			path:                path,
 			supported_list_file: supported_list_file,
-			expected_packages:   expected_packages_map,
-			package_name_only:   package_name_only_map},
+			expected_packages:   expected_packages_arr,
+			package_name_only:   package_name_only_arr},
 	}
 
 	return p, nil

--- a/src/newrelic/integration/php_packages.go
+++ b/src/newrelic/integration/php_packages.go
@@ -138,33 +138,35 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 	var package_name_only string
 	var expected_packages_map []string
 	var package_name_only_map []string
-	var ok, ok2 bool
+	var command_ok, supported_ok, expected_ok bool
+	var ok bool
 	var err error
 
-	command, ok := params["command"]
-	if !ok {
-		return nil, fmt.Errorf("Improper EXPECT_PHP_PACKAGES config - must specify 'command' option - got %+v", params)
-	}
+	command, command_ok := params["command"]
 
 	// either expect a "supported_packages" key which specifies a file listing all possible packages agent
 	// can detect and this is used to filter the auto-discovered packages (by integration_runner using "command")
-	supported_list_file, ok = params["supported_packages"]
+	supported_list_file, supported_ok = params["supported_packages"]
 
 	// or "expected_packages" which is specifies a fixed list of packages we expect to show up in this test
-	expected_packages, ok2 = params["expected_packages"]
-	if ok2 {
+	expected_packages, expected_ok = params["expected_packages"]
+	if expected_ok {
 		expected_packages_map, err = ParsePackagesList(expected_packages)
 		if nil != err {
 			return nil, fmt.Errorf("Error parsing expected_packages list %s\n", err.Error())
 		}
 	}
 
-	if ok && ok2 {
-		return nil, fmt.Errorf("Improper EXPECT_PHP_PACKAGES config - cannot specify supported_packages and expected packages - got %+v", params)
+	if supported_ok && expected_ok {
+		return nil, fmt.Errorf("Improper EXPECT_PHP_PACKAGES config - cannot specify 'supported_packages' and 'expected packages' - got %+v", params)
 	}
 
-	if !ok && !ok2 {
-		return nil, fmt.Errorf("Improper EXPECT_PHP_PACKAGES config - must specify supported_packages or expected packages - got %+v", params)
+	if !supported_ok && !expected_ok {
+		return nil, fmt.Errorf("Improper EXPECT_PHP_PACKAGES config - must specify 'supported_packages' or 'expected packages' - got %+v", params)
+	}
+
+	if supported_ok && !command_ok {
+		return nil, fmt.Errorf("Improper EXPECT_PHP_PACKAGES config - must specify 'command' option with `supported_packages` - got %+v", params)
 	}
 
 	// optional option to specify which packages will only have a name because agent cannot determine the version

--- a/src/newrelic/integration/php_packages.go
+++ b/src/newrelic/integration/php_packages.go
@@ -217,7 +217,7 @@ func LoadSupportedPackagesList(path, supportedListFile string) ([]string, error)
 // expect string containing comma separated list of package names
 // returns an array of strings with all leading/trailing whitespace removed
 func ParsePackagesList(expectedPackages string) ([]string, error) {
-	tmp := strings.Replace(expectedPackages, " ", "", -1)
+	tmp := strings.ReplaceAll(expectedPackages, " ", "")
 	return strings.Split(tmp, ","), nil
 }
 

--- a/src/newrelic/integration/php_packages.go
+++ b/src/newrelic/integration/php_packages.go
@@ -238,6 +238,22 @@ func (pkgs *PhpPackagesCollection) GatherInstalledPackages() ([]PhpPackage, erro
 
 	var supported []string
 
+	// get list of packages we expected the agent to detect
+	// this can be one of 2 scenarios:
+	//  1) test case used the "supported_packages" option which gives a JSON file which
+	//     lists all the packages the agent can detect
+	//  2) test case used the "expected_packages" options which provides a comma separated
+	//     list of packages we expect the agent to detect
+	//
+	//  Option #1 is preferable as it provides the most comprehensive view of what the agent can do.
+	//
+	//  Option #2 is needed because some test cases do not exercise all the packages which are 
+	//  installed and so the agent will not detect everything for that test case run which it could
+	//  theorectically detect if the test case used all the available packages installed.
+	//
+	//  Once the list of packages the agent is expected to detect is created it is used to filter
+	//  down the package list returned by running the "command" (usually composer) option for the
+	//  test case provided.
 	if 0 < len(pkgs.config.supported_list_file) {
 		supported, err = LoadSupportedPackagesList(pkgs.config.path, pkgs.config.supported_list_file)
 		if nil != err {
@@ -245,9 +261,6 @@ func (pkgs *PhpPackagesCollection) GatherInstalledPackages() ([]PhpPackage, erro
 		}
 	} else if 0 < len(pkgs.config.expected_packages) {
 		supported = pkgs.config.expected_packages
-		if nil != err {
-			return nil, err
-		}
 	} else {
 		return nil, fmt.Errorf("Error determining expected packages - supported_list_file and expected_packages are both empty")
 	}

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -579,7 +579,7 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 				if nil != expectedPkgsCollection.config.package_name_only {
 					test_package_name_only = slices.Contains(expectedPkgsCollection.config.package_name_only, actualPackages[i].Name)
 					if test_package_name_only {
-						t.AddNote("Tested package name only")
+						t.AddNote(fmt.Sprintf("Tested package name only for packages: %+v", expectedPkgsCollection.config.package_name_only))
 					}
 				}
 				fmt.Printf("test_package_name_only: %d\n", test_package_name_only)

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -570,14 +570,14 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 		}
 		for i, _ := range expectedPackages {
 			if expectedPackages[i].Name == actualPackages[i].Name {
-				test_package_name_only := false
-				if nil != expectedPkgsCollection.config.package_name_only {
-					test_package_name_only = slices.Contains(expectedPkgsCollection.config.package_name_only, actualPackages[i].Name)
-					if test_package_name_only {
-						t.AddNote(fmt.Sprintf("Tested package name only for packages: %+v", expectedPkgsCollection.config.package_name_only))
+				testPackageNameOnly := false
+				if nil != expectedPkgsCollection.config.packageNameOnly {
+					testPackageNameOnly = slices.Contains(expectedPkgsCollection.config.packageNameOnly, actualPackages[i].Name)
+					if testPackageNameOnly {
+						t.AddNote(fmt.Sprintf("Tested package name only for packages: %+v", expectedPkgsCollection.config.packageNameOnly))
 					}
 				}
-				if test_package_name_only || expectedPackages[i].Version == actualPackages[i].Version {
+				if testPackageNameOnly || expectedPackages[i].Version == actualPackages[i].Version {
 					continue
 				}
 			}

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -571,18 +571,12 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 		for i, _ := range expectedPackages {
 			if expectedPackages[i].Name == actualPackages[i].Name {
 				test_package_name_only := false
-
-				fmt.Printf("expectedPkgsCollection: %+v\n", expectedPkgsCollection)
-				fmt.Printf("expectedPkgsCollection.config.package_name_only: %+v  actualPackages[i].Name: %s",
-					expectedPkgsCollection.config.package_name_only, actualPackages[i].Name)
-
 				if nil != expectedPkgsCollection.config.package_name_only {
 					test_package_name_only = slices.Contains(expectedPkgsCollection.config.package_name_only, actualPackages[i].Name)
 					if test_package_name_only {
 						t.AddNote(fmt.Sprintf("Tested package name only for packages: %+v", expectedPkgsCollection.config.package_name_only))
 					}
 				}
-				fmt.Printf("test_package_name_only: %d\n", test_package_name_only)
 				if test_package_name_only || expectedPackages[i].Version == actualPackages[i].Version {
 					continue
 				}


### PR DESCRIPTION
This PR includes the following:
- Removes the "options" option which was used to specify that detected packages would not have version info.  This was applied to all packages detected and was too limiting as some test cases had some packages with versions and others without (laravel for example).  This has been replaced with the "package_names_only" options which allows giving a comma separated list of packages which only have names detected.
- Adds checks to verify only one of "supported_packages" or "expected_packages" is given.
- Improves how "expected_packages" was implemented to overcome some internal issues that existed.