### PR TITLE
fix(installer): tarball installer checks for ini in mods-available

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1386,7 +1386,7 @@ EOF
 
       if [ -d "${cfg_pfx}/mods-available" -a -f "${cfg_pfx}/mods-available/newrelic.ini" ]; then
         pi_inidir_cli="${cfg_pfx}/mods-available"
-        if [ -n ${pi_inidir_dso} ]; then
+        if [ -n "${pi_inidir_dso}" ]; then
           pi_inidir_dso="${cfg_pfx}/mods-available"
         fi
       fi

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1371,6 +1371,27 @@ EOF
       if [ -d "${cfg_pfx}/fpm/conf.d" ]; then
         pi_inidir_dso="${cfg_pfx}/fpm/conf.d"
       fi
+
+      #
+      # Debian can use a mods-available directory to store the ini files.
+      # It creates a symlink from the ini file in the conf.d directory that
+      # our installer can fail to find (because the symlink is prefixed with
+      # "20-" (notably the number can change based on configurations).
+      # While this install script will not install into the mods-available
+      # directory, our .deb installer can. Therefore, we want to detect if
+      # newrelic has previously been installed in the mods-available directory
+      # so that we do not create an additional ini file -- which would result in
+      # the conf.d directory having both newrelic.ini and 20-newrelic.ini.
+      #
+
+      if [ -d "${cfg_pfx}/mods-available" -a -f "${cfg_pfx}/mods-available/newrelic.ini" ]; then
+        if [ -f ${pi_inidir_cli}/*-newrelic.ini ]; then
+          pi_inidir_cli="${cfg_pfx}/mods-available"
+        fi
+        if [ -f ${pi_inidir_dso}/*-newrelic.ini ]; then
+          pi_inidir_dso="${cfg_pfx}/mods-available"
+        fi
+      fi
     fi
   done
 

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1385,10 +1385,8 @@ EOF
       #
 
       if [ -d "${cfg_pfx}/mods-available" -a -f "${cfg_pfx}/mods-available/newrelic.ini" ]; then
-        if [ -f ${pi_inidir_cli}/*-newrelic.ini ]; then
-          pi_inidir_cli="${cfg_pfx}/mods-available"
-        fi
-        if [ -f ${pi_inidir_dso}/*-newrelic.ini ]; then
+        pi_inidir_cli="${cfg_pfx}/mods-available"
+        if [ -n ${pi_inidir_dso} ]; then
           pi_inidir_dso="${cfg_pfx}/mods-available"
         fi
       fi


### PR DESCRIPTION
Debian uses a directory called "mods-available" to house ini files. It's `phpenmod` and `phpdismod` allow command-line management of extensions in directory. It also creates a symlink ini file to this "mods-available" directory in the normal conf.d directory. The issue is that this symlink is prefixed with a number (for example 20-newrelic.ini). This prefix prevents our tarball installer from recognizing that a newrelic.ini already exists, resulting in 2 ini files: a newrelic.ini and a 20-newrelic.ini.

Our .deb package installer scouts out the "mods-available" directory and installs therein when possible. That means that if a customer installs via package but upgrades via tarball (not recommended), then their system gets the duplicates.

This change makes our tarball installer scout for a potential previous installation in mods-available.

Fixes https://github.com/newrelic/newrelic-php-agent/issues/399