### PR TITLE
fix agent unit tests

### DIFF
--- a/agent/config.m4
+++ b/agent/config.m4
@@ -239,6 +239,9 @@ if test "$PHP_NEWRELIC" = "yes"; then
   dnl Define $(PHP_CONFIG) so we can call it when building tests.
   PHP_SUBST(PHP_CONFIG)
 
+  dnl Make sure we include the source directory in the include search path.
+  PHP_ADD_INCLUDE([$abs_srcdir], [1])
+
   dnl Include the Makefile.frag, which we use to handle build time
   dnl dependencies.
   PHP_ADD_MAKEFILE_FRAGMENT

--- a/agent/tests/test_agent.c
+++ b/agent/tests/test_agent.c
@@ -142,7 +142,11 @@ static void test_function_debug_name(TSRMLS_D) {
   func = nr_php_zval_to_function(closure TSRMLS_CC);
   name = nr_php_function_debug_name(func);
 
+#if ZEND_MODULE_API_NO < ZEND_8_4_X_API_NO
   tlib_pass_if_str_equal("closure", "{closure} declared at -:1", name);
+#else
+  tlib_pass_if_str_equal("closure", "{closure:-:1} declared at -:1", name);
+#endif
 
   nr_php_zval_free(&closure);
   nr_free(name);


### PR DESCRIPTION
PHP's build system received a fix for 'out of tree' builds - see https://github.com/php/php-src/pull/13516. This broke build of agent's unit tests which require agent's source directory to be in the include search path. Working agent's unit tests showed that `test_function_debug_name` needed its expectations tweaked - closures are named differently on PHP 8.4.