### PR TITLE
tests: make tests deterministic

### DIFF
--- a/tests/integration/jit/function/test_span_class_function.php
+++ b/tests/integration/jit/function/test_span_class_function.php
@@ -244,6 +244,7 @@ newrelic_add_custom_tracer('main');
 newrelic_add_custom_tracer('Classname::functionName');
 function main()
 {
+  time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped.
   echo 'Hello';
 }
 main();

--- a/tests/integration/jit/tracing/test_span_class_function.php
+++ b/tests/integration/jit/tracing/test_span_class_function.php
@@ -243,6 +243,7 @@ newrelic_add_custom_tracer('main');
 newrelic_add_custom_tracer('Classname::functionName');
 function main()
 {
+  time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped.
   echo 'Hello';
 }
 main();

--- a/tests/integration/lang/trampoline/test_trampoline_02.php
+++ b/tests/integration/lang/trampoline/test_trampoline_02.php
@@ -77,6 +77,7 @@ Custom/class@anonymous::execute, 2
 $anon = new class() {
   function execute()
   {
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped.
     new ReflectionClass('Wrapper');
   }
 };
@@ -84,6 +85,7 @@ $anon = new class() {
 $anon2 = new class() {
   function execute()
   {
+    time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped.
     new ReflectionClass('Wrapper');
   }
 };

--- a/tests/integration/opcache/disabled/test_span_class_function.php
+++ b/tests/integration/opcache/disabled/test_span_class_function.php
@@ -245,6 +245,7 @@ newrelic_add_custom_tracer('main');
 newrelic_add_custom_tracer('Classname::functionName');
 function main()
 {
+  time_nanosleep(0, 50000); // force non-zero duration for the segment not to be dropped.
   echo 'Hello';
 }
 main();


### PR DESCRIPTION
Force non-zero duration of helper user function. When tests execute fast enough, the helper function's segment start time and end time are equal and this causes the segment to be dropped. To address this test instability, non-zero duration is forced on test helper user functions. This is a follow up to #781.