### PR TITLE
chore(agent): remove obsolete code (11/17)

### DIFF
--- a/agent/php_pdo_private.h
+++ b/agent/php_pdo_private.h
@@ -118,9 +118,9 @@ extern int nr_php_pdo_rebind_apply_parameter(struct pdo_bound_param_data* param,
  */
 static inline pdo_dbh_t* nr_php_pdo_get_database_object_internal(
     zval* dbh TSRMLS_DC) {
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+#if ZEND_MODULE_API_NO >= ZEND_7_2_X_API_NO /* PHP 7.2+ */
   return Z_PDO_DBH_P(dbh);
-#endif /* PHP7+ */
+#endif /* PHP 7.2+ */
 }
 
 /*
@@ -136,9 +136,9 @@ static inline pdo_dbh_t* nr_php_pdo_get_database_object_internal(
  */
 static inline pdo_stmt_t* nr_php_pdo_get_statement_object_internal(
     zval* stmt TSRMLS_DC) {
-#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
+#if ZEND_MODULE_API_NO >= ZEND_7_2_X_API_NO /* PHP 7.2+ */
   return Z_PDO_STMT_P(stmt);
-#endif /* PHP7+ */
+#endif /* PHP 7.2+ */
 }
 
 /*

--- a/agent/php_pdo_private.h
+++ b/agent/php_pdo_private.h
@@ -118,9 +118,7 @@ extern int nr_php_pdo_rebind_apply_parameter(struct pdo_bound_param_data* param,
  */
 static inline pdo_dbh_t* nr_php_pdo_get_database_object_internal(
     zval* dbh TSRMLS_DC) {
-#if ZEND_MODULE_API_NO >= ZEND_7_2_X_API_NO /* PHP 7.2+ */
   return Z_PDO_DBH_P(dbh);
-#endif /* PHP 7.2+ */
 }
 
 /*
@@ -136,9 +134,7 @@ static inline pdo_dbh_t* nr_php_pdo_get_database_object_internal(
  */
 static inline pdo_stmt_t* nr_php_pdo_get_statement_object_internal(
     zval* stmt TSRMLS_DC) {
-#if ZEND_MODULE_API_NO >= ZEND_7_2_X_API_NO /* PHP 7.2+ */
   return Z_PDO_STMT_P(stmt);
-#endif /* PHP 7.2+ */
 }
 
 /*

--- a/agent/php_pdo_private.h
+++ b/agent/php_pdo_private.h
@@ -118,11 +118,9 @@ extern int nr_php_pdo_rebind_apply_parameter(struct pdo_bound_param_data* param,
  */
 static inline pdo_dbh_t* nr_php_pdo_get_database_object_internal(
     zval* dbh TSRMLS_DC) {
-#ifdef PHP7
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
   return Z_PDO_DBH_P(dbh);
-#else
-  return (pdo_dbh_t*)zend_object_store_get_object(dbh TSRMLS_CC);
-#endif /* PHP7 */
+#endif /* PHP7+ */
 }
 
 /*
@@ -138,11 +136,9 @@ static inline pdo_dbh_t* nr_php_pdo_get_database_object_internal(
  */
 static inline pdo_stmt_t* nr_php_pdo_get_statement_object_internal(
     zval* stmt TSRMLS_DC) {
-#ifdef PHP7
+#if ZEND_MODULE_API_NO >= ZEND_7_0_X_API_NO /* PHP 7.0+ */
   return Z_PDO_STMT_P(stmt);
-#else
-  return (pdo_stmt_t*)zend_object_store_get_object(stmt TSRMLS_CC);
-#endif /* PHP7 */
+#endif /* PHP7+ */
 }
 
 /*


### PR DESCRIPTION
This PR removes obsolete `PHP7` codeblocks. PR: 11/17