### PR TITLE
build: fix axiom's build dependency check

### DIFF
--- a/axiom/Makefile
+++ b/axiom/Makefile
@@ -195,7 +195,10 @@ nr_config.h: configure Makefile
 #
 # Build the 8T protobuf code.
 #
-v1.pb-c.c: v1.proto protobuf-c
+v1.pb-c.c: v1.proto
+ifeq (0,$(HAVE_PROTOBUF_C))
+	$(error Build dependency 'protobuf-c' not found.)
+endif
 	$(PROTOBUF_C_PREFIX)/bin/protoc-c --c_out=. $<
 
 #
@@ -204,12 +207,6 @@ v1.pb-c.c: v1.proto protobuf-c
 #
 v1.pb-c.o: v1.pb-c.c
 	$(CC) $(AXIOM_CPPFLAGS) $(CPPFLAGS) $(AXIOM_CFLAGS) $(PCRE_CFLAGS) $(VENDOR_CFLAGS) $(CFLAGS) -MMD -MP -Wno-cast-qual -c $< -o $@
-
-.PHONY: protobuf-c
-protobuf-c:
-ifeq (0,$(HAVE_PROTOBUF_C))
-	$(error Build dependency 'protobuf-c' not found.)
-endif
 
 #
 # Track the flags passed to the compiler to force a rebuild when they change.


### PR DESCRIPTION
Make the `HAVE_PROTOBUF_C != 0` check part of recipe where its needed rather than making the check in a phony target. Using phony target results in axiom rebuilding axiom every time.

Fixup of #1012.