### PR TITLE
fix(agent): end guzzle's external segment for rejected request

### DIFF
--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -112,14 +112,10 @@ static void nr_guzzle6_requesthandler_handle_response(zval* handler,
   nr_segment_external_params_t external_params = {.library = "Guzzle 6"};
   zval* request;
   zval* method;
-  zval* status;
+  zval* status = NULL;
 
   if (NR_FAILURE
       == nr_guzzle_obj_find_and_remove(handler, &segment TSRMLS_CC)) {
-    return;
-  }
-
-  if (!nr_php_psr7_is_response(response TSRMLS_CC)) {
     return;
   }
 
@@ -133,30 +129,32 @@ static void nr_guzzle6_requesthandler_handle_response(zval* handler,
     return;
   }
 
-  /*
-   * Get the X-NewRelic-App-Data response header. If there isn't one, NULL is
-   * returned, and everything still works just fine.
-   */
-  external_params.encoded_response_header
-      = nr_php_psr7_message_get_header(response, X_NEWRELIC_APP_DATA TSRMLS_CC);
-
-  if (NRPRG(txn) && NRTXN(special_flags.debug_cat)) {
-    nrl_verbosedebug(
-        NRL_CAT, "CAT: outbound response: transport='Guzzle 6' %s=" NRP_FMT,
-        X_NEWRELIC_APP_DATA, NRP_CAT(external_params.encoded_response_header));
-  }
-
-  status = nr_php_call(response, "getStatusCode");
-
-  if (nr_php_is_zval_valid_integer(status)) {
-    external_params.status = Z_LVAL_P(status);
-  }
-
   method = nr_php_call(request, "getMethod");
 
   if (nr_php_is_zval_valid_string(method)) {
     external_params.procedure
         = nr_strndup(Z_STRVAL_P(method), Z_STRLEN_P(method));
+  }
+
+  if (NULL != response && nr_php_psr7_is_response(response TSRMLS_CC)) {
+    /*
+    * Get the X-NewRelic-App-Data response header. If there isn't one, NULL is
+    * returned, and everything still works just fine.
+    */
+    external_params.encoded_response_header
+        = nr_php_psr7_message_get_header(response, X_NEWRELIC_APP_DATA TSRMLS_CC);
+
+    if (NRPRG(txn) && NRTXN(special_flags.debug_cat)) {
+      nrl_verbosedebug(
+          NRL_CAT, "CAT: outbound response: transport='Guzzle 6' %s=" NRP_FMT,
+          X_NEWRELIC_APP_DATA, NRP_CAT(external_params.encoded_response_header));
+    }
+
+    status = nr_php_call(response, "getStatusCode");
+
+    if (nr_php_is_zval_valid_integer(status)) {
+      external_params.status = Z_LVAL_P(status);
+    }
   }
 
   nr_segment_external_end(&segment, &external_params);
@@ -291,6 +289,12 @@ static PHP_NAMED_FUNCTION(nr_guzzle6_requesthandler_onrejected) {
     return;
   }
 
+  this_obj = NR_PHP_USER_FN_THIS();
+  if (NULL == this_obj) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: cannot obtain 'this'", __func__);
+    return;
+  }
+
   /*
    * See if this is an exception that we can get a response from. We're going
    * to look for BadResponseException because, although it inherits from
@@ -305,18 +309,13 @@ static PHP_NAMED_FUNCTION(nr_guzzle6_requesthandler_onrejected) {
    */
   if (!nr_php_object_instanceof_class(
           exc, "GuzzleHttp\\Exception\\BadResponseException" TSRMLS_CC)) {
+    nr_guzzle6_requesthandler_handle_response(this_obj, NULL);
     return;
   }
 
   response = nr_php_call(exc, "getResponse");
   if (NULL == response) {
     nrl_verbosedebug(NRL_FRAMEWORK, "%s: error calling getResponse", __func__);
-    return;
-  }
-
-  this_obj = NR_PHP_USER_FN_THIS();
-  if (NULL == this_obj) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: cannot obtain 'this'", __func__);
     return;
   }
 

--- a/daemon/cmd/integration_runner/main.go
+++ b/daemon/cmd/integration_runner/main.go
@@ -245,6 +245,16 @@ func catRequest(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
+func delayRequest(w http.ResponseWriter, r *http.Request) {
+	duration := r.URL.Query().Get("duration")
+	io.WriteString(w, "waiting...")
+	d, err := time.ParseDuration(duration)
+	if nil != err {
+		d = 0
+	}
+	time.Sleep(d)
+}
+
 func init() {
 	//setup typed flags
 	flag.Var(&flagLicense, "license", "use a license key other than the hard coded default. Supports @filename syntax for loading from files.")
@@ -303,6 +313,7 @@ func main() {
 		io.WriteString(w, "Hello world!")
 	})
 	mux.HandleFunc("/cat", catRequest)
+	mux.HandleFunc("/delay", delayRequest)
 	addr := "127.0.0.1:" + strconv.Itoa(*flagExternalPort)
 	srv := &http.Server{Addr: addr, Handler: mux}
 	ln, err := net.Listen("tcp", addr)

--- a/daemon/cmd/integration_runner/main.go
+++ b/daemon/cmd/integration_runner/main.go
@@ -375,6 +375,7 @@ func main() {
 
 	// Env vars common to all tests.
 	ctx.Env["EXTERNAL_HOST"] = externalHost
+	os.Setenv("EXTERNAL_HOST", externalHost)
 
 	handler, err := startDaemon("unix", *flagPort, flagSecurityToken.String(), flagSecuityPolicies.String())
 	if err != nil {

--- a/daemon/cmd/integration_runner/main.go
+++ b/daemon/cmd/integration_runner/main.go
@@ -375,7 +375,6 @@ func main() {
 
 	// Env vars common to all tests.
 	ctx.Env["EXTERNAL_HOST"] = externalHost
-	os.Setenv("EXTERNAL_HOST", externalHost)
 
 	handler, err := startDaemon("unix", *flagPort, flagSecurityToken.String(), flagSecuityPolicies.String())
 	if err != nil {

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -684,7 +684,7 @@ func (t *Test) Compare(harvest *newrelic.Harvest) {
 	}
 
 	if nil != t.metricsExist {
-		for _, name := range strings.Split(strings.TrimSpace(string(t.metricsExist)), "\n") {
+		for _, name := range strings.Split(strings.TrimSpace(string(t.subEnvVars(t.metricsExist))), "\n") {
 			name = strings.TrimSpace(name)
 			actual := strings.Replace(name, "__FILE__", t.Path, -1)
 			if !harvest.Metrics.Has(actual) {
@@ -694,7 +694,7 @@ func (t *Test) Compare(harvest *newrelic.Harvest) {
 	}
 
 	if nil != t.metricsDontExist {
-		for _, name := range strings.Split(strings.TrimSpace(string(t.metricsDontExist)), "\n") {
+		for _, name := range strings.Split(strings.TrimSpace(string(t.subEnvVars(t.metricsDontExist))), "\n") {
 			name = strings.TrimSpace(name)
 			actual := strings.Replace(name, "__FILE__", t.Path, -1)
 			if harvest.Metrics.Has(actual) {

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -289,9 +289,9 @@ func (t *Test) subEnvVars(in []byte) []byte {
 	re := regexp.MustCompile("ENV\\[.*?\\]")
 	return re.ReplaceAllFunc(in, func(match []byte) []byte {
 		k := string(match[4 : len(match)-1])
-		v, present := os.LookupEnv(k)
+		v, present := t.Env[k]
 		if !present {
-			v = t.Env[k]
+			v = os.Getenv(k)
 		}
 		return []byte(v)
 	})

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -199,17 +199,8 @@ func merge(a, b map[string]string) map[string]string {
 	return merged
 }
 
-// merge e into Test.Env but don't overwrite existing keys
-func (t *Test) mergeEnv(e map[string]string) {
-	for k, v := range e {
-		if _, present := t.Env[k]; !present {
-			t.Env[k] = v
-		}
-	}
-}
-
 func (t *Test) MakeRun(ctx *Context) (Tx, error) {
-	t.mergeEnv(ctx.Env)
+	t.Env = merge(ctx.Env, t.Env)
 	settings := merge(ctx.Settings, t.Settings)
 	settings["newrelic.appname"] = t.Name
 
@@ -237,7 +228,7 @@ func (t *Test) MakeSkipIf(ctx *Context) (Tx, error) {
 		return nil, nil
 	}
 
-	t.mergeEnv(ctx.Env)
+	t.Env = merge(ctx.Env, t.Env)
 	settings := merge(ctx.Settings, t.Settings)
 	settings["newrelic.appname"] = "skipif"
 

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -199,10 +199,17 @@ func merge(a, b map[string]string) map[string]string {
 	return merged
 }
 
-func (t *Test) MakeRun(ctx *Context) (Tx, error) {
-	for k, v := range ctx.Env {
-		t.Env[k] = v
+// merge e into Test.Env but don't overwrite existing keys
+func (t *Test) mergeEnv(e map[string]string) {
+	for k, v := range e {
+		if _, present := t.Env[k]; !present {
+			t.Env[k] = v
+		}
 	}
+}
+
+func (t *Test) MakeRun(ctx *Context) (Tx, error) {
+	t.mergeEnv(ctx.Env)
 	settings := merge(ctx.Settings, t.Settings)
 	settings["newrelic.appname"] = t.Name
 
@@ -230,9 +237,7 @@ func (t *Test) MakeSkipIf(ctx *Context) (Tx, error) {
 		return nil, nil
 	}
 
-	for k, v := range ctx.Env {
-		t.Env[k] = v
-	}
+	t.mergeEnv(ctx.Env)
 	settings := merge(ctx.Settings, t.Settings)
 	settings["newrelic.appname"] = "skipif"
 

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -345,7 +345,7 @@ func (t *Test) compareSpanEventsLike(harvest *newrelic.Harvest) {
 		return
 	}
 
-	if err := json.Unmarshal(t.spanEventsLike, &x2); nil != err {
+	if err := json.Unmarshal(SubEnvVars(t.spanEventsLike), &x2); nil != err {
 		t.Fatal(fmt.Errorf("unable to parse expected spans like json for fuzzy matching: %v", err))
 		return
 	}

--- a/daemon/internal/newrelic/integration/test_test.go
+++ b/daemon/internal/newrelic/integration/test_test.go
@@ -78,6 +78,10 @@ func TestSubsEnvVar(t *testing.T) {
 			in:   []byte("External/ENV[" + k + "]/all"),
 			want: []byte("External/" + v + "/all"),
 		},
+		{
+			in:   []byte("External/ENV[NON_EXISTING_KEY]/all"),
+			want: []byte("External//all"),
+		},
 	}
 
 	for i, tt := range tests {

--- a/daemon/internal/newrelic/integration/test_test.go
+++ b/daemon/internal/newrelic/integration/test_test.go
@@ -95,35 +95,35 @@ func makeTestWithEnv(name string, e map[string]string) *Test {
 	return t
 }
 
-func TestMergeEnv(t *testing.T) {
-	os_k := "OS_KEY"
-	os_v := "os_value"
-	test_k := "TEST_KEY"
-	test_v := "test_value"
-	os_env := map[string]string{
-		os_k: os_v,
+func TestMerge(t *testing.T) {
+	m1_k := "OS_KEY"
+	m1_v := "os_value"
+	m2_k := "TEST_KEY"
+	m2_v := "test_value"
+	m1 := map[string]string{
+		m1_k: m1_v,
 	}
-	test_same_env := map[string]string{
-		os_k: test_v,
+	m2 := map[string]string{
+		m2_k: m2_v,
 	}
-	test_diff_env := map[string]string{
-		test_k: test_v,
+	same_key_diff_val := map[string]string{
+		m1_k: m2_v,
 	}
 	tests := []struct {
 		name string
-		env  map[string]string
+		m    map[string]string
+		k    string
 		want string
 	}{
-		{name: "TestNoEnv", env: nil, want: os_v},
-		{name: "TestWithSameEnv", env: test_same_env, want: test_v},
-		{name: "TestWithDiffEnv", env: test_diff_env, want: os_v},
+		{name: "MergeEmptyMap", m: nil, k: m1_k, want: m1_v},
+		{name: "MergeDiffMaps", m: m2, k: m1_k, want: m1_v},
+		{name: "MergeMapWithSameKeys", m: same_key_diff_val, k: m1_k, want: m2_v},
 	}
 	for i, tt := range tests {
-		test := makeTestWithEnv(tt.name, tt.env)
-		test.mergeEnv(os_env)
-		got := test.Env[os_k]
+		mm := merge(m1, tt.m)
+		got := mm[tt.k]
 		if got != tt.want {
-			t.Errorf("%d. %s - got: %s; want %s", i, test.Name, got, tt.want)
+			t.Errorf("%d. %s - got: %s; want %s", i, tt.name, got, tt.want)
 		}
 	}
 }

--- a/tests/integration/external/guzzle6/test_bad_response_exception_async.php
+++ b/tests/integration/external/guzzle6/test_bad_response_exception_async.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for an async external reqest that ends up throwing BadResponseException exception
+is marked as http, uri and status code are captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+External/example.com/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External/example.com/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://example.com/resource",
+      "http.method": "GET",
+      "http.statusCode": 404
+    }
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS null*/
+
+/*EXPECT
+all's well that ends well
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\BadResponseException(
+      "ClientException", 
+      $request,
+      $response
+      )
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+
+]);
+
+$promise = $client->sendAsync($request);
+GuzzleHttp\Promise\Utils::settle($promise)->wait();
+
+echo "all's well that ends well" . PHP_EOL;

--- a/tests/integration/external/guzzle6/test_bad_response_exception_async.php
+++ b/tests/integration/external/guzzle6/test_bad_response_exception_async.php
@@ -21,8 +21,12 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
 /*EXPECT_METRICS_EXIST
-External/example.com/all
+External/ENV[TEST_EXTERNAL_HOST]/all
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE
@@ -32,7 +36,7 @@ External/example.com/all
       "traceId": "??",
       "duration": "??",
       "transactionId": "??",
-      "name": "External/example.com/all",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
       "guid": "??",
       "type": "Span",
       "category": "http",
@@ -45,7 +49,7 @@ External/example.com/all
     },
     {},
     {
-      "http.url": "http://example.com/resource",
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
       "http.method": "GET",
       "http.statusCode": 404
     }
@@ -63,7 +67,9 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
 require_guzzle(6);
 
-$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
 $response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
 
 $stack = GuzzleHttp\HandlerStack::create(

--- a/tests/integration/external/guzzle6/test_bad_response_exception_async.php
+++ b/tests/integration/external/guzzle6/test_bad_response_exception_async.php
@@ -61,7 +61,7 @@ all's well that ends well
 
 require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
-require_guzzle(7);
+require_guzzle(6);
 
 $request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
 $response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");

--- a/tests/integration/external/guzzle6/test_bad_response_exception_async.php
+++ b/tests/integration/external/guzzle6/test_bad_response_exception_async.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for an async external reqest that ends up throwing BadResponseException exception
+Test that the span for an async external request that ends up throwing BadResponseException exception
 is marked as http, uri and status code are captured.
 */
 

--- a/tests/integration/external/guzzle6/test_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_bad_response_exception_sync.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for a sync external reqest that ends up throwing BadResponseException exception
+is marked as http, uri and status code are captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+External/example.com/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External/example.com/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://example.com/resource",
+      "http.method": "GET",
+      "http.statusCode": 404
+    }
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS null*/
+
+/*EXPECT
+gotcha!
+all's well that ends well
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new GuzzleHttp\Exception\BadResponseException(
+      "ClientException", 
+      $request,
+      $response
+      )
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+
+]);
+
+try {
+  $response = $client->send($request);
+} catch (GuzzleHttp\Exception\BadResponseException $e) {
+  echo "gotcha!". PHP_EOL;
+}
+
+echo "all's well that ends well" . PHP_EOL;

--- a/tests/integration/external/guzzle6/test_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_bad_response_exception_sync.php
@@ -21,8 +21,12 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
 /*EXPECT_METRICS_EXIST
-External/example.com/all
+External/ENV[TEST_EXTERNAL_HOST]/all
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE
@@ -32,7 +36,7 @@ External/example.com/all
       "traceId": "??",
       "duration": "??",
       "transactionId": "??",
-      "name": "External/example.com/all",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
       "guid": "??",
       "type": "Span",
       "category": "http",
@@ -45,7 +49,7 @@ External/example.com/all
     },
     {},
     {
-      "http.url": "http://example.com/resource",
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
       "http.method": "GET",
       "http.statusCode": 404
     }
@@ -64,7 +68,9 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
 require_guzzle(6);
 
-$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
 $response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
 
 $stack = GuzzleHttp\HandlerStack::create(

--- a/tests/integration/external/guzzle6/test_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_bad_response_exception_sync.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for a sync external reqest that ends up throwing BadResponseException exception
+Test that the span for a sync external request that ends up throwing BadResponseException exception
 is marked as http, uri and status code are captured.
 */
 

--- a/tests/integration/external/guzzle6/test_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_bad_response_exception_sync.php
@@ -62,7 +62,7 @@ all's well that ends well
 
 require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
-require_guzzle(7);
+require_guzzle(6);
 
 $request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
 $response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");

--- a/tests/integration/external/guzzle6/test_timeout_async.php
+++ b/tests/integration/external/guzzle6/test_timeout_async.php
@@ -41,7 +41,7 @@ newrelic.code_level_metrics.enabled = 0
     },
     {},
     {
-      "http.url": "??",
+      "http.url": "http://ENV[EXTERNAL_HOST]/delay",
       "http.method": "GET",
       "http.statusCode": 0
     }

--- a/tests/integration/external/guzzle6/test_timeout_async.php
+++ b/tests/integration/external/guzzle6/test_timeout_async.php
@@ -20,6 +20,9 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*EXPECT_METRICS_EXIST
+External/127.0.0.1/all
+*/
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [

--- a/tests/integration/external/guzzle6/test_timeout_async.php
+++ b/tests/integration/external/guzzle6/test_timeout_async.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for an async external reqest that times out is marked as http and uri is captured.
+Test that the span for an async external request that times out is marked as http and uri is captured. Status code is marked as 0.
 */
 
 /*SKIPIF

--- a/tests/integration/external/guzzle6/test_timeout_async.php
+++ b/tests/integration/external/guzzle6/test_timeout_async.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for an async external reqest that times out is marked as http and uri is captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External\/127.0.0.1\/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "??",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(6);
+
+$client = new GuzzleHttp\Client([
+  // Base URI is used with relative requests
+  'base_uri' => "$EXTERNAL_HOST",
+  // Set a short timeout, shorter than delay duration in the request
+  'timeout'  => 0.01,
+]);
+
+$promise = $client->getAsync('/delay?duration=100ms');
+GuzzleHttp\Promise\Utils::settle($promise)->wait();

--- a/tests/integration/external/guzzle6/test_timeout_sync.php
+++ b/tests/integration/external/guzzle6/test_timeout_sync.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for an sync external reqest that times out is marked as http and uri is captured.
+Test that the span for an sync external request that times out is marked as http and uri is captured. Status code is marked as 0.
 */
 
 /*SKIPIF

--- a/tests/integration/external/guzzle6/test_timeout_sync.php
+++ b/tests/integration/external/guzzle6/test_timeout_sync.php
@@ -41,7 +41,7 @@ newrelic.code_level_metrics.enabled = 0
     },
     {},
     {
-      "http.url": "??",
+      "http.url": "http://ENV[EXTERNAL_HOST]/delay",
       "http.method": "GET",
       "http.statusCode": 0
     }

--- a/tests/integration/external/guzzle6/test_timeout_sync.php
+++ b/tests/integration/external/guzzle6/test_timeout_sync.php
@@ -20,6 +20,9 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*EXPECT_METRICS_EXIST
+External/127.0.0.1/all
+*/
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [

--- a/tests/integration/external/guzzle6/test_timeout_sync.php
+++ b/tests/integration/external/guzzle6/test_timeout_sync.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for an sync external reqest that times out is marked as http and uri is captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External\/127.0.0.1\/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "??",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(6);
+
+$client = new GuzzleHttp\Client([
+  // Base URI is used with relative requests
+  'base_uri' => "$EXTERNAL_HOST",
+  // Set a short timeout, shorter than delay duration in the request
+  'timeout'  => 0.01,
+]);
+
+$response = $client->get('/delay?duration=100ms');
+

--- a/tests/integration/external/guzzle6/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_async.php
@@ -21,8 +21,12 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
 /*EXPECT_METRICS_EXIST
-External/example.com/all
+External/ENV[TEST_EXTERNAL_HOST]/all
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE
@@ -32,7 +36,7 @@ External/example.com/all
       "traceId": "??",
       "duration": "??",
       "transactionId": "??",
-      "name": "External\/example.com\/all",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
       "guid": "??",
       "type": "Span",
       "category": "http",
@@ -45,7 +49,7 @@ External/example.com/all
     },
     {},
     {
-      "http.url": "http://example.com/resource",
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
       "http.method": "GET",
       "http.statusCode": 0
     }
@@ -63,7 +67,9 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
 require_guzzle(6);
 
-$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
 
 $stack = GuzzleHttp\HandlerStack::create(
   new GuzzleHttp\Handler\MockHandler([

--- a/tests/integration/external/guzzle6/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_async.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for an async external reqest that ends up throwing exception other than BadResponseException
+Test that the span for an async external request that ends up throwing exception other than BadResponseException
 is marked as http and uri is captured.
 */
 

--- a/tests/integration/external/guzzle6/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_async.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for an async external reqest that ends up throwing exception other than BadResponseException
+is marked as http and uri is captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+External/example.com/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External\/example.com\/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://example.com/resource",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS null*/
+
+/*EXPECT
+all's well that ends well
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\TransferException()
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+]);
+
+$promise = $client->sendAsync($request);
+GuzzleHttp\Promise\Utils::settle($promise)->wait();
+
+echo "all's well that ends well" . PHP_EOL;

--- a/tests/integration/external/guzzle6/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_async.php
@@ -61,7 +61,7 @@ all's well that ends well
 
 require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
-require_guzzle(7);
+require_guzzle(6);
 
 $request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
 

--- a/tests/integration/external/guzzle6/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_async.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 Test that the span for an async external request that ends up throwing exception other than BadResponseException
-is marked as http and uri is captured.
+is marked as http and uri is captured. Status code is marked as 0.
 */
 
 /*SKIPIF

--- a/tests/integration/external/guzzle6/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_sync.php
@@ -62,7 +62,7 @@ all's well that ends well
 
 require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
-require_guzzle(7);
+require_guzzle(6);
 
 $request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
 

--- a/tests/integration/external/guzzle6/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_sync.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 Test that the span for a sync external request that ends up throwing exception other than BadResponseException
-is marked as http and uri is captured.
+is marked as http and uri is captured. Status code is marked as 0.
 */
 
 /*SKIPIF

--- a/tests/integration/external/guzzle6/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_sync.php
@@ -21,8 +21,12 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
 /*EXPECT_METRICS_EXIST
-External/example.com/all
+External/ENV[TEST_EXTERNAL_HOST]/all
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE
@@ -32,7 +36,7 @@ External/example.com/all
       "traceId": "??",
       "duration": "??",
       "transactionId": "??",
-      "name": "External\/example.com\/all",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
       "guid": "??",
       "type": "Span",
       "category": "http",
@@ -45,7 +49,7 @@ External/example.com/all
     },
     {},
     {
-      "http.url": "http://example.com/resource",
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
       "http.method": "GET",
       "http.statusCode": 0
     }
@@ -64,7 +68,9 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
 require_guzzle(6);
 
-$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
 
 $stack = GuzzleHttp\HandlerStack::create(
   new GuzzleHttp\Handler\MockHandler([

--- a/tests/integration/external/guzzle6/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_sync.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for a sync external reqest that ends up throwing exception other than BadResponseException
+is marked as http and uri is captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+External/example.com/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External\/example.com\/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://example.com/resource",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS null*/
+
+/*EXPECT
+gotcha!
+all's well that ends well
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\TransferException()
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+]);
+
+try {
+  $response = $client->send($request);
+} catch (\GuzzleHttp\Exception\TransferException $e) {
+  echo "gotcha!". PHP_EOL;
+}
+
+echo "all's well that ends well" . PHP_EOL;

--- a/tests/integration/external/guzzle6/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_transfer_exception_sync.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for a sync external reqest that ends up throwing exception other than BadResponseException
+Test that the span for a sync external request that ends up throwing exception other than BadResponseException
 is marked as http and uri is captured.
 */
 

--- a/tests/integration/external/guzzle6/test_uncaught_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle6/test_uncaught_bad_response_exception_sync.php
@@ -1,0 +1,165 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for a sync external request that ends up throwing an uncaught BadResponseException
+is marked as http, uri and status code are captured. Additionally, test that exception is recorded
+as traced error, error event, and the root span has error attributes.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+log_errors=0
+display_errors=1
+*/
+
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
+/*EXPECT_METRICS_EXIST
+External/ENV[TEST_EXTERNAL_HOST]/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "generic",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "OtherTransaction/php__FILE__",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "nr.entryPoint": true,
+      "transaction.name": "OtherTransaction/php__FILE__"
+    },
+    {},
+    {
+      "error.message": "Uncaught exception 'GuzzleHttp\\Exception\\BadResponseException' with message 'ClientException' in __FILE__:??",
+      "error.class": "GuzzleHttp\\Exception\\BadResponseException"
+    }
+  ],
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
+      "http.method": "GET",
+      "http.statusCode": 404
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "Uncaught exception 'GuzzleHttp\\Exception\\BadResponseException' with message 'ClientException' in __FILE__:??",
+      "GuzzleHttp\\Exception\\BadResponseException",
+      {
+        "stack_trace": [],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "GuzzleHttp\\Exception\\BadResponseException",
+        "error.message": "Uncaught exception 'GuzzleHttp\\Exception\\BadResponseException' with message 'ClientException' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "externalDuration": "??",
+        "externalCallCount": 1,
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*Fatal error: Uncaught GuzzleHttp\\Exception\\BadResponseException: ClientException.*
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(6);
+
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
+$response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\BadResponseException(
+      "ClientException", 
+      $request,
+      $response
+      )
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+
+]);
+
+$response = $client->send($request);
+
+echo "you should not see this" . PHP_EOL;

--- a/tests/integration/external/guzzle6/test_uncaught_transfer_exception_async.php
+++ b/tests/integration/external/guzzle6/test_uncaught_transfer_exception_async.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for a async external request that ends up throwing an uncaught exception
+(other than BadResponseException) is marked as http and uri is captured. Additionally,
+test that exception is recorded as traced error, error event, and the root span has error
+attributes.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+log_errors=0
+display_errors=1
+*/
+
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
+/*EXPECT_METRICS_EXIST
+External/ENV[TEST_EXTERNAL_HOST]/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "generic",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "OtherTransaction/php__FILE__",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "nr.entryPoint": true,
+      "transaction.name": "OtherTransaction/php__FILE__"
+    },
+    {},
+    {
+      "error.message": "Uncaught exception 'GuzzleHttp\\Exception\\TransferException' with message 'I'm covered in bees!!!' in __FILE__:??",
+      "error.class": "GuzzleHttp\\Exception\\TransferException"
+    }
+  ],
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "Uncaught exception 'GuzzleHttp\\Exception\\TransferException' with message 'I'm covered in bees!!!' in __FILE__:??",
+      "GuzzleHttp\\Exception\\TransferException",
+      {
+        "stack_trace": [],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS 
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "GuzzleHttp\\Exception\\TransferException",
+        "error.message": "Uncaught exception 'GuzzleHttp\\Exception\\TransferException' with message 'I'm covered in bees!!!' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "externalDuration": "??",
+        "externalCallCount": 1,
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*Fatal error: Uncaught GuzzleHttp\\Exception\\TransferException: I'm covered in bees!!!
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(6);
+
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\TransferException("I'm covered in bees!!!")
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+]);
+
+$promise = $client->sendAsync($request);
+$promise->wait();
+
+echo "you should not see this" . PHP_EOL;

--- a/tests/integration/external/guzzle7/test_bad_response_exception_async.php
+++ b/tests/integration/external/guzzle7/test_bad_response_exception_async.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for an async external reqest that ends up throwing BadResponseException exception
+is marked as http, uri and status code are captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+External/example.com/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External/example.com/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://example.com/resource",
+      "http.method": "GET",
+      "http.statusCode": 404
+    }
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS null*/
+
+/*EXPECT
+all's well that ends well
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\BadResponseException(
+      "ClientException", 
+      $request,
+      $response
+      )
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+
+]);
+
+$promise = $client->sendAsync($request);
+GuzzleHttp\Promise\Utils::settle($promise)->wait();
+
+echo "all's well that ends well" . PHP_EOL;

--- a/tests/integration/external/guzzle7/test_bad_response_exception_async.php
+++ b/tests/integration/external/guzzle7/test_bad_response_exception_async.php
@@ -21,8 +21,12 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
 /*EXPECT_METRICS_EXIST
-External/example.com/all
+External/ENV[TEST_EXTERNAL_HOST]/all
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE
@@ -32,7 +36,7 @@ External/example.com/all
       "traceId": "??",
       "duration": "??",
       "transactionId": "??",
-      "name": "External/example.com/all",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
       "guid": "??",
       "type": "Span",
       "category": "http",
@@ -45,7 +49,7 @@ External/example.com/all
     },
     {},
     {
-      "http.url": "http://example.com/resource",
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
       "http.method": "GET",
       "http.statusCode": 404
     }
@@ -63,7 +67,9 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
 require_guzzle(7);
 
-$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
 $response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
 
 $stack = GuzzleHttp\HandlerStack::create(

--- a/tests/integration/external/guzzle7/test_bad_response_exception_async.php
+++ b/tests/integration/external/guzzle7/test_bad_response_exception_async.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for an async external reqest that ends up throwing BadResponseException exception
+Test that the span for an async external request that ends up throwing BadResponseException exception
 is marked as http, uri and status code are captured.
 */
 

--- a/tests/integration/external/guzzle7/test_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle7/test_bad_response_exception_sync.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for a sync external reqest that ends up throwing BadResponseException exception
+Test that the span for a sync external request that ends up throwing BadResponseException exception
 is marked as http, uri and status code are captured.
 */
 

--- a/tests/integration/external/guzzle7/test_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle7/test_bad_response_exception_sync.php
@@ -21,8 +21,12 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
 /*EXPECT_METRICS_EXIST
-External/example.com/all
+External/ENV[TEST_EXTERNAL_HOST]/all
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE
@@ -32,7 +36,7 @@ External/example.com/all
       "traceId": "??",
       "duration": "??",
       "transactionId": "??",
-      "name": "External/example.com/all",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
       "guid": "??",
       "type": "Span",
       "category": "http",
@@ -45,7 +49,7 @@ External/example.com/all
     },
     {},
     {
-      "http.url": "http://example.com/resource",
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
       "http.method": "GET",
       "http.statusCode": 404
     }
@@ -64,7 +68,9 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
 require_guzzle(7);
 
-$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
 $response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
 
 $stack = GuzzleHttp\HandlerStack::create(

--- a/tests/integration/external/guzzle7/test_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle7/test_bad_response_exception_sync.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for a sync external reqest that ends up throwing BadResponseException exception
+is marked as http, uri and status code are captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+External/example.com/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External/example.com/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://example.com/resource",
+      "http.method": "GET",
+      "http.statusCode": 404
+    }
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS null*/
+
+/*EXPECT
+gotcha!
+all's well that ends well
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\BadResponseException(
+      "ClientException", 
+      $request,
+      $response
+      )
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+
+]);
+
+try {
+  $response = $client->send($request);
+} catch (\GuzzleHttp\Exception\BadResponseException $e) {
+  echo "gotcha!". PHP_EOL;
+}
+
+echo "all's well that ends well" . PHP_EOL;

--- a/tests/integration/external/guzzle7/test_timeout_async.php
+++ b/tests/integration/external/guzzle7/test_timeout_async.php
@@ -41,7 +41,7 @@ newrelic.code_level_metrics.enabled = 0
     },
     {},
     {
-      "http.url": "??",
+      "http.url": "http://ENV[EXTERNAL_HOST]/delay",
       "http.method": "GET",
       "http.statusCode": 0
     }

--- a/tests/integration/external/guzzle7/test_timeout_async.php
+++ b/tests/integration/external/guzzle7/test_timeout_async.php
@@ -20,6 +20,9 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*EXPECT_METRICS_EXIST
+External/127.0.0.1/all
+*/
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [

--- a/tests/integration/external/guzzle7/test_timeout_async.php
+++ b/tests/integration/external/guzzle7/test_timeout_async.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for an async external reqest that times out is marked as http and uri is captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External\/127.0.0.1\/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "??",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$client = new GuzzleHttp\Client([
+  // Base URI is used with relative requests
+  'base_uri' => "$EXTERNAL_HOST",
+  // Set a short timeout, shorter than delay duration in the request
+  'timeout'  => 0.01,
+]);
+
+$promise = $client->getAsync('/delay?duration=100ms');
+GuzzleHttp\Promise\Utils::settle($promise)->wait();

--- a/tests/integration/external/guzzle7/test_timeout_async.php
+++ b/tests/integration/external/guzzle7/test_timeout_async.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for an async external reqest that times out is marked as http and uri is captured.
+Test that the span for an async external request that times out is marked as http and uri is captured. Status code is marked as 0.
 */
 
 /*SKIPIF

--- a/tests/integration/external/guzzle7/test_timeout_sync.php
+++ b/tests/integration/external/guzzle7/test_timeout_sync.php
@@ -41,7 +41,7 @@ newrelic.code_level_metrics.enabled = 0
     },
     {},
     {
-      "http.url": "??",
+      "http.url": "http://ENV[EXTERNAL_HOST]/delay",
       "http.method": "GET",
       "http.statusCode": 0
     }

--- a/tests/integration/external/guzzle7/test_timeout_sync.php
+++ b/tests/integration/external/guzzle7/test_timeout_sync.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for an sync external reqest that times out is marked as http and uri is captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External\/127.0.0.1\/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "??",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$client = new GuzzleHttp\Client([
+  // Base URI is used with relative requests
+  'base_uri' => "$EXTERNAL_HOST",
+  // Set a short timeout, shorter than delay duration in the request
+  'timeout'  => 0.01,
+]);
+
+$response = $client->get('/delay?duration=100ms');
+

--- a/tests/integration/external/guzzle7/test_timeout_sync.php
+++ b/tests/integration/external/guzzle7/test_timeout_sync.php
@@ -20,6 +20,9 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*EXPECT_METRICS_EXIST
+External/127.0.0.1/all
+*/
 
 /*EXPECT_SPAN_EVENTS_LIKE
 [

--- a/tests/integration/external/guzzle7/test_timeout_sync.php
+++ b/tests/integration/external/guzzle7/test_timeout_sync.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for an sync external reqest that times out is marked as http and uri is captured.
+Test that the span for an sync external request that times out is marked as http and uri is captured.
 */
 
 /*SKIPIF

--- a/tests/integration/external/guzzle7/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle7/test_transfer_exception_async.php
@@ -21,8 +21,12 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
 /*EXPECT_METRICS_EXIST
-External/example.com/all
+External/ENV[TEST_EXTERNAL_HOST]/all
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE
@@ -32,7 +36,7 @@ External/example.com/all
       "traceId": "??",
       "duration": "??",
       "transactionId": "??",
-      "name": "External\/example.com\/all",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
       "guid": "??",
       "type": "Span",
       "category": "http",
@@ -45,7 +49,7 @@ External/example.com/all
     },
     {},
     {
-      "http.url": "http://example.com/resource",
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
       "http.method": "GET",
       "http.statusCode": 0
     }
@@ -63,7 +67,9 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
 require_guzzle(7);
 
-$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
 
 $stack = GuzzleHttp\HandlerStack::create(
   new GuzzleHttp\Handler\MockHandler([

--- a/tests/integration/external/guzzle7/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle7/test_transfer_exception_async.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for an async external reqest that ends up throwing exception other than BadResponseException
+Test that the span for an async external request that ends up throwing exception other than BadResponseException
 is marked as http and uri is captured.
 */
 

--- a/tests/integration/external/guzzle7/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle7/test_transfer_exception_async.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for an async external reqest that ends up throwing exception other than BadResponseException
+is marked as http and uri is captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+External/example.com/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External\/example.com\/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://example.com/resource",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS null*/
+
+/*EXPECT
+all's well that ends well
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\TransferException()
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+]);
+
+$promise = $client->sendAsync($request);
+GuzzleHttp\Promise\Utils::settle($promise)->wait();
+
+echo "all's well that ends well" . PHP_EOL;

--- a/tests/integration/external/guzzle7/test_transfer_exception_async.php
+++ b/tests/integration/external/guzzle7/test_transfer_exception_async.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 Test that the span for an async external request that ends up throwing exception other than BadResponseException
-is marked as http and uri is captured.
+is marked as http and uri is captured. Status code is marked as 0.
 */
 
 /*SKIPIF

--- a/tests/integration/external/guzzle7/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle7/test_transfer_exception_sync.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 Test that the span for a sync external request that ends up throwing exception other than BadResponseException
-is marked as http and uri is captured.
+is marked as http and uri is captured. Status code is marked as 0.
 */
 
 /*SKIPIF

--- a/tests/integration/external/guzzle7/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle7/test_transfer_exception_sync.php
@@ -21,8 +21,12 @@ newrelic.transaction_tracer.detail = 1
 newrelic.code_level_metrics.enabled = 0
 */
 
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
 /*EXPECT_METRICS_EXIST
-External/example.com/all
+External/ENV[TEST_EXTERNAL_HOST]/all
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE
@@ -32,7 +36,7 @@ External/example.com/all
       "traceId": "??",
       "duration": "??",
       "transactionId": "??",
-      "name": "External\/example.com\/all",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
       "guid": "??",
       "type": "Span",
       "category": "http",
@@ -45,7 +49,7 @@ External/example.com/all
     },
     {},
     {
-      "http.url": "http://example.com/resource",
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
       "http.method": "GET",
       "http.statusCode": 0
     }
@@ -64,7 +68,9 @@ require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
 require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
 require_guzzle(7);
 
-$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
 
 $stack = GuzzleHttp\HandlerStack::create(
   new GuzzleHttp\Handler\MockHandler([

--- a/tests/integration/external/guzzle7/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle7/test_transfer_exception_sync.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for a sync external reqest that ends up throwing exception other than BadResponseException
+is marked as http and uri is captured.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+External/example.com/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External\/example.com\/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://example.com/resource",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS null*/
+
+/*EXPECT
+gotcha!
+all's well that ends well
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://example.com/resource");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\TransferException()
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+]);
+
+try {
+  $response = $client->send($request);
+} catch (\GuzzleHttp\Exception\TransferException $e) {
+  echo "gotcha!". PHP_EOL;
+}
+
+echo "all's well that ends well" . PHP_EOL;

--- a/tests/integration/external/guzzle7/test_transfer_exception_sync.php
+++ b/tests/integration/external/guzzle7/test_transfer_exception_sync.php
@@ -5,7 +5,7 @@
  */
 
 /*DESCRIPTION
-Test that the span for a sync external reqest that ends up throwing exception other than BadResponseException
+Test that the span for a sync external request that ends up throwing exception other than BadResponseException
 is marked as http and uri is captured.
 */
 

--- a/tests/integration/external/guzzle7/test_uncaught_bad_response_exception_sync.php
+++ b/tests/integration/external/guzzle7/test_uncaught_bad_response_exception_sync.php
@@ -1,0 +1,165 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for a sync external request that ends up throwing an uncaught BadResponseException
+is marked as http, uri and status code are captured. Additionally, test that exception is recorded
+as traced error, error event, and the root span has error attributes.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+log_errors=0
+display_errors=1
+*/
+
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
+/*EXPECT_METRICS_EXIST
+External/ENV[TEST_EXTERNAL_HOST]/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "generic",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "OtherTransaction/php__FILE__",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "nr.entryPoint": true,
+      "transaction.name": "OtherTransaction/php__FILE__"
+    },
+    {},
+    {
+      "error.message": "Uncaught exception 'GuzzleHttp\\Exception\\BadResponseException' with message 'ClientException' in __FILE__:??",
+      "error.class": "GuzzleHttp\\Exception\\BadResponseException"
+    }
+  ],
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
+      "http.method": "GET",
+      "http.statusCode": 404
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "Uncaught exception 'GuzzleHttp\\Exception\\BadResponseException' with message 'ClientException' in __FILE__:??",
+      "GuzzleHttp\\Exception\\BadResponseException",
+      {
+        "stack_trace": [],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "GuzzleHttp\\Exception\\BadResponseException",
+        "error.message": "Uncaught exception 'GuzzleHttp\\Exception\\BadResponseException' with message 'ClientException' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "externalDuration": "??",
+        "externalCallCount": 1,
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*Fatal error: Uncaught GuzzleHttp\\Exception\\BadResponseException: ClientException.*
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
+$response = new \GuzzleHttp\Psr7\Response(404, [], "Not found!");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\BadResponseException(
+      "ClientException", 
+      $request,
+      $response
+      )
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+
+]);
+
+$response = $client->send($request);
+
+echo "you should not see this" . PHP_EOL;

--- a/tests/integration/external/guzzle7/test_uncaught_transfer_exception_async.php
+++ b/tests/integration/external/guzzle7/test_uncaught_transfer_exception_async.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the span for a async external request that ends up throwing an uncaught exception
+(other than BadResponseException) is marked as http and uri is captured. Additionally,
+test that exception is recorded as traced error, error event, and the root span has error
+attributes.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0
+newrelic.transaction_tracer.detail = 1
+newrelic.code_level_metrics.enabled = 0
+log_errors=0
+display_errors=1
+*/
+
+/*ENVIRONMENT
+TEST_EXTERNAL_HOST=example.com
+*/
+
+/*EXPECT_METRICS_EXIST
+External/ENV[TEST_EXTERNAL_HOST]/all
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "generic",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "OtherTransaction/php__FILE__",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "nr.entryPoint": true,
+      "transaction.name": "OtherTransaction/php__FILE__"
+    },
+    {},
+    {
+      "error.message": "Uncaught exception 'GuzzleHttp\\Exception\\TransferException' with message 'I'm covered in bees!!!' in __FILE__:??",
+      "error.class": "GuzzleHttp\\Exception\\TransferException"
+    }
+  ],
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "External/ENV[TEST_EXTERNAL_HOST]/all",
+      "guid": "??",
+      "type": "Span",
+      "category": "http",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Guzzle 6"
+    },
+    {},
+    {
+      "http.url": "http://ENV[TEST_EXTERNAL_HOST]/resource",
+      "http.method": "GET",
+      "http.statusCode": 0
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "Uncaught exception 'GuzzleHttp\\Exception\\TransferException' with message 'I'm covered in bees!!!' in __FILE__:??",
+      "GuzzleHttp\\Exception\\TransferException",
+      {
+        "stack_trace": [],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS 
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "GuzzleHttp\\Exception\\TransferException",
+        "error.message": "Uncaught exception 'GuzzleHttp\\Exception\\TransferException' with message 'I'm covered in bees!!!' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "externalDuration": "??",
+        "externalCallCount": 1,
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_REGEX
+^\s*Fatal error: Uncaught GuzzleHttp\\Exception\\TransferException: I'm covered in bees!!!
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/unpack_guzzle.php');
+require_guzzle(7);
+
+$TEST_EXTERNAL_HOST=getenv('TEST_EXTERNAL_HOST');
+
+$request = new \GuzzleHttp\Psr7\Request('GET', "http://$TEST_EXTERNAL_HOST/resource");
+
+$stack = GuzzleHttp\HandlerStack::create(
+  new GuzzleHttp\Handler\MockHandler([
+    new \GuzzleHttp\Exception\TransferException("I'm covered in bees!!!")
+  ]));
+
+$client = new GuzzleHttp\Client([
+  'handler' => $stack,
+]);
+
+$promise = $client->sendAsync($request);
+$promise->wait();
+
+echo "you should not see this" . PHP_EOL;


### PR DESCRIPTION
Modify the onRejected handler to end guzzle's external segment even when
there's no response. This allows to mark the span as an external span and
capture the uri and method of the request. Additionally when sync requests is
rejected, onRejected callback is not called via `PromiseInterface::then` and
needs to be called manually.

Fixes #320.