### PR TITLE
fix(daemon): enable `go vet` check on pull requests

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -44,6 +44,39 @@ jobs:
             echo "$GOFMT_REPORTED_FILES" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+  govet:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout newrelic-php-agent code
+        uses: actions/checkout@v4
+        with:
+          path: php-agent
+      - name: Get go version
+        id: get-go-version
+        run: |
+          echo "go toolchain version required to build the daemon:"
+          toolchain="$(awk '/^toolchain */ {gsub(/^go/, "", $2); print $2}' ./php-agent/daemon/go.mod)"
+          echo "[${toolchain}]"
+          echo "go-toolchain-version=${toolchain}" >> $GITHUB_OUTPUT
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.get-go-version.outputs.go-toolchain-version }}
+          cache-dependency-path: "**/*.sum"
+      - name: Verify go version
+        run: |
+          echo "Verify correct go toolchain version is used"
+          actual="$(go version)"
+          echo "Actual: [$actual]"
+          expected="go version go${{ steps.get-go-version.outputs.go-toolchain-version }} linux/amd64"
+          echo "Expected: [$expected]"
+          if [ "$actual" != "$expected" ]; then
+            exit 1
+          fi
+      - name: Run go vet
+        run: go vet -C ./php-agent/daemon ./...
+        shell: bash
   daemon-unit-tests:
     runs-on: ubuntu-latest
     env:

--- a/daemon/internal/newrelic/utilization/kubernetes.go
+++ b/daemon/internal/newrelic/utilization/kubernetes.go
@@ -11,7 +11,7 @@ import (
 )
 
 type kubernetes struct {
-	KubernetesServiceHost string `json:"kubernetes_service_host",omitempty`
+	KubernetesServiceHost string `json:"kubernetes_service_host,omitempty"`
 
 	// Having a custom getter allows the unit tests to mock os.Getenv().
 	environmentVariableGetter func(key string) string


### PR DESCRIPTION
Address issues spotted by `go vet`:
- [fix syntax of kubernetes.KubernetesServiceHost struct tags](https://github.com/newrelic/newrelic-php-agent/commit/d7ba91983f9b81a35afc05d2aa04dd38b99c8368)
- [ensure context.cancel() is always called to avoid context leak](https://github.com/newrelic/newrelic-php-agent/commit/c3e1e40465378e529315c21295159ade416e8894)

[Add go vet check for pull requests](https://github.com/newrelic/newrelic-php-agent/commit/630dcbffd5062fcfd1ebfe107ec6ab5b9b356161)