### PR TITLE
ci: fix CodeQL's agent scan (#1002)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'c-cpp', 'go' ]
+        language: [ 'go' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-22.04'
     timeout-minutes: 360
     permissions:
       # required for all workflows
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: [ 'c-cpp', 'go' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:


### PR DESCRIPTION
Fix agent build scan by pinning runner to ubuntu-22.04. ubuntu-24.04, which is what ubuntu-latest has recently become, doesn't have agent's build dependency (libpcre3-dev) installed.