### PR TITLE
fix(tests): Fixes package-name-only test case

### DIFF
--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -604,7 +604,17 @@ func (t *Test) comparePhpPackages(harvest *newrelic.Harvest) {
 					expected_version = override_version.(string)
 				}
 
-				if testPackageNameOnly || expected_version == actualPackages[i].Version {
+				if testPackageNameOnly {
+					if " " != actualPackages[i].Version {
+						t.Fail(fmt.Errorf("Expected no package version and a package version was detected - expected \" \" actual %+v. ",
+							actualPackages[i].Version))
+						return
+					} else {
+						continue
+					}
+				}
+
+				if expected_version == actualPackages[i].Version {
 					continue
 				}
 			}


### PR DESCRIPTION
The PHP package test was not being correctly checked for the case where the package was specified as `package_name_only` and a version was actually created for the package.