### PR TITLE
fix: de-duplicate php package data

### DIFF
--- a/daemon/internal/newrelic/app_test.go
+++ b/daemon/internal/newrelic/app_test.go
@@ -613,3 +613,41 @@ func TestMaxPayloadSizeInBytesFromConnectReply(t *testing.T) {
 		t.Errorf("parseConnectReply(something), got [%v], expected [%v]", c.MaxPayloadSizeInBytes, expectedMaxPayloadSizeInBytes)
 	}
 }
+
+func TestFilterPhpPackages(t *testing.T) {
+	app := &App{
+		PhpPackages: make(map[PhpPackagesKey]struct{}),
+	}
+	var nilData []byte = nil
+	emptyData := []byte(`[[{}]]`)
+	validData := []byte(`[["drupal","6.0",{}]]`)
+	moreValidData := []byte(`[["wordpress","7.0",{}],["symfony","5.1",{}]]`)
+	duplicateData := []byte(`[["drupal","6.0",{}]]`)
+
+	filteredData := app.filterPhpPackages(nilData)
+	if filteredData != nil {
+		t.Errorf("expected 'nil' result on 'nil' input, got [%v]", filteredData)
+	}
+
+	filteredData = app.filterPhpPackages(emptyData)
+	if filteredData != nil {
+		t.Errorf("expected 'nil' result on empty data input, got [%v]", filteredData)
+	}
+
+	expect := []byte(`[["drupal","6.0",{}]]`)
+	filteredData = app.filterPhpPackages(validData)
+	if string(filteredData) != string(expect) {
+		t.Errorf("expected [%v], got [%v]", string(expect), string(filteredData))
+	}
+
+	expect = []byte(`[["wordpress","7.0",{}],["symfony","5.1",{}]]`)
+	filteredData = app.filterPhpPackages(moreValidData)
+	if string(filteredData) != string(expect) {
+		t.Errorf("expected [%v], got [%v]", string(expect), string(filteredData))
+	}
+
+	filteredData = app.filterPhpPackages(duplicateData)
+	if filteredData != nil {
+		t.Errorf("expected 'nil', got [%v]", filteredData)
+	}
+}

--- a/daemon/internal/newrelic/php_packages.go
+++ b/daemon/internal/newrelic/php_packages.go
@@ -13,6 +13,11 @@ import (
 	"github.com/newrelic/newrelic-php-agent/daemon/internal/newrelic/log"
 )
 
+type PhpPackagesKey struct {
+	Name 	string
+	Version string
+}
+
 // phpPackages represents all detected packages reported by an agent.
 type PhpPackages struct {
 	numSeen int

--- a/daemon/internal/newrelic/processor.go
+++ b/daemon/internal/newrelic/processor.go
@@ -699,6 +699,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType, du_chan ch
 		txnTraces := harvest.TxnTraces
 		phpPackages := harvest.PhpPackages
 
+		phpPackages.data = ah.App.filterPhpPackages(phpPackages.data)
 		harvest.Metrics = NewMetricTable(limits.MaxMetrics, time.Now())
 		harvest.Errors = NewErrorHeap(limits.MaxErrors)
 		harvest.SlowSQLs = NewSlowSQLs(limits.MaxSlowSQLs)


### PR DESCRIPTION
adds a filter for package data already sent during the current connection instance to prevent sending duplicate data between harvests.