### PR TITLE
feat(tests): Adds override for package version

### DIFF
--- a/daemon/internal/newrelic/integration/php_packages.go
+++ b/daemon/internal/newrelic/integration/php_packages.go
@@ -186,7 +186,7 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 	// on a release.
 	//
 	// this is a JSON file of the format
-	//  { 
+	//  {
 	//     "<expected>": "<override",
 	//     ...
 	//  }
@@ -199,8 +199,7 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 	//
 	//  which creates overrides to version "4.13.0" to change its expecation to "4.12.0"
 	//  and "3.4.5" to be changed to an expectation of "3.4.4"
-	}
-		overrideVersionsFile, ok = params["override_versions_file"]
+	overrideVersionsFile, ok = params["override_versions_file"]
 
 	p := &PhpPackagesCollection{
 		config: PhpPackagesConfiguration{

--- a/daemon/internal/newrelic/integration/php_packages.go
+++ b/daemon/internal/newrelic/integration/php_packages.go
@@ -180,7 +180,27 @@ func NewPhpPackagesCollection(path string, config []byte) (*PhpPackagesCollectio
 	}
 
 	// option file containing overrides for expected package versions
-	overrideVersionsFile, ok = params["override_versions_file"]
+	// this is useful when a package is detected as the wrong version
+	// because the internal mechanism the agent uses to get pacakge
+	// versions was not updated by the upstream maintainers properly
+	// on a release.
+	//
+	// this is a JSON file of the format
+	//  { 
+	//     "<expected>": "<override",
+	//     ...
+	//  }
+	//
+	// such as:
+	//  {
+	//     "4.13.0": "4.12.0",
+	//     "3.4.5": "3.4.4"
+	//  }
+	//
+	//  which creates overrides to version "4.13.0" to change its expecation to "4.12.0"
+	//  and "3.4.5" to be changed to an expectation of "3.4.4"
+	}
+		overrideVersionsFile, ok = params["override_versions_file"]
 
 	p := &PhpPackagesCollection{
 		config: PhpPackagesConfiguration{


### PR DESCRIPTION
Adds a "override_versions_file" option for EXPECT_PHP_PACKAGE that allows specifying overrides for given expected versions detected.  This is useful for when a package did not modify the internal data structure used to by the agent to detect its version, causing the package test to fail.

The override file should be in the same directory as the test_php_package.php test and is a JSON file implementing a simple dictionary like:

{
    "4.13.0": "4.12.0"
}

In this case this specifies if the packge version "4.13.0" is detected then override this expectation with the version "4.12.0".  In this example the upstream package bumped up to 4.13.0 but did not change the internal version variable so the agent still detects it as 4.12.0.