### PR TITLE
feat(agent): improve package major version metric creation

### DIFF
--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -107,6 +107,7 @@ TEST_BINARIES = \
 	tests/test_php_minit \
 	tests/test_php_stack \
 	tests/test_php_stacked_segment \
+	tests/test_php_txn \
 	tests/test_php_wrapper \
 	tests/test_predis \
 	tests/test_redis \

--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -885,11 +885,7 @@ void nr_drupal_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-  
-  nr_fw_support_add_package_supportability_metric(
-      NRPRG(txn), PHP_PACKAGE_NAME, NULL,
-      nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                  PHP_PACKAGE_NAME));
-
 }

--- a/agent/fw_drupal.c
+++ b/agent/fw_drupal.c
@@ -885,7 +885,8 @@ void nr_drupal_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -761,6 +761,6 @@ void nr_drupal8_enable(TSRMLS_D) {
                            PHP_PACKAGE_VERSION_UNKNOWN);
   }
 
-  nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                 NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -669,7 +669,6 @@ NR_PHP_WRAPPER_END
 void nr_drupal_version() {
   zval* zval_version = NULL;
   zend_class_entry* class_entry = NULL;
-  nr_php_package_t* p = NULL;
 
   class_entry = nr_php_find_class("drupal");
   if (NULL == class_entry) {
@@ -688,10 +687,8 @@ void nr_drupal_version() {
   if (nr_php_is_zval_valid_string(zval_version)) {
     char* version = Z_STRVAL_P(zval_version);
     if (NRINI(vulnerability_management_package_detection_enabled)) {
-      p = nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+      nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
     }
-    nr_fw_support_add_package_supportability_metric(
-        NRPRG(txn), PHP_PACKAGE_NAME, version, p);
   }
 
   nr_php_zval_free(&zval_version);
@@ -763,4 +760,7 @@ void nr_drupal8_enable(TSRMLS_D) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
   }
+
+  nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                 NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
 }

--- a/agent/fw_laminas3.c
+++ b/agent/fw_laminas3.c
@@ -167,9 +167,7 @@ void nr_laminas3_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-  nr_fw_support_add_package_supportability_metric(
-      NRPRG(txn), PHP_PACKAGE_NAME, NULL,
-      nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                  PHP_PACKAGE_NAME));  
 }

--- a/agent/fw_laminas3.c
+++ b/agent/fw_laminas3.c
@@ -167,7 +167,8 @@ void nr_laminas3_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -962,9 +962,10 @@ NR_PHP_WRAPPER(nr_laravel_application_construct) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     // Add php package to transaction
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               version);
 
   if (version) {
     nrl_debug(NRL_FRAMEWORK, "Laravel version is " NRP_FMT, NRP_PHP(version));

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -949,7 +949,6 @@ NR_PHP_WRAPPER(nr_laravel_application_construct) {
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   ;
   char* version = NULL;
-  nr_php_package_t* p = NULL;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
@@ -962,10 +961,10 @@ NR_PHP_WRAPPER(nr_laravel_application_construct) {
 
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     // Add php package to transaction
-    p = nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+    nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-  nr_fw_support_add_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
-                                                  version, p);
 
   if (version) {
     nrl_debug(NRL_FRAMEWORK, "Laravel version is " NRP_FMT, NRP_PHP(version));

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -237,10 +237,7 @@ void nr_lumen_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-
-  nr_fw_support_add_package_supportability_metric(
-      NRPRG(txn), PHP_PACKAGE_NAME, NULL,
-      nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                  PHP_PACKAGE_NAME));
 }

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -237,7 +237,8 @@ void nr_lumen_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -152,7 +152,6 @@ NR_PHP_WRAPPER_END
 NR_PHP_WRAPPER(nr_slim_application_construct) {
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
   char* version = NULL;
-  nr_php_package_t* p = NULL;
 
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
@@ -161,11 +160,10 @@ NR_PHP_WRAPPER(nr_slim_application_construct) {
 
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     // Add php package to transaction
-    p = nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+    nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-
-  nr_fw_support_add_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
-                                                  version, p);
 
   nr_free(version);
   nr_php_scope_release(&this_var);

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -161,9 +161,10 @@ NR_PHP_WRAPPER(nr_slim_application_construct) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     // Add php package to transaction
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               version);
 
   nr_free(version);
   nr_php_scope_release(&this_var);

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -281,7 +281,8 @@ void nr_symfony4_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -281,10 +281,7 @@ void nr_symfony4_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-
-  nr_fw_support_add_package_supportability_metric(
-      NRPRG(txn), PHP_PACKAGE_NAME, NULL,
-      nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                  PHP_PACKAGE_NAME));  
 }

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -811,9 +811,10 @@ void nr_wordpress_version() {
       char* version = Z_STRVAL(retval);
       if (NRINI(vulnerability_management_package_detection_enabled)) {
         nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
-        nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                       NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
       }
+
+      nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                                   version);
     }
     zval_dtor(&retval);
   }

--- a/agent/fw_wordpress.c
+++ b/agent/fw_wordpress.c
@@ -804,18 +804,16 @@ void nr_wordpress_version() {
         "})();";
 
   zval retval;
-  int result
-      = zend_eval_string(func_string, &retval, "Get Wordpress Version");
-  nr_php_package_t* p = NULL;
+  int result = zend_eval_string(func_string, &retval, "Get Wordpress Version");
   // Add php package to transaction
   if (SUCCESS == result) {
     if (nr_php_is_zval_valid_string(&retval)) {
       char* version = Z_STRVAL(retval);
       if (NRINI(vulnerability_management_package_detection_enabled)) {
-        p = nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+        nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+        nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                       NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
       }
-      nr_fw_support_add_package_supportability_metric(
-          NRPRG(txn), PHP_PACKAGE_NAME, version, p);
     }
     zval_dtor(&retval);
   }

--- a/agent/fw_yii.c
+++ b/agent/fw_yii.c
@@ -226,10 +226,7 @@ void nr_yii2_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-  
-  nr_fw_support_add_package_supportability_metric(
-      NRPRG(txn), PHP_PACKAGE_NAME, NULL,
-      nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                  PHP_PACKAGE_NAME));
 }

--- a/agent/fw_yii.c
+++ b/agent/fw_yii.c
@@ -226,7 +226,8 @@ void nr_yii2_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_aws_sdk_php.c
+++ b/agent/lib_aws_sdk_php.c
@@ -56,7 +56,6 @@ void nr_lib_aws_sdk_php_handle_version() {
   zval* zval_version = NULL;
   zend_class_entry* class_entry = NULL;
   char* version = NULL;
-  nr_php_package_t* p = NULL;
 
   class_entry = nr_php_find_class("aws\\sdk");
   if (NULL != class_entry) {
@@ -68,10 +67,11 @@ void nr_lib_aws_sdk_php_handle_version() {
   }
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     /* Add php package to transaction */
-    p = nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+    nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-  nr_fw_support_add_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
-                                                  version, p);
+
   nr_php_zval_free(&zval_version);
 }
 

--- a/agent/lib_aws_sdk_php.c
+++ b/agent/lib_aws_sdk_php.c
@@ -68,9 +68,10 @@ void nr_lib_aws_sdk_php_handle_version() {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     /* Add php package to transaction */
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               version);
 
   nr_php_zval_free(&zval_version);
 }

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -110,9 +110,7 @@ void nr_doctrine2_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-  nr_fw_support_add_package_supportability_metric(
-      NRPRG(txn), PHP_PACKAGE_NAME, NULL,
-      nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                  PHP_PACKAGE_NAME));  
 }

--- a/agent/lib_doctrine2.c
+++ b/agent/lib_doctrine2.c
@@ -110,7 +110,8 @@ void nr_doctrine2_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_guzzle4.c
+++ b/agent/lib_guzzle4.c
@@ -524,12 +524,9 @@ void nr_guzzle4_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-
-  nr_fw_support_add_package_supportability_metric(
-      NRPRG(txn), PHP_PACKAGE_NAME, NULL,
-      nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                  PHP_PACKAGE_NAME));
 }
 
 void nr_guzzle4_minit(TSRMLS_D) {

--- a/agent/lib_guzzle4.c
+++ b/agent/lib_guzzle4.c
@@ -524,9 +524,10 @@ void nr_guzzle4_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }
 
 void nr_guzzle4_minit(TSRMLS_D) {

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -352,19 +352,10 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
 
   char* version = nr_php_get_object_constant(this_var, "VERSION");
-  nr_php_package_t* p = NULL;
 
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     // Add php package to transaction
-    p = nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
-
-    /* mark package for package major metric creation later if
-     * a full version was detected
-     */
-    if (NULL != version) {
-      nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                     NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
-    }
+    nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
   }
 
   /*
@@ -378,10 +369,15 @@ NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
    */
   if (NULL == version) {
     version = nr_php_get_object_constant(this_var, "MAJOR_VERSION");
-    nr_fw_support_add_package_supportability_metric(
-        NRPRG(txn), PHP_PACKAGE_NAME, version, p);
   }
 
+  /* if version is still NULL that is OK this next call will accept
+   * that value and when supportability metrics are made for
+   * packages if another method has determined the package version
+   * (composer api for example) then it will be filled in at that time
+   */
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               version);
   nr_free(version);
 
   (void)wraprec;

--- a/agent/lib_mongodb.c
+++ b/agent/lib_mongodb.c
@@ -449,7 +449,8 @@ void nr_mongodb_enable() {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_mongodb.c
+++ b/agent/lib_mongodb.c
@@ -449,10 +449,7 @@ void nr_mongodb_enable() {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-
-  nr_fw_support_add_package_supportability_metric(
-    NRPRG(txn), PHP_PACKAGE_NAME, NULL,
-    nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                PHP_PACKAGE_NAME));
 }

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -378,10 +378,8 @@ NR_PHP_WRAPPER(nr_monolog_logger_addrecord) {
         = nr_monolog_get_timestamp(api, argc, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
     char version[MAJOR_VERSION_LENGTH];
     snprintf(version, sizeof(version), "%d", api);
-    nr_fw_support_add_package_supportability_metric(
-        NRPRG(txn), PHP_PACKAGE_NAME, version,
-        nr_php_packages_get_package(NRPRG(txn)->php_packages,
-                                    PHP_PACKAGE_NAME));
+    nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                                 version);
   }
 
   /* Record the log event */
@@ -524,14 +522,8 @@ void nr_monolog_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
-    /* Usually we would set the package major metric option here, but legacy
-     * VM detection will get the version from the logger API constant
-     * and we create the package major metric then as it will work even
-     * if the composer API is not being used for VM.
-     *
-     * The version detection is done in the addRecord wrapper and only
-     * returns a major number, so this value is not stored in the PHP
-     * package record for monolog.  This is different than most packages.
-     */
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_monolog.c
+++ b/agent/lib_monolog.c
@@ -524,5 +524,14 @@ void nr_monolog_enable(TSRMLS_D) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
+    /* Usually we would set the package major metric option here, but legacy
+     * VM detection will get the version from the logger API constant
+     * and we create the package major metric then as it will work even
+     * if the composer API is not being used for VM.
+     *
+     * The version detection is done in the addRecord wrapper and only
+     * returns a major number, so this value is not stored in the PHP
+     * package record for monolog.  This is different than most packages.
+     */
   }
 }

--- a/agent/lib_phpunit.c
+++ b/agent/lib_phpunit.c
@@ -14,6 +14,8 @@
 #include "util_logging.h"
 #include "util_strings.h"
 
+#define PHP_PACKAGE_NAME "phpunit/phpunit"
+
 /*
  * PHPUnit instrumentation
  * =======================
@@ -697,7 +699,10 @@ void nr_phpunit_enable(TSRMLS_D) {
       nr_phpunit_instrument_testresult_adderror TSRMLS_CC);
 
   if (NRINI(vulnerability_management_package_detection_enabled)) {
-    nr_txn_add_php_package(NRPRG(txn), "phpunit/phpunit",
+    nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME,
                            PHP_PACKAGE_VERSION_UNKNOWN);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
 }

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -653,9 +653,10 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     // Add php package to transaction
     nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
-    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
-                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
+
+  nr_txn_suggest_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
+                                               version);
 
   nr_free(version);
 

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -644,7 +644,6 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   zval* conn = NULL;
   zval* params = nr_php_arg_get(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   zval* scope = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-  nr_php_package_t* p = NULL;
 
   (void)wraprec;
 
@@ -653,10 +652,11 @@ NR_PHP_WRAPPER(nr_predis_client_construct) {
   char* version = nr_php_get_object_constant(scope, "VERSION");
   if (NRINI(vulnerability_management_package_detection_enabled)) {
     // Add php package to transaction
-    p = nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+    nr_txn_add_php_package(NRPRG(txn), PHP_PACKAGE_NAME, version);
+    nr_txn_php_package_set_options(NRPRG(txn), PHP_PACKAGE_NAME,
+                                   NR_PHP_PACKAGE_OPTION_MAJOR_METRIC);
   }
-  nr_fw_support_add_package_supportability_metric(NRPRG(txn), PHP_PACKAGE_NAME,
-                                                  version, p);
+
   nr_free(version);
 
   /*

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -713,10 +713,10 @@ void nr_php_txn_create_agent_php_version_metrics(nrtxn_t* txn) {
   nr_php_txn_create_php_version_metric(txn, version);
 }
 
-static void nr_php_txn_php_package_create_major_metric(void* value,
-                                                       const char* key,
-                                                       size_t key_len,
-                                                       void* user_data) {
+void nr_php_txn_php_package_create_major_metric(void* value,
+                                                const char* key,
+                                                size_t key_len,
+                                                void* user_data) {
   nrtxn_t* txn = (nrtxn_t*)user_data;
   nr_php_package_t* suggested = value;
   nr_php_package_t* actual = NULL;
@@ -738,12 +738,12 @@ static void nr_php_txn_php_package_create_major_metric(void* value,
   actual
       = nr_php_packages_get_package(txn->php_packages, suggested->package_name);
 
-  nrl_verbosedebug(NRL_INSTRUMENT,
-                   "Creating PHP Package Supportability Metric for package "
-                   "'%s', suggested version '%s', actual version '%s'",
-                   NRSAFESTR(suggested->package_name),
-                   NRSAFESTR(suggested->package_version),
-                   NRSAFESTR(NULL != actual ? actual->package_version : ""));
+  nrl_verbosedebug(
+      NRL_INSTRUMENT,
+      "Creating PHP Package Supportability Metric for package "
+      "'%s', suggested version '%s', actual version '%s'",
+      NRSAFESTR(suggested->package_name), NRSAFESTR(suggested->package_version),
+      NRSAFESTR(NULL != actual ? actual->package_version : "NULL"));
   nr_fw_support_add_package_supportability_metric(
       txn, suggested->package_name, suggested->package_version, actual);
 }
@@ -753,7 +753,7 @@ void nr_php_txn_create_packages_major_metrics(nrtxn_t* txn) {
     return;
   }
 
-  nr_php_packages_iterate(txn->php_package_suggestions,
+  nr_php_packages_iterate(txn->php_package_major_version_metrics_suggestions,
                           nr_php_txn_php_package_create_major_metric, txn);
 }
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -724,6 +724,10 @@ static void nr_php_txn_php_package_create_major_metric(void* value,
   (void)key;
   (void)key_len;
 
+  if (NULL == txn) {
+    return;
+  }
+
   if (NULL == suggested) {
     return;
   }
@@ -739,7 +743,7 @@ static void nr_php_txn_php_package_create_major_metric(void* value,
                    "'%s', suggested version '%s', actual version '%s'",
                    NRSAFESTR(suggested->package_name),
                    NRSAFESTR(suggested->package_version),
-                   NRSAFESTR(actual ? actual->package_version : ""));
+                   NRSAFESTR(NULL != actual ? actual->package_version : ""));
   nr_fw_support_add_package_supportability_metric(
       txn, suggested->package_name, suggested->package_version, actual);
 }

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -718,24 +718,30 @@ static void nr_php_txn_php_package_create_major_metric(void* value,
                                                        size_t key_len,
                                                        void* user_data) {
   nrtxn_t* txn = (nrtxn_t*)user_data;
-  nr_php_package_t* package = value;
+  nr_php_package_t* suggested = value;
+  nr_php_package_t* actual = NULL;
 
   (void)key;
   (void)key_len;
 
-  if (NULL == package) {
+  if (NULL == suggested) {
     return;
   }
 
-  if (package->options & NR_PHP_PACKAGE_OPTION_MAJOR_METRIC) {
-    nrl_verbosedebug(NRL_INSTRUMENT,
-                     "Creating PHP Package Supportability Metric for package "
-                     "'%s', version '%s'",
-                     NRSAFESTR(package->package_name),
-                     NRSAFESTR(package->package_version));
-    nr_fw_support_add_package_supportability_metric(
-        txn, package->package_name, package->package_version, NULL);
-  }
+  /* see if the actual packages has a version we can use over the
+   * one provided with the suggested package
+   */
+  actual
+      = nr_php_packages_get_package(txn->php_packages, suggested->package_name);
+
+  nrl_verbosedebug(NRL_INSTRUMENT,
+                   "Creating PHP Package Supportability Metric for package "
+                   "'%s', suggested version '%s', actual version '%s'",
+                   NRSAFESTR(suggested->package_name),
+                   NRSAFESTR(suggested->package_version),
+                   NRSAFESTR(actual ? actual->package_version : ""));
+  nr_fw_support_add_package_supportability_metric(
+      txn, suggested->package_name, suggested->package_version, actual);
 }
 
 void nr_php_txn_create_packages_major_metrics(nrtxn_t* txn) {
@@ -743,7 +749,7 @@ void nr_php_txn_create_packages_major_metrics(nrtxn_t* txn) {
     return;
   }
 
-  nr_php_packages_iterate(txn->php_packages,
+  nr_php_packages_iterate(txn->php_package_suggestions,
                           nr_php_txn_php_package_create_major_metric, txn);
 }
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1211,7 +1211,7 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
     /* Agent and PHP version metrics*/
     nr_php_txn_create_agent_php_version_metrics(txn);
 
-    /* PHP packages major number metrics */
+    /* PHP packages major version metrics */
     nr_php_txn_create_packages_major_metrics(txn);
 
     /* Add CPU and memory metrics */

--- a/agent/php_txn_private.h
+++ b/agent/php_txn_private.h
@@ -67,6 +67,20 @@ extern void nr_php_txn_create_php_version_metric(nrtxn_t* txn,
                                                  const char* version);
 
 /*
+ * Purpose : Callback for nr_php_packages_iterate to create major
+ *           version metrics.
+ *
+ * Params  : 1. PHP suggestion package version
+ *           2. PHP suggestion package name
+ *           3. PHP suggestion package name length
+ *           4. The current transaction (via userdata)
+ */
+extern void nr_php_txn_php_package_create_major_metric(void* value,
+                                                       const char* key,
+                                                       size_t key_len,
+                                                       void* user_data);
+
+/*
  * Purpose : Create and record metric for a package major versions.
  *
  * Params  : 1. The current transaction.

--- a/agent/php_txn_private.h
+++ b/agent/php_txn_private.h
@@ -65,3 +65,10 @@ extern void nr_php_txn_create_agent_version_metric(nrtxn_t* txn);
  */
 extern void nr_php_txn_create_php_version_metric(nrtxn_t* txn,
                                                  const char* version);
+
+/*
+ * Purpose : Create and record metric for a package major versions.
+ *
+ * Params  : 1. The current transaction.
+ */
+extern void nr_php_txn_create_packages_major_metrics(nrtxn_t* txn);

--- a/agent/tests/test_lib_aws_sdk_php.c
+++ b/agent/tests/test_lib_aws_sdk_php.c
@@ -123,8 +123,9 @@ static void test_nr_lib_aws_sdk_php_handle_version(void) {
   }
 
   /*
-   * Aws/Sdk class does not exist, should not create package metric suggestion
-   * if no version This case should never happen in real situations.
+   * Aws/Sdk class does not exist, should create package metric suggestion
+   * with PHP_PACKAGE_VERSION_UNKNOWN version. This case should never happen
+   * in real situations.
    */
   tlib_php_request_start();
 
@@ -133,17 +134,14 @@ static void test_nr_lib_aws_sdk_php_handle_version(void) {
   p = nr_php_packages_get_package(
       NRPRG(txn)->php_package_major_version_metrics_suggestions, LIBRARY_NAME);
 
-  test_description = nr_formatf(TEST_DESCRIPTION_FMT, i, library_versions[i],
-                                "suggestion created");
-  tlib_pass_if_not_null(test_description, p);
-  nr_free(test_description);
-
-  test_description
-      = nr_formatf(TEST_DESCRIPTION_FMT, i, library_versions[i],
-                   "suggested version set to PHP_PACKAGE_VERSION_UNKNOWN");
-  tlib_pass_if_str_equal(test_description, PHP_PACKAGE_VERSION_UNKNOWN,
-                         p->package_version);
-  nr_free(test_description);
+  tlib_pass_if_not_null(
+      "nr_lib_aws_sdk_php_handle_version when Aws\\Sdk class is not defined - "
+      "suggestion created",
+      p);
+  tlib_pass_if_str_equal(
+      "nr_lib_aws_sdk_php_handle_version when Aws\\Sdk class is not defined - "
+      "suggested version set to PHP_PACKAGE_VERSION_UNKNOWN",
+      PHP_PACKAGE_VERSION_UNKNOWN, p->package_version);
 
   tlib_php_request_end();
 }

--- a/agent/tests/test_lib_aws_sdk_php.c
+++ b/agent/tests/test_lib_aws_sdk_php.c
@@ -80,14 +80,14 @@ static void test_nr_lib_aws_sdk_php_add_supportability_service_metric(void) {
 
 static void test_nr_lib_aws_sdk_php_handle_version(void) {
 #define LIBRARY_NAME "aws/aws-sdk-php"
-#define LIBRARY_MAJOR_VERSION "7"
-#define LIBRARY_MAJOR_VERSION_2 "10"
-#define LIBRARY_MAJOR_VERSION_3 "100"
-#define LIBRARY_MAJOR_VERSION_4 "4.23"
-#define LIBRARY_MAJOR_VERSION_55 "55.34"
-#define LIBRARY_MAJOR_VERSION_6123 "6123.45"
-#define LIBRARY_MAJOR_VERSION_0 "0.4.5"
-#define PACKAGE_METRIC "Supportability/PHP/package/" LIBRARY_NAME
+  const char* library_versions[]
+      = {"7", "10", "100", "4.23", "55.34", "6123.45", "0.4.5"};
+  nr_php_package_t* p = NULL;
+#define TEST_DESCRIPTION_FMT                                                  \
+  "nr_lib_aws_sdk_php_handle_version with library_versions[%ld]=%s: package " \
+  "major version metric - %s"
+  char* test_description = NULL;
+  size_t i = 0;
 
   /*
    * If lib_aws_sdk_php_handle_version function is ever called, we have already
@@ -95,73 +95,55 @@ static void test_nr_lib_aws_sdk_php_handle_version(void) {
    */
 
   /*
-   * Aws/Sdk exists. Should return aws package metric with
+   * Aws/Sdk class exists. Should create aws package metric suggestion with
    * version
    */
-  tlib_php_request_start();
-  declare_aws_sdk_class("Aws", "Sdk", LIBRARY_MAJOR_VERSION);
-  nr_lib_aws_sdk_php_handle_version();
-  tlib_pass_if_not_null("version test 1: package metric created",
-                        nrm_find(NRPRG(txn)->unscoped_metrics, PACKAGE_METRIC
-                                 "/" LIBRARY_MAJOR_VERSION "/detected"));
-  tlib_php_request_end();
+  for (i = 0; i < sizeof(library_versions) / sizeof(library_versions[0]); i++) {
+    tlib_php_request_start();
 
-  tlib_php_request_start();
-  declare_aws_sdk_class("Aws", "Sdk", LIBRARY_MAJOR_VERSION_2);
-  nr_lib_aws_sdk_php_handle_version();
-  tlib_pass_if_not_null("version test 2: package metric created",
-                        nrm_find(NRPRG(txn)->unscoped_metrics, PACKAGE_METRIC
-                                 "/" LIBRARY_MAJOR_VERSION_2 "/detected"));
-  tlib_php_request_end();
+    declare_aws_sdk_class("Aws", "Sdk", library_versions[i]);
+    nr_lib_aws_sdk_php_handle_version();
 
-  tlib_php_request_start();
-  declare_aws_sdk_class("Aws", "Sdk", LIBRARY_MAJOR_VERSION_3);
-  nr_lib_aws_sdk_php_handle_version();
-  tlib_pass_if_not_null("version test 3: package metric created",
-                        nrm_find(NRPRG(txn)->unscoped_metrics, PACKAGE_METRIC
-                                 "/" LIBRARY_MAJOR_VERSION_3 "/detected"));
-  tlib_php_request_end();
+    p = nr_php_packages_get_package(NRPRG(txn)->php_package_suggestions,
+                                    LIBRARY_NAME);
 
-  tlib_php_request_start();
-  declare_aws_sdk_class("Aws", "Sdk", LIBRARY_MAJOR_VERSION_4);
-  nr_lib_aws_sdk_php_handle_version();
-  tlib_pass_if_not_null(
-      "version test 4: package metric created",
-      nrm_find(NRPRG(txn)->unscoped_metrics, PACKAGE_METRIC "/4/detected"));
-  tlib_php_request_end();
+    test_description = nr_formatf(TEST_DESCRIPTION_FMT, i, library_versions[i],
+                                  "suggestion created");
+    tlib_pass_if_not_null(test_description, p);
+    nr_free(test_description);
 
-  tlib_php_request_start();
-  declare_aws_sdk_class("Aws", "Sdk", LIBRARY_MAJOR_VERSION_55);
-  nr_lib_aws_sdk_php_handle_version();
-  tlib_pass_if_not_null(
-      "version test 5: package metric created",
-      nrm_find(NRPRG(txn)->unscoped_metrics, PACKAGE_METRIC "/55/detected"));
-  tlib_php_request_end();
+    test_description = nr_formatf(TEST_DESCRIPTION_FMT, i, library_versions[i],
+                                  "suggested version set");
+    tlib_pass_if_str_equal(test_description, library_versions[i],
+                           p->package_version);
+    nr_free(test_description);
 
-  tlib_php_request_start();
-  declare_aws_sdk_class("Aws", "Sdk", LIBRARY_MAJOR_VERSION_6123);
-  nr_lib_aws_sdk_php_handle_version();
-  tlib_pass_if_not_null(
-      "version test 6: package metric created",
-      nrm_find(NRPRG(txn)->unscoped_metrics, PACKAGE_METRIC "/6123/detected"));
-  tlib_php_request_end();
-
-  tlib_php_request_start();
-  declare_aws_sdk_class("Aws", "Sdk", LIBRARY_MAJOR_VERSION_0);
-  nr_lib_aws_sdk_php_handle_version();
-  tlib_pass_if_not_null(
-      "version test 7: package metric created",
-      nrm_find(NRPRG(txn)->unscoped_metrics, PACKAGE_METRIC "/0/detected"));
-  tlib_php_request_end();
+    tlib_php_request_end();
+  }
 
   /*
-   * Aws/Sdk does not exist, should not return package metric if no version
-   * This case should never happen in real situations.
+   * Aws/Sdk class does not exist, should not create package metric suggestion
+   * if no version This case should never happen in real situations.
    */
   tlib_php_request_start();
+
   nr_lib_aws_sdk_php_handle_version();
-  tlib_pass_if_null("aws library metric created",
-                    nrm_find(NRPRG(txn)->unscoped_metrics, PACKAGE_METRIC));
+
+  p = nr_php_packages_get_package(NRPRG(txn)->php_package_suggestions,
+                                  LIBRARY_NAME);
+
+  test_description = nr_formatf(TEST_DESCRIPTION_FMT, i, library_versions[i],
+                                "suggestion created");
+  tlib_pass_if_not_null(test_description, p);
+  nr_free(test_description);
+
+  test_description
+      = nr_formatf(TEST_DESCRIPTION_FMT, i, library_versions[i],
+                   "suggested version set to PHP_PACKAGE_VERSION_UNKNOWN");
+  tlib_pass_if_str_equal(test_description, PHP_PACKAGE_VERSION_UNKNOWN,
+                         p->package_version);
+  nr_free(test_description);
+
   tlib_php_request_end();
 }
 

--- a/agent/tests/test_lib_aws_sdk_php.c
+++ b/agent/tests/test_lib_aws_sdk_php.c
@@ -104,8 +104,9 @@ static void test_nr_lib_aws_sdk_php_handle_version(void) {
     declare_aws_sdk_class("Aws", "Sdk", library_versions[i]);
     nr_lib_aws_sdk_php_handle_version();
 
-    p = nr_php_packages_get_package(NRPRG(txn)->php_package_suggestions,
-                                    LIBRARY_NAME);
+    p = nr_php_packages_get_package(
+        NRPRG(txn)->php_package_major_version_metrics_suggestions,
+        LIBRARY_NAME);
 
     test_description = nr_formatf(TEST_DESCRIPTION_FMT, i, library_versions[i],
                                   "suggestion created");
@@ -129,8 +130,8 @@ static void test_nr_lib_aws_sdk_php_handle_version(void) {
 
   nr_lib_aws_sdk_php_handle_version();
 
-  p = nr_php_packages_get_package(NRPRG(txn)->php_package_suggestions,
-                                  LIBRARY_NAME);
+  p = nr_php_packages_get_package(
+      NRPRG(txn)->php_package_major_version_metrics_suggestions, LIBRARY_NAME);
 
   test_description = nr_formatf(TEST_DESCRIPTION_FMT, i, library_versions[i],
                                 "suggestion created");

--- a/agent/tests/test_php_txn.c
+++ b/agent/tests/test_php_txn.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "tlib_php.h"
+
+#include "php_agent.h"
+#include "php_txn_private.h"
+
+#define LIBRARY_NAME "php/php-package"
+#define PACKAGE_VERSION "1.2.3"
+#define PACKAGE_MAJOR_VERSION "1"
+#define COMPOSER_PACKAGE_VERSION "2.1.3"
+#define COMPOSER_MAJOR_VERSION "2"
+#define PACKAGE_METRIC_PREFIX "Supportability/PHP/package/"
+#define PACKAGE_METRIC PACKAGE_METRIC_PREFIX LIBRARY_NAME
+
+tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};
+
+nr_php_package_t php_package
+    = {.package_name = LIBRARY_NAME,
+       .package_version = PACKAGE_VERSION,
+       .source_priority = NR_PHP_PACKAGE_SOURCE_COMPOSER};
+
+static void test_nr_php_txn_php_package_create_major_metric() {
+  nrtxn_t t;
+  nrtxn_t* txn = &t;
+
+  txn->unscoped_metrics = nrm_table_create(10);
+  txn->php_packages = nr_php_packages_create();
+  txn->php_package_major_version_metrics_suggestions = nr_php_packages_create();
+
+  tlib_php_request_start();
+
+  /* need to call callback with invalid values to make sure it doesnt crash
+   * code depends on txn and txn->php_packages existing so these are created
+   * above with the package suggestions data structure included for good measure
+   */
+
+  /* this tests these params in callback:
+   * suggested = NULL
+   * actual = NULL
+   * key = NULL
+   * txn = NULL
+   */
+  nr_php_txn_php_package_create_major_metric(NULL, NULL, 0, NULL);
+  tlib_pass_if_int_equal("NULL txn, metric not created", 0,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  /* this tests these params in callback:
+   * suggested = NULL
+   * actual = NULL
+   * key != NULL
+   * txn != NULL
+   */
+  nr_php_txn_php_package_create_major_metric(NULL, LIBRARY_NAME,
+                                             strlen(LIBRARY_NAME), (void*)txn);
+  tlib_pass_if_int_equal("NULL value, metric not created", 0,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  /* the key is not actually used by the callback - just the package name
+   * in the suggested package so this casee will still create a metric
+   */
+  /* this tests these params in callback:
+   * suggested != NULL
+   * actual = NULL
+   * key = NULL
+   * txn = != NULL
+   */
+  nr_php_txn_php_package_create_major_metric(&php_package, NULL, 0, (void*)txn);
+  tlib_pass_if_int_equal("NULL key, metric created", 1,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  /* cleanup */
+  nr_php_packages_destroy(&txn->php_packages);
+  nr_php_packages_destroy(&txn->php_package_major_version_metrics_suggestions);
+  nrm_table_destroy(&txn->unscoped_metrics);
+
+  tlib_php_request_end();
+}
+
+static void test_nr_php_txn_create_packages_major_metrics() {
+  nrtxn_t t;
+  nrtxn_t* txn = &t;
+
+  txn->unscoped_metrics = nrm_table_create(10);
+  txn->php_packages = nr_php_packages_create();
+  txn->php_package_major_version_metrics_suggestions = nr_php_packages_create();
+
+  tlib_php_request_start();
+
+  /* invalid txn should not crash */
+  nr_php_txn_create_packages_major_metrics(NULL);
+  tlib_pass_if_int_equal("NULL txn, metric not created", 0,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  /* test with valid txn no package suggestions */
+  nr_php_txn_create_packages_major_metrics(txn);
+  tlib_pass_if_int_equal("valid txn with no suggestions, metric not created", 0,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  /*
+   * Tests:
+   *        1. suggestion with NULL version, no packages
+   *        2. suggestion with PHP_PACKAGE_VERSION_UNKNOWN version, no packages
+   *        3. suggestion with known version, no packages
+   *        4. package with known version and suggestion with known version
+   *        5. package with known version and suggestion with unknown version
+   *        6. package with unknown version and suggestion with known version
+   *        7. package with unknown version and suggestion with unknown version
+   *        8. test that causes "actual" to be NULL in callback
+   */
+
+  /* 1. suggestion with NULL version, no packages */
+  nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME, NULL);
+  nr_php_txn_create_packages_major_metrics(txn);
+  tlib_pass_if_int_equal("suggestion with NULL version, metric not created", 0,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  /* 2. suggestion with PHP_PACKAGE_VERSION_UNKNOWN version, no packages
+   * also
+   * 8. test that causes "actual" to be NULL in callback
+   */
+  nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
+  nr_php_txn_create_packages_major_metrics(txn);
+  tlib_pass_if_int_equal(
+      "suggestion with PHP_PACKAGE_VERSION_UNKNOWN version, metric not created",
+      0, nrm_table_size(txn->unscoped_metrics));
+
+  /* 3. suggestion with known version, no packages
+   * also
+   * 8. test that causes "actual" to be NULL in callback
+   */
+  nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME,
+                                               PACKAGE_VERSION);
+  nr_php_txn_create_packages_major_metrics(txn);
+  tlib_pass_if_int_equal("suggestion with valid version, metric created", 1,
+                         nrm_table_size(txn->unscoped_metrics));
+  tlib_pass_if_not_null(
+      "php package major version is used for 'detected' metric",
+      nrm_find(txn->unscoped_metrics,
+               PACKAGE_METRIC "/" PACKAGE_MAJOR_VERSION "/detected"));
+
+  /* reset metrics */
+  nrm_table_destroy(&txn->unscoped_metrics);
+  txn->unscoped_metrics = nrm_table_create(10);
+
+  /* 4. package with known version and suggestion with known version
+   *
+   * add a package with a "better" version determined from composer api
+   * and use existing suggestion which has a different version
+   */
+  nr_txn_add_php_package_from_source(txn, LIBRARY_NAME,
+                                     COMPOSER_PACKAGE_VERSION,
+                                     NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  nr_php_txn_create_packages_major_metrics(txn);
+  tlib_pass_if_int_equal("suggestion with valid version, metric created", 1,
+                         nrm_table_size(txn->unscoped_metrics));
+  tlib_pass_if_not_null(
+      "php package major version is used for 'detected' metric",
+      nrm_find(txn->unscoped_metrics,
+               PACKAGE_METRIC "/" COMPOSER_MAJOR_VERSION "/detected"));
+
+  /* reset suggestions, leave package with known version in place */
+  nr_php_packages_destroy(&txn->php_package_major_version_metrics_suggestions);
+  txn->php_package_major_version_metrics_suggestions = nr_php_packages_create();
+
+  /* reset metrics */
+  nrm_table_destroy(&txn->unscoped_metrics);
+  txn->unscoped_metrics = nrm_table_create(10);
+
+  /* 5. package with known version and suggestion with unknown version
+   *
+   * add a suggestion with no version and test metric uses package version
+   */
+  nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
+  nr_php_txn_create_packages_major_metrics(txn);
+  tlib_pass_if_int_equal("suggestion with valid version, metric created", 1,
+                         nrm_table_size(txn->unscoped_metrics));
+  tlib_pass_if_not_null(
+      "php package major version is used for 'detected' metric",
+      nrm_find(txn->unscoped_metrics,
+               PACKAGE_METRIC "/" COMPOSER_MAJOR_VERSION "/detected"));
+
+  /* reset everything */
+  nrm_table_destroy(&txn->unscoped_metrics);
+  txn->unscoped_metrics = nrm_table_create(10);
+  nr_php_packages_destroy(&txn->php_packages);
+  txn->php_packages = nr_php_packages_create();
+  nr_php_packages_destroy(&txn->php_package_major_version_metrics_suggestions);
+  txn->php_package_major_version_metrics_suggestions = nr_php_packages_create();
+
+  /* 6. package with unknown version and suggestion with known version */
+  nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME,
+                                               PACKAGE_VERSION);
+  nr_txn_add_php_package_from_source(txn, LIBRARY_NAME,
+                                     PHP_PACKAGE_VERSION_UNKNOWN,
+                                     NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  nr_php_txn_create_packages_major_metrics(txn);
+  tlib_pass_if_int_equal("suggestion with valid version, metric created", 1,
+                         nrm_table_size(txn->unscoped_metrics));
+  tlib_pass_if_not_null(
+      "php package suggestion major version is used for 'detected' metric",
+      nrm_find(txn->unscoped_metrics,
+               PACKAGE_METRIC "/" PACKAGE_MAJOR_VERSION "/detected"));
+
+  /* reset everything */
+  nrm_table_destroy(&txn->unscoped_metrics);
+  txn->unscoped_metrics = nrm_table_create(10);
+  nr_php_packages_destroy(&txn->php_packages);
+  txn->php_packages = nr_php_packages_create();
+  nr_php_packages_destroy(&txn->php_package_major_version_metrics_suggestions);
+  txn->php_package_major_version_metrics_suggestions = nr_php_packages_create();
+
+  /* 7. package with unknown version and suggestion with unknown version */
+  nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME,
+                                               PHP_PACKAGE_VERSION_UNKNOWN);
+  nr_txn_add_php_package_from_source(txn, LIBRARY_NAME,
+                                     PHP_PACKAGE_VERSION_UNKNOWN,
+                                     NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  nr_php_txn_create_packages_major_metrics(txn);
+  tlib_pass_if_int_equal(
+      "suggestion and package w/o version, metric not created", 0,
+      nrm_table_size(txn->unscoped_metrics));
+
+  /* cleanup */
+  nr_php_packages_destroy(&txn->php_packages);
+  nr_php_packages_destroy(&txn->php_package_major_version_metrics_suggestions);
+  nrm_table_destroy(&txn->unscoped_metrics);
+
+  tlib_php_request_end();
+}
+
+void test_main(void* p NRUNUSED) {
+  tlib_php_engine_create("");
+  test_nr_php_txn_php_package_create_major_metric();
+  test_nr_php_txn_create_packages_major_metrics();
+  tlib_php_engine_destroy();
+}

--- a/agent/tests/test_php_txn.c
+++ b/agent/tests/test_php_txn.c
@@ -8,9 +8,9 @@
 #include "php_agent.h"
 #include "php_txn_private.h"
 
-#define LIBRARY_NAME "php/php-package"
-#define PACKAGE_VERSION "1.2.3"
-#define PACKAGE_MAJOR_VERSION "1"
+#define LIBRARY_NAME "vendor_name/package_name"
+#define LIBRARY_VERSION "1.2.3"
+#define LIBRARY_MAJOR_VERSION "1"
 #define COMPOSER_PACKAGE_VERSION "2.1.3"
 #define COMPOSER_MAJOR_VERSION "2"
 #define PACKAGE_METRIC_PREFIX "Supportability/PHP/package/"
@@ -20,7 +20,7 @@ tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};
 
 nr_php_package_t php_package
     = {.package_name = LIBRARY_NAME,
-       .package_version = PACKAGE_VERSION,
+       .package_version = LIBRARY_VERSION,
        .source_priority = NR_PHP_PACKAGE_SOURCE_COMPOSER};
 
 static void test_nr_php_txn_php_package_create_major_metric() {
@@ -134,14 +134,14 @@ static void test_nr_php_txn_create_packages_major_metrics() {
    * 8. test that causes "actual" to be NULL in callback
    */
   nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME,
-                                               PACKAGE_VERSION);
+                                               LIBRARY_VERSION);
   nr_php_txn_create_packages_major_metrics(txn);
   tlib_pass_if_int_equal("suggestion with valid version, metric created", 1,
                          nrm_table_size(txn->unscoped_metrics));
   tlib_pass_if_not_null(
       "php package major version is used for 'detected' metric",
       nrm_find(txn->unscoped_metrics,
-               PACKAGE_METRIC "/" PACKAGE_MAJOR_VERSION "/detected"));
+               PACKAGE_METRIC "/" LIBRARY_MAJOR_VERSION "/detected"));
 
   /* reset metrics */
   nrm_table_destroy(&txn->unscoped_metrics);
@@ -195,7 +195,7 @@ static void test_nr_php_txn_create_packages_major_metrics() {
 
   /* 6. package with unknown version and suggestion with known version */
   nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME,
-                                               PACKAGE_VERSION);
+                                               LIBRARY_VERSION);
   nr_txn_add_php_package_from_source(txn, LIBRARY_NAME,
                                      PHP_PACKAGE_VERSION_UNKNOWN,
                                      NR_PHP_PACKAGE_SOURCE_COMPOSER);
@@ -205,7 +205,7 @@ static void test_nr_php_txn_create_packages_major_metrics() {
   tlib_pass_if_not_null(
       "php package suggestion major version is used for 'detected' metric",
       nrm_find(txn->unscoped_metrics,
-               PACKAGE_METRIC "/" PACKAGE_MAJOR_VERSION "/detected"));
+               PACKAGE_METRIC "/" LIBRARY_MAJOR_VERSION "/detected"));
 
   /* reset everything */
   nrm_table_destroy(&txn->unscoped_metrics);

--- a/axiom/nr_php_packages.c
+++ b/axiom/nr_php_packages.c
@@ -55,6 +55,7 @@ nr_php_package_t* nr_php_package_create_with_source(char* name, char* version, c
                                        // string with a space according to spec
   }
   p->source_priority = source_priority;
+  p->options = 0;
 
   nrl_verbosedebug(NRL_INSTRUMENT, "Creating PHP Package '%s', version '%s', source %s",
                    p->package_name, p->package_version, nr_php_package_source_priority_to_string(source_priority));
@@ -71,6 +72,20 @@ void nr_php_package_destroy(nr_php_package_t* p) {
     nr_free(p->package_version);
     nr_free(p);
   }
+}
+
+void nr_php_package_set_options(nr_php_package_t* p,
+                                nr_php_package_options_t options) {
+  if (NULL != p) {
+    p->options = options;
+  }
+}
+
+nr_php_package_options_t nr_php_package_get_options(nr_php_package_t* p) {
+  if (NULL == p) {
+    return 0;
+  }
+  return p->options;
 }
 
 nr_php_packages_t* nr_php_packages_create() {
@@ -114,6 +129,58 @@ nr_php_package_t* nr_php_packages_add_package(nr_php_packages_t* h,
 
   nr_hashmap_set(h->data, p->package_name, nr_strlen(p->package_name), p);
   return p;
+}
+
+void nr_php_packages_set_package_options(nr_php_packages_t* h,
+                                         const char* package_name,
+                                         nr_php_package_options_t options) {
+  nr_php_package_t* package;
+
+  if (NULL == h) {
+    return;
+  }
+
+  if (nr_strempty(package_name)) {
+    return;
+  }
+
+  package = nr_php_packages_get_package(h, package_name);
+  if (NULL == package) {
+    return;
+  }
+
+  nr_php_package_set_options(package, options);
+}
+
+nr_php_package_options_t nr_php_packages_get_package_options(
+    nr_php_packages_t* h,
+    const char* package_name) {
+  nr_php_package_t* package;
+
+  if (NULL == h) {
+    return 0;
+  }
+
+  if (nr_strempty(package_name)) {
+    return 0;
+  }
+
+  package = nr_php_packages_get_package(h, package_name);
+  if (NULL == package) {
+    return 0;
+  }
+
+  return nr_php_package_get_options(package);
+}
+
+void nr_php_packages_iterate(nr_php_packages_t* packages,
+                             nr_php_packages_iter_t callback,
+                             void* userdata) {
+  if (NULL == packages || NULL == callback) {
+    return;
+  }
+
+  nr_hashmap_apply(packages->data, (nr_hashmap_apply_func_t)callback, userdata);
 }
 
 char* nr_php_package_to_json(nr_php_package_t* package) {

--- a/axiom/nr_php_packages.c
+++ b/axiom/nr_php_packages.c
@@ -25,6 +25,8 @@ typedef struct {
 
 static inline const char* nr_php_package_source_priority_to_string(const nr_php_package_source_priority_t source_priority) {
   switch (source_priority) {
+    case NR_PHP_PACKAGE_SOURCE_SUGGESTION:
+      return "suggestion";
     case NR_PHP_PACKAGE_SOURCE_LEGACY:
       return "legacy";
     case NR_PHP_PACKAGE_SOURCE_COMPOSER:
@@ -34,7 +36,10 @@ static inline const char* nr_php_package_source_priority_to_string(const nr_php_
   }
 }
 
-nr_php_package_t* nr_php_package_create_with_source(char* name, char* version, const nr_php_package_source_priority_t source_priority) {
+nr_php_package_t* nr_php_package_create_with_source(
+    const char* name,
+    const char* version,
+    const nr_php_package_source_priority_t source_priority) {
   nr_php_package_t* p = NULL;
 
   if (NULL == name) {
@@ -55,14 +60,13 @@ nr_php_package_t* nr_php_package_create_with_source(char* name, char* version, c
                                        // string with a space according to spec
   }
   p->source_priority = source_priority;
-  p->options = 0;
 
   nrl_verbosedebug(NRL_INSTRUMENT, "Creating PHP Package '%s', version '%s', source %s",
                    p->package_name, p->package_version, nr_php_package_source_priority_to_string(source_priority));
   return p;
 }
 
-nr_php_package_t* nr_php_package_create(char* name, char* version) {
+nr_php_package_t* nr_php_package_create(const char* name, const char* version) {
   return nr_php_package_create_with_source(name, version, NR_PHP_PACKAGE_SOURCE_LEGACY);
 }
 
@@ -72,20 +76,6 @@ void nr_php_package_destroy(nr_php_package_t* p) {
     nr_free(p->package_version);
     nr_free(p);
   }
-}
-
-void nr_php_package_set_options(nr_php_package_t* p,
-                                nr_php_package_options_t options) {
-  if (NULL != p) {
-    p->options = options;
-  }
-}
-
-nr_php_package_options_t nr_php_package_get_options(nr_php_package_t* p) {
-  if (NULL == p) {
-    return 0;
-  }
-  return p->options;
 }
 
 nr_php_packages_t* nr_php_packages_create() {
@@ -129,48 +119,6 @@ nr_php_package_t* nr_php_packages_add_package(nr_php_packages_t* h,
 
   nr_hashmap_set(h->data, p->package_name, nr_strlen(p->package_name), p);
   return p;
-}
-
-void nr_php_packages_set_package_options(nr_php_packages_t* h,
-                                         const char* package_name,
-                                         nr_php_package_options_t options) {
-  nr_php_package_t* package;
-
-  if (NULL == h) {
-    return;
-  }
-
-  if (nr_strempty(package_name)) {
-    return;
-  }
-
-  package = nr_php_packages_get_package(h, package_name);
-  if (NULL == package) {
-    return;
-  }
-
-  nr_php_package_set_options(package, options);
-}
-
-nr_php_package_options_t nr_php_packages_get_package_options(
-    nr_php_packages_t* h,
-    const char* package_name) {
-  nr_php_package_t* package;
-
-  if (NULL == h) {
-    return 0;
-  }
-
-  if (nr_strempty(package_name)) {
-    return 0;
-  }
-
-  package = nr_php_packages_get_package(h, package_name);
-  if (NULL == package) {
-    return 0;
-  }
-
-  return nr_php_package_get_options(package);
 }
 
 void nr_php_packages_iterate(nr_php_packages_t* packages,

--- a/axiom/nr_php_packages.h
+++ b/axiom/nr_php_packages.h
@@ -19,15 +19,24 @@ typedef enum {
   NR_PHP_PACKAGE_SOURCE_COMPOSER
 } nr_php_package_source_priority_t;
 
+#define NR_PHP_PACKAGE_OPTION_MAJOR_METRIC (1 << 0)
+typedef uint32_t nr_php_package_options_t;
+
 typedef struct _nr_php_package_t {
   char* package_name;
   char* package_version;
   nr_php_package_source_priority_t source_priority;
+  nr_php_package_options_t options;
 } nr_php_package_t;
 
 typedef struct _nr_php_packages_t {
   nr_hashmap_t* data;
 } nr_php_packages_t;
+
+typedef void(nr_php_packages_iter_t)(void* value,
+                                     const char* name,
+                                     size_t name_len,
+                                     void* user_data);
 
 /*
  * Purpose : Create a new php package with desired source priority. If the name is null, then no package will
@@ -68,6 +77,32 @@ extern nr_php_package_t* nr_php_package_create(char* name, char* version);
  * Returns : Nothing
  */
 extern void nr_php_package_destroy(nr_php_package_t* p);
+
+/*
+ * Purpose : Sets the options on a php package.
+ *           The options are used to store additional information about the
+ *           package.
+ *
+ * Params  : 1. A pointer to the pointer of nr_php_package_t
+ *           2. Options to set on the package, represented as a bit field
+ *              stored in the nr_php_package_options_t type
+ *
+ * Returns : Nothing
+ */
+extern void nr_php_package_set_options(nr_php_package_t* p,
+                                       nr_php_package_options_t options);
+
+/*
+ * Purpose : Gets the options on a php package.
+ *           The options are used to store additional information about the
+ *           package.
+ *
+ * Params  : 1. A pointer to the pointer of nr_php_package_t
+ *
+ * Returns : Options to set on the package, represented as a bit field
+ *           stored in the nr_php_package_options_t type
+ */
+extern nr_php_package_options_t nr_php_package_get_options(nr_php_package_t* p);
 
 /*
  * Purpose : Allocate memory for new collection that will hold packages
@@ -149,8 +184,9 @@ static inline int nr_php_packages_has_package(nr_php_packages_t* h,
  *
  * Returns : Returns pointer to php package if the package exists or NULL
  */
-static inline nr_php_package_t* nr_php_packages_get_package(nr_php_packages_t* php_packages,
-                                              const char* package_name) {
+static inline nr_php_package_t* nr_php_packages_get_package(
+    nr_php_packages_t* php_packages,
+    const char* package_name) {
   if (NULL == package_name) {
     return NULL;
   }
@@ -160,6 +196,44 @@ static inline nr_php_package_t* nr_php_packages_get_package(nr_php_packages_t* p
   }
   return NULL;
 }
+
+/*
+ * Purpose : Set package options for a package in the collection
+ *
+ * Params  : 1. A pointer to nr_php_packages_t
+ *           2. The name of the package to modify
+ *           3. The options to set on the package
+ *
+ * Returns : Nothing
+ */
+void nr_php_packages_set_package_options(nr_php_packages_t* h,
+                                         const char* package_name,
+                                         nr_php_package_options_t options);
+
+/*
+ * Purpose : Get package options for a package in the collection
+ *
+ * Params  : 1. A pointer to nr_php_packages_t
+ *           2. The name of the package to modify
+ *
+ * Returns : The options to for the package.
+ */
+nr_php_package_options_t nr_php_packages_get_package_options(
+    nr_php_packages_t* h,
+    const char* package_name);
+
+/*
+ * Purpose : Iterate over packages calling callback function
+ *
+ * Params  : 1. A pointer to nr_php_packages_t
+ *           2. Callback function (nr_php_packages_iter_t)
+ *           3. Pointer to user data (can be NULL)
+ *
+ * Returns : Nothing
+ */
+void nr_php_packages_iterate(nr_php_packages_t* packages,
+                             nr_php_packages_iter_t callback,
+                             void* userdata);
 
 /*
  * Purpose : Converts a package to a json

--- a/axiom/nr_php_packages.h
+++ b/axiom/nr_php_packages.h
@@ -15,18 +15,15 @@
 #define PHP_PACKAGE_VERSION_UNKNOWN " "
 
 typedef enum {
+  NR_PHP_PACKAGE_SOURCE_SUGGESTION,
   NR_PHP_PACKAGE_SOURCE_LEGACY,
   NR_PHP_PACKAGE_SOURCE_COMPOSER
 } nr_php_package_source_priority_t;
-
-#define NR_PHP_PACKAGE_OPTION_MAJOR_METRIC (1 << 0)
-typedef uint32_t nr_php_package_options_t;
 
 typedef struct _nr_php_package_t {
   char* package_name;
   char* package_version;
   nr_php_package_source_priority_t source_priority;
-  nr_php_package_options_t options;
 } nr_php_package_t;
 
 typedef struct _nr_php_packages_t {
@@ -52,7 +49,10 @@ typedef void(nr_php_packages_iter_t)(void* value,
  *           nr_php_packages_add_package() is not called, then it must be freed
  *           by nr_php_package_destroy()
  */
-extern nr_php_package_t* nr_php_package_create_with_source(char* name, char* version, const nr_php_package_source_priority_t source_priority);
+extern nr_php_package_t* nr_php_package_create_with_source(
+    const char* name,
+    const char* version,
+    const nr_php_package_source_priority_t source_priority);
 
 /*
  * Purpose : Create a new php package with legacy source priority. If the name is null, then no package will
@@ -67,7 +67,8 @@ extern nr_php_package_t* nr_php_package_create_with_source(char* name, char* ver
  *           nr_php_packages_add_package() is not called, then it must be freed
  *           by nr_php_package_destroy()
  */
-extern nr_php_package_t* nr_php_package_create(char* name, char* version);
+extern nr_php_package_t* nr_php_package_create(const char* name,
+                                               const char* version);
 
 /*
  * Purpose : Destroy/free php package
@@ -77,32 +78,6 @@ extern nr_php_package_t* nr_php_package_create(char* name, char* version);
  * Returns : Nothing
  */
 extern void nr_php_package_destroy(nr_php_package_t* p);
-
-/*
- * Purpose : Sets the options on a php package.
- *           The options are used to store additional information about the
- *           package.
- *
- * Params  : 1. A pointer to the pointer of nr_php_package_t
- *           2. Options to set on the package, represented as a bit field
- *              stored in the nr_php_package_options_t type
- *
- * Returns : Nothing
- */
-extern void nr_php_package_set_options(nr_php_package_t* p,
-                                       nr_php_package_options_t options);
-
-/*
- * Purpose : Gets the options on a php package.
- *           The options are used to store additional information about the
- *           package.
- *
- * Params  : 1. A pointer to the pointer of nr_php_package_t
- *
- * Returns : Options to set on the package, represented as a bit field
- *           stored in the nr_php_package_options_t type
- */
-extern nr_php_package_options_t nr_php_package_get_options(nr_php_package_t* p);
 
 /*
  * Purpose : Allocate memory for new collection that will hold packages
@@ -196,31 +171,6 @@ static inline nr_php_package_t* nr_php_packages_get_package(
   }
   return NULL;
 }
-
-/*
- * Purpose : Set package options for a package in the collection
- *
- * Params  : 1. A pointer to nr_php_packages_t
- *           2. The name of the package to modify
- *           3. The options to set on the package
- *
- * Returns : Nothing
- */
-void nr_php_packages_set_package_options(nr_php_packages_t* h,
-                                         const char* package_name,
-                                         nr_php_package_options_t options);
-
-/*
- * Purpose : Get package options for a package in the collection
- *
- * Params  : 1. A pointer to nr_php_packages_t
- *           2. The name of the package to modify
- *
- * Returns : The options to for the package.
- */
-nr_php_package_options_t nr_php_packages_get_package_options(
-    nr_php_packages_t* h,
-    const char* package_name);
 
 /*
  * Purpose : Iterate over packages calling callback function

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -542,7 +542,7 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nt->custom_events = nr_analytics_events_create(app->limits.custom_events);
   nt->log_events = nr_log_events_create(app->limits.log_events);
   nt->php_packages = nr_php_packages_create();
-  nt->php_package_suggestions = nr_php_packages_create();
+  nt->php_package_major_version_metrics_suggestions = nr_php_packages_create();
 
   /*
    * reset flag for creation of one-time logging metrics
@@ -1247,7 +1247,7 @@ void nr_txn_destroy_fields(nrtxn_t* txn) {
   nr_segment_destroy_tree(txn->segment_root);
   nr_hashmap_destroy(&txn->parent_stacks);
   nr_php_packages_destroy(&txn->php_packages);
-  nr_php_packages_destroy(&txn->php_package_suggestions);
+  nr_php_packages_destroy(&txn->php_package_major_version_metrics_suggestions);
   nr_stack_destroy_fields(&txn->default_parent_stack);
   nr_slab_destroy(&txn->segment_slab);
   nr_minmax_heap_set_destructor(txn->segment_heap, NULL, NULL);
@@ -3540,5 +3540,6 @@ void nr_txn_suggest_package_supportability_metric(nrtxn_t* txn,
 
   p = nr_php_package_create_with_source(package_name, package_version,
                                         NR_PHP_PACKAGE_SOURCE_SUGGESTION);
-  nr_php_packages_add_package(txn->php_package_suggestions, p);
+  nr_php_packages_add_package(
+      txn->php_package_major_version_metrics_suggestions, p);
 }

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3519,3 +3519,14 @@ nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
   return nr_txn_add_php_package_from_source(txn, package_name, package_version,
                                             NR_PHP_PACKAGE_SOURCE_LEGACY);
 }
+
+void nr_txn_php_package_set_options(nrtxn_t* txn,
+                                    char* package_name,
+                                    nr_php_package_options_t options) {
+  nr_php_packages_set_package_options(txn->php_packages, package_name, options);
+}
+
+nr_php_package_options_t nr_txn_php_package_get_options(nrtxn_t* txn,
+                                                        char* package_name) {
+  return nr_php_packages_get_package_options(txn->php_packages, package_name);
+}

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -286,8 +286,9 @@ typedef struct _nrtxn_t {
       custom_events;               /* Custom events created through the API. */
   nr_log_events_t* log_events;     /* Log events pool */
   nr_php_packages_t* php_packages; /* Detected php packages */
-  nr_php_packages_t* php_package_suggestions; /* Suggested packages for major
-                                                 metric creation */
+  nr_php_packages_t*
+      php_package_major_version_metrics_suggestions; /* Suggested packages for
+                                  major metric creation */
   nrtime_t user_cpu[NR_CPU_USAGE_COUNT]; /* User CPU usage */
   nrtime_t sys_cpu[NR_CPU_USAGE_COUNT];  /* System CPU usage */
 
@@ -1205,10 +1206,10 @@ extern nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
 /*
  * Purpose : Add php package suggestion to transaction. This function
  * can be used when Vulnerability Management is not enabled.  It will
- * add the package to the transaction's php_package_suggestions list.
- * At the end of the transaction this list is traversed and any
- * suggestions with a known version will have a package major version
- * metric created.
+ * add the package to the transaction's
+ * php_package_major_version_metrics_suggestions list. At the end of the
+ * transaction this list is traversed and any suggestions with a known version
+ * will have a package major version metric created.
  *
  * Params  : 1. The transaction
  *           2. Package name

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -1196,8 +1196,35 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
  *
  * Returns : pointer to added package on success or NULL otherwise.
  */
-nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
-                                         char* package_name,
-                                         char* package_version);
+extern nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
+                                                char* package_name,
+                                                char* package_version);
+
+/*
+ * Purpose : Set option(s) on a php package. Options contain
+ *           additional context for each package.
+ *
+ * Params  : 1. The transaction
+ *           2. Package name
+ *           3. Option(s) to set (nr_php_packages_options_t)
+ *
+ * Returns : Nothing.
+ */
+extern void nr_txn_php_package_set_options(nrtxn_t* txn,
+                                           char* package_name,
+                                           nr_php_package_options_t options);
+
+/*
+ * Purpose : Get option(s) on a php package. Options contain
+ *           additional context for each package.
+ *
+ * Params  : 1. The transaction
+ *           2. Package name
+ *
+ * Returns : Option(s) to set (nr_php_packages_options_t).
+ */
+extern nr_php_package_options_t nr_txn_php_package_get_options(
+    nrtxn_t* txn,
+    char* package_name);
 
 #endif /* NR_TXN_HDR */

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -286,6 +286,8 @@ typedef struct _nrtxn_t {
       custom_events;               /* Custom events created through the API. */
   nr_log_events_t* log_events;     /* Log events pool */
   nr_php_packages_t* php_packages; /* Detected php packages */
+  nr_php_packages_t* php_package_suggestions; /* Suggested packages for major
+                                                 metric creation */
   nrtime_t user_cpu[NR_CPU_USAGE_COUNT]; /* User CPU usage */
   nrtime_t sys_cpu[NR_CPU_USAGE_COUNT];  /* System CPU usage */
 
@@ -1201,30 +1203,21 @@ extern nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
                                                 char* package_version);
 
 /*
- * Purpose : Set option(s) on a php package. Options contain
- *           additional context for each package.
+ * Purpose : Add php package suggestion to transaction. This function
+ * can be used when Vulnerability Management is not enabled.  It will
+ * add the package to the transaction's php_package_suggestions list.
+ * At the end of the transaction this list is traversed and any
+ * suggestions with a known version will have a package major version
+ * metric created.
  *
  * Params  : 1. The transaction
  *           2. Package name
- *           3. Option(s) to set (nr_php_packages_options_t)
+ *           3. Package version (can be NULL or PHP_PACKAGE_VERSION_UNKNOWN)
  *
  * Returns : Nothing.
  */
-extern void nr_txn_php_package_set_options(nrtxn_t* txn,
-                                           char* package_name,
-                                           nr_php_package_options_t options);
-
-/*
- * Purpose : Get option(s) on a php package. Options contain
- *           additional context for each package.
- *
- * Params  : 1. The transaction
- *           2. Package name
- *
- * Returns : Option(s) to set (nr_php_packages_options_t).
- */
-extern nr_php_package_options_t nr_txn_php_package_get_options(
+extern void nr_txn_suggest_package_supportability_metric(
     nrtxn_t* txn,
-    char* package_name);
-
+    const char* package_name,
+    const char* package_version);
 #endif /* NR_TXN_HDR */

--- a/axiom/tests/.gitignore
+++ b/axiom/tests/.gitignore
@@ -82,6 +82,7 @@ test_number_converter
 test_obfuscate
 test_object
 test_offsets
+test_php_packages
 test_postgres
 test_quarantine
 test_random

--- a/axiom/tests/test_php_packages.c
+++ b/axiom/tests/test_php_packages.c
@@ -310,10 +310,6 @@ static void nr_php_packages_itereate_callback(void* value,
   const char* name = key;
   nrbuf_t* buf = (nrbuf_t*)user_data;
 
-  (void)key_len;
-  (void)name;
-  (void)package;
-
   if (NULL == buf) {
     return;
   }

--- a/axiom/tests/test_php_packages.c
+++ b/axiom/tests/test_php_packages.c
@@ -7,7 +7,6 @@
 #include "tlib_main.h"
 #include "util_memory.h"
 
-#include "stdio.h"
 static void test_php_package_create_destroy(void) {
   nr_php_package_t* package;
   nr_php_package_t* null_package = NULL;

--- a/axiom/tests/test_php_packages.c
+++ b/axiom/tests/test_php_packages.c
@@ -7,6 +7,7 @@
 #include "tlib_main.h"
 #include "util_memory.h"
 
+#include "stdio.h"
 static void test_php_package_create_destroy(void) {
   nr_php_package_t* package;
   nr_php_package_t* null_package = NULL;
@@ -301,6 +302,78 @@ static void test_php_package_priority(void) {
   nr_php_packages_destroy(&hm);
 }
 
+static void nr_php_packages_itereate_callback(void* value,
+                                                const char* key,
+                                                size_t key_len,
+                                                void* user_data) {
+  nr_php_package_t* package = value;
+  const char* name = key;
+  nrbuf_t* buf = (nrbuf_t*)user_data;
+
+  (void)key_len;
+  (void)name;
+  (void)package;
+
+  if (NULL == buf) {
+    return;
+  }
+
+  /* append name, len, version to string */
+  nr_buffer_add(buf, name, key_len);
+  nr_buffer_add(buf, NR_PSTR(","));
+  nr_buffer_add(buf, package->package_version,
+                nr_strlen(package->package_version));
+  nr_buffer_add(buf, NR_PSTR("\n"));
+}
+
+static void test_php_package_iterate(void) {
+  nr_php_package_t* package1;
+  nr_php_package_t* package2;
+  nr_php_package_t* package3;
+  nr_php_packages_t* hm = nr_php_packages_create();
+  nrbuf_t* buf;
+  int count;
+
+  // Test: create multiple new packages and add to hashmap
+  package1 = nr_php_package_create("name1", "name1_version");
+  package2 = nr_php_package_create("name2", "name2_version");
+  package3 = nr_php_package_create("name3", "name3_version");
+
+  nr_php_packages_add_package(hm, package1);
+  nr_php_packages_add_package(hm, package2);
+  nr_php_packages_add_package(hm, package3);
+
+  count = nr_php_packages_count(hm);
+
+  tlib_pass_if_int_equal("package count", 3, count);
+
+  /* tests with invalid values 
+   * NOTE: nr_buffer_cptr(buf) will return NULL if no data is in the buffer
+   */
+  buf = nr_buffer_create(0, 0);
+  nr_php_packages_iterate(NULL, nr_php_packages_itereate_callback, (void*)buf);
+  tlib_pass_if_null("iterate with NULL hashmap", nr_buffer_cptr(buf));
+  nr_php_packages_iterate(hm, nr_php_packages_itereate_callback, NULL);
+  tlib_pass_if_null("iterate with NULL userdata", nr_buffer_cptr(buf));
+  nr_php_packages_iterate(hm, NULL, (void*)buf);
+  tlib_pass_if_null("iterate with NULL callback", nr_buffer_cptr(buf));
+  nr_php_packages_iterate(NULL, NULL, NULL);
+  tlib_pass_if_null("iterate with all NULL", nr_buffer_cptr(buf));
+  nr_buffer_destroy(&buf);
+
+  /* test with valid values */
+  buf = nr_buffer_create(0, 0);
+  nr_php_packages_iterate(hm, nr_php_packages_itereate_callback, (void*)buf);
+  nr_buffer_add(buf, NR_PSTR("\0"));
+  tlib_pass_if_str_equal("iterate created proper string",
+                         "name1,name1_version\nname2,name2_version\nname3,name3_version\n", nr_buffer_cptr(buf));
+  nr_buffer_destroy(&buf);
+
+  nr_php_packages_destroy(&hm);
+}
+
+
+
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = -1, .state_size = 0};
 
@@ -313,4 +386,5 @@ void test_main(void* p NRUNUSED) {
   test_php_package_exists_in_hashmap();
   test_php_package_without_version();
   test_php_package_priority();
+  test_php_package_iterate();
 }

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8632,6 +8632,123 @@ static void test_nr_txn_add_php_package(void) {
   nr_txn_destroy(&txn);
 }
 
+static void test_nr_txn_add_php_package_from_source(void) {
+  char* json;
+  char* package_name1 = "Laravel";
+  char* package_version1 = "8.83.27";
+  char* package_name2 = "Slim";
+  char* package_version2 = "4.12.0";
+  char* package_name3 = "Drupal";
+  char* package_version3 = NULL;
+  char* package_name4 = "Wordpress";
+  char* package_version4 = PHP_PACKAGE_VERSION_UNKNOWN;
+  nrtxn_t* txn = new_txn(0);
+  nr_php_package_t* p1 = NULL;
+  nr_php_package_t* p2 = NULL;
+
+  /*
+   * NULL parameters: ensure it does not crash
+   */
+  nr_txn_add_php_package_from_source(NULL, NULL, NULL, 0);
+  nr_txn_add_php_package_from_source(NULL, package_name1, package_version1, 0);
+  nr_txn_add_php_package_from_source(txn, NULL, package_version1, 0);
+  nr_txn_add_php_package_from_source(txn, package_name1, NULL, 0);
+
+  // Test: add php packages to transaction
+  nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                     NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  nr_txn_add_php_package_from_source(txn, package_name2, package_version2,
+                                     NR_PHP_PACKAGE_SOURCE_LEGACY);
+  nr_txn_add_php_package_from_source(txn, package_name3, package_version3,
+                                     NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  nr_txn_add_php_package_from_source(txn, package_name4, package_version4,
+                                     NR_PHP_PACKAGE_SOURCE_LEGACY);
+  json = nr_php_packages_to_json(txn->php_packages);
+
+  tlib_pass_if_str_equal("correct json",
+                         "[[\"Laravel\",\"8.83.27\",{}],"
+                         "[\"Drupal\",\" \",{}],[\"Wordpress\",\" \",{}],"
+                         "[\"Slim\",\"4.12.0\",{}]]",
+                         json);
+
+  nr_free(json);
+  nr_txn_destroy(&txn);
+
+  txn = new_txn(0);
+  p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                          NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  p2 = nr_txn_add_php_package_from_source(txn, package_name1, package_version2,
+                                          NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  tlib_pass_if_ptr_equal(
+      "same package name, different version, add returns same pointer", p1, p2);
+  nr_txn_destroy(&txn);
+
+  txn = new_txn(0);
+  p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                          NR_PHP_PACKAGE_SOURCE_LEGACY);
+  p2 = nr_txn_add_php_package_from_source(txn, package_name1, package_version2,
+                                          NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  tlib_pass_if_ptr_equal(
+      "same package name, different version, add returns different pointer", p1,
+      p2);
+  tlib_pass_if_str_equal("composer version used", package_version2,
+                         p2->package_version);
+
+  nr_txn_destroy(&txn);
+}
+
+static void test_nr_txn_suggest_package_supportability_metric(void) {
+  char* json;
+  char* package_name1 = "Laravel";
+  char* package_version1 = "8.83.27";
+  char* package_name2 = "Slim";
+  char* package_version2 = "4.12.0";
+  char* package_name3 = "Drupal";
+  char* package_version3 = NULL;
+  char* package_name4 = "Wordpress";
+  char* package_version4 = PHP_PACKAGE_VERSION_UNKNOWN;
+  nrtxn_t* txn = new_txn(0);
+  nr_php_package_t* p1 = NULL;
+  nr_php_package_t* p2 = NULL;
+
+  /*
+   * NULL parameters: ensure it does not crash
+   */
+  nr_txn_suggest_package_supportability_metric(NULL, NULL, NULL);
+  nr_txn_suggest_package_supportability_metric(NULL, package_name1,
+                                               package_version1);
+  nr_txn_suggest_package_supportability_metric(txn, NULL, package_version1);
+  nr_txn_suggest_package_supportability_metric(txn, package_name1, NULL);
+
+  // Test: add php packages to transaction
+  nr_txn_suggest_package_supportability_metric(txn, package_name1,
+                                               package_version1);
+  nr_txn_suggest_package_supportability_metric(txn, package_name2,
+                                               package_version2);
+  nr_txn_suggest_package_supportability_metric(txn, package_name3,
+                                               package_version3);
+  nr_txn_suggest_package_supportability_metric(txn, package_name4,
+                                               package_version4);
+  json = nr_php_packages_to_json(
+      txn->php_package_major_version_metrics_suggestions);
+
+  tlib_pass_if_str_equal("correct json",
+                         "[[\"Laravel\",\"8.83.27\",{}],"
+                         "[\"Drupal\",\" \",{}],[\"Wordpress\",\" \",{}],"
+                         "[\"Slim\",\"4.12.0\",{}]]",
+                         json);
+
+  nr_free(json);
+  nr_txn_destroy(&txn);
+
+  txn = new_txn(0);
+  p1 = nr_txn_add_php_package(txn, package_name1, package_version1);
+  p2 = nr_txn_add_php_package(txn, package_name1, package_version2);
+  tlib_pass_if_ptr_equal(
+      "same package name, different version, add returns same pointer", p1, p2);
+  nr_txn_destroy(&txn);
+}
+
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = 2, .state_size = sizeof(test_txn_state_t)};
 
@@ -8734,4 +8851,6 @@ void test_main(void* p NRUNUSED) {
   test_record_log_event();
   test_txn_log_configuration();
   test_nr_txn_add_php_package();
+  test_nr_txn_add_php_package_from_source();
+  test_nr_txn_suggest_package_supportability_metric();
 }

--- a/tests/integration/logging/monolog2/test_monolog_basic.php
+++ b/tests/integration/logging/monolog2/test_monolog_basic.php
@@ -58,7 +58,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]]

--- a/tests/integration/logging/monolog2/test_monolog_cat.php
+++ b/tests/integration/logging/monolog2/test_monolog_cat.php
@@ -56,7 +56,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_context_simple.php
+++ b/tests/integration/logging/monolog2/test_monolog_context_simple.php
@@ -59,7 +59,7 @@ monolog2.EMERGENCY: object value not converted {"object":{"Monolog\\Logger":[]}}
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_decoration_and_forwarding.php
+++ b/tests/integration/logging/monolog2/test_monolog_decoration_and_forwarding.php
@@ -113,7 +113,7 @@ ok - entity.name correct
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/api/get_linking_metadata"},                         [16, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/enabled"},              [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_disable_metrics.php
+++ b/tests/integration/logging/monolog2/test_monolog_disable_metrics.php
@@ -51,7 +51,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_drop_empty.php
+++ b/tests/integration/logging/monolog2/test_monolog_drop_empty.php
@@ -57,7 +57,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_large_message_limit.php
+++ b/tests/integration/logging/monolog2/test_monolog_large_message_limit.php
@@ -40,7 +40,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_large_message_limit_drops.php
+++ b/tests/integration/logging/monolog2/test_monolog_large_message_limit_drops.php
@@ -40,7 +40,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1666, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_limit_log_events.php
+++ b/tests/integration/logging/monolog2/test_monolog_limit_log_events.php
@@ -58,7 +58,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_limit_zero_events.php
+++ b/tests/integration/logging/monolog2/test_monolog_limit_zero_events.php
@@ -58,7 +58,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid1.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid1.php
@@ -45,7 +45,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid2.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid2.php
@@ -45,7 +45,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid3.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid3.php
@@ -45,7 +45,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid4.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_events_max_samples_stored_invalid4.php
@@ -45,7 +45,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog2/test_monolog_log_level_filter.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_level_filter.php
@@ -60,7 +60,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog2/test_monolog_log_level_filter_invalid.php
+++ b/tests/integration/logging/monolog2/test_monolog_log_level_filter_invalid.php
@@ -61,7 +61,7 @@ monolog2.EMERGENCY: emergency []
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/2/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog3/test_monolog_basic.php
+++ b/tests/integration/logging/monolog3/test_monolog_basic.php
@@ -56,7 +56,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_cat.php
+++ b/tests/integration/logging/monolog3/test_monolog_cat.php
@@ -56,7 +56,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_context_simple.php
+++ b/tests/integration/logging/monolog3/test_monolog_context_simple.php
@@ -59,7 +59,7 @@ monolog3.EMERGENCY: object value not converted {"object":{"Monolog\\Logger":[]}}
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_decoration_and_forwarding.php
+++ b/tests/integration/logging/monolog3/test_monolog_decoration_and_forwarding.php
@@ -113,7 +113,7 @@ ok - entity.name correct
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/api/get_linking_metadata"},                         [16, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/enabled"},              [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                  [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_disable_metrics.php
+++ b/tests/integration/logging/monolog3/test_monolog_disable_metrics.php
@@ -51,7 +51,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_drop_empty.php
+++ b/tests/integration/logging/monolog3/test_monolog_drop_empty.php
@@ -57,7 +57,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_large_message_limit.php
+++ b/tests/integration/logging/monolog3/test_monolog_large_message_limit.php
@@ -40,7 +40,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_large_message_limit_drops.php
+++ b/tests/integration/logging/monolog3/test_monolog_large_message_limit_drops.php
@@ -40,7 +40,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1666, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_limit_log_events.php
+++ b/tests/integration/logging/monolog3/test_monolog_limit_log_events.php
@@ -58,7 +58,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_limit_zero_events.php
+++ b/tests/integration/logging/monolog3/test_monolog_limit_zero_events.php
@@ -58,7 +58,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "OtherTransactionTotalTime"},                                       [1, "??", "??", "??", "??", "??"]],
     [{"name": "OtherTransactionTotalTime/php__FILE__"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid1.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid1.php
@@ -45,7 +45,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/LocalDecorating/PHP/disabled"},             [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid2.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid2.php
@@ -45,7 +45,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid3.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid3.php
@@ -45,7 +45,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid4.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_events_max_samples_stored_invalid4.php
@@ -45,7 +45,7 @@ newrelic.application_logging.forwarding.log_level = DEBUG
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [833, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog3/test_monolog_log_level_filter.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_level_filter.php
@@ -60,7 +60,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]

--- a/tests/integration/logging/monolog3/test_monolog_log_level_filter_invalid.php
+++ b/tests/integration/logging/monolog3/test_monolog_log_level_filter_invalid.php
@@ -61,7 +61,7 @@ monolog3.EMERGENCY: emergency []
     [{"name": "Supportability/Logging/Forwarding/PHP/enabled"},                   [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/Metrics/PHP/enabled"},                      [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/Logging/PHP/Monolog/enabled"},                      [1, "??", "??", "??", "??", "??"]],
-    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [8, "??", "??", "??", "??", "??"]],
+    [{"name": "Supportability/PHP/package/monolog/monolog/3/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name": "Supportability/library/Monolog/detected"},                         [1, "??", "??", "??", "??", "??"]]
   ]
 ]


### PR DESCRIPTION
Change how the package major number metrics are created. This now occurs
in R_SHUTDOWN.  This allows the use of package versions from ALL sources
including the Composer API.  Whenever instrumentation for a package detects
a package, it can create a package suggestion.  Initially if a version is not
known it is fine to use PHP_PACKAGE_VERSION_UNKNOWN.  If later the
instrumentation determines a version from a class constant, etc, then
the suggestion can be updated with the version.

At the end of the transaction the suggestions are iterated over and
the actual package data (which could include Composer API data) is
referenced and a major number supportability metric is created with the
best version available.