### PR TITLE
fix(agent): Fix nr_header_create_distributed_trace_map mem leak when hashmap is destroyed

### DIFF
--- a/axiom/nr_header.c
+++ b/axiom/nr_header.c
@@ -48,7 +48,8 @@ nr_hashmap_t* nr_header_create_distributed_trace_map(const char* nr_header,
     return NULL;
   }
 
-  header_map = nr_hashmap_create(NULL);
+  header_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_hashmap_dtor_str);
+
   if (nr_header) {
     nr_hashmap_set(header_map, NR_PSTR(NEWRELIC), nr_strdup(nr_header));
   }

--- a/axiom/tests/test_header.c
+++ b/axiom/tests/test_header.c
@@ -1702,6 +1702,75 @@ static void test_account_id_from_cross_process_id(void) {
       nr_header_account_id_from_cross_process_id("10#10"));
 }
 
+static void test_nr_header_create_distributed_trace_map(void) {
+  nr_hashmap_t* header_map = NULL;
+  char* tracestate = "tracestate";
+  char* traceparent = "traceparent";
+  char* dt_payload = "newrelic";
+
+  header_map = nr_header_create_distributed_trace_map(NULL, NULL, NULL);
+  tlib_pass_if_null(
+      "NULL payload and NULL traceparent should return NULL header map",
+      header_map);
+
+  header_map = nr_header_create_distributed_trace_map(NULL, NULL, tracestate);
+  tlib_pass_if_null(
+      "NULL payload and NULL traceparent should return NULL header map",
+      header_map);
+
+  header_map = nr_header_create_distributed_trace_map(dt_payload, NULL, NULL);
+  tlib_pass_if_not_null("if valid dt_payload should return a header map",
+                        header_map);
+  tlib_pass_if_size_t_equal(
+      "1 header passed in so should expect headers hashmap size of 1", 1,
+      nr_hashmap_count(header_map));
+  nr_hashmap_destroy(&header_map);
+
+  header_map
+      = nr_header_create_distributed_trace_map(dt_payload, traceparent, NULL);
+  tlib_pass_if_not_null("if valid dt_payload should return a header map",
+                        header_map);
+  tlib_pass_if_size_t_equal(
+      "2 headers passed in so should expect headers hashmap size of 2", 2,
+      nr_hashmap_count(header_map));
+  nr_hashmap_destroy(&header_map);
+
+  header_map
+      = nr_header_create_distributed_trace_map(dt_payload, NULL, tracestate);
+  tlib_pass_if_not_null("if valid dt_payload should return a header map",
+                        header_map);
+  tlib_pass_if_size_t_equal(
+      "2 headers passed in so should expect headers hashmap size of 2", 2,
+      nr_hashmap_count(header_map));
+  nr_hashmap_destroy(&header_map);
+
+  header_map = nr_header_create_distributed_trace_map(dt_payload, traceparent,
+                                                      tracestate);
+  tlib_pass_if_not_null("if valid dt_payload should return a header map",
+                        header_map);
+  tlib_pass_if_size_t_equal(
+      "3 headers passed in so should expect headers hashmap size of 3", 3,
+      nr_hashmap_count(header_map));
+  nr_hashmap_destroy(&header_map);
+
+  header_map
+      = nr_header_create_distributed_trace_map(NULL, traceparent, tracestate);
+  tlib_pass_if_not_null("if valid traceparent should return a header map",
+                        header_map);
+  tlib_pass_if_size_t_equal(
+      "Two headers passed in so should expect headers hashmap size of 2", 2,
+      nr_hashmap_count(header_map));
+  nr_hashmap_destroy(&header_map);
+
+  header_map = nr_header_create_distributed_trace_map(NULL, traceparent, NULL);
+  tlib_pass_if_not_null("if valid traceparent should return a header map",
+                        header_map);
+  tlib_pass_if_size_t_equal(
+      "1 header passed in so should expect headers hashmap size of 1", 1,
+      nr_hashmap_count(header_map));
+  nr_hashmap_destroy(&header_map);
+}
+
 tlib_parallel_info_t parallel_info = {.suggested_nthreads = 2, .state_size = 0};
 
 void test_main(void* p NRUNUSED) {
@@ -1721,4 +1790,5 @@ void test_main(void* p NRUNUSED) {
   test_set_cat_txn();
   test_set_synthetics_txn();
   test_account_id_from_cross_process_id();
+  test_nr_header_create_distributed_trace_map();
 }


### PR DESCRIPTION
This function created a new hashmap, but didn's pass the string dtor in so any strdupped values were not being freed when the hashmap was destroyed.

valgrind output from a multiverse run showed:

==220==    by 0x6AA4680: nr_strdup (util_memory.c:156)
==220==    by 0x6A83BD3: nr_header_create_distributed_trace_map (nr_header.c:60)
==220==    by 0x6A45D28: nr_php_amqplib_retrieve_dt_headers (lib_php_amqplib.c:503)
==220==    by 0x6A45D28: nr_rabbitmq_basic_get (lib_php_amqplib.c:742)
==220==    by 0x6A74993: nr_zend_call_orig_execute_special (php_user_instrument.c:105)
==220==    by 0x6A52EAA: nr_php_instrument_func_end (php_execute.c:2086)
==220==    by 0x6A54D5B: nr_php_observer_fcall_end (php_execute.c:2188)
==220==    by 0x71D7ED: zend_observer_fcall_end (in /usr/local/bin/php)
==220==    by 0x6E79FF: execute_ex (in /usr/local/bin/php)
==220==    by 0x6F0B42: zend_execute (in /usr/local/bin/php)
==220==    by 0x67C06F: zend_execute_scripts (in /usr/local/bin/php)
==220==    by 0x60FA3D: php_execute_script (in /usr/local/bin/php)

after applying the fix, valgrind had no issues.