### PR TITLE
fix: install correctly on bare bones OSs

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1780,6 +1780,10 @@ EOF
   set_osdifile
 
   if [ -z "${ispkg}" ]; then
+    # ensure target directory exists
+    if [ ! -d "$(dirname ${osdifile})" ]; then
+      logcmd mkdir -p -m 0755 "$(dirname ${osdifile})"
+    fi
     if logcmd cp -f "${ilibdir}/scripts/init.${ostype}" "${osdifile}"; then
       logcmd chmod 755 "${osdifile}" || {
         fatal "failed to set permissions on ${osdifile}"
@@ -1798,6 +1802,10 @@ EOF
     fi
 
     if [ -n "${sysconf}" -a ! -f "${sysconf}" ]; then
+      # ensure target directory exists
+      if [ ! -d "$(dirname ${sysconf})" ]; then
+        logcmd mkdir -p -m 0755 "$(dirname ${sysconf})"
+      fi
       if logcmd cp -f "${ilibdir}/scripts/newrelic.sysconfig" "${sysconf}"; then
         logcmd chmod 755 "${sysconf}" || {
           fatal "failed to set permissions on ${sysconf}"

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -852,8 +852,8 @@ disp_get_php_list() {
 
 set_osdifile() {
   osdifile=
-  if [ -n "${NR_INSTALL_INITFILE}" ]; then
-    osdifile="${NR_INSTALL_INITFILE}"
+  if [ -n "${NR_INSTALL_INITSCRIPT}" ]; then
+    osdifile="${NR_INSTALL_INITSCRIPT}"
   fi
   if [ "${ostype}" = "darwin" ]; then
     : ${osdifile:=/usr/bin/newrelic-daemon-service}


### PR DESCRIPTION
Some OSs stripped down to bare bones (like base OS container images) don't have all directories needed by the installer (e.g. /etc/init.d). Package installers simply create these directories. Make tarball installer behave similar to package installer and create required directories.

Fixes #905.