### PR TITLE
fix(agent): Fixes newrelic_notice_error() API for PHP 8+

### DIFF
--- a/tests/integration/api/notice_error/test_bad_inputs.php
+++ b/tests/integration/api/notice_error/test_bad_inputs.php
@@ -15,6 +15,9 @@ ok - 2 args
 ok - 2 args
 ok - 3 args
 ok - 4 args
+ok - 4 args
+ok - 4 args
+ok - 4 args
 ok - 5 args
 ok - 6 args
 */
@@ -32,9 +35,15 @@ tap_equal(null, newrelic_notice_error(curl_init()), "1 arg");
 tap_equal(null, newrelic_notice_error("", 42), "2 args");
 tap_equal(null, newrelic_notice_error("", array()), "2 args");
 
-// Three and four argument forms are not allowed.
+// Three argument forms are not allowed.
 tap_equal(null, newrelic_notice_error(42, "message", "file"), "3 args");
-tap_equal(null, newrelic_notice_error(42, "message", "file", __LINE__), "4 args");
+
+// Four argument form requires integer, string, string, integer
+// This is like the five argument form but for PHP 8+ where the context is not supplied
+tap_equal(null, newrelic_notice_error("", "message", "file", __LINE__), "4 args");
+tap_equal(null, newrelic_notice_error(42, array(), "file", __LINE__), "4 args");
+tap_equal(null, newrelic_notice_error("", "message", array(), __LINE__), "4 args");
+tap_equal(null, newrelic_notice_error("", "message", "file", ""), "4 args");
 
 // Five argument form requires second arg to be convertible to a string.
 tap_equal(null, newrelic_notice_error("", curl_init()), "5 args");

--- a/tests/integration/api/notice_error/test_good_1_arg_exception.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_exception.php
@@ -89,6 +89,37 @@ called with 1 argument which is an exception.
 ]
 */
 
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "Exception",
+        "errorMessage": "Noticed exception 'Exception' with message '1 arg exception' in __FILE__:??"
+      }
+    ]
+  ]
+]
+*/
+
 require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
 
 function a()

--- a/tests/integration/api/notice_error/test_good_1_arg_exception.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_exception.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a traced error when newrelic_notice_error is
+called with 1 argument which is an exception.
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "Noticed exception 'Exception' with message '1 arg exception' in __FILE__:??",
+      "Exception",
+      {
+        "stack_trace": [
+          " in a called at __FILE__ (??)"
+     ],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "Exception",
+        "error.message": "Noticed exception 'Exception' with message '1 arg exception' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "Custom\/a",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??"
+    },
+    {},
+    {
+      "error.message": "Noticed exception 'Exception' with message '1 arg exception' in __FILE__:??",
+      "error.class": "Exception",
+      "code.lineno": "??",
+      "code.filepath": "__FILE__",
+      "code.function": "a"
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+
+function a()
+{
+  // One argument with an exception - this is tricky because most
+  // values are implicitly convertible to strings. Use a resource to prevent this.
+  newrelic_notice_error("1 arg", new Exception("1 arg exception"));
+}
+
+
+a();

--- a/tests/integration/api/notice_error/test_good_1_arg_exception_handler.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_exception_handler.php
@@ -110,6 +110,37 @@ used as a callback handler for set_exception_handler().
 ]
 */
 
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "Exception",
+        "errorMessage": "Noticed exception 'Exception' with message '1 arg exception' in __FILE__:??"
+      }
+    ]
+  ]
+]
+*/
+
 function a()
 {
   throw new Exception("1 arg exception");

--- a/tests/integration/api/notice_error/test_good_1_arg_exception_handler.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_exception_handler.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a traced error when newrelic_notice_error is
+called with 1 argument which is an exception.
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "Noticed exception 'Exception' with message '1 arg exception' in __FILE__:??",
+      "Exception",
+      {
+        "stack_trace": [
+          " in a called at __FILE__ (??)"
+     ],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "Exception",
+        "error.message": "Noticed exception 'Exception' with message '1 arg exception' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "OtherTransaction\/php__FILE__",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "nr.entryPoint": true,
+      "transaction.name": "OtherTransaction\/php__FILE__"
+    },
+    {},
+    {
+      "error.message": "Noticed exception 'Exception' with message '1 arg exception' in __FILE__:??",
+      "error.class": "Exception"
+    }
+  ],
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "Custom\/a",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??"
+    },
+    {},
+    {
+      "error.message": "Uncaught exception 'Exception' with message '1 arg exception' in __FILE__:??",
+      "error.class": "Exception",
+      "code.lineno": "??",
+      "code.filepath": "__FILE__",
+      "code.function": "a"
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+
+function a()
+{
+  throw new Exception("1 arg exception");
+}
+
+set_exception_handler('newrelic_notice_error');
+a();

--- a/tests/integration/api/notice_error/test_good_1_arg_exception_handler.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_exception_handler.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 The agent should record a traced error when newrelic_notice_error is
-called with 1 argument which is an exception.
+used as a callback handler for set_exception_handler().
 */
 
 /*EXPECT_TRACED_ERRORS

--- a/tests/integration/api/notice_error/test_good_1_arg_exception_handler.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_exception_handler.php
@@ -110,8 +110,6 @@ used as a callback handler for set_exception_handler().
 ]
 */
 
-require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
-
 function a()
 {
   throw new Exception("1 arg exception");

--- a/tests/integration/api/notice_error/test_good_1_arg_string.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_string.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 The agent should record a traced error when newrelic_notice_error is
-called with 1 argument which is an string.
+called with 1 argument which is a string.
 */
 
 /*EXPECT_TRACED_ERRORS

--- a/tests/integration/api/notice_error/test_good_1_arg_string.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_string.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a traced error when newrelic_notice_error is
+called with 1 argument which is an string.
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "Exception 1 arg string",
+      "NoticedError",
+      {
+        "stack_trace": [
+          " in newrelic_notice_error called at __FILE__ (??)",
+          " in a called at __FILE__ (??)"
+        ],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "NoticedError",
+        "error.message": "Exception 1 arg string",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "Custom\/a",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??"
+    },
+    {},
+    {
+      "error.message": "Exception 1 arg string",
+      "error.class": "NoticedError",
+      "code.lineno": "??",
+      "code.filepath": "__FILE__",
+      "code.function": "a"
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+
+function a()
+{
+  // First arg must be a string or an exception. 
+  newrelic_notice_error("Exception 1 arg string");
+}
+
+a();

--- a/tests/integration/api/notice_error/test_good_1_arg_string.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_string.php
@@ -90,8 +90,6 @@ called with 1 argument which is an string.
 ]
 */
 
-require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
-
 function a()
 {
   // First arg must be a string or an exception. 

--- a/tests/integration/api/notice_error/test_good_1_arg_string.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_string.php
@@ -90,6 +90,69 @@ called with 1 argument which is a string.
 ]
 */
 
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "NoticedError",
+        "errorMessage": "Exception 1 arg string"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "NoticedError",
+        "errorMessage": "Exception 1 arg string"
+      }
+    ]
+  ]
+]
+*/
+
 function a()
 {
   // First arg must be a string or an exception. 

--- a/tests/integration/api/notice_error/test_good_1_arg_string.php
+++ b/tests/integration/api/notice_error/test_good_1_arg_string.php
@@ -122,37 +122,6 @@ called with 1 argument which is a string.
 ]
 */
 
-/*EXPECT_ANALYTICS_EVENTS
-[
-  "?? agent run id",
-  {
-    "reservoir_size": "??",
-    "events_seen": "??"
-  },
-  [
-    [
-      {
-        "type": "Transaction",
-        "name": "OtherTransaction\/php__FILE__",
-        "timestamp": "??",
-        "duration": "??",
-        "totalTime": "??",
-        "guid": "??",
-        "sampled": true,
-        "priority": "??",
-        "traceId": "??",
-        "error": true
-      },
-      {},
-      {
-        "errorType": "NoticedError",
-        "errorMessage": "Exception 1 arg string"
-      }
-    ]
-  ]
-]
-*/
-
 function a()
 {
   // First arg must be a string or an exception. 

--- a/tests/integration/api/notice_error/test_good_2_args.php
+++ b/tests/integration/api/notice_error/test_good_2_args.php
@@ -89,6 +89,37 @@ called with 2 parameters.
 ]
 */
 
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "Exception",
+        "errorMessage": "Noticed exception 'Exception' with message '2 arg exception' in __FILE__:??"
+      }
+    ]
+  ]
+]
+*/
+
 function a()
 {
   // Args must be string, exception.

--- a/tests/integration/api/notice_error/test_good_2_args.php
+++ b/tests/integration/api/notice_error/test_good_2_args.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a traced error when newrelic_notice_error is
+called with 2 parameters.
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "Noticed exception 'Exception' with message '2 arg exception' in __FILE__:??",
+      "Exception",
+      {
+        "stack_trace": [
+          " in a called at __FILE__ (??)"
+        ],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "Exception",
+        "error.message": "Noticed exception 'Exception' with message '2 arg exception' in __FILE__:??",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "Custom\/a",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??"
+    },
+    {},
+    {
+      "error.message": "Noticed exception 'Exception' with message '2 arg exception' in __FILE__:??",
+      "error.class": "Exception",
+      "code.lineno": "??",
+      "code.filepath": "__FILE__",
+      "code.function": "a"
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+
+function a()
+{
+  // Args must be string, exception.
+  newrelic_notice_error("2 arg", new Exception("2 arg exception"));
+}
+
+a();

--- a/tests/integration/api/notice_error/test_good_2_args.php
+++ b/tests/integration/api/notice_error/test_good_2_args.php
@@ -89,8 +89,6 @@ called with 2 parameters.
 ]
 */
 
-require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
-
 function a()
 {
   // Args must be string, exception.

--- a/tests/integration/api/notice_error/test_good_4_args.php
+++ b/tests/integration/api/notice_error/test_good_4_args.php
@@ -90,6 +90,38 @@ called with 4 parameters.
 ]
 */
 
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "NoticedError",
+        "errorMessage": "4 arg error"
+      }
+    ]
+  ]
+]
+*/
+
+
 function a() {
     // Four argument form requires integer, string, string, integer
     // This is like the five argument form but for PHP 8+ where the context is not supplied

--- a/tests/integration/api/notice_error/test_good_4_args.php
+++ b/tests/integration/api/notice_error/test_good_4_args.php
@@ -90,8 +90,6 @@ called with 4 parameters.
 ]
 */
 
-require_once(realpath(dirname( __FILE__ )) . '/../../../include/tap.php');
-
 function a() {
     // Four argument form requires integer, string, string, integer
     // This is like the five argument form but for PHP 8+ where the context is not supplied

--- a/tests/integration/api/notice_error/test_good_4_args.php
+++ b/tests/integration/api/notice_error/test_good_4_args.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a traced error when newrelic_notice_error is
+called with 4 parameters.
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "4 arg error",
+      "NoticedError",
+      {
+        "stack_trace": [
+          " in newrelic_notice_error called at __FILE__ (??)",
+          " in a called at __FILE__ (??)"
+        ],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "NoticedError",
+        "error.message": "4 arg error",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "Custom\/a",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??"
+    },
+    {},
+    {
+      "error.message": "4 arg error",
+      "error.class": "NoticedError",
+      "code.lineno": "??",
+      "code.filepath": "__FILE__",
+      "code.function": "a"
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname( __FILE__ )) . '/../../../include/tap.php');
+
+function a() {
+    // Four argument form requires integer, string, string, integer
+    // This is like the five argument form but for PHP 8+ where the context is not supplied
+    newrelic_notice_error(42, "4 arg error", "file", __LINE__);
+}
+
+a();

--- a/tests/integration/api/notice_error/test_good_4_args_error_handler.php
+++ b/tests/integration/api/notice_error/test_good_4_args_error_handler.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 The agent should record a traced error when newrelic_notice_error is
-called with 4 parameters.
+used as a callback handler for set_error_handler().
 */
 
 /*EXPECT_TRACED_ERRORS

--- a/tests/integration/api/notice_error/test_good_4_args_error_handler.php
+++ b/tests/integration/api/notice_error/test_good_4_args_error_handler.php
@@ -110,6 +110,37 @@ used as a callback handler for set_error_handler().
 ]
 */
 
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "NoticedError",
+        "errorMessage": "4 arg error"
+      }
+    ]
+  ]
+]
+*/
+
 function a() {
     trigger_error("4 arg error", E_USER_ERROR);
 }

--- a/tests/integration/api/notice_error/test_good_4_args_error_handler.php
+++ b/tests/integration/api/notice_error/test_good_4_args_error_handler.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a traced error when newrelic_notice_error is
+called with 4 parameters.
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "4 arg error",
+      "NoticedError",
+      {
+        "stack_trace": [
+          " in newrelic_notice_error called at ? (?)",
+          " in trigger_error called at __FILE__ (??)",
+          " in a called at __FILE__ (??)"
+        ],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "NoticedError",
+        "error.message": "4 arg error",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "OtherTransaction\/php__FILE__",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "nr.entryPoint": true,
+      "transaction.name": "OtherTransaction\/php__FILE__"
+    },
+    {},
+    {
+    }
+  ],
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "Custom\/a",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??"
+    },
+    {},
+    {
+      "error.message": "4 arg error",
+      "error.class": "NoticedError",
+      "code.lineno": "??",
+      "code.filepath": "__FILE__",
+      "code.function": "a"
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname( __FILE__ )) . '/../../../include/tap.php');
+
+function a() {
+    trigger_error("4 arg error", E_USER_ERROR);
+}
+
+set_error_handler('newrelic_notice_error', E_USER_ERROR);
+a();

--- a/tests/integration/api/notice_error/test_good_4_args_error_handler.php
+++ b/tests/integration/api/notice_error/test_good_4_args_error_handler.php
@@ -110,8 +110,6 @@ used as a callback handler for set_error_handler().
 ]
 */
 
-require_once(realpath(dirname( __FILE__ )) . '/../../../include/tap.php');
-
 function a() {
     trigger_error("4 arg error", E_USER_ERROR);
 }

--- a/tests/integration/api/notice_error/test_good_5_args.php
+++ b/tests/integration/api/notice_error/test_good_5_args.php
@@ -90,6 +90,38 @@ called with 5 parameters.
 ]
 */
 
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "NoticedError",
+        "errorMessage": "5 arg error"
+      }
+    ]
+  ]
+]
+*/
+
 function a() {
   // Five argument form requires second arg to be convertible to a string.
   newrelic_notice_error(42, "5 arg error", "file", __LINE__, "string");

--- a/tests/integration/api/notice_error/test_good_5_args.php
+++ b/tests/integration/api/notice_error/test_good_5_args.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a traced error when newrelic_notice_error is
+called with 5 parameters.
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "5 arg error",
+      "NoticedError",
+      {
+        "stack_trace": [
+          " in newrelic_notice_error called at __FILE__ (??)",
+          " in a called at __FILE__ (??)"
+        ],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "NoticedError",
+        "error.message": "5 arg error",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "Custom\/a",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??"
+    },
+    {},
+    {
+      "error.message": "5 arg error",
+      "error.class": "NoticedError",
+      "code.lineno": "??",
+      "code.filepath": "__FILE__",
+      "code.function": "a"
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname( __FILE__ )) . '/../../../include/tap.php');
+
+function a() {
+  // Five argument form requires second arg to be convertible to a string.
+  newrelic_notice_error(42, "5 arg error", "file", __LINE__, "string");
+}
+
+a();

--- a/tests/integration/api/notice_error/test_good_5_args.php
+++ b/tests/integration/api/notice_error/test_good_5_args.php
@@ -90,8 +90,6 @@ called with 5 parameters.
 ]
 */
 
-require_once(realpath(dirname( __FILE__ )) . '/../../../include/tap.php');
-
 function a() {
   // Five argument form requires second arg to be convertible to a string.
   newrelic_notice_error(42, "5 arg error", "file", __LINE__, "string");

--- a/tests/integration/api/notice_error/test_good_5_args_error_handler.php
+++ b/tests/integration/api/notice_error/test_good_5_args_error_handler.php
@@ -110,8 +110,6 @@ used as a callback handler for set_error_handler().
 ]
 */
 
-require_once(realpath(dirname( __FILE__ )) . '/../../../include/tap.php');
-
 function a() {
     trigger_error("5 arg error", E_USER_ERROR);
 }

--- a/tests/integration/api/notice_error/test_good_5_args_error_handler.php
+++ b/tests/integration/api/notice_error/test_good_5_args_error_handler.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a traced error when newrelic_notice_error is
+called with 5 parameters.
+*/
+
+/*EXPECT_TRACED_ERRORS
+[
+  "?? agent run id",
+  [
+    [
+      "?? when",
+      "OtherTransaction/php__FILE__",
+      "5 arg error",
+      "NoticedError",
+      {
+        "stack_trace": [
+          " in newrelic_notice_error called at ? (?)",
+          " in trigger_error called at __FILE__ (??)",
+          " in a called at __FILE__ (??)"
+        ],
+        "agentAttributes": "??",
+        "intrinsics": "??"
+      },
+      "?? transaction ID"
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ERROR_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "TransactionError",
+        "timestamp": "??",
+        "error.class": "NoticedError",
+        "error.message": "5 arg error",
+        "transactionName": "OtherTransaction\/php__FILE__",
+        "duration": "??",
+        "nr.transactionGuid": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "spanId": "??"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "OtherTransaction\/php__FILE__",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "nr.entryPoint": true,
+      "transaction.name": "OtherTransaction\/php__FILE__"
+    },
+    {},
+    {
+    }
+  ],
+  [
+    {
+      "traceId": "??",
+      "duration": "??",
+      "transactionId": "??",
+      "name": "Custom\/a",
+      "guid": "??",
+      "type": "Span",
+      "category": "generic",
+      "priority": "??",
+      "sampled": true,
+      "timestamp": "??",
+      "parentId": "??"
+    },
+    {},
+    {
+      "error.message": "5 arg error",
+      "error.class": "NoticedError",
+      "code.lineno": "??",
+      "code.filepath": "__FILE__",
+      "code.function": "a"
+    }
+  ]
+]
+*/
+
+require_once(realpath(dirname( __FILE__ )) . '/../../../include/tap.php');
+
+function a() {
+    trigger_error("5 arg error", E_USER_ERROR);
+}
+
+set_error_handler('newrelic_notice_error', E_USER_ERROR);
+a();

--- a/tests/integration/api/notice_error/test_good_5_args_error_handler.php
+++ b/tests/integration/api/notice_error/test_good_5_args_error_handler.php
@@ -6,7 +6,7 @@
 
 /*DESCRIPTION
 The agent should record a traced error when newrelic_notice_error is
-called with 5 parameters.
+used as a callback handler for set_error_handler().
 */
 
 /*EXPECT_TRACED_ERRORS

--- a/tests/integration/api/notice_error/test_good_5_args_error_handler.php
+++ b/tests/integration/api/notice_error/test_good_5_args_error_handler.php
@@ -110,6 +110,37 @@ used as a callback handler for set_error_handler().
 ]
 */
 
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": "??",
+    "events_seen": "??"
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": true
+      },
+      {},
+      {
+        "errorType": "NoticedError",
+        "errorMessage": "5 arg error"
+      }
+    ]
+  ]
+]
+*/
+
 function a() {
     trigger_error("5 arg error", E_USER_ERROR);
 }


### PR DESCRIPTION
Starting with PHP 8.0 the `set_error_handler()` callback function signature drops the `$errcontext` final parameter so it only contains 4 parameters.  This caused using `newrelic_notice_error()` as a callback handler for PHP 8+ to not work as the API call did not accept only 4 arguments.  This PR adds support for this function signature.  There are also numerous tests added that will hopefully caught this kind of issue in the future.