### PR TITLE
fix(agent): revert to using `zend_error_cb` hook for error reporting

### DIFF
--- a/agent/php_error.c
+++ b/agent/php_error.c
@@ -563,11 +563,6 @@ void nr_php_error_cb(int type,
                      const char* format,
                      va_list args) {
 #endif /* PHP >= 8.1 */
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
-    && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
-  (void)error_filename;
-  (void)error_lineno;
-#endif
   TSRMLS_FETCH();
   char* stack_json = NULL;
   const char* errclass = NULL;
@@ -623,19 +618,17 @@ void nr_php_error_cb(int type,
     nr_free(stack_json);
   }
   /*
-   * Call through to the actual error handler for PHP 7.4 and below.
-   * For PHP 8+ we have registered our error handler with the Observer
-   * API so there is no need to callback to the original.
-   */
-  /*
    * Call through to the actual error handler.
    */
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
   if (0 != NR_PHP_PROCESS_GLOBALS(orig_error_cb)) {
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
     NR_PHP_PROCESS_GLOBALS(orig_error_cb)
     (type, error_filename, error_lineno, format, args);
-  }
+#else
+    NR_PHP_PROCESS_GLOBALS(orig_error_cb)
+    (type, error_filename, error_lineno, message);
 #endif /* PHP < 8.0 */
+  }
 }
 
 nr_status_t nr_php_error_record_exception(nrtxn_t* txn,

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -769,8 +769,6 @@ void nr_php_late_initialization(void) {
    * our own error callback handler. Otherwise, we do.
    */
 
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO \
-    || defined OVERWRITE_ZEND_EXECUTE_DATA /* < PHP8 */
   if (0 == zend_get_extension("Xdebug")) {
     NR_PHP_PROCESS_GLOBALS(orig_error_cb) = zend_error_cb;
     zend_error_cb = nr_php_error_cb;
@@ -779,7 +777,6 @@ void nr_php_late_initialization(void) {
                 "the Xdebug extension prevents the New Relic agent from "
                 "gathering errors. No errors will be recorded.");
   }
-#endif /* end of < PHP8 or not using OAPI*/
 
   /*
    * Install our signal handler, unless the user has set a special flag

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -94,7 +94,6 @@ void nr_php_observer_minit() {
    * Register the Observer API handlers.
    */
   zend_observer_fcall_register(nr_php_fcall_register_handlers);
-  zend_observer_error_register(nr_php_error_cb);
 
   /*
    * For Observer API with PHP 8+, we no longer need to ovewrwrite the zend


### PR DESCRIPTION
Remove unwanted error reporting by overwriting zend_error_cb instead of using OAPI.