### PR TITLE
fix(scripts): fix rhel and alpine init scripts

### DIFF
--- a/agent/scripts/init.alpine
+++ b/agent/scripts/init.alpine
@@ -1,9 +1,8 @@
+#!/sbin/openrc-run
 #
 # Copyright 2020 New Relic Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-
-#!/sbin/openrc-run
 
 description="New Relic Daemon"
 command="${nrdaemon:-/usr/bin/newrelic-daemon}"

--- a/agent/scripts/init.rhel
+++ b/agent/scripts/init.rhel
@@ -240,7 +240,7 @@ EOF
         success
         echo
       else
-        echo " [ OK ]"
+        echo " [  OK  ]"
       fi
     fi
     return 0

--- a/agent/scripts/init.rhel
+++ b/agent/scripts/init.rhel
@@ -250,7 +250,7 @@ EOF
         failure
         echo
       else
-        echo " [ FAILED ]"
+        echo " [FAILED]"
       fi
     fi
     return 1

--- a/agent/scripts/init.rhel
+++ b/agent/scripts/init.rhel
@@ -10,6 +10,15 @@
 # processname: newrelic-daemon
 # config:      /etc/newrelic/newrelic.cfg
 #
+### BEGIN INIT INFO
+# Provides:          newrelic-daemon
+# Required-Start:    $all
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:	     0 1 6
+# Description: The New Relic Daemon is used by the New Relic PHP Agent to communicate
+#               with the New Relic Backend
+### END INIT INFO
 
 LANG=C
 NAME=newrelic-daemon
@@ -18,7 +27,11 @@ DESC="New Relic Daemon"
 #
 # Source function library.
 #
-. /etc/init.d/functions
+has_initd_functions=0
+if [ -f /etc/init.d/functions ]; then
+  . /etc/init.d/functions
+  has_initd_functions=1
+fi
 
 ulimit -n 2048 > /dev/null 2>&1
 
@@ -223,14 +236,18 @@ EOF
 
   if running ; then
     if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
-      success
-      echo
+      if [ $has_initd_functions -eq 1 ]; then
+        success
+        echo
+      fi
     fi
     return 0
   else
     if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
-      failure
-      echo
+      if [ $has_initd_functions -eq 1 ]; then
+        failure
+        echo
+      fi
     fi
     return 1
   fi
@@ -274,14 +291,18 @@ stop() {
 
     if running ; then
       if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
-        failure
-        echo
+        if [ $has_initd_functions -eq 1 ]; then
+          failure
+          echo
+        fi
       fi
       return 1
     else
       if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
-        success
-        echo
+        if [ $has_initd_functions -eq 1 ]; then
+          success
+          echo
+        fi
       fi
       return 0
     fi

--- a/agent/scripts/init.rhel
+++ b/agent/scripts/init.rhel
@@ -239,6 +239,8 @@ EOF
       if [ $has_initd_functions -eq 1 ]; then
         success
         echo
+      else
+        echo " [ OK ]"
       fi
     fi
     return 0
@@ -247,6 +249,8 @@ EOF
       if [ $has_initd_functions -eq 1 ]; then
         failure
         echo
+      else
+        echo " [ FAILED ]"
       fi
     fi
     return 1
@@ -294,6 +298,8 @@ stop() {
         if [ $has_initd_functions -eq 1 ]; then
           failure
           echo
+        else
+          echo " [ FAILED ]"
         fi
       fi
       return 1
@@ -302,6 +308,8 @@ stop() {
         if [ $has_initd_functions -eq 1 ]; then
           success
           echo
+        else
+          echo " [ OK ]"
         fi
       fi
       return 0

--- a/agent/scripts/init.rhel
+++ b/agent/scripts/init.rhel
@@ -299,7 +299,7 @@ stop() {
           failure
           echo
         else
-          echo " [ FAILED ]"
+          echo " [FAILED]"
         fi
       fi
       return 1
@@ -309,7 +309,7 @@ stop() {
           success
           echo
         else
-          echo " [ OK ]"
+          echo " [  OK  ]"
         fi
       fi
       return 0


### PR DESCRIPTION
Systemd systems may not have access to the functions file provided by initscripts. The code from initscripts is provided under the GNU v2 license and will not be pulled in.

Additionally, a header comment block must be added, using https://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/initscrcomconv.html for specs