### PR TITLE
fix(tests): Reverts use of slices.Contains

### DIFF
--- a/src/newrelic/integration/php_packages.go
+++ b/src/newrelic/integration/php_packages.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 )
@@ -282,7 +281,7 @@ func (pkgs *PhpPackagesCollection) GatherInstalledPackages() ([]PhpPackage, erro
 		json.Unmarshal([]byte(out), &detected)
 		for _, v := range detected.Installed {
 			//fmt.Printf("composer detected %s %s\n", v.Name, v.Version)
-			if slices.Contains(supported, v.Name) {
+			if StringSliceContains(supported, v.Name) {
 				var version string
 
 				// remove any 'v' from front of version string

--- a/src/newrelic/integration/string_slice.go
+++ b/src/newrelic/integration/string_slice.go
@@ -1,0 +1,13 @@
+package integration
+
+// check if string is contained in an array of strings
+// for legacy Go as it would be preferable to use the slices
+func StringSliceContains(slice []string, text string) bool {
+	for _, val := range slice {
+		if text == val {
+			return true
+		}
+	}
+
+	return false
+}

--- a/src/newrelic/integration/test.go
+++ b/src/newrelic/integration/test.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 	"time"
 
@@ -572,7 +571,7 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 			if expectedPackages[i].Name == actualPackages[i].Name {
 				testPackageNameOnly := false
 				if nil != expectedPkgsCollection.config.packageNameOnly {
-					testPackageNameOnly = slices.Contains(expectedPkgsCollection.config.packageNameOnly, actualPackages[i].Name)
+					testPackageNameOnly = StringSliceContains(expectedPkgsCollection.config.packageNameOnly, actualPackages[i].Name)
 					if testPackageNameOnly {
 						t.AddNote(fmt.Sprintf("Tested package name only for packages: %+v", expectedPkgsCollection.config.packageNameOnly))
 					}


### PR DESCRIPTION
To retain ability to build on older golang compilers.