### PR TITLE
chore(agent): remove obsolete PHP 5.x ZEND_MODULE_API_NO usage

### DIFF
--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -197,11 +197,7 @@ static int nr_drupal8_is_function_in_call_stack(const char* function,
   trace = nr_php_zval_alloc();
 
   /* Grab the actual backtrace. */
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
   zend_fetch_debug_backtrace(trace, 0, 1, 0 TSRMLS_CC);
-#else /* PHP < 5.4 */
-  zend_fetch_debug_backtrace(trace, 0, 1 TSRMLS_CC);
-#endif
 
   if (!nr_php_is_zval_valid_array(trace)) {
     nrl_error(NRL_TXN, "%s: trace should never not be an array", __func__);

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -490,13 +490,8 @@ leave:
  *
  */
 NR_PHP_WRAPPER(nr_laravel5_exception_render) {
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
   const char* class_name = NULL;
   const char* ignored = NULL;
-#else
-  char* class_name = NULL;
-  char* ignored = NULL;
-#endif /* PHP >= 5.4 */
 
   char* name = NULL;
 

--- a/agent/fw_lumen.c
+++ b/agent/fw_lumen.c
@@ -166,13 +166,8 @@ NR_PHP_WRAPPER(nr_lumen_exception) {
 
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_LUMEN);
 
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
   const char* class_name = NULL;
   const char* ignored = NULL;
-#else
-  char* class_name = NULL;
-  char* ignored = NULL;
-#endif /* PHP >= 5.4 */
 
   char* name = NULL;
 

--- a/agent/lib_guzzle4.c
+++ b/agent/lib_guzzle4.c
@@ -41,7 +41,6 @@
  * we just won't build the Guzzle 4 support on older versions and will instead
  * provide simple stubs for the two exported functions to avoid linking errors.
  */
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
 
 /* {{{ Convenience functions for Guzzle interface checks */
 
@@ -572,31 +571,3 @@ void nr_guzzle4_rshutdown(TSRMLS_D) {
   nr_php_remove_interface_from_class(nr_guzzle4_subscriber_ce,
                                      iface_ce TSRMLS_CC);
 }
-
-#else /* PHP >= 5.4.0 */
-
-/*
- * Stub implementations of the exported functions from this module for
- * PHP < 5.4.
- */
-
-NR_PHP_WRAPPER_START(nr_guzzle4_client_construct) {
-  (void)wraprec;
-  NR_UNUSED_SPECIALFN;
-  NR_UNUSED_TSRMLS;
-}
-NR_PHP_WRAPPER_END
-
-void nr_guzzle4_enable(TSRMLS_D) {
-  NR_UNUSED_TSRMLS
-}
-
-void nr_guzzle4_minit(TSRMLS_D) {
-  NR_UNUSED_TSRMLS
-}
-
-void nr_guzzle4_rshutdown(TSRMLS_D) {
-  NR_UNUSED_TSRMLS
-}
-
-#endif /* PHP >= 5.4.0 */

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -65,7 +65,6 @@
  * support on older versions and will instead provide simple stubs for the two
  * exported functions to avoid linking errors.
  */
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
 
 /* {{{ newrelic\Guzzle6\RequestHandler class definition and methods */
 
@@ -525,22 +524,3 @@ void nr_guzzle6_minit(TSRMLS_D) {
   zend_declare_property_null(nr_guzzle6_requesthandler_ce, NR_PSTR("request"),
                              ZEND_ACC_PRIVATE TSRMLS_CC);
 }
-
-#else /* PHP < 5.5 */
-
-NR_PHP_WRAPPER_START(nr_guzzle6_client_construct) {
-  (void)wraprec;
-  NR_UNUSED_SPECIALFN;
-  NR_UNUSED_TSRMLS;
-}
-NR_PHP_WRAPPER_END
-
-void nr_guzzle6_enable(TSRMLS_D) {
-  NR_UNUSED_TSRMLS
-}
-
-void nr_guzzle6_minit(TSRMLS_D) {
-  NR_UNUSED_TSRMLS;
-}
-
-#endif /* 5.5.x */

--- a/agent/php_agent.c
+++ b/agent/php_agent.c
@@ -258,22 +258,16 @@ zend_execute_data* nr_get_zend_execute_data(NR_EXECUTE_PROTO TSRMLS_DC) {
       = EG(current_execute_data); /* via zend engine global data structure */
   NR_UNUSED_SPECIALFN;
   NR_UNUSED_FUNC_RETURN_VALUE;
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
-  {
-    /*
-     * ptra is argument passed in to us, it might be NULL if the caller doesn't
-     * have that info.
-     */
-    zend_execute_data* ptra = execute_data;
-    if (NULL != ptra) {
-      return ptra;
-    } else {
-      return ptrg;
-    }
+  /*
+   * ptra is argument passed in to us, it might be NULL if the caller doesn't
+   * have that info.
+   */
+  zend_execute_data* ptra = execute_data;
+  if (NULL != ptra) {
+    return ptra;
+  } else {
+    return ptrg;
   }
-#else /* PHP < 5.5 */
-  return ptrg;
-#endif
 }
 
 /*
@@ -314,15 +308,11 @@ zend_execute_data* nr_php_get_caller_execute_data(NR_EXECUTE_PROTO,
   NR_UNUSED_SPECIALFN;
   NR_UNUSED_TSRMLS;
 
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
   ced = execute_data;
 
   if (NULL == ced) {
     ced = nr_get_zend_execute_data(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   }
-#else /* PHP < 5.5 */
-  ced = nr_get_zend_execute_data(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-#endif
 
   for (i = 0; i < offset; i++) {
     if (NULL == ced) {

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -408,15 +408,9 @@ static inline zend_function* nr_php_execute_function(
   NR_UNUSED_TSRMLS;
   NR_UNUSED_FUNC_RETURN_VALUE;
 
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
   if (NULL == execute_data) {
     return NULL;
   }
-#else
-  if (NULL == op_array_arg) {
-    return NULL;
-  }
-#endif
 
   return execute_data->func;
 }

--- a/agent/php_api.c
+++ b/agent/php_api.c
@@ -627,17 +627,10 @@ static nrobj_t* nr_php_api_zval_to_attribute_obj(const zval* z TSRMLS_DC) {
       return NULL;
 #endif /* PHP < 7.3 */
 
-#if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
     case IS_CONSTANT_AST:
       nr_php_api_error(NR_PHP_API_INVALID_ATTRIBUTE_FMT,
                        get_active_function_name(TSRMLS_C), "constant AST");
       return NULL;
-#else
-    case IS_CONSTANT_ARRAY:
-      nr_php_api_error(NR_PHP_API_INVALID_ATTRIBUTE_FMT,
-                       get_active_function_name(TSRMLS_C), "constant array");
-      return NULL;
-#endif /* PHP >= 5.6 */
 
     default:
       nr_php_api_error(NR_PHP_API_INVALID_ATTRIBUTE_FMT,
@@ -736,15 +729,9 @@ PHP_FUNCTION(newrelic_add_custom_parameter) {
       break;
 #endif /* PHP < 7.3 */
 
-#if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
     case IS_CONSTANT_AST:
       key = nr_strdup("(Constant AST)"); /* NOTTESTED */
       break;
-#else
-    case IS_CONSTANT_ARRAY:
-      key = nr_strdup("(Constant array)"); /* NOTTESTED */
-      break;
-#endif /* PHP >= 5.6 */
 
     default:
       key = nr_strdup("(?)"); /* NOTTESTED */

--- a/agent/php_call.c
+++ b/agent/php_call.c
@@ -204,10 +204,8 @@ void nr_php_call_user_func_array_handler(nrphpcufafn_t handler,
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
     caller = nr_php_get_caller(EG(current_execute_data), NULL, 1 TSRMLS_CC);
-#elif ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
-    caller = nr_php_get_caller(EG(current_execute_data), 1 TSRMLS_CC);
 #else
-    caller = nr_php_get_caller(NULL, 1 TSRMLS_CC);
+    caller = nr_php_get_caller(EG(current_execute_data), 1 TSRMLS_CC);
 #endif /* PHP >= 5.5 */
   }
 

--- a/agent/php_environment.c
+++ b/agent/php_environment.c
@@ -185,7 +185,6 @@ static void call_phpinfo(TSRMLS_D) {
   sapi_module.phpinfo_as_text = save_sapi_flag;
 }
 
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
 /*
  * PHP's output system was rewritten in PHP 5.4. Among the many new
  * capabilities, internal output handlers can register an opaque pointer that
@@ -274,34 +273,6 @@ static void nr_php_gather_php_information(nrobj_t* env TSRMLS_DC) {
 end:
   nr_buffer_destroy(&buf);
 }
-#else
-static void nr_php_gather_php_information(nrobj_t* env TSRMLS_DC) {
-  zval* output_handler = NULL;
-  long chunk_size = 0;
-  zend_bool erase = 1;
-  zval* tmp_obj = NULL;
-
-  if (FAILURE
-      == php_start_ob_buffer(output_handler, chunk_size, erase TSRMLS_CC)) {
-    /* don't call phpinfo() if we can't buffer because otherwise we're
-     * going to dump into the user's page.
-     */
-    return;
-  }
-
-  call_phpinfo(TSRMLS_C);
-
-  tmp_obj = nr_php_zval_alloc();
-
-  php_ob_get_buffer(tmp_obj TSRMLS_CC);
-  php_end_ob_buffer(0, 0 TSRMLS_CC);
-
-  nr_php_parse_rocket_assignment_list(Z_STRVAL_P(tmp_obj), Z_STRLEN_P(tmp_obj),
-                                      env);
-
-  nr_php_zval_free(&tmp_obj);
-}
-#endif /* PHP >= 5.4 */
 
 static void nr_php_gather_machine_information(nrobj_t* env) {
   const char* dyno_value = NULL;

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1634,18 +1634,7 @@ void nr_php_execute_internal(zend_execute_data* execute_data,
    * implementing it.
    */
   if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_executes)) {
-#if ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
     nr_php_show_exec_internal(NR_EXECUTE_ORIG_ARGS_OVERWRITE, func TSRMLS_CC);
-#else
-    /*
-     * We're passing the same pointer twice. This is inefficient. However, no
-     * user is ever likely to be affected, since this is a code path handling
-     * a special flag, and it makes the nr_php_show_exec_internal() API cleaner
-     * for modern versions of PHP without needing to have another function
-     * conditionally compiled.
-     */
-    nr_php_show_exec_internal((zend_op_array*)func, func TSRMLS_CC);
-#endif /* PHP >= 5.5 */
   }
   segment = nr_segment_start(NRPRG(txn), NULL, NULL);
   CALL_ORIGINAL;

--- a/agent/php_includes.h
+++ b/agent/php_includes.h
@@ -41,10 +41,6 @@
  * Zend Engine API numbers.
  * Find these numbers at: php-src/Zend/zend_modules.h
  */
-#define ZEND_5_3_X_API_NO 20090626
-#define ZEND_5_4_X_API_NO 20100525
-#define ZEND_5_5_X_API_NO 20121212
-#define ZEND_5_6_X_API_NO 20131226
 #define ZEND_7_2_X_API_NO 20170718
 #define ZEND_7_3_X_API_NO 20180731
 #define ZEND_7_4_X_API_NO 20190902
@@ -58,11 +54,7 @@
 #include "Zend/zend_observer.h"
 #endif
 
-#if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
 #include "Zend/zend_virtual_cwd.h"
-#else /* PHP < 5.6 */
-#include "tsrm_virtual_cwd.h"
-#endif
 
 #if defined(ZTS)
 #include "TSRM.h"

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -1231,11 +1231,9 @@ NR_INNER_WRAPPER(mysqli_stmt_bind_param) {
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
     argv[i] = nr_php_get_user_func_arg(i + 1, EG(current_execute_data),
                                        NULL TSRMLS_CC);
-#elif ZEND_MODULE_API_NO >= ZEND_5_5_X_API_NO
+#else
     argv[i]
         = nr_php_get_user_func_arg(i + 1, EG(current_execute_data) TSRMLS_CC);
-#else /* PHP < 5.5 */
-    argv[i] = nr_php_get_user_func_arg(i + 1, EG(active_op_array) TSRMLS_CC);
 #endif
   }
 

--- a/agent/php_output.c
+++ b/agent/php_output.c
@@ -38,12 +38,7 @@
  */
 
 int nr_php_output_has_content(int flags) {
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
   return !(flags & PHP_OUTPUT_HANDLER_CLEAN);
-#else
-  (void)flags;
-  return 1;
-#endif /* PHP >= 5.4 */
 }
 
 void nr_php_output_install_handler(const char* name,
@@ -63,32 +58,12 @@ void nr_php_output_install_handler(const char* name,
    * On PHP 5.3, php_ob_set_internal_handler doesn't check for duplicate
    * handlers, so we check with php_ob_handler_used.
    */
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
-  {
-    int flags = PHP_OUTPUT_HANDLER_STDFLAGS;
-    size_t chunk_size = 40960;
-    int name_len = nr_strlen(name);
+  int flags = PHP_OUTPUT_HANDLER_STDFLAGS;
+  size_t chunk_size = 40960;
+  int name_len = nr_strlen(name);
 
-    php_output_start_internal(name, name_len, handler, chunk_size,
-                              flags TSRMLS_CC);
-  }
-#else /* PHP < 5.4 */
-  /* Everything else before it */
-  {
-    zend_bool erase = 1;
-    uint buffer_size = 40960;
-    char name_duplicate[256];
-
-    /* Copy the name onto the stack to avoid const warnings. */
-    name_duplicate[0] = '\0';
-    snprintf(name_duplicate, sizeof(name_duplicate), "%s", name);
-
-    if (!php_ob_handler_used(name_duplicate TSRMLS_CC)) {
-      php_ob_set_internal_handler(handler, buffer_size, name_duplicate,
-                                  erase TSRMLS_CC);
-    }
-  }
-#endif
+  php_output_start_internal(name, name_len, handler, chunk_size,
+                            flags TSRMLS_CC);
 }
 
 int nr_php_output_is_end(int flags) {

--- a/agent/php_stack.c
+++ b/agent/php_stack.c
@@ -150,12 +150,7 @@ zval* nr_php_backtrace(TSRMLS_D) {
 
   trace = nr_php_zval_alloc();
 
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
   zend_fetch_debug_backtrace(trace, skip_last, options, limit TSRMLS_CC);
-#else /* PHP < 5.4 */
-  zend_fetch_debug_backtrace(trace, skip_last, options TSRMLS_CC);
-  (void)limit;
-#endif
 
   return trace;
 }

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -247,11 +247,7 @@ static int nr_php_capture_request_parameter(zval* element,
  * IS_CONSTANT_AST. For the purposes of this function, it can be
  * considered the same thing.
  */
-#if ZEND_MODULE_API_NO >= ZEND_5_6_X_API_NO
     case IS_CONSTANT_AST:
-#else
-    case IS_CONSTANT_ARRAY:
-#endif /* PHP >= 5.6 */
       nr_strcpy(datastr, "[constants]");
       break;
 

--- a/agent/tests/test_mongodb.c
+++ b/agent/tests/test_mongodb.c
@@ -15,7 +15,6 @@ tlib_parallel_info_t parallel_info
 /*
  * The mongodb extension requires PHP 5.4.
  */
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
 
 static char* system_host_name;
 
@@ -204,9 +203,3 @@ void test_main(void* p NRUNUSED) {
 
   nr_free(system_host_name);
 }
-
-#else
-
-void test_main(void* p NRUNUSED) {}
-
-#endif /* PHP >= 5.4 */

--- a/agent/tests/test_output.c
+++ b/agent/tests/test_output.c
@@ -26,7 +26,6 @@ tlib_parallel_info_t parallel_info
   } while (0)
 
 static void test_output_flags(void) {
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO
   test_output_flag_func("has content", nr_php_output_has_content, 1,
                         PHP_OUTPUT_HANDLER_WRITE);
   test_output_flag_func("has content", nr_php_output_has_content, 1,
@@ -62,31 +61,6 @@ static void test_output_flags(void) {
   test_output_flag_func("is start", nr_php_output_is_start, 0,
                         PHP_OUTPUT_HANDLER_FINAL);
   test_output_flag_func("is start", nr_php_output_is_start, 1, INT_MAX);
-#else  /* PHP < 5.4 */
-  test_output_flag_func("has content", nr_php_output_has_content, 1,
-                        PHP_OUTPUT_HANDLER_START);
-  test_output_flag_func("has content", nr_php_output_has_content, 1,
-                        PHP_OUTPUT_HANDLER_CONT);
-  test_output_flag_func("has content", nr_php_output_has_content, 1,
-                        PHP_OUTPUT_HANDLER_END);
-  test_output_flag_func("has content", nr_php_output_has_content, 1, INT_MAX);
-
-  test_output_flag_func("is end", nr_php_output_is_end, 0,
-                        PHP_OUTPUT_HANDLER_START);
-  test_output_flag_func("is end", nr_php_output_is_end, 0,
-                        PHP_OUTPUT_HANDLER_CONT);
-  test_output_flag_func("is end", nr_php_output_is_end, 1,
-                        PHP_OUTPUT_HANDLER_END);
-  test_output_flag_func("is end", nr_php_output_is_end, 1, INT_MAX);
-
-  test_output_flag_func("is start", nr_php_output_is_start, 1,
-                        PHP_OUTPUT_HANDLER_START);
-  test_output_flag_func("is start", nr_php_output_is_start, 0,
-                        PHP_OUTPUT_HANDLER_CONT);
-  test_output_flag_func("is start", nr_php_output_is_start, 0,
-                        PHP_OUTPUT_HANDLER_END);
-  test_output_flag_func("is start", nr_php_output_is_start, 1, INT_MAX);
-#endif /* PHP >= 5.4 */
 }
 
 /*

--- a/agent/tests/tlib_php.c
+++ b/agent/tests/tlib_php.c
@@ -122,17 +122,6 @@ static zend_string* ZEND_FASTCALL tlib_php_init_interned_string(const char* str,
 }
 #endif /* PHP >= 7.3 */
 
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO \
-    && ZEND_MODULE_API_NO < ZEND_7_2_X_API_NO
-static void tlib_php_interned_strings_restore(TSRMLS_D) {
-  NR_UNUSED_TSRMLS;
-}
-
-static void tlib_php_interned_strings_snapshot(TSRMLS_D) {
-  NR_UNUSED_TSRMLS;
-}
-#endif /* PHP >= 5.4 && PHP < 7.2 */
-
 /* }}} */
 
 static nr_status_t stub_cmd_appinfo_tx(int daemon_fd, nrapp_t* app);
@@ -287,18 +276,6 @@ nr_status_t tlib_php_engine_create(const char* extra_ini PTSRMLS_DC) {
     return NR_FAILURE;
   }
 #endif
-
-  /*
-   * As noted above, we now replace the interned string callbacks on PHP
-   * 5.4-7.1, inclusive. The effect of these replacements is to disable
-   * interned strings.
-   */
-#if ZEND_MODULE_API_NO >= ZEND_5_4_X_API_NO \
-    && ZEND_MODULE_API_NO < ZEND_7_2_X_API_NO
-  zend_new_interned_string = tlib_php_new_interned_string;
-  zend_interned_strings_restore = tlib_php_interned_strings_restore;
-  zend_interned_strings_snapshot = tlib_php_interned_strings_snapshot;
-#endif /* PHP >= 5.4 && PHP < 7.2 */
 
   /*
    * Register the resource type we use to fake resources. We are module 0


### PR DESCRIPTION
This PR removes obsolete PHP 5.x `ZEND_MODULE_API_NO` usage from the agent codebase.