### PR TITLE
fix(testing): Fixes count check for apdex metrics

### DIFF
--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -544,7 +544,12 @@ func (t *Test) compareMetricsExist(harvest *newrelic.Harvest) {
 				actualCount := int64(math.Round(actualData.([]interface{})[0].(float64)))
 
 				metricPasses := false
-				if (count == -1 && actualCount > 0) || (actualCount == count) {
+
+				// apdex metrics can have a count of 0 since the count field is
+				// actually the "satisfied" count, not a total count of metric
+				// as it is for other types of metrics
+				apdex_metric := strings.HasPrefix(expected, "Apdex/")
+				if (count == -1 && (apdex_metric || actualCount > 0)) || (actualCount == count) {
 					metricPasses = true
 				}
 


### PR DESCRIPTION
The current code for EXPECT_METRICS_EXIST would verify the count of any metric was >0 before passing the test.  However, with apdex metrics the first field is not the count of metrics but the count of the number of times the transaction time was less than apdex_t.  This change allows for the count to be 0 for apdex metrics.