### PR TITLE
feat(agent): update default for wp hooks options

### DIFF
--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1896,7 +1896,7 @@ static PHP_INI_MH(nr_custom_events_max_samples_stored_mh) {
   return SUCCESS;
 }
 
-#define DEFAULT_WORDPRESS_HOOKS_OPTIONS "all_callbacks"
+#define DEFAULT_WORDPRESS_HOOKS_OPTIONS "plugin_callbacks"
 static PHP_INI_MH(nr_wordpress_hooks_options_mh) {
   nrinistr_t* p;
 

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1169,17 +1169,17 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ; Setting: newrelic.framework.wordpress.hooks.options
 ; Type   : string (all_callbacks, plugin_callbacks, threshold)
 ; Scope  : per-directory
-; Default: all_callbacks
+; Default: plugin_callbacks
 ; Info   : Sets the options how WordPress hooks are instrumented.
 ;
 ;          New Relic agent can provide different levels of insights into WordPress hooks.
-;          By default, all hook callbacks functions are instrumented ("all_callbacks").
-;          To reduce agent's overhead it is possible to limit the instrumentation to only
-;          plugin/theme callbacks ("plugin_callbacks"). Third option is to monitor hooks
-;          without instrumenting callbacks ("threshold"). This option does not give insights
-;          about plugins/themes.
+;          By default, only plugin/theme callbacks are instrumented ("plugin_callbacks").
+;          At the cost of increased agent's overhead it is possible to extend the
+;          instrumentation to all hook callbacks functions ("all_callbacks")nly. Third option
+;          is to monitor hooks without instrumenting callbacks ("threshold"). This option
+;          does not give insights about plugins/themes.
 ;
-;newrelic.framework.wordpress.hooks.options = "all_callbacks"
+;newrelic.framework.wordpress.hooks.options = "plugin_callbacks"
 
 ; Setting: newrelic.framework.wordpress.hooks.threshold
 ; Type   : time specification string ("500ms", "1s750ms" etc)

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1175,7 +1175,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          New Relic agent can provide different levels of insights into WordPress hooks.
 ;          By default, only plugin/theme callbacks are instrumented ("plugin_callbacks").
 ;          At the cost of increased agent's overhead it is possible to extend the
-;          instrumentation to all hook callbacks functions ("all_callbacks")nly. Third option
+;          instrumentation to all hook callbacks functions ("all_callbacks"). Third option
 ;          is to monitor hooks without instrumenting callbacks ("threshold"). This option
 ;          does not give insights about plugins/themes.
 ;

--- a/tests/integration/frameworks/wordpress/test_wordpress_00.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_00.php
@@ -9,8 +9,8 @@ Test WordPress default instrumentation. The agent should:
  - detect WordPress framework
  - name the web transaction as an 'Action' named after the template used to generate the page
  - detect custom plugins and themes
- - generate hooks metrics for all callback functions executions; the execution time of callback
-   functions from wordpress core, custom plugins and themes is captured.
+ - generate hooks metrics only for plugins and themes callback functions executions; 
+   only the execution time of callback functions from custom plugins and themes is captured.
 No errors should be generated.
 */
 
@@ -40,11 +40,11 @@ Framework/WordPress/Plugin/mock-plugin1
 Framework/WordPress/Plugin/mock-plugin2
 Framework/WordPress/Plugin/mock-theme1
 Framework/WordPress/Plugin/mock-theme2
-Framework/WordPress/Hook/wp_init
-Framework/WordPress/Hook/the_content
 */
 
 /*EXPECT_METRICS_DONT_EXIST
+Framework/WordPress/Hook/wp_init
+Framework/WordPress/Hook/the_content
 */
 
 /*EXPECT_ERROR_EVENTS null */

--- a/tests/integration/frameworks/wordpress/test_wordpress_00.php7.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_00.php7.php
@@ -9,8 +9,8 @@ Test WordPress default instrumentation. The agent should:
  - detect WordPress framework
  - name the web transaction as an 'Action' named after the template used to generate the page
  - detect custom plugins and themes
- - generate hooks metrics for all callback functions executions; the execution time of callback
-   functions from wordpress core, custom plugins and themes is captured.
+ - generate hooks metrics only for plugins and themes callback functions executions; 
+   only the execution time of callback functions from custom plugins and themes is captured.
 No errors should be generated.
 */
 
@@ -32,11 +32,11 @@ Framework/WordPress/Plugin/mock-plugin1
 Framework/WordPress/Plugin/mock-plugin2
 Framework/WordPress/Plugin/mock-theme1
 Framework/WordPress/Plugin/mock-theme2
-Framework/WordPress/Hook/wp_init
-Framework/WordPress/Hook/the_content
 */
 
 /*EXPECT_METRICS_DONT_EXIST
+Framework/WordPress/Hook/wp_init
+Framework/WordPress/Hook/the_content
 */
 
 /*EXPECT_ERROR_EVENTS null */

--- a/tests/integration/frameworks/wordpress/test_wordpress_00_1.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_00_1.php
@@ -10,8 +10,8 @@ The agent should:
  - detect WordPress framework
  - name the web transaction as an 'Action' named after the template used to generate the page
  - detect custom plugins and themes
- - generate hooks metrics for all callback functions executions; the execution time of callback
-   functions from wordpress core, custom plugins and themes is captured.
+ - generate hooks metrics only for plugins and themes callback functions executions; 
+   only the execution time of callback functions from custom plugins and themes is captured.
 No errors should be generated.
 */
 
@@ -34,11 +34,11 @@ Framework/WordPress/Plugin/mock-plugin1
 Framework/WordPress/Plugin/mock-plugin2
 Framework/WordPress/Plugin/mock-theme1
 Framework/WordPress/Plugin/mock-theme2
-Framework/WordPress/Hook/wp_init
-Framework/WordPress/Hook/the_content
 */
 
 /*EXPECT_METRICS_DONT_EXIST
+Framework/WordPress/Hook/wp_init
+Framework/WordPress/Hook/the_content
 */
 
 /*EXPECT_ERROR_EVENTS null */

--- a/tests/integration/frameworks/wordpress/test_wordpress_00_2.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_00_2.php
@@ -10,8 +10,8 @@ The agent should:
  - detect WordPress framework
  - name the web transaction as an 'Action' named after the template used to generate the page
  - detect custom plugins and themes
- - generate hooks metrics for all callback functions executions; the execution time of callback
-   functions from wordpress core, custom plugins and themes is captured.
+ - generate hooks metrics only for plugins and themes callback functions executions; 
+   only the execution time of callback functions from custom plugins and themes is captured.
 No errors should be generated.
 */
 
@@ -34,11 +34,11 @@ Framework/WordPress/Plugin/mock-plugin1
 Framework/WordPress/Plugin/mock-plugin2
 Framework/WordPress/Plugin/mock-theme1
 Framework/WordPress/Plugin/mock-theme2
-Framework/WordPress/Hook/wp_init
-Framework/WordPress/Hook/the_content
 */
 
 /*EXPECT_METRICS_DONT_EXIST
+Framework/WordPress/Hook/wp_init
+Framework/WordPress/Hook/the_content
 */
 
 /*EXPECT_ERROR_EVENTS null */

--- a/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_apply_filters.php
@@ -8,8 +8,8 @@
 The agent should properly instrument Wordpress apply_filters hooks. Since the
 mocked hooks are detected by the agent as WordPress core (plugin_from_function 
 returns NULL), and WordPress core callbacks are not instrumented by default,
-therefore newrelic.framework.wordpress.core needs to be set to true for the
-agent to generate the hooks metrics.
+therefore newrelic.framework.wordpress.hooks.options needs to be set to 
+"all_callbacks" for the agent to generate the hooks metrics.
 */
 
 /*SKIPIF
@@ -18,7 +18,7 @@ agent to generate the hooks metrics.
 /*INI
 newrelic.framework = wordpress
 newrelic.framework.wordpress.hooks_threshold = 0
-newrelic.framework.wordpress.core = true
+newrelic.framework.wordpress.hooks.options = all_callbacks
 */
 
 /*EXPECT

--- a/tests/integration/frameworks/wordpress/test_wordpress_do_action.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_do_action.php
@@ -8,8 +8,8 @@
 The agent should properly instrument Wordpress do_action hooks. Since the
 mocked hooks are detected by the agent as WordPress core (plugin_from_function 
 returns NULL), and WordPress core callbacks are not instrumented by default,
-therefore newrelic.framework.wordpress.core needs to be set to true for the
-agent to generate the hooks metrics.
+therefore newrelic.framework.wordpress.hooks.options needs to be set to 
+"all_callbacks" for the agent to generate the hooks metrics.
 */
 
 /*SKIPIF
@@ -17,8 +17,7 @@ agent to generate the hooks metrics.
 
 /*INI
 newrelic.framework = wordpress
-newrelic.framework.wordpress.hooks_threshold = 0
-newrelic.framework.wordpress.core = true
+newrelic.framework.wordpress.hooks.options = all_callbacks
 */
 
 /*EXPECT

--- a/tests/integration/frameworks/wordpress/test_wordpress_transaction_name_hooks_on.php
+++ b/tests/integration/frameworks/wordpress/test_wordpress_transaction_name_hooks_on.php
@@ -11,17 +11,15 @@ since WordPress hooks are enabled, Framework/WordPress/Hook/template_include
 metric should be generated and the hook function should be instrumented.
 However, since the mocked hooks are detected by the agent as WordPress core
 (plugin_from_function  returns NULL), and WordPress core callbacks are not
-instrumented by default, therefore newrelic.framework.wordpress.core needs
-to be set to true for the agent to generate the hooks metrics.
+instrumented by default, therefore therefore newrelic.framework.wordpress.hooks.options
+needs to be set to  "all_callbacks" for the agent to generate the hooks metrics.
 */
 
 /*SKIPIF*/
 
 /*INI
 newrelic.framework = wordpress
-newrelic.framework.wordpress.hooks = true
-newrelic.framework.wordpress.hooks_threshold = 0
-newrelic.framework.wordpress.core = true
+newrelic.framework.wordpress.hooks.options = all_callbacks
 */
 
 /*ENVIRONMENT


### PR DESCRIPTION
By default the agent will only instrument hook callbacks from plugins/themes and will not instrument hook callbacks from wordpress core.