### PR TITLE
fix(daemon): Adds escaping for log forwarded labels

### DIFF
--- a/daemon/internal/newrelic/log_events_test.go
+++ b/daemon/internal/newrelic/log_events_test.go
@@ -27,6 +27,8 @@ var (
 		LogForwardingLabelsTestCase{name: "Invalid keys", labels: `[{"label_tipe":"type1","label_valyue":"value1"}]`, expected: `{}`},
 		LogForwardingLabelsTestCase{name: "Space in value", labels: `[{"label_type":"type1","label_value":"value 1"}]`, expected: `{"tags.type1":"value 1"}`},
 		LogForwardingLabelsTestCase{name: "Space in key", labels: `[{"label_type":"type 1","label_value":"value1"}]`, expected: `{"tags.type 1":"value1"}`},
+		LogForwardingLabelsTestCase{name: "Empty value", labels: `[{"label_type":"type1","label_value":""}]`, expected: `{}`},
+		LogForwardingLabelsTestCase{name: "Empty key", labels: `[{"label_type":"","label_value":"value1"}]`, expected: `{}`},
 	}
 )
 


### PR DESCRIPTION
This PR corrects how the collector JSON for log forwarded labels handles log label key and values which have characters which must be escaped for JSON marshaling. The change is restricted to the daemon code to generate the log label JSON and does not impact the agent side of things.

The fix is to use the Go `json` module to handle the creation of the JSON.  It will handle the escaping as needed.  The array of label key/value pairs is converted to a Go `map` which is then marshaled into JSON.  The case where either the label or value is empty (an invalid label) is handled so that these are not forwarded.  This case should not occur as labels of this type should not be created by the agent but this check is added as additional protection against this case.