### PR TITLE
ci: fix test-pull-request workflow

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -193,6 +193,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: agent.gcov-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
+          include-hidden-files: true
           path: php-agent/agent/.libs/*.gc*
   integration-tests:
     needs: [daemon-unit-tests, agent-unit-test]


### PR DESCRIPTION
[`actions/upload-artifacts@v4.4.0`](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) includes a breaking change of that causes hidden directories and files not being uploaded. Since code coverage artifacts are in `agent/.libs` directory, this functionality needs to disabled. Set `include-hidden-files` to true when uploading code coverage artifacts.