### PR TITLE
fix ZEND_8_4_X_API_NO value

### DIFF
--- a/agent/config.m4
+++ b/agent/config.m4
@@ -239,6 +239,9 @@ if test "$PHP_NEWRELIC" = "yes"; then
   dnl Define $(PHP_CONFIG) so we can call it when building tests.
   PHP_SUBST(PHP_CONFIG)
 
+  dnl Make sure we include the source directory in the include search path.
+  PHP_ADD_INCLUDE([$abs_srcdir], [1])
+
   dnl Include the Makefile.frag, which we use to handle build time
   dnl dependencies.
   PHP_ADD_MAKEFILE_FRAGMENT

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -338,7 +338,7 @@ fi
 #    (8.0, 8.1, 8.2, 8.3, 8.4)
 # for x64 and aarch64
 if [ ${arch} = x64 ] || [ ${arch} = aarch64 ]; then
-  for pmv in "20200930" "20210902" "20220829" "20230831" "20240925"; do
+  for pmv in "20200930" "20210902" "20220829" "20230831" "20240924"; do
     check_file "${ilibdir}/agent/${arch}/newrelic-${pmv}.so"
   done
 fi
@@ -1240,7 +1240,7 @@ does not exist. This particular instance of PHP will be skipped.
     8.1.*)  pi_modver="20210902" ;;
     8.2.*)  pi_modver="20220829" ;;
     8.3.*)  pi_modver="20230831" ;;
-    8.4.*)  pi_modver="20240925" ;;
+    8.4.*)  pi_modver="20240924" ;;
   esac
   log "${pdir}: pi_modver=${pi_modver}"
 

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -54,7 +54,7 @@
 #define ZEND_8_1_X_API_NO 20210902
 #define ZEND_8_2_X_API_NO 20220829
 #define ZEND_8_3_X_API_NO 20230831
-#define ZEND_8_4_X_API_NO 20240925
+#define ZEND_8_4_X_API_NO 20240924
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8+ */
 #include "Zend/zend_observer.h"

--- a/agent/tests/test_agent.c
+++ b/agent/tests/test_agent.c
@@ -142,7 +142,11 @@ static void test_function_debug_name(TSRMLS_D) {
   func = nr_php_zval_to_function(closure TSRMLS_CC);
   name = nr_php_function_debug_name(func);
 
+#if ZEND_MODULE_API_NO < ZEND_8_4_X_API_NO
   tlib_pass_if_str_equal("closure", "{closure} declared at -:1", name);
+#else
+  tlib_pass_if_str_equal("closure", "{closure:-:1} declared at -:1", name);
+#endif
 
   nr_php_zval_free(&closure);
   nr_free(name);

--- a/make/release.mk
+++ b/make/release.mk
@@ -163,7 +163,7 @@ release-$1-zts: Makefile agent | releases/$$(RELEASE_OS)/agent/$$(RELEASE_ARCH)/
 
 endef
 
-$(eval $(call RELEASE_AGENT_TARGET,8.4,20240925))
+$(eval $(call RELEASE_AGENT_TARGET,8.4,20240924))
 $(eval $(call RELEASE_AGENT_TARGET,8.3,20230831))
 $(eval $(call RELEASE_AGENT_TARGET,8.2,20220829))
 $(eval $(call RELEASE_AGENT_TARGET,8.1,20210902))


### PR DESCRIPTION
`ZEND_MODULE_API_NO` for PHP 8.4 is actually `20240924` - see https://github.com/php/php-src/blob/PHP-8.4/Zend/zend_modules.h#L34.