### PR TITLE
refactor(agent): improve logging when adding named tracers

### DIFF
--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -570,13 +570,13 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
       return p; /* return the wraprec we are duplicating */
     }
   }
-#else
-  wraprec = nr_php_user_instrument_wraprec_hashmap_add(namestr, namestrlen);
-#endif
   nrl_verbosedebug(
       NRL_INSTRUMENT, "adding custom for '" NRP_FMT_UQ "%.5s" NRP_FMT_UQ "'",
       NRP_PHP(wraprec->classname),
       (0 == wraprec->classname) ? "" : "::", NRP_PHP(wraprec->funcname));
+#else
+  wraprec = nr_php_user_instrument_wraprec_hashmap_add(namestr, namestrlen);
+#endif
 
   nr_php_wrap_user_function_internal(wraprec TSRMLS_CC);
   nr_php_add_custom_tracer_common(wraprec);

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -437,6 +437,7 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add(const char* namestr, size
 
     wraprec->supportability_metric = nr_txn_create_fn_supportability_metric(
         wraprec->funcname, wraprec->classname);
+    nrl_verbosedebug(NRL_INSTRUMENT, "adding custom wrapper for '%s'", namestr);
   } else {
     nrl_verbosedebug(NRL_INSTRUMENT, "reusing custom wrapper for '%s'", namestr);
   }


### PR DESCRIPTION
Make log messages easier to understand when adding a named custom tracer by logging only a single message. Instead of logging one message when the wraprec is added, and two messages when wraprec is re-used, log a single message that indicates if the wraprec was added or re-used.