### PR TITLE
fix(tests): Fixes mysqli test by adding missing slowsql

### DIFF
--- a/tests/integration/mysqli/test_explain_reused_id_multiple_001.php
+++ b/tests/integration/mysqli/test_explain_reused_id_multiple_001.php
@@ -25,8 +25,7 @@ newrelic.transaction_tracer.explain_threshold = 500
 newrelic.transaction_tracer.record_sql = obfuscated
 */
 
-/*
-
+/*EXPECT_SLOW_SQLS
 [
   [
     [


### PR DESCRIPTION
A EXPECT_SLOW_SQLS specification was left out of one test from PR #881 .