### PR TITLE
fix(testing): Handles Apdex metrics count correctly

### DIFF
--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -549,7 +549,7 @@ func (t *Test) compareMetricsExist(harvest *newrelic.Harvest) {
 				// actually the "satisfied" count, not a total count of metric
 				// as it is for other types of metrics
 				apdex_metric := strings.HasPrefix(expected, "Apdex/")
-				if (count == -1 && (apdex_metric || actualCount > 0)) || (actualCount == count) {
+				if (apdex_metric || (count == -1 && actualCount > 0)) || (actualCount == count) {
 					metricPasses = true
 				}
 


### PR DESCRIPTION
The existing code did not handle an Apdex metric correctly if a count of "1" was specified.  It only worked if no count was specified.  This change allows either form to work.