### PR TITLE
fix(agent): nr_execute_handle_autoload needs null check for txn

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -891,6 +891,14 @@ static void nr_execute_handle_autoload(const char* filename,
     return;
   }
 
+  /* 
+  *  There is a possibility of the txn being NULL if nr_php_end_txn has been called. 
+  *  Verify txn is not null before dereferencing and continuing on.
+  */  
+  if (NULL == NRPRG(txn)) {
+    return;
+  }
+  
   if (NRPRG(txn)->composer_info.autoload_detected) {
     // autoload already handled
     return;


### PR DESCRIPTION
`nr_execute_handle_autoload` wasn't accounting for the possibility of txn being null which would lead to unpredictable behavior when accessing it [here](https://github.com/newrelic/newrelic-php-agent/blob/dev/agent/php_execute.c#L894).

txn can be null in cases where nr_php_txn_end has been called.
such as: https://github.com/newrelic/newrelic-php-agent/blob/dev/agent/fw_laravel_queue.c#L355-L356

