### PR TITLE
fix(agent): Fixes Doctrine 2.18+ detection

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -484,7 +484,11 @@ typedef struct _nr_library_table_t {
  */
 // clang-format: off
 static nr_library_table_t libraries[] = {
+    /* Doctrine < 2.18 */
     {"Doctrine 2", NR_PSTR("doctrine/orm/query.php"), nr_doctrine2_enable},
+    /* Doctrine 2.18 reworked the directory structure */
+    {"Doctrine 2", NR_PSTR("doctrine/orm/src/query.php"), nr_doctrine2_enable},
+
     {"Guzzle 3", NR_PSTR("guzzle/http/client.php"), nr_guzzle3_enable},
     {"Guzzle 4-5", NR_PSTR("hasemitterinterface.php"), nr_guzzle4_enable},
     {"Guzzle 6", NR_PSTR("guzzle/src/functions_include.php"), nr_guzzle6_enable},


### PR DESCRIPTION
Addresses changes in Doctrine 2.18+ (but not 3.x) that affected detection.

There was a [commit](https://github.com/doctrine/orm/commit/073f2aa891249e582e63320cab34b035b591cf22) for Doctrine 2.18 that reworked the directory structure of the Doctrine library.  This PR adds another file for Doctrine to allow it to be auto-detected. 
