### PR TITLE
chore: Sets default make target to agent only [TEST - DO NOT MERGE]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ endif
 export AR CC CFLAGS CPPFLAGS LDFLAGS
 
 .PHONY: all
-all: agent daemon
+all: agent
 
 #
 # Print some of the build specific variables so they can be computed


### PR DESCRIPTION
To support the CodeQL C/C++ scanner `autobuild` functionality move the default `make` target to just `agent` so only C/C++ code it built.  This is necessary because the current build env the CodeQL C/C++ scanner uses contains a too old Go compiler to build the `daemon` target.

Ideally the CodeQL tool/workflow could be configured to just target `agent` and that would be the recommended long term solution.