### PR TITLE
fix(agent): change detection file for Magento

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -387,7 +387,7 @@ static const nr_framework_table_t all_frameworks[] = {
 
     {"Magento", "magento", NR_PSTR("app/mage.php"), 0, nr_magento1_enable,
      NR_FW_MAGENTO1},
-    {"Magento2", "magento2", NR_PSTR("magento/framework/app/bootstrap.php"), 0,
+    {"Magento2", "magento2", NR_PSTR("magento/framework/registration.php"), 0,
      nr_magento2_enable, NR_FW_MAGENTO2},
 
     {"MediaWiki", "mediawiki", NR_PSTR("includes/webstart.php"), 0, nr_mediawiki_enable,


### PR DESCRIPTION
This PR changes the detection file for Magento to ensure compatibility with PHP 8.2 and above because the current file that is used is not detected because of the empty file optimizations that were introduced in PHP 8.2