### PR TITLE
ci: fix scheduled security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,4 +45,5 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
+          checkout_path: ./php-agent
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
[`codeql-action/upload-sarif`](https://github.com/github/codeql-action/blob/v3/upload-sarif/action.yml#L12C3-L12C16) needs to know where the scanned code was checked out if it has been checked out to a subdir of `github.workspace`.