### PR TITLE
feat(agent): add server.address field for datastores

### DIFF
--- a/axiom/nr_span_event.c
+++ b/axiom/nr_span_event.c
@@ -322,7 +322,13 @@ void nr_span_event_set_datastore(nr_span_event_t* event,
       nro_set_hash_string(event->agent_attributes, "peer.address", new_value);
       break;
     case NR_SPAN_DATASTORE_PEER_HOSTNAME:
+      /*
+       * Both peer.hostname and server.address are expected to have the same
+       * value. server.address is used to create the entity relationship map
+       * and peer.hostname is maintained for backwards consistency.
+       */
       nro_set_hash_string(event->agent_attributes, "peer.hostname", new_value);
+      nro_set_hash_string(event->agent_attributes, "server.address", new_value);
       break;
   }
   return;

--- a/tests/integration/jit/function/test_span_events_are_created_from_segments.php
+++ b/tests/integration/jit/function/test_span_events_are_created_from_segments.php
@@ -99,6 +99,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ]

--- a/tests/integration/jit/function/test_span_events_are_created_upon_caught_error.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_caught_error.php
@@ -117,6 +117,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_are_created_upon_caught_error.php84.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_caught_error.php84.php
@@ -118,6 +118,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_are_created_upon_exit.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_exit.php
@@ -79,6 +79,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_error.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_error.php
@@ -84,6 +84,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_error.php84.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_error.php84.php
@@ -85,6 +85,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_handled_exception.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_handled_exception.php
@@ -120,6 +120,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_handled_exception.php84.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_handled_exception.php84.php
@@ -121,6 +121,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_handled_exception_invalid_handler.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_handled_exception_invalid_handler.php
@@ -131,6 +131,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_unhandled_exception.php
+++ b/tests/integration/jit/function/test_span_events_are_created_upon_uncaught_unhandled_exception.php
@@ -118,6 +118,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_error_collector_disabled.php
+++ b/tests/integration/jit/function/test_span_events_error_collector_disabled.php
@@ -84,6 +84,7 @@ null
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/function/test_span_events_exception_uncaught_nested.php
+++ b/tests/integration/jit/function/test_span_events_exception_uncaught_nested.php
@@ -114,6 +114,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_from_segments.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_from_segments.php
@@ -99,6 +99,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ]

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_caught_error.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_caught_error.php
@@ -116,6 +116,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_caught_error.php84.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_caught_error.php84.php
@@ -117,6 +117,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_exit.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_exit.php
@@ -79,6 +79,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_error.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_error.php
@@ -84,6 +84,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_error.php84.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_error.php84.php
@@ -85,6 +85,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_handled_exception.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_handled_exception.php
@@ -117,6 +117,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_handled_exception.php84.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_handled_exception.php84.php
@@ -118,6 +118,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_handled_exception_invalid_handler.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_handled_exception_invalid_handler.php
@@ -126,6 +126,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_unhandled_exception.php
+++ b/tests/integration/jit/tracing/test_span_events_are_created_upon_uncaught_unhandled_exception.php
@@ -118,6 +118,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_error_collector_disabled.php
+++ b/tests/integration/jit/tracing/test_span_events_error_collector_disabled.php
@@ -85,6 +85,7 @@ null
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/jit/tracing/test_span_events_exception_uncaught_nested.php
+++ b/tests/integration/jit/tracing/test_span_events_exception_uncaught_nested.php
@@ -115,6 +115,7 @@ zend_extension=opcache.so
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_from_segments.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_from_segments.php
@@ -95,6 +95,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ]

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php
@@ -114,6 +114,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php84.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_caught_error.php84.php
@@ -114,6 +114,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_exit.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_exit.php
@@ -75,6 +75,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php
@@ -80,6 +80,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php84.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_error.php84.php
@@ -81,6 +81,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php
@@ -119,6 +119,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php7.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php7.php
@@ -87,6 +87,7 @@ null
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php84.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_handled_exception.php84.php
@@ -117,6 +117,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_unhandled_exception.php
+++ b/tests/integration/opcache/disabled/test_span_events_are_created_upon_uncaught_unhandled_exception.php
@@ -114,6 +114,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_error_collector_disabled.php
+++ b/tests/integration/opcache/disabled/test_span_events_error_collector_disabled.php
@@ -81,6 +81,7 @@ null
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/opcache/disabled/test_span_events_exception_uncaught_nested.php
+++ b/tests/integration/opcache/disabled/test_span_events_exception_uncaught_nested.php
@@ -110,6 +110,7 @@ opcache.jit=function
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/pdo/mysql/base-class/test_instance_reporting_port.php
+++ b/tests/integration/pdo/mysql/base-class/test_instance_reporting_port.php
@@ -143,6 +143,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[MYSQL_HOST]",
+      "server.address": "ENV[MYSQL_HOST]",
       "peer.address": "ENV[MYSQL_HOST]:ENV[MYSQL_PORT]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/pdo/mysql/base-class/test_instance_reporting_socket.php
+++ b/tests/integration/pdo/mysql/base-class/test_instance_reporting_socket.php
@@ -118,6 +118,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "__HOST__",
+      "server.address": "__HOST__",
       "peer.address": "__HOST__:ENV[MYSQL_SOCKET]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "CREATE TABLE ENV[DATASTORE_COLLECTION] (id INT, description VARCHAR(?));"
@@ -142,6 +143,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "__HOST__",
+      "server.address": "__HOST__",
       "peer.address": "__HOST__:ENV[MYSQL_SOCKET]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/pdo/mysql/constructor/test_instance_reporting_port.php
+++ b/tests/integration/pdo/mysql/constructor/test_instance_reporting_port.php
@@ -120,6 +120,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[MYSQL_HOST]",
+      "server.address": "ENV[MYSQL_HOST]",
       "peer.address": "ENV[MYSQL_HOST]:ENV[MYSQL_PORT]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "CREATE TABLE ENV[DATASTORE_COLLECTION] (id INT, description VARCHAR(?));"
@@ -144,6 +145,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[MYSQL_HOST]",
+      "server.address": "ENV[MYSQL_HOST]",
       "peer.address": "ENV[MYSQL_HOST]:ENV[MYSQL_PORT]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/pdo/mysql/constructor/test_instance_reporting_socket.php
+++ b/tests/integration/pdo/mysql/constructor/test_instance_reporting_socket.php
@@ -119,6 +119,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "__HOST__",
+      "server.address": "__HOST__",
       "peer.address": "__HOST__:ENV[MYSQL_SOCKET]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "CREATE TABLE ENV[DATASTORE_COLLECTION] (id INT, description VARCHAR(?));"
@@ -143,6 +144,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "__HOST__",
+      "server.address": "__HOST__",
       "peer.address": "__HOST__:ENV[MYSQL_SOCKET]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/pdo/mysql/factory/test_instance_reporting_port.php
+++ b/tests/integration/pdo/mysql/factory/test_instance_reporting_port.php
@@ -120,6 +120,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[MYSQL_HOST]",
+      "server.address": "ENV[MYSQL_HOST]",
       "peer.address": "ENV[MYSQL_HOST]:ENV[MYSQL_PORT]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "CREATE TABLE ENV[DATASTORE_COLLECTION] (id INT, description VARCHAR(?));"
@@ -144,6 +145,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[MYSQL_HOST]",
+      "server.address": "ENV[MYSQL_HOST]",
       "peer.address": "ENV[MYSQL_HOST]:ENV[MYSQL_PORT]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/pdo/mysql/factory/test_instance_reporting_socket.php
+++ b/tests/integration/pdo/mysql/factory/test_instance_reporting_socket.php
@@ -119,6 +119,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "__HOST__",
+      "server.address": "__HOST__",
       "peer.address": "__HOST__:ENV[MYSQL_SOCKET]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "CREATE TABLE ENV[DATASTORE_COLLECTION] (id INT, description VARCHAR(?));"
@@ -143,6 +144,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "__HOST__",
+      "server.address": "__HOST__",
       "peer.address": "__HOST__:ENV[MYSQL_SOCKET]",
       "db.instance": "ENV[MYSQL_DB]",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/pdo/pgsql/base-class/test_instance_reporting_port.php
+++ b/tests/integration/pdo/pgsql/base-class/test_instance_reporting_port.php
@@ -118,6 +118,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[PG_HOST]",
+      "server.address": "ENV[PG_HOST]",
       "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
       "db.instance": "postgres",
       "db.statement": "CREATE TABLE ENV[DATASTORE_COLLECTION] (id INT, description VARCHAR(?));"
@@ -142,6 +143,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[PG_HOST]",
+      "server.address": "ENV[PG_HOST]",
       "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
       "db.instance": "postgres",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/pdo/pgsql/constructor/test_instance_reporting_port.php
+++ b/tests/integration/pdo/pgsql/constructor/test_instance_reporting_port.php
@@ -119,6 +119,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[PG_HOST]",
+      "server.address": "ENV[PG_HOST]",
       "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
       "db.instance": "postgres",
       "db.statement": "CREATE TABLE ENV[DATASTORE_COLLECTION] (id INT, description VARCHAR(?));"
@@ -143,6 +144,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[PG_HOST]",
+      "server.address": "ENV[PG_HOST]",
       "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
       "db.instance": "postgres",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/pdo/pgsql/factory/test_instance_reporting_port.php
+++ b/tests/integration/pdo/pgsql/factory/test_instance_reporting_port.php
@@ -119,6 +119,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[PG_HOST]",
+      "server.address": "ENV[PG_HOST]",
       "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
       "db.instance": "postgres",
       "db.statement": "CREATE TABLE ENV[DATASTORE_COLLECTION] (id INT, description VARCHAR(?));"
@@ -143,6 +144,7 @@ Supportability/TxnData/SlowSQL, 1
     {},
     {
       "peer.hostname": "ENV[PG_HOST]",
+      "server.address": "ENV[PG_HOST]",
       "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
       "db.instance": "postgres",
       "db.statement": "DROP TABLE ENV[DATASTORE_COLLECTION];"

--- a/tests/integration/span_events/test_span_events_are_created_from_segments.php
+++ b/tests/integration/span_events/test_span_events_are_created_from_segments.php
@@ -64,7 +64,7 @@ newrelic.cross_application_tracer.enabled = false
       },
       {},
       {
-        "code.lineno": 99,
+        "code.lineno": 100,
         "code.filepath": "__FILE__",
         "code.function": "a"
       }
@@ -89,6 +89,7 @@ newrelic.cross_application_tracer.enabled = false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ]

--- a/tests/integration/span_events/test_span_events_are_created_from_segments.php5.php
+++ b/tests/integration/span_events/test_span_events_are_created_from_segments.php5.php
@@ -79,6 +79,7 @@ newrelic.code_level_metrics.enabled=false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ]

--- a/tests/integration/span_events/test_span_events_are_created_upon_caught_error.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_caught_error.php
@@ -74,6 +74,7 @@ log_errors=0
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_are_created_upon_caught_error.php84.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_caught_error.php84.php
@@ -72,6 +72,7 @@ log_errors=0
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],
@@ -93,7 +94,7 @@ log_errors=0
       {
         "error.message": "foo",
         "error.class": "E_USER_WARNING",
-        "code.lineno": 137,
+        "code.lineno": 138,
         "code.filepath": "__FILE__",
         "code.function": "a"
       }
@@ -114,7 +115,7 @@ log_errors=0
       },
       {},
       {
-        "code.lineno":  131,
+        "code.lineno":  132,
         "code.filepath": "__FILE__",
         "code.function": "{closure:__FILE__:??}"
       }

--- a/tests/integration/span_events/test_span_events_are_created_upon_exit.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_exit.php
@@ -69,6 +69,7 @@ newrelic.cross_application_tracer.enabled = false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],
@@ -88,7 +89,7 @@ newrelic.cross_application_tracer.enabled = false
       },
       {},
       {
-        "code.lineno": 100,
+        "code.lineno": 101,
         "code.filepath": "__FILE__",
         "code.function": "a"
       }

--- a/tests/integration/span_events/test_span_events_are_created_upon_exit.php5.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_exit.php5.php
@@ -63,6 +63,7 @@ newrelic.code_level_metrics.enabled=false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_error.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_error.php
@@ -74,6 +74,7 @@ log_errors=0
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_error.php5.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_error.php5.php
@@ -72,6 +72,7 @@ if (version_compare(PHP_VERSION, "8.4", ">=")) {
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_error.php84.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_error.php84.php
@@ -72,6 +72,7 @@ log_errors=0
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],
@@ -93,7 +94,7 @@ log_errors=0
       {
         "error.message": "foo",
         "error.class": "E_USER_WARNING",
-        "code.lineno": 109,
+        "code.lineno": 110,
         "code.filepath": "__FILE__",
         "code.function": "a"
       }

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_handled_exception.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_handled_exception.php
@@ -106,6 +106,7 @@ newrelic.cross_application_tracer.enabled = false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_handled_exception.php7.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_handled_exception.php7.php
@@ -76,6 +76,7 @@ null
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_handled_exception.php84.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_handled_exception.php84.php
@@ -104,6 +104,7 @@ newrelic.cross_application_tracer.enabled = false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_unhandled_exception.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_unhandled_exception.php
@@ -74,6 +74,7 @@ log_errors=0
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],
@@ -95,7 +96,7 @@ log_errors=0
       {
         "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
         "error.class": "RuntimeException",
-        "code.lineno": 111,
+        "code.lineno": 112,
         "code.filepath": "__FILE__",
         "code.function": "a"
       }

--- a/tests/integration/span_events/test_span_events_are_created_upon_uncaught_unhandled_exception.php5.php
+++ b/tests/integration/span_events/test_span_events_are_created_upon_uncaught_unhandled_exception.php5.php
@@ -68,6 +68,7 @@ newrelic.code_level_metrics.enabled=false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_error_collector_disabled.php
+++ b/tests/integration/span_events/test_span_events_error_collector_disabled.php
@@ -70,6 +70,7 @@ log_errors=0
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],
@@ -89,7 +90,7 @@ log_errors=0
       },
       {},
       {
-        "code.lineno": 101,
+        "code.lineno": 102,
         "code.filepath": "__FILE__",
         "code.function": "a"
       }

--- a/tests/integration/span_events/test_span_events_error_collector_disabled.php5.php
+++ b/tests/integration/span_events/test_span_events_error_collector_disabled.php5.php
@@ -64,6 +64,7 @@ newrelic.code_level_metrics.enabled=false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],

--- a/tests/integration/span_events/test_span_events_exception_uncaught_nested.php
+++ b/tests/integration/span_events/test_span_events_exception_uncaught_nested.php
@@ -104,6 +104,7 @@ log_errors=0
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],
@@ -125,7 +126,7 @@ log_errors=0
       {
         "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
         "error.class": "RuntimeException",
-        "code.lineno": 187,
+        "code.lineno": 188,
         "code.filepath": "__FILE__",
         "code.function": "a"
       }
@@ -148,7 +149,7 @@ log_errors=0
       {
         "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
         "error.class": "RuntimeException",
-        "code.lineno": 193,
+        "code.lineno": 194,
         "code.filepath": "__FILE__",
         "code.function": "b"
       }
@@ -171,7 +172,7 @@ log_errors=0
       {
         "error.message": "Uncaught exception 'RuntimeException' with message 'oops' in __FILE__:??",
         "error.class": "RuntimeException",
-        "code.lineno": 199,
+        "code.lineno": 200,
         "code.filepath": "__FILE__",
         "code.function": "c"
       }

--- a/tests/integration/span_events/test_span_events_exception_uncaught_nested.php5.php
+++ b/tests/integration/span_events/test_span_events_exception_uncaught_nested.php5.php
@@ -98,6 +98,7 @@ newrelic.code_level_metrics.enabled=false
       {
         "db.instance": "unknown",
         "peer.hostname": "unknown",
+        "server.address": "unknown",
         "peer.address": "unknown:unknown"
       }
     ],


### PR DESCRIPTION
This field is needed for some entity relationship mappings (currently only AWS Redshift). Per the spec, this field contains the same data as `peer.hostname`.