### PR TITLE
fix call to alloca in a loop php_api_datastore 

### DIFF
--- a/agent/php_api_datastore.c
+++ b/agent/php_api_datastore.c
@@ -54,10 +54,17 @@ zval* nr_php_api_datastore_validate(const HashTable* params) {
         return NULL;
       } else if (datastore_validators[i].default_value) {
         char* default_value
-            = nr_alloca(sizeof(datastore_validators[i].default_value));
+            = malloc(sizeof(datastore_validators[i].default_value));
 
-        nr_strcpy(default_value, datastore_validators[i].default_value);
-        nr_php_add_assoc_string(validated_params, key, default_value);
+        if (default_value) {
+            nr_strcpy(default_value, datastore_validators[i].default_value);
+            nr_php_add_assoc_string(validated_params, key, default_value);
+            free(default_value);
+        } else {
+            zend_error(E_WARNING, "Memory allocation failed for default_value");
+            nr_php_zval_free(&validated_params);
+            return NULL;
+        }
       }
     } else {
       zval* copy = nr_php_zval_alloc();


### PR DESCRIPTION
https://github.com/newrelic/newrelic-php-agent/blob/765888d9998b6af7897fd43e03c75acb3f5619b8/agent/php_api_datastore.c#L57-L60

fixed `php_api_datastore` call to alloca in a loop, replace the use of `nr_alloca` with `malloc` to allocate memory on the heap. This ensures that memory is properly freed after each iteration, avoiding stack overflow risks. Specifically:
1. Replace `nr_alloca(sizeof(datastore_validators[i].default_value))` with `malloc(sizeof(datastore_validators[i].default_value))`.
2. Add a call to `free(default_value)` after the memory is used in each iteration to prevent memory leaks.
3. Ensure no other functionality is altered.

### References
- [ALLOCA(3)](http://man7.org/linux/man-pages/man3/alloca.3.html)
- [a62bb80fd79866414412de6145af51bd](https://gist.github.com/odaysec/a62bb80fd79866414412de6145af51bd)
