### PR TITLE
style(daemon): gofmt daemon module

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -371,7 +371,7 @@ func main() {
 			proxy = false
 		} else {
 			log.Debugf("ARGV[%d]: %s", i, os.Args[i])
-			if ("--proxy" == os.Args[i]) {
+			if "--proxy" == os.Args[i] {
 				proxy = true
 			}
 		}
@@ -570,10 +570,9 @@ func (env *Environment) Set(key, value string) {
 
 // initLog opens the daemon log based on the current configuration settings.
 // If no log has been specified, initLog will try the following standard
-// locations.
-//
-//   /var/log/newrelic/newrelic-daemon.log
-//   /var/log/newrelic-daemon.log
+// locations:
+//   - /var/log/newrelic/newrelic-daemon.log
+//   - /var/log/newrelic-daemon.log
 //
 // If no suitable location can be found, a generic error is returned.
 func initLog(cfg *Config) error {

--- a/daemon/cmd/stressor/main.go
+++ b/daemon/cmd/stressor/main.go
@@ -122,8 +122,8 @@ const DaemonSampleRate = 3 * time.Second
 
 // Application Behavior Constants
 // In order to roughly mimic the PHP agent, these should settings match
-//  NR_APP_UNKNOWN_QUERY_BACKOFF_LIMIT_SECONDS
-//  NR_APP_REFRESH_QUERY_PERIOD_SECONDS
+//   - NR_APP_UNKNOWN_QUERY_BACKOFF_LIMIT_SECONDS
+//   - NR_APP_REFRESH_QUERY_PERIOD_SECONDS
 const (
 	connectedAppInfoPeriod   = 20 * time.Second
 	unconnectedAppInfoPeriod = 5 * time.Second

--- a/daemon/internal/flatbuffersdata/data_test.go
+++ b/daemon/internal/flatbuffersdata/data_test.go
@@ -150,15 +150,15 @@ func TestFlatbuffersTxnData(t *testing.T) {
 	// compilation to handle this rather than the flakier runtime.Version()
 	// string.
 	expect := `[` +
-	`{"name":"Supportability/TxnData/CustomEvents","forced":true,"data":[1,3,0,3,3,9]},` +
-	`{"name":"Supportability/TxnData/Metrics","forced":true,"data":[1,2,0,2,2,4]},` +
-	`{"name":"Supportability/TxnData/Size","forced":true,"data":[1,1408,0,1408,1408,1982464]},` +
-	`{"name":"Supportability/TxnData/SlowSQL","forced":true,"data":[1,1,0,1,1,1]},` +
-	`{"name":"Supportability/TxnData/TraceSize","forced":true,"data":[1,2,0,2,2,4]},` +
-	`{"name":"forced","forced":true,"data":[6,5,4,3,2,1]},` +
-	`{"name":"scoped","forced":false,"data":[1,2,3,4,5,6]},` +
-	`{"name":"scoped","forced":false,"data":[1,2,3,4,5,6]}` +
-	`]`
+		`{"name":"Supportability/TxnData/CustomEvents","forced":true,"data":[1,3,0,3,3,9]},` +
+		`{"name":"Supportability/TxnData/Metrics","forced":true,"data":[1,2,0,2,2,4]},` +
+		`{"name":"Supportability/TxnData/Size","forced":true,"data":[1,1408,0,1408,1408,1982464]},` +
+		`{"name":"Supportability/TxnData/SlowSQL","forced":true,"data":[1,1,0,1,1,1]},` +
+		`{"name":"Supportability/TxnData/TraceSize","forced":true,"data":[1,2,0,2,2,4]},` +
+		`{"name":"forced","forced":true,"data":[6,5,4,3,2,1]},` +
+		`{"name":"scoped","forced":false,"data":[1,2,3,4,5,6]},` +
+		`{"name":"scoped","forced":false,"data":[1,2,3,4,5,6]}` +
+		`]`
 
 	if s != expect {
 		t.Fatal(s, expect)

--- a/daemon/internal/newrelic/collector/client.go
+++ b/daemon/internal/newrelic/collector/client.go
@@ -58,15 +58,15 @@ type RpmControls struct {
 // Agent Behavior Summary:
 //
 // on connect/preconnect:
-//     410 means shutdown
-//     200, 202 mean success (start run)
-//     all other response codes and errors mean try after backoff
+//   - 410 means shutdown
+//   - 200, 202 mean success (start run)
+//   - all other response codes and errors mean try after backoff
 //
 // on harvest:
-//     410 means shutdown
-//     401, 409 mean restart run
-//     408, 429, 500, 503 mean save data for next harvest
-//     all other response codes and errors discard the data and continue the current harvest
+//   - 410 means shutdown
+//   - 401, 409 mean restart run
+//   - 408, 429, 500, 503 mean save data for next harvest
+//   - all other response codes and errors discard the data and continue the current harvest
 type RPMResponse struct {
 	StatusCode int
 	Body       []byte
@@ -97,7 +97,6 @@ func removeURLFromError(err error) error {
 		ue.URL = "**REDACTED-URL**"
 	}
 
-
 	return err
 }
 
@@ -116,7 +115,7 @@ func (resp RPMResponse) IsDisconnect() bool {
 
 // IsRestartException indicates that the agent should restart.
 // 401 (License Exception) is considered a restart exception according to the spec,
-//   and is included here as such, however the PHP agent will not restart on a 401 and instead stop
+// and is included here as such, however the PHP agent will not restart on a 401 and instead stop
 func (resp RPMResponse) IsRestartException() bool {
 	return resp.StatusCode == 401 || resp.StatusCode == 409
 }

--- a/daemon/internal/newrelic/config/config.go
+++ b/daemon/internal/newrelic/config/config.go
@@ -65,13 +65,13 @@ func NewDecoder(r io.Reader) *Decoder {
 //
 // Decode implements the following PEG.
 //
-// INI     = ((KEYWORD WS* '=' WS* VALUE) / COMMENT / WS)*
-// KEYWORD = ALPHA (ALPHA / NUMERIC / '_' / '.')*
-// VALUE   = QUOTED / DQUOTED / RAW
-// QUOTED  = '\'' .* '\''
-// DQUOTED = '"' .* '"'
-// RAW     = .* EOL
-// COMMENT = ('#' / ';') .* EOL
+//	INI     = ((KEYWORD WS* '=' WS* VALUE) / COMMENT / WS)*
+//	KEYWORD = ALPHA (ALPHA / NUMERIC / '_' / '.')*
+//	VALUE   = QUOTED / DQUOTED / RAW
+//	QUOTED  = '\'' .* '\''
+//	DQUOTED = '"' .* '"'
+//	RAW     = .* EOL
+//	COMMENT = ('#' / ';') .* EOL
 func (d *Decoder) Decode(v interface{}) (err error) {
 	val := reflect.ValueOf(v)
 	if val.Kind() != reflect.Ptr {

--- a/daemon/internal/newrelic/harvest_trigger.go
+++ b/daemon/internal/newrelic/harvest_trigger.go
@@ -65,10 +65,10 @@ func triggerBuilder(t HarvestType, duration time.Duration) HarvestTriggerFunc {
 
 // To create a group of goroutines that may be cancelled by sending a single
 // message on a single channel, this function:
-// - Creates a cancel channel for the goroutine function f.
-// - Starts the goroutine.
-// - Returns the newly-created cancel channel so that it may be added to a
-//   broadcast group.
+//   - Creates a cancel channel for the goroutine function f.
+//   - Starts the goroutine.
+//   - Returns the newly-created cancel channel so that it may be added to a
+//     broadcast group.
 func startGroupMember(f HarvestTriggerFunc, trigger chan HarvestType) chan bool {
 	cancel := make(chan bool)
 	go f(trigger, cancel)
@@ -144,10 +144,10 @@ func customTriggerBuilder(reply *ConnectReply) HarvestTriggerFunc {
 
 // This function returns the harvest trigger function that should be used for
 // this agent.  In priority order:
-//   1. Either it uses the ConnectReply to build custom triggers as specified by
-//      the New Relic server-side collector.
-//   2. Or it creates a default harvest trigger, harvesting all data at the
-//      default period.
+//  1. Either it uses the ConnectReply to build custom triggers as specified by
+//     the New Relic server-side collector.
+//  2. Or it creates a default harvest trigger, harvesting all data at the
+//     default period.
 func getHarvestTrigger(key collector.LicenseKey, reply *ConnectReply) HarvestTriggerFunc {
 	// Build a trigger from the server-side collector configuration.
 	if reply.isHarvestAll() {

--- a/daemon/internal/newrelic/integration/parse.go
+++ b/daemon/internal/newrelic/integration/parse.go
@@ -228,7 +228,6 @@ func parsePHPModules(t *Test, content []byte) error {
 	return nil
 }
 
-
 func parseAnalyticEvents(test *Test, content []byte) error {
 	test.analyticEvents = content
 	return nil

--- a/daemon/internal/newrelic/integration/php_packages.go
+++ b/daemon/internal/newrelic/integration/php_packages.go
@@ -51,13 +51,14 @@ type ComposerJSON struct {
 	Installed []ComposerPackage
 }
 
-//
 // Given a JSON harvest payload, extract the PHP packages
 //
-// Params 1 : JSON byte string containing update_loaded_modules endpoint data
+// Params 1:
+//   - JSON byte string containing update_loaded_modules endpoint data
 //
-// Returns :  []PhpPackage with extracted package info, sorted by package name
-//            nil upon error processing JSON
+// Returns:
+//   - []PhpPackage with extracted package info, sorted by package name
+//   - nil upon error processing JSON
 func GetPhpPackagesFromData(data []byte) ([]PhpPackage, error) {
 	var pkgs []PhpPackage
 	var x []interface{}
@@ -279,11 +280,11 @@ func (pkgs *PhpPackagesCollection) OverrideVersionsFile() string {
 
 // Detects installed PHP packages
 //
-// Returns :  []PhpPackage with extracted package info, sorted by package name
-//            nil upon error processing JSON
+// Returns:
+//   - []PhpPackage with extracted package info, sorted by package name
+//   - nil upon error processing JSON
 //
-// Notes   :  Currently only supports an application created with composer
-//
+// Notes: Currently only supports an application created with composer
 func (pkgs *PhpPackagesCollection) GatherInstalledPackages() ([]PhpPackage, error) {
 
 	var err error

--- a/daemon/internal/newrelic/processor_test.go
+++ b/daemon/internal/newrelic/processor_test.go
@@ -1473,11 +1473,11 @@ func TestShouldConnect(t *testing.T) {
 	}
 }
 
-// runs a mocked test of resolution of agent harvest limit request and value returned by collector
+// Runs a mocked test of resolution of agent harvest limit request and value returned by collector.
 // Notes:
-//   eventType:     "log_event_data" or "custom_event_data" (no others supported currently)
-//   agentLimit:     Harvest limit from agent (INI file) for a 60 second harvest period
-//   collectorLimit: Harvest limit sent from collector for a 5 second harvest period
+//   - eventType:     "log_event_data" or "custom_event_data" (no others supported currently)
+//   - agentLimit:     Harvest limit from agent (INI file) for a 60 second harvest period
+//   - collectorLimit: Harvest limit sent from collector for a 5 second harvest period
 //
 // Be aware the agentLimit will be scaled down by 12 (60/5) before being compared to the
 // collectorLimit.

--- a/daemon/internal/newrelic/utilization/utilization_hash.go
+++ b/daemon/internal/newrelic/utilization/utilization_hash.go
@@ -207,8 +207,8 @@ func OverrideDockerId(util *Data, id string) error {
 	if nil == util.Vendors {
 		util.Vendors = &vendors{}
 	}
-	util.Vendors.Docker = &docker{ID: id}	
-	return nil	
+	util.Vendors.Docker = &docker{ID: id}
+	return nil
 }
 
 func OverrideVendors(util *Data) {
@@ -222,20 +222,20 @@ func OverrideVendors(util *Data) {
 }
 
 func GetDockerId(util *Data) (string, error) {
-    id := ""
-    if nil == util {
-        return id, fmt.Errorf("Util is nil")
-    }
-    if util.Vendors.isEmpty() {
-        return id, fmt.Errorf("Vendors structure is empty")
-    }
-    if nil == util.Vendors.Docker {
-        return id, fmt.Errorf("Docker structure is empty")
-    }
+	id := ""
+	if nil == util {
+		return id, fmt.Errorf("Util is nil")
+	}
+	if util.Vendors.isEmpty() {
+		return id, fmt.Errorf("Vendors structure is empty")
+	}
+	if nil == util.Vendors.Docker {
+		return id, fmt.Errorf("Docker structure is empty")
+	}
 
-    id = util.Vendors.Docker.ID
+	id = util.Vendors.Docker.ID
 
-    return id, nil
+	return id, nil
 }
 
 func GatherMemory(util *Data) error {


### PR DESCRIPTION
Apply `gofmt` suggestions preserving semantics of comments. go1.19 changed how `gofmt` formats [Go Doc Comments](https://go.dev/doc/comment) therefore some doc strings needed small adjustments from what `gofmt` suggested.