### PR TITLE
Release 10.17 Amendment

### DIFF
--- a/agent/fw_hooks.h
+++ b/agent/fw_hooks.h
@@ -58,6 +58,5 @@ extern void nr_monolog_enable(TSRMLS_D);
 /* Vulnerability Management Packages */
 extern void nr_drupal_version(void);
 extern void nr_wordpress_version(void);
-extern void nr_phpunit_version(void);
 
 #endif /* FW_HOOKS_HDR */

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -666,22 +666,6 @@ static int nr_phpunit_are_statuses_valid(TSRMLS_D) {
   return 1;
 }
 
-void nr_phpunit_version() {
-  char* string = "PHPUnit\\Runner\\Version::id();";
-  zval retval;
-  int result
-      = zend_eval_string(string, &retval, "Retrieve PHPUnit Version");
-
-  // Add php package to transaction
-  if (result == SUCCESS) {
-    if (Z_TYPE(retval) == IS_STRING) {
-      char* version = Z_STRVAL(retval);
-      nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit", version);
-    }
-    zval_dtor(&retval);
-  }
-}
-
 void nr_phpunit_enable(TSRMLS_D) {
   if (!NRINI(phpunit_events_enabled)) {
     return;

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -605,7 +605,6 @@ typedef struct _nr_vuln_mgmt_table_t {
 /* Note that all paths should be in lowercase. */
 static const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
     {"Drupal", "core/lib/drupal.php", nr_drupal_version},
-    {"PHPUnit", "runner/version.php", nr_phpunit_version},
     {"Wordpress", "wp-includes/version.php", nr_wordpress_version},
 };
 


### PR DESCRIPTION
This amendment does the following:

- Modified how Drupal extracts the version in a more robust way.
- Ensure Wordpress extracts the version without erroring out
- Remove Phpunit version extraction code