### PR TITLE
ci: update actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -55,9 +55,9 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon_test
       - name: Save integration_runner for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}-${{ github.run_id }}
           path: php-agent/bin/integration_runner
   agent-unit-test:
     runs-on: ubuntu-latest
@@ -124,21 +124,21 @@ jobs:
           -e ENABLE_COVERAGE=${{matrix.codecov}}
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-check
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
           path: php-agent/agent/.libs/*.gc*
   integration-tests:
     needs: [daemon-unit-tests, agent-unit-test]
@@ -161,26 +161,30 @@ jobs:
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Get integration_runner
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
+          pattern: integration_runner-*
+          merge-multiple: true
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          pattern: newrelic.so-*
+          merge-multiple: true
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          pattern: axiom.gcov-*
+          merge-multiple: true
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          pattern: agent.gcov-*
+          merge-multiple: true
           path: php-agent/agent/.libs
       - name: Prep artifacts for use
         run: |

--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Save integration_runner for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}-${{ github.job }}-${{ github.run_id }}
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin/integration_runner
   agent-unit-test:
     runs-on: ubuntu-latest
@@ -126,19 +126,19 @@ jobs:
       - name: Save newrelic.so for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
         uses: actions/upload-artifact@v4
         with:
-          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
         uses: actions/upload-artifact@v4
         with:
-          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs/*.gc*
   integration-tests:
     needs: [daemon-unit-tests, agent-unit-test]

--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Save integration_runner for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}-${{ github.run_id }}
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/bin/integration_runner
   agent-unit-test:
     runs-on: ubuntu-latest
@@ -126,19 +126,19 @@ jobs:
       - name: Save newrelic.so for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
         uses: actions/upload-artifact@v4
         with:
-          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
         uses: actions/upload-artifact@v4
         with:
-          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/agent/.libs/*.gc*
   integration-tests:
     needs: [daemon-unit-tests, agent-unit-test]

--- a/.github/workflows/code-coverage-baseline.yml
+++ b/.github/workflows/code-coverage-baseline.yml
@@ -163,28 +163,24 @@ jobs:
       - name: Get integration_runner
         uses: actions/download-artifact@v4
         with:
-          pattern: integration_runner-*
-          merge-multiple: true
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
         uses: actions/download-artifact@v4
         with:
-          pattern: newrelic.so-*
-          merge-multiple: true
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
         uses: actions/download-artifact@v4
         with:
-          pattern: axiom.gcov-*
-          merge-multiple: true
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
         uses: actions/download-artifact@v4
         with:
-          pattern: agent.gcov-*
-          merge-multiple: true
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs
       - name: Prep artifacts for use
         run: |

--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -64,5 +64,5 @@ jobs:
       - name: Save newrelic.so for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
+          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so

--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -64,5 +64,5 @@ jobs:
       - name: Save newrelic.so for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}-${{ github.run_id }}
+          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/agent/modules/newrelic.so

--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -62,7 +62,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
+          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}-${{ github.run_id }}
           path: php-agent/agent/modules/newrelic.so

--- a/.github/workflows/make-for-platform-on-arch.yml
+++ b/.github/workflows/make-for-platform-on-arch.yml
@@ -78,7 +78,7 @@ jobs:
           -e APP_supportability=${{secrets.APP_SUPPORTABILITY}}
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION ${{inputs.make-target}}
       - name: Save ${{inputs.make-target}} artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}
+          name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}-${{ github.run_id }}
           path: php-agent/${{ inputs.artifact-pattern }}

--- a/.github/workflows/make-for-platform-on-arch.yml
+++ b/.github/workflows/make-for-platform-on-arch.yml
@@ -80,5 +80,5 @@ jobs:
       - name: Save ${{inputs.make-target}} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}-${{ github.job }}-${{ github.run_id }}
+          name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}
           path: php-agent/${{ inputs.artifact-pattern }}

--- a/.github/workflows/make-for-platform-on-arch.yml
+++ b/.github/workflows/make-for-platform-on-arch.yml
@@ -80,5 +80,5 @@ jobs:
       - name: Save ${{inputs.make-target}} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}-${{ github.run_id }}
+          name: ${{inputs.artifact-name}}-${{matrix.platform}}-${{inputs.arch}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/${{ inputs.artifact-pattern }}

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get newrelic.so
         uses: actions/download-artifact@v4
         with:
-          name: newrelic.so-*
+          pattern: newrelic.so-*
           merge-multiple: true
           path: php-agent/agent/modules
       - name: Prep artifacts for use

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -43,14 +43,16 @@ jobs:
           repository: ${{ inputs.origin }}/newrelic-php-agent
           ref: ${{ inputs.ref }}
       - name: Get integration_runner
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{inputs.arch}}
+          pattern: integration_runner-*
+          merge-multiple: true
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
+          name: newrelic.so-*
+          merge-multiple: true
           path: php-agent/agent/modules
       - name: Prep artifacts for use
         run: |

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -45,14 +45,12 @@ jobs:
       - name: Get integration_runner
         uses: actions/download-artifact@v4
         with:
-          pattern: integration_runner-*
-          merge-multiple: true
+          name: integration_runner-${{matrix.platform}}-${{inputs.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
         uses: actions/download-artifact@v4
         with:
-          pattern: newrelic.so-*
-          merge-multiple: true
+          name: newrelic.so-${{matrix.platform}}-${{inputs.arch}}-${{matrix.php}}
           path: php-agent/agent/modules
       - name: Prep artifacts for use
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
-          name: release-from-gha-${{ github.job }}-${{ github.run_id }}
+          name: release-from-gha-${{ github.job }}-${{ github.run_id }}-${{ matrix.platform }}-${{ matrix.arch }}
           if-no-files-found: error
   agent_release:
     env:
@@ -90,5 +90,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
-          name: release-from-gha-${{ github.job }}-${{ github.run_id }}
+          name: release-from-gha-${{ github.job }}-${{ github.run_id }}-${{ matrix.platform }}-${{ matrix.arch }}
           if-no-files-found: error

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
-          name: release-from-gha-${{ github.run_id }}
+          name: release-from-gha-${{ github.job }}-${{ github.run_id }}
           if-no-files-found: error
   agent_release:
     env:
@@ -90,5 +90,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
-          name: release-from-gha-${{ github.run_id }}
+          name: release-from-gha-${{ github.job }}-${{ github.run_id }}
           if-no-files-found: error

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
-          name: release-from-gha-${{ github.job }}-${{ github.run_id }}-${{ matrix.platform }}-${{ matrix.arch }}
+          name: release-from-gha-${{ matrix.platform }}-${{ matrix.arch }}
           if-no-files-found: error
   agent_release:
     env:
@@ -90,5 +90,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
-          name: release-from-gha-${{ github.job }}-${{ github.run_id }}-${{ matrix.platform }}-${{ matrix.arch }}
+          name: release-from-gha-${{ matrix.platform }}-${{ matrix.arch }}
           if-no-files-found: error

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -52,10 +52,10 @@ jobs:
           -e BUILD_NUMBER=${{inputs.build-number}}
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION release-daemon
       - name: Save build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
-          name: release-from-gha
+          name: release-from-gha-${{ github.run_id }}
           if-no-files-found: error
   agent_release:
     env:
@@ -87,8 +87,8 @@ jobs:
           -e BUILD_NUMBER=${{inputs.build-number}}
           $IMAGE_NAME:agent-builder-php${{matrix.php_ver}}-${{matrix.platform}}-$IMAGE_VERSION release-${{matrix.php_ver}}-gha
       - name: Save build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: newrelic-php-agent/releases
-          name: release-from-gha
+          name: release-from-gha-${{ github.run_id }}
           if-no-files-found: error

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Save integration_runner for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}-${{ github.run_id }}
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/bin/integration_runner
   agent-unit-test:
     runs-on: ubuntu-latest
@@ -161,19 +161,19 @@ jobs:
       - name: Save newrelic.so for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
         uses: actions/upload-artifact@v4
         with:
-          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
         uses: actions/upload-artifact@v4
         with:
-          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
           path: php-agent/agent/.libs/*.gc*
   integration-tests:
     needs: [daemon-unit-tests, agent-unit-test]

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -209,27 +209,23 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: integration_runner-*
-          merge-multiple: true
           path: php-agent/bin
       - name: Get newrelic.so
         uses: actions/download-artifact@v4
         with:
           pattern: newrelic.so-*
-          merge-multiple: true
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
         uses: actions/download-artifact@v4
         with:
           pattern: axiom.gcov-*
-          merge-multiple: true
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
         uses: actions/download-artifact@v4
         with:
           pattern: agent.gcov-*
-          merge-multiple: true
           path: php-agent/agent/.libs
       - name: Prep artifacts for use
         run: |

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Save integration_runner for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}-${{ github.job }}-${{ github.run_id }}
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin/integration_runner
   agent-unit-test:
     runs-on: ubuntu-latest
@@ -161,19 +161,19 @@ jobs:
       - name: Save newrelic.so for integration tests
         uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
         uses: actions/upload-artifact@v4
         with:
-          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
         uses: actions/upload-artifact@v4
         with:
-          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.job }}-${{ github.run_id }}
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs/*.gc*
   integration-tests:
     needs: [daemon-unit-tests, agent-unit-test]

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -58,9 +58,9 @@ jobs:
           -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
           $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon_test
       - name: Save integration_runner for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}-${{ github.run_id }}
           path: php-agent/bin/integration_runner
   agent-unit-test:
     runs-on: ubuntu-latest
@@ -159,21 +159,21 @@ jobs:
           -e ENABLE_COVERAGE=${{matrix.codecov}}
           $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-${{ steps.get-check-variant.outputs.AGENT_CHECK_VARIANT }}
       - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
           path: php-agent/agent/modules/newrelic.so
       - name: Save axiom gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
           path: php-agent/axiom/*.gc*
       - name: Save agent gcov data files (*.gcno, *.gcna)
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}-${{ github.run_id }}
           path: php-agent/agent/.libs/*.gc*
   integration-tests:
     needs: [daemon-unit-tests, agent-unit-test]
@@ -206,26 +206,30 @@ jobs:
         with:
           path: php-agent
       - name: Get integration_runner
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
+          pattern: integration_runner-*
+          merge-multiple: true
           path: php-agent/bin
       - name: Get newrelic.so
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          pattern: newrelic.so-*
+          merge-multiple: true
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          pattern: axiom.gcov-*
+          merge-multiple: true
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          pattern: agent.gcov-*
+          merge-multiple: true
           path: php-agent/agent/.libs
       - name: Prep artifacts for use
         run: |

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -208,24 +208,24 @@ jobs:
       - name: Get integration_runner
         uses: actions/download-artifact@v4
         with:
-          pattern: integration_runner-*
+          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin
       - name: Get newrelic.so
         uses: actions/download-artifact@v4
         with:
-          pattern: newrelic.so-*
+          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/modules
       - name: Get axiom gcov data files
         if: ${{ matrix.codecov == 1 }}
         uses: actions/download-artifact@v4
         with:
-          pattern: axiom.gcov-*
+          name: axiom.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/axiom
       - name: Get agent gcov data files
         if: ${{ matrix.codecov == 1 }}
         uses: actions/download-artifact@v4
         with:
-          pattern: agent.gcov-*
+          name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
           path: php-agent/agent/.libs
       - name: Prep artifacts for use
         run: |


### PR DESCRIPTION
This PR updates `actions/upload-artifact` and `actions/download-artifact` to v4 which uses Node 20:

actions/upload-artifact@v3 -> v4: https://github.com/actions/upload-artifact/releases/tag/v4.0.0
actions/download-artifact@v3 -> v4: https://github.com/actions/download-artifact/releases/tag/v4.0.0