### PR TITLE
fix(agent): Fixes warning from mysqli when explaining slow SQL queries (GH issue 875)

### DIFF
--- a/agent/php_mysqli.c
+++ b/agent/php_mysqli.c
@@ -353,6 +353,31 @@ nr_status_t nr_php_mysqli_query_set_query(nr_php_object_handle_t handle,
   return NR_SUCCESS;
 }
 
+nr_status_t nr_php_mysqli_query_clear_query(nr_php_object_handle_t handle) {
+  zval* metadata = NULL;
+
+  /* If a metadata entry exists then clear the "query" tag from it.
+   *  If an entry does not exist then nothing needs to be done.
+   */
+  metadata = nr_php_mysqli_query_find(handle);
+  if (NULL == metadata) {
+    return NR_FAILURE;
+  }
+
+  /* Clear the "query" element */
+  nr_php_zend_hash_del(Z_ARRVAL_P(metadata), "query");
+
+  /*
+   * Since the query is cleared so must the bind parameters, so let's get rid of
+   * whatever's here. We'll ignore the return values, since if the keys don't
+   * already exist no harm is done.
+   */
+  nr_php_zend_hash_del(Z_ARRVAL_P(metadata), "bind_args");
+  nr_php_zend_hash_del(Z_ARRVAL_P(metadata), "bind_format");
+
+  return NR_SUCCESS;
+}
+
 int nr_php_mysqli_zval_is_link(const zval* zv TSRMLS_DC) {
   if (NULL == zv) {
     return 0;

--- a/agent/php_mysqli.h
+++ b/agent/php_mysqli.h
@@ -88,6 +88,15 @@ extern nr_status_t nr_php_mysqli_query_set_link(
     zval* link TSRMLS_DC);
 
 /*
+ * Purpose : Clear the SQL used to prepare a MySQLi statement.
+ *
+ * Params  : 1. The object handle of the statement.
+ *
+ * Returns : NR_SUCCESS or NR_FAILURE.
+ */
+extern nr_status_t nr_php_mysqli_query_clear_query(nr_php_object_handle_t handle);
+
+/*
  * Purpose : Save the SQL used to prepare a MySQLi statement.
  *
  * Params  : 1. The object handle of the statement.

--- a/tests/integration/mysqli/test_explain_reused_id_multiple_001.php
+++ b/tests/integration/mysqli/test_explain_reused_id_multiple_001.php
@@ -1,0 +1,124 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should generate explain plans even when object IDs are reused
+and some of the SQL strings are not explainable.  This tests that if
+a object ID is reused and a new mysqli::stmt object is created with an
+unexplainable SQL string that the "mysqli_entries" entry for this
+object ID ("handle") has it "query" parameter cleared.  This prevents
+using an older, stale "query" parameter (from a myqsli::stmt object
+which was reclaimed by PHP) being using incorrectly with a newer query.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.transaction_tracer.explain_enabled = true
+newrelic.transaction_tracer.explain_threshold = 500
+newrelic.transaction_tracer.record_sql = obfuscated
+*/
+
+/*
+
+[
+  [
+    [
+      "OtherTransaction/php__FILE__",
+      "\u003cunknown\u003e",
+      "??",
+      "SELECT TABLE_NAME FROM information_schema.tables WHERE table_name=? AND SLEEP(?);;",
+      "Datastore/statement/MySQL/tables/select",
+      1,
+      "??",
+      "??",
+      "??",
+      {
+        "backtrace": [
+          " in mysqli_stmt::execute called at __FILE__ (??)",
+          " in doSQL called at __FILE__ (??)"
+        ]
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+If you see this message, it didn't crash
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+/* Create a mysqli::stmt object using "prepare" but do not execute.
+   The result will be the mysqli:stmt object will be released when
+   this function exits and be reused.
+ */
+function justPrepare($dbConn)
+{
+    $stmt2 = $dbConn->prepare("SELECT ?");
+}
+
+/* Run an SQL query.
+   Params:
+      $dbConn         mysql connection object
+      $delay          delay for query in seconds
+      $explainable    true if query is explainable, otherwise an
+                      unexplainable sql query is run
+*/
+function doSQL($dbConn, $delay, $explainable) {
+
+    /* if sql statement has 2 ';' then agent considers it as multi-statement
+       and treats it as unexplainable, see nr_php_explain_mysql_query_is_explainable()
+    */
+    if ($explainable) {
+        $suffix = "";
+    } else {
+        $suffix = ";;";
+    }
+
+    $stmt = $dbConn->prepare("SELECT TABLE_NAME FROM information_schema.tables WHERE table_name=? AND SLEEP(?)" . $suffix);
+
+    if (! $stmt) {
+        throw new Exception("Prepare Failed : " . $dbConn->error);
+    }
+
+    $table = "STATISTICS";
+    $stmt->bind_param('si', $table, $delay);
+    if (! $stmt->execute()) {
+        throw new Exception("Execute Failed : " . $stmt->error);
+    }
+
+    $stmt->bind_result($someId);
+    $stmt->fetch();
+    $stmt->close();
+}
+
+/* main code */
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/config.php');
+
+$dbConn = new mysqli($MYSQL_HOST, $MYSQL_USER, $MYSQL_PASSWD, $MYSQL_DB, $MYSQL_PORT, $MYSQL_SOCKET);
+
+/* run a test where a prepared, explainable statement is prepared
+   but not executed.  Then run a prepared, unexplainable slow sql
+   query which should not be explained.  This will lead to the
+   first stmt object being reused for the second slow sql query.
+
+   Tests for reqgression of a bug where the query string
+   from a previous, explainable SQL query with the same object ID
+   ("handle") would be used in error.
+*/
+
+justPrepare($dbConn);
+doSQL($dbConn, 1, false);
+
+echo "If you see this message, it didn't crash\n";
+

--- a/tests/integration/mysqli/test_explain_reused_id_multiple_002.php
+++ b/tests/integration/mysqli/test_explain_reused_id_multiple_002.php
@@ -160,9 +160,9 @@ $dbConn = new mysqli($MYSQL_HOST, $MYSQL_USER, $MYSQL_PASSWD, $MYSQL_DB, $MYSQL_
    but not executed.  Then run a prepared, unexplainable slow sql
    query which should not be explained.  This will lead to the
    first stmt object being reused for the second slow sql query.
-   Then run an explaiaable, slow SQL query and confirm it is
+   Then run an explainable, slow SQL query and confirm it is
    explained.
-   
+
    Tests for reqgression of a bug where the query string
    from a previous, explainable SQL query with the same object ID
    ("handle") would be used in error.

--- a/tests/integration/mysqli/test_explain_reused_id_multiple_002.php
+++ b/tests/integration/mysqli/test_explain_reused_id_multiple_002.php
@@ -1,0 +1,176 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should generate explain plans even when object IDs are reused
+and some of the SQL strings are not explainable.  This tests that if
+a object ID is reused and a new mysqli::stmt object is created with an
+unexplainable SQL string that the "mysqli_entries" entry for this
+object ID ("handle") has it "query" parameter cleared.  This prevents
+using an older, stale "query" parameter (from a myqsli::stmt object
+which was reclaimed by PHP) being using incorrectly with a newer query.
+
+This test is like "_001" version but an additional, explainable slow SQL
+query in run at the end to ensure these are also recorded properly.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.transaction_tracer.explain_enabled = true
+newrelic.transaction_tracer.explain_threshold = 500
+newrelic.transaction_tracer.record_sql = obfuscated
+*/
+
+/*EXPECT_SLOW_SQLS
+[
+  [
+    [
+      "OtherTransaction/php__FILE__",
+      "\u003cunknown\u003e",
+      "??",
+      "SELECT TABLE_NAME FROM information_schema.tables WHERE table_name=? AND SLEEP(?)",
+      "Datastore/statement/MySQL/tables/select",
+      1,
+      "??",
+      "??",
+      "??",
+      {
+        "explain_plan": [
+          [
+            "id",
+            "select_type",
+            "table",
+            "type",
+            "possible_keys",
+            "key",
+            "key_len",
+            "ref",
+            "rows",
+            "Extra"
+          ],
+          [
+            [
+              1,
+              "SIMPLE",
+              "tables",
+              "ALL",
+              null,
+              "TABLE_NAME",
+              null,
+              null,
+              null,
+              "Using where; Skip_open_table; Scanned 1 database"
+            ]
+          ]
+        ],
+        "backtrace": [
+          " in mysqli_stmt::execute called at __FILE__ (??)",
+          " in doSQL called at __FILE__ (??)"
+        ]
+      }
+    ],
+    [
+      "OtherTransaction/php__FILE__",
+      "\u003cunknown\u003e",
+      "??",
+      "SELECT TABLE_NAME FROM information_schema.tables WHERE table_name=? AND SLEEP(?);;",
+      "Datastore/statement/MySQL/tables/select",
+      1,
+      "??",
+      "??",
+      "??",
+      {
+        "backtrace": [
+          " in mysqli_stmt::execute called at __FILE__ (??)",
+          " in doSQL called at __FILE__ (??)"
+        ]
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+If you see this message, it didn't crash
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+/* Create a mysqli::stmt object using "prepare" but do not execute.
+   The result will be the mysqli:stmt object will be released when
+   this function exits and be reused.
+ */
+function justPrepare($dbConn)
+{
+    $stmt2 = $dbConn->prepare("SELECT ?");
+}
+
+/* Run an SQL query.
+   Params:
+      $dbConn         mysql connection object
+      $delay          delay for query in seconds
+      $explainable    true if query is explainable, otherwise an
+                      unexplainable sql query is run
+*/
+function doSQL($dbConn, $delay, $explainable) {
+
+    /* if sql statement has 2 ';' then agent considers it as multi-statement
+       and treats it as unexplainable, see nr_php_explain_mysql_query_is_explainable()
+    */
+    if ($explainable) {
+        $suffix = "";
+    } else {
+        $suffix = ";;";
+    }
+
+    $stmt = $dbConn->prepare("SELECT TABLE_NAME FROM information_schema.tables WHERE table_name=? AND SLEEP(?)" . $suffix);
+
+    if (! $stmt) {
+        throw new Exception("Prepare Failed : " . $dbConn->error);
+    }
+
+    $table = "STATISTICS";
+    $stmt->bind_param('si', $table, $delay);
+    if (! $stmt->execute()) {
+        throw new Exception("Execute Failed : " . $stmt->error);
+    }
+
+    $stmt->bind_result($someId);
+    $stmt->fetch();
+    $stmt->close();
+}
+
+
+
+/* main code */
+require_once(realpath (dirname ( __FILE__ )) . '/../../include/config.php');
+
+$dbConn = new mysqli($MYSQL_HOST, $MYSQL_USER, $MYSQL_PASSWD, $MYSQL_DB, $MYSQL_PORT, $MYSQL_SOCKET);
+
+/* run a test where a prepared, explainable statement is prepared
+   but not executed.  Then run a prepared, unexplainable slow sql
+   query which should not be explained.  This will lead to the
+   first stmt object being reused for the second slow sql query.
+   Then run an explaiaable, slow SQL query and confirm it is
+   explained.
+   
+   Tests for reqgression of a bug where the query string
+   from a previous, explainable SQL query with the same object ID
+   ("handle") would be used in error.
+*/
+
+justPrepare($dbConn);
+doSQL($dbConn, 1, false);
+doSQL($dbConn, 1, true);
+
+echo "If you see this message, it didn't crash\n";
+


### PR DESCRIPTION
In GH issue #875 it was reported a warning is generated when using prepared statements with `mysqli`.  The issue included excellent instructions on how to reproduce the issue.  This PR addresses the cause of the warning.  

To understand the cause of the warning requires understanding how the agent handles `mysqli::stmt` objects.  When a SQL statement is prepared via mysqli the agent will store the SQL string in a global hashmap called `mysqli_queries` *if* the SQL is considered explainable (determined via `nr_php_explain_mysql_query_is_explainable()`), otherwise it is just ignored.  Later when a slow SQL query is detected the SQL string is retrieved and used to explain the query.

An additional factor is when a `mysqli::stmt` object is released it goes into a free pool PHP keeps which allows it to quickly hand out an allocated section of memory when a new object is created.  Each object has a `object ID` (referenced as a `handle` in the agent for the relevant code).  When an the allocated object is reused from the free pool it retains the same `object ID`.

The agent used the `object ID` (`handle`) as the key for storing the prepared SQL string for explainable SQL strings.  Now what if an explainable query comes through, the string is stored, and then that object is released.  A new query is prepared with a string that is NOT explainable and gets the object container with the same `object ID` as the explainable one just released.  The string stored in `mysqli_queries` using that `object ID` as the key is now stale.  If the new, unexplainable query is slow then the agent will pull this stale string and try to run an explain with it - leading to the warning.

The fix is to clear any query string for a given `object ID` if the query string is unexplainable.

Integration tests were added (based on the reproduction case) that test for a regression of this fix.