### PR TITLE
fix(testing): Handles __FILE__ correctly for EXPECT_METRICS_EXIST

### DIFF
--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -465,8 +465,8 @@ func (t *Test) compareMetricsExist(harvest *newrelic.Harvest) {
 		var count int64
 
 		fields := strings.Split(spec, ",")
-		name := fields[0]
-		name = strings.TrimSpace(name)
+		expected := fields[0]
+		expected = strings.TrimSpace(expected)
 
 		// -1 means just test for existence without forcing an exact count
 		count = -1
@@ -483,7 +483,6 @@ func (t *Test) compareMetricsExist(harvest *newrelic.Harvest) {
 				}
 			}
 		}
-		expected := strings.Replace(name, "__FILE__", t.Path, -1)
 
 		id := newrelic.AgentRunID("?? agent run id")
 		actualJSON, _ := newrelic.IntegrationData(harvest.Metrics, id, time.Now())


### PR DESCRIPTION
The logic for handling "__FILE__" was reversed and this PR fixes it.  The idea is that the actual JSON harvest will have the file name replaced with "__FILE__" and so the expected string should contain "__FILE__" and not have the actual file name inserted as the old code did.