### PR TITLE
test(integration): improve valgrind

### DIFF
--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -24,6 +24,10 @@ on:
         description: 'runner type'
         required: true
         type: string
+      use-valgrind:
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   test-agent:
@@ -83,7 +87,7 @@ jobs:
         run: |
           docker exec \
           -e PHPS=${{matrix.php}} \
-          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
+          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so ${{ inputs.arch != 'arm64' && inputs.use-valgrind && '-valgrind /usr/bin/valgrind' }}" \
           -e APP_supportability=${{secrets.APP_SUPPORTABILITY}} \
           -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}} \
           -e ACCOUNT_supportability_trusted=${{secrets.ACCOUNT_SUPPORTABILITY_TRUSTED}} \

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -29,7 +29,11 @@ on:
         - ubuntu-20.04-16core
         - ubuntu-22.04-4core
         - ubuntu-latest
-
+      use-valgrind:
+        description: 'Use valgrind?'
+        required: true
+        default: false
+        type: boolean
 jobs:
   build-test-runner-amd64:
     uses: ./.github/workflows/make-for-platform-on-arch.yml
@@ -81,6 +85,7 @@ jobs:
     with:
       origin: ${{ inputs.origin }}
       ref: ${{ inputs.ref }}
+      use-valgrind: ${{ inputs.use-valgrind }}
       arch: amd64
       runs-on: ubuntu-latest
       continue-on-error: false
@@ -91,6 +96,7 @@ jobs:
     with:
       origin: ${{ inputs.origin }}
       ref: ${{ inputs.ref }}
+      use-valgrind: ${{ inputs.use-valgrind }}
       arch: arm64
       runs-on: ${{inputs.runner-type}}
       continue-on-error: true

--- a/daemon/cmd/integration_runner/main.go
+++ b/daemon/cmd/integration_runner/main.go
@@ -344,6 +344,10 @@ func main() {
 
 	ctx = integration.NewContext(*flagPHP, *flagCGI)
 	ctx.Valgrind = *flagValgrind
+	if (ctx.Valgrind != "" && *flagWorkers != 1) {
+		fmt.Fprintf(os.Stderr, "cannot run valgrind on multiple workers\n", err)
+		os.Exit(1)
+	}
 	ctx.Timeout = *flagTimeout
 
 	// Settings common to all tests.

--- a/daemon/internal/newrelic/integration/transaction.go
+++ b/daemon/internal/newrelic/integration/transaction.go
@@ -48,7 +48,7 @@ func PhpTx(src Script, env, settings map[string]string, ctx *Context) (Tx, error
 
 	args := phpArgs(nil, filepath.Base(src.Name()), false, settings)
 
-	if ctx.Valgrind != "" {
+	if ctx.Valgrind != "" && settings["newrelic.appname"] != "skipif" {
 		txn = &ValgrindCLI{
 			CLI: CLI{
 				Path: ctx.PHP,
@@ -81,6 +81,7 @@ func PhpTx(src Script, env, settings map[string]string, ctx *Context) (Tx, error
 // See: https://tools.ietf.org/html/rfc3875
 func CgiTx(src Script, env, settings map[string]string, headers http.Header, ctx *Context) (Tx, error) {
 	var err error
+	var txn Tx
 
 	req := &http.Request{
 		Method:     env["REQUEST_METHOD"],
@@ -105,34 +106,69 @@ func CgiTx(src Script, env, settings map[string]string, headers http.Header, ctx
 		return nil, fmt.Errorf("unable to create cgi request: %v", err)
 	}
 
-	tx := &CGI{
-		request: req,
-		handler: &cgi.Handler{
-			Path: ctx.CGI,
-			Dir:  src.Dir(),
-			Args: phpArgs(nil, "", false, settings),
-		},
-	}
-
-	tx.handler.Env = append(tx.handler.Env,
-		"SCRIPT_FILENAME="+scriptFile,
-		"SCRIPT_NAME=/"+filepath.Base(src.Name()),
-		"REDIRECT_STATUS=200")
-	tx.handler.Env = append(tx.handler.Env, flatten(env)...)
-
-	// If the environment includes a REQUEST_URI and doesn't include an explicit
-	// PATH_INFO, we'll set it here to avoid problems with Go's CGI package
-	// attempting to guess what the PATH_INFO should be.
-	if ruri, ok := env["REQUEST_URI"]; ok {
-		if _, ok := env["PATH_INFO"]; !ok {
-			tx.handler.Env = append(tx.handler.Env, "PATH_INFO="+ruri)
+	if ctx.Valgrind != "" {
+		tx := &ValgrindCGI{
+			CGI: CGI{
+				request: req,
+				handler: &cgi.Handler{
+					Path: ctx.CGI,
+					Dir:  src.Dir(),
+					Args: phpArgs(nil, "", false, settings),
+				},
+			},
+			Valgrind: ctx.Valgrind,
+			Timeout:  60*time.Second,
 		}
+		tx.handler.Env = append(tx.handler.Env,
+			"SCRIPT_FILENAME="+scriptFile,
+			"SCRIPT_NAME=/"+filepath.Base(src.Name()),
+			"REDIRECT_STATUS=200")
+		tx.handler.Env = append(tx.handler.Env, flatten(env)...)
+
+		// If the environment includes a REQUEST_URI and doesn't include an explicit
+		// PATH_INFO, we'll set it here to avoid problems with Go's CGI package
+		// attempting to guess what the PATH_INFO should be.
+		if ruri, ok := env["REQUEST_URI"]; ok {
+			if _, ok := env["PATH_INFO"]; !ok {
+				tx.handler.Env = append(tx.handler.Env, "PATH_INFO="+ruri)
+			}
+		}
+
+		if !src.IsFile() {
+			return withTempFile(tx, src.Name(), src.Bytes()), nil
+		}
+		txn = tx
+	} else {
+		tx := &CGI{
+			request: req,
+			handler: &cgi.Handler{
+				Path: ctx.CGI,
+				Dir:  src.Dir(),
+				Args: phpArgs(nil, "", false, settings),
+			},
+		}
+		tx.handler.Env = append(tx.handler.Env,
+			"SCRIPT_FILENAME="+scriptFile,
+			"SCRIPT_NAME=/"+filepath.Base(src.Name()),
+			"REDIRECT_STATUS=200")
+		tx.handler.Env = append(tx.handler.Env, flatten(env)...)
+
+		// If the environment includes a REQUEST_URI and doesn't include an explicit
+		// PATH_INFO, we'll set it here to avoid problems with Go's CGI package
+		// attempting to guess what the PATH_INFO should be.
+		if ruri, ok := env["REQUEST_URI"]; ok {
+			if _, ok := env["PATH_INFO"]; !ok {
+				tx.handler.Env = append(tx.handler.Env, "PATH_INFO="+ruri)
+			}
+		}
+
+		if !src.IsFile() {
+			return withTempFile(tx, src.Name(), src.Bytes()), nil
+		}
+		txn = tx
 	}
 
-	if !src.IsFile() {
-		return withTempFile(tx, src.Name(), src.Bytes()), nil
-	}
-	return tx, nil
+	return txn, nil
 }
 
 // phpArgs builds the command line for a PHP process.


### PR DESCRIPTION
This PR:
1) adds the option to run valgrind on integration tests in GHA
2) adds the ability to run valgrind on CGI tests
3) no longer runs valgrind on SKIPIFs
4) changes the valgrind lock mechanism to allow subprocesses (i.e. curl) to not be locked out