### PR TITLE
chore(agent): Changes code to use NR string routines

### DIFF
--- a/agent/lib_aws_sdk_php.c
+++ b/agent/lib_aws_sdk_php.c
@@ -88,9 +88,9 @@ void nr_lib_aws_sdk_php_add_supportability_service_metric(
   }
 
   cp = buf;
-  strcpy(cp, PHP_AWS_SDK_SERVICE_NAME_METRIC_PREFIX);
+  nr_strcpy(cp, PHP_AWS_SDK_SERVICE_NAME_METRIC_PREFIX);
   cp += PHP_AWS_SDK_SERVICE_NAME_METRIC_PREFIX_LEN - 1;
-  strlcpy(cp, service_name, MAX_AWS_SERVICE_NAME_LEN);
+  nr_strlcpy(cp, service_name, MAX_AWS_SERVICE_NAME_LEN);
   nrm_force_add(NRPRG(txn) ? NRTXN(unscoped_metrics) : 0, buf, 0);
 }
 

--- a/axiom/nr_distributed_trace.c
+++ b/axiom/nr_distributed_trace.c
@@ -497,7 +497,7 @@ void nr_distributed_trace_set_trace_id(nr_distributed_trace_t* dt,
         for (int i = 0; i < padding; i++) {
           dest[i] = '0';
         }
-        strcpy(dest + padding, trace_id);
+        nr_strcpy(dest + padding, trace_id);
         dt->trace_id = dest;
       } else {
         dt->trace_id = nr_strdup(trace_id);


### PR DESCRIPTION
Switches to use nr_strlcpy and nr_strcpy instead of libc versions for better platform generality.