### PR TITLE
fix(agent): Don't send only major version to vm package

### DIFF
--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -352,13 +352,19 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
 
   char* version = nr_php_get_object_constant(this_var, "VERSION");
-  if (NULL == version) {
-    version = nr_php_get_object_constant(this_var, "MAJOR_VERSION");
-  }
 
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     // Add php package to transaction
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+  }
+
+  /*
+ * If we were unable to get the full version before, at least we can extract
+ * the major version to send to the supportability metric.
+ * This is relevant to guzzle7+ which no longer supplies full version.
+ */
+  if (NULL == version) {
+    version = nr_php_get_object_constant(this_var, "MAJOR_VERSION");
   }
   nr_fw_support_add_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
                                                   version);


### PR DESCRIPTION
Guzzle 7+ was sending only the major version to the vm package If only major version is available, it should not be sent.
However, we can still use major version for the supportability metric.