### PR TITLE
feat(agent): composer api package detection on by default

### DIFF
--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -7,6 +7,7 @@
 #include "fw_hooks.h"
 #include "fw_support.h"
 #include "nr_txn.h"
+#include "php_globals.h"
 #include "util_logging.h"
 #include "util_memory.h"
 #include "util_syscalls.h"
@@ -136,6 +137,13 @@ static void nr_execute_handle_autoload_composer_get_packages_information(
                      __func__);
     return;
   }
+
+  if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)) {
+    // set the per-process flag to true to avoid re-running composer api
+    // detection when the per-process detection is enabled.
+    NR_PHP_PROCESS_GLOBALS(composer_packages_detected) = 1;
+  }
+
   if (IS_ARRAY == Z_TYPE(retval)) {
     zend_string* package_name = NULL;
     zval* package_version = NULL;

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -904,6 +904,13 @@ static void nr_execute_handle_autoload(const char* filename,
     return;
   }
 
+  if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)
+      && NR_PHP_PROCESS_GLOBALS(composer_packages_detected)) {
+    // do nothing if per-process detection is enabled and the flag to track
+    // detection is true
+    return;
+  }
+
   if (!nr_striendswith(STR_AND_LEN(filename), AUTOLOAD_MAGIC_FILE,
                        AUTOLOAD_MAGIC_FILE_LEN)) {
     // not an autoload file

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -75,6 +75,12 @@ typedef struct _nrphpglobals_t {
   int apache_threaded; /* 1 if a threaded MPM is in use, 0 otherwise */
   int preload_framework_library_detection; /* Enables preloading framework and
                                               library detection */
+  int composer_api_per_process_detection;  /* Enables per-process VM package
+                                              detection when Composer API is also
+                                              enabled */
+  int composer_packages_detected; /* Flag to indicate that Composer package
+                                    detection has run. Used in conjunction with
+                                    composer_api_per_process_detection. */
   char* docker_id; /* 64 byte hex docker ID parsed from /proc/self/mountinfo */
 
   /* Original PHP callback pointer contents */

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -456,6 +456,7 @@ PHP_MINIT_FUNCTION(newrelic) {
       = nr_php_check_for_upgrade_license_key();
   NR_PHP_PROCESS_GLOBALS(high_security) = 0;
   NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection) = 1;
+  NR_PHP_PROCESS_GLOBALS(composer_packages_detected) = 0;
   nr_php_populate_apache_process_globals();
   nr_php_api_distributed_trace_register_userland_class(TSRMLS_C);
   /*

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -537,6 +537,28 @@ static PHP_INI_MH(nr_preload_framework_library_detection_mh) {
   return SUCCESS;
 }
 
+static PHP_INI_MH(nr_composer_per_process_detection_mh) {
+  int val;
+
+  (void)entry;
+  (void)NEW_VALUE_LEN;
+  (void)mh_arg1;
+  (void)mh_arg2;
+  (void)mh_arg3;
+  (void)stage;
+  NR_UNUSED_TSRMLS;
+
+  val = nr_bool_from_str(NEW_VALUE);
+
+  if (-1 == val) {
+    return FAILURE;
+  }
+
+  NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection) = val ? 1 : 0;
+
+  return SUCCESS;
+}
+
 static PHP_INI_MH(nr_loglevel_mh) {
   nr_status_t rv;
 
@@ -2054,6 +2076,17 @@ PHP_INI_ENTRY_EX("newrelic.preload_framework_library_detection",
                  NR_PHP_SYSTEM,
                  nr_preload_framework_library_detection_mh,
                  0)
+
+/*
+ * Enables per-process Composer API package detection and reporting. Depends on
+ * newrelic.vulnerability_management.composer_api.enabled.
+ */
+PHP_INI_ENTRY_EX(
+    "newrelic.vulnerability_management.composer_api.per_process_detection",
+    "1",
+    NR_PHP_SYSTEM,
+    nr_composer_per_process_detection_mh,
+    0)
 
 /*
  * Daemon

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -552,10 +552,10 @@ static PHP_INI_MH(nr_composer_per_process_detection_mh) {
 
   if (-1 == val) {
     nrl_warning(NRL_INIT,
-                "The value %d is not valid for the "
+                "The value %s is not valid for the "
                 "newrelic.vulnerability_management.composer_api.per_process_"
                 "detection setting, using default value instead.",
-                val);
+                NEW_VALUE);
     return FAILURE;
   }
 

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -551,6 +551,11 @@ static PHP_INI_MH(nr_composer_per_process_detection_mh) {
   val = nr_bool_from_str(NEW_VALUE);
 
   if (-1 == val) {
+    nrl_warning(NRL_INIT,
+                "The value %d is not valid for the "
+                "newrelic.vulnerability_management.composer_api.per_process_"
+                "detection setting, using default value instead.",
+                val);
     return FAILURE;
   }
 

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -3135,7 +3135,7 @@ STD_PHP_INI_ENTRY_EX("newrelic.vulnerability_management.package_detection.enable
                      nr_enabled_disabled_dh)
 
 STD_PHP_INI_ENTRY_EX("newrelic.vulnerability_management.composer_api.enabled",
-                     "0",
+                     "1",
                      NR_PHP_REQUEST,
                      nr_boolean_mh,
                      vulnerability_management_composer_api_enabled,

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -552,7 +552,7 @@ static PHP_INI_MH(nr_composer_per_process_detection_mh) {
 
   if (-1 == val) {
     nrl_warning(NRL_INIT,
-                "The value %s is not valid for the "
+                "The value \"%s\" is not valid for the "
                 "newrelic.vulnerability_management.composer_api.per_process_"
                 "detection setting, using default value instead.",
                 NEW_VALUE);

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1375,7 +1375,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ; Default: true
 ; Info   : Controls the frequency at which Composer API samples the runtime environment
 ;          for package data. When set to `true`, sampling will only occur once per process.
-;          If false, Composer will sample the environment every request.
+;          If false, Composer will sample the environment every request, increasing the frequency which this package detection is performed.
 ;
 ;newrelic.vulnerability_management.composer_api.per_process_detection = true
 

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1369,6 +1369,16 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;newrelic.vulnerability_management.composer_api.enabled = true
 
+; Setting: newrelic.vulnerability_management.composer_api.per_process_detection
+; Type   : boolean
+; Scope  : system
+; Default: true
+; Info   : Controls the frequency at which Composer API samples the runtime environment
+;          for package data. When set to `true`, sampling will only occur once per process.
+;          If false, Composer will sample the environment every request.
+;
+;newrelic.vulnerability_management.composer_api.per_process_detection = true
+
 ; Setting: newrelic.message_tracer.segment_parameters.enabled
 ; Type   : boolean
 ; Scope  : per-directory

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -1363,11 +1363,11 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ; Setting: newrelic.vulnerability_management.composer_api.enabled
 ; Type   : boolean
 ; Scope  : per-directory
-; Default: false
+; Default: true
 ; Info   : Toggles whether the agent should try using Composer's runtime API
 ;          to gather package information for vulnerability management.
 ;
-;newrelic.vulnerability_management.composer_api.enabled = false
+;newrelic.vulnerability_management.composer_api.enabled = true
 
 ; Setting: newrelic.message_tracer.segment_parameters.enabled
 ; Type   : boolean

--- a/tests/integration/autoloader/test_autoloader_with_composer_disabled.php
+++ b/tests/integration/autoloader/test_autoloader_with_composer_disabled.php
@@ -12,6 +12,7 @@ package supportability metrics and package harvest must not be present.
 */
 
 /*INI
+newrelic.vulnerability_management.composer_api.enabled = false
 */
 
 /*EXPECT_PHP_PACKAGES null*/

--- a/tests/integration/autoloader/test_autoloader_without_composer_disabled.php
+++ b/tests/integration/autoloader/test_autoloader_without_composer_disabled.php
@@ -11,6 +11,7 @@ Autoloader and Composer libraries must not be present.
 */
 
 /*INI
+newrelic.vulnerability_management.composer_api.enabled = false
 */
 
 /*EXPECT_METRICS_DONT_EXIST

--- a/tests/integration/external/guzzle5/test_cat.php
+++ b/tests/integration/external/guzzle5/test_cat.php
@@ -52,6 +52,8 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_cat.php
+++ b/tests/integration/external/guzzle5/test_cat.php
@@ -53,7 +53,6 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt.php
+++ b/tests/integration/external/guzzle5/test_dt.php
@@ -41,6 +41,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt.php
+++ b/tests/integration/external/guzzle5/test_dt.php
@@ -42,7 +42,6 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
@@ -42,6 +42,8 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
@@ -43,7 +43,6 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics.php
@@ -72,6 +72,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics.php
@@ -73,7 +73,6 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
@@ -76,7 +76,6 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
@@ -75,6 +75,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle5/test_no_cat_no_dt.php
@@ -44,7 +44,6 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},[1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle5/test_no_cat_no_dt.php
@@ -43,6 +43,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},[1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_cat.php
+++ b/tests/integration/external/guzzle6/test_cat.php
@@ -54,6 +54,8 @@ X-NewRelic-App-Data=??
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},[1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt.php
+++ b/tests/integration/external/guzzle6/test_dt.php
@@ -44,6 +44,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
@@ -45,6 +45,8 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics.php
@@ -67,6 +67,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics_logging_off.php
@@ -70,6 +70,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle6/test_no_cat_no_dt.php
@@ -44,6 +44,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"},[1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_cat.php
+++ b/tests/integration/external/guzzle7/test_cat.php
@@ -54,6 +54,8 @@ X-NewRelic-App-Data=??
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_dt.php
+++ b/tests/integration/external/guzzle7/test_dt.php
@@ -44,6 +44,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
@@ -44,7 +44,7 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
-    [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
@@ -45,6 +45,8 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle7/test_dt_synthetics.php
@@ -67,6 +67,8 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle7/test_no_cat_no_dt.php
@@ -44,6 +44,8 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
+    [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/LocalDecorating/PHP/disabled"}, [1, "??", "??", "??", "??", "??"]],


### PR DESCRIPTION
Changes the default configuration value for composer-based package detection to `true`.

An additional configuration value, `newrelic.vulnerability_management.composer_api.per_process_detection`, has also been added to control the frequency at which composer sampling occurs. By default, this setting will be enabled, only sampling Composer API data once per php-fpm process. This improves baseline performance to make the enablement of Composer API package detection a negligible overhead impact.