### PR TITLE
fix redundant null check due to previous dereference

### DIFF
--- a/agent/fw_drupal8.c
+++ b/agent/fw_drupal8.c
@@ -276,41 +276,43 @@ NR_PHP_WRAPPER(nr_drupal8_name_the_wt) {
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_DRUPAL8);
   NR_PHP_WRAPPER_CALL;
 
-  if (retval_ptr && *retval_ptr) {
-    zval* retval = *retval_ptr;
+  if (retval_ptr) {
+    if (*retval_ptr) {
+      zval* retval = *retval_ptr;
 
-    /*
-     * Note that the name returned from nr_php_callable_to_string may be
-     * suboptimal for anonymous functions, closures and generators. It doesn't
-     * appear that Drupal 8 has a way to define any of those as controllers at
-     * present, but should this be added, it may cause MGI. We would likely
-     * want to change from using the generated class name to using a name
-     * synthesised from the definition file and line of the callable.
-     */
-    char* name = nr_php_callable_to_string(retval TSRMLS_CC);
-
-    /*
-     * Drupal 8 has a concept of title callbacks, which are controllers
-     * attached to other controllers that return the page title. We don't want
-     * to consider these for the purposes of transaction naming.
-     */
-    if ((NULL != name)
-        && (0
-            == nr_drupal8_is_function_in_call_stack(
-                "getTitle",
-                "Drupal\\Core\\Controller\\TitleResolver" TSRMLS_CC))) {
       /*
-       * This is marked as OK to overwrite because we generally want the last
-       * controller. Drupal 8 will often start by invoking a very general
-       * controller, such as
-       * Drupal\Core\Controller\HtmlPageController->content, before delegating
-       * control to the real controller.
+       * Note that the name returned from nr_php_callable_to_string may be
+       * suboptimal for anonymous functions, closures and generators. It doesn't
+       * appear that Drupal 8 has a way to define any of those as controllers at
+       * present, but should this be added, it may cause MGI. We would likely
+       * want to change from using the generated class name to using a name
+       * synthesised from the definition file and line of the callable.
        */
-      nr_txn_set_path("Drupal8", NRPRG(txn), name, NR_PATH_TYPE_ACTION,
-                      NR_NOT_OK_TO_OVERWRITE);
-    }
+      char* name = nr_php_callable_to_string(retval TSRMLS_CC);
 
-    nr_free(name);
+      /*
+       * Drupal 8 has a concept of title callbacks, which are controllers
+       * attached to other controllers that return the page title. We don't want
+       * to consider these for the purposes of transaction naming.
+       */
+      if ((NULL != name)
+          && (0
+              == nr_drupal8_is_function_in_call_stack(
+                  "getTitle",
+                  "Drupal\\Core\\Controller\\TitleResolver" TSRMLS_CC))) {
+        /*
+         * This is marked as OK to overwrite because we generally want the last
+         * controller. Drupal 8 will often start by invoking a very general
+         * controller, such as
+         * Drupal\Core\Controller\HtmlPageController->content, before delegating
+         * control to the real controller.
+         */
+        nr_txn_set_path("Drupal8", NRPRG(txn), name, NR_PATH_TYPE_ACTION,
+                        NR_NOT_OK_TO_OVERWRITE);
+      }
+
+      nr_free(name);
+    }
   }
 }
 NR_PHP_WRAPPER_END

--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -1098,12 +1098,13 @@ NR_PHP_WRAPPER(nr_laravel_routes_get_route_for_methods) {
    * route then we don't need to do any extra work.
    */
   route = NR_GET_RETURN_VALUE_PTR;
-  NR_PHP_WRAPPER_CALL;
 
   /* If the method did not return a route, then end gracefully. */
   if (NULL == route || !nr_php_is_zval_valid_object(*route)) {
     goto end;
   }
+
+  NR_PHP_WRAPPER_CALL;
 
   /* Grab the first argument, which should be a request. */
   arg_request = nr_php_arg_get(1, NR_EXECUTE_ORIG_ARGS TSRMLS_CC);

--- a/agent/fw_laravel_queue.c
+++ b/agent/fw_laravel_queue.c
@@ -780,10 +780,14 @@ NR_PHP_WRAPPER(nr_laravel_queue_queue_createpayload) {
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
 
+  if (NULL == retval_ptr) {
+    goto end;
+  }
+
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_LARAVEL);
   NR_PHP_WRAPPER_CALL;
 
-  if ((NULL == retval_ptr) || !nr_php_is_zval_non_empty_string(*retval_ptr)) {
+  if (!nr_php_is_zval_non_empty_string(*retval_ptr)) {
     goto end;
   }
 

--- a/agent/fw_magento2.c
+++ b/agent/fw_magento2.c
@@ -156,9 +156,11 @@ NR_PHP_WRAPPER(nr_magento2_pagecache_kernel_load) {
    * Magento\Framework\App\Response\Http if there is a cache hit and false
    * otherwise.
    */
-  if (response && nr_php_is_zval_valid_object(*response)) {
-    nr_txn_set_path("Magento", NRPRG(txn), name, NR_PATH_TYPE_ACTION,
-                    NR_OK_TO_OVERWRITE);
+  if (response) {
+    if (nr_php_is_zval_valid_object(*response)) {
+      nr_txn_set_path("Magento", NRPRG(txn), name, NR_PATH_TYPE_ACTION,
+                      NR_OK_TO_OVERWRITE);
+    }
   }
 }
 NR_PHP_WRAPPER_END

--- a/agent/fw_mediawiki.c
+++ b/agent/fw_mediawiki.c
@@ -167,11 +167,14 @@ NR_PHP_WRAPPER(nr_mediawiki_getaction) {
   NR_PHP_WRAPPER_REQUIRE_FRAMEWORK(NR_FW_MEDIAWIKI);
 
   return_value = NR_GET_RETURN_VALUE_PTR;
+  if (NULL == return_value) {
+    nrl_verbosedebug(NRL_FRAMEWORK, "%s: return value is null", __func__);
+    goto leave;
+  }
 
   NR_PHP_WRAPPER_CALL;
 
-  if ((NULL == return_value)
-      || (0 == nr_php_is_zval_non_empty_string(*return_value))) {
+  if (0 == nr_php_is_zval_non_empty_string(*return_value)) {
     nrl_verbosedebug(NRL_FRAMEWORK, "%s: return value is invalid", __func__);
     goto leave;
   }

--- a/agent/fw_slim.c
+++ b/agent/fw_slim.c
@@ -71,9 +71,11 @@ NR_PHP_WRAPPER(nr_slim2_route_dispatch) {
    * Route::dispatch returns true if it handled the request; otherwise, false.
    */
 
-  if (txn_name && retval_ptr && nr_php_is_zval_true(*retval_ptr)) {
-    nr_txn_set_path("Slim", NRPRG(txn), txn_name, NR_PATH_TYPE_ACTION,
-                    NR_OK_TO_OVERWRITE);
+  if (txn_name && retval_ptr) {
+    if (nr_php_is_zval_true(*retval_ptr)) {
+      nr_txn_set_path("Slim", NRPRG(txn), txn_name, NR_PATH_TYPE_ACTION,
+                      NR_OK_TO_OVERWRITE);
+    }
   }
 
   nr_free(txn_name);

--- a/agent/lib_aws_sdk_php.c
+++ b/agent/lib_aws_sdk_php.c
@@ -864,9 +864,13 @@ NR_PHP_WRAPPER(nr_create_aws_service_metric) {
   zval** ret_val_ptr = NULL;
   ret_val_ptr = NR_GET_RETURN_VALUE_PTR;
 
+  if (NULL == ret_val_ptr) {
+    return;
+  }
+
   NR_PHP_WRAPPER_CALL;
 
-  if (NULL != ret_val_ptr && nr_php_is_zval_valid_array(*ret_val_ptr)) {
+  if (nr_php_is_zval_valid_array(*ret_val_ptr)) {
     /* obtain ret_val_ptr[0] which contains the service name */
     zval* service_name
         = nr_php_zend_hash_index_find(Z_ARRVAL_P(*ret_val_ptr), 0);

--- a/agent/lib_php_amqplib.c
+++ b/agent/lib_php_amqplib.c
@@ -712,11 +712,12 @@ NR_PHP_WRAPPER(nr_rabbitmq_basic_get) {
    *The retval should be an AMQPMessage. nr_php_is_zval_* ops do NULL checks
    * as well.
    */
-  if (NULL != retval_ptr && nr_php_is_zval_valid_object(*retval_ptr)) {
-    /*
-     *  Get the exchange and routing key from the AMQPMessage
-     */
-    amqp_exchange = nr_php_get_zval_object_property(*retval_ptr, "exchange");
+  if (NULL != retval_ptr) {
+   if (nr_php_is_zval_valid_object(*retval_ptr)) {
+     /*
+      *  Get the exchange and routing key from the AMQPMessage
+      */
+     amqp_exchange = nr_php_get_zval_object_property(*retval_ptr, "exchange");
     if (nr_php_is_zval_non_empty_string(amqp_exchange)) {
       /* Used with consumer only; this is exchange name.  Exchange name is
        * Default in case of empty string. */

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -606,14 +606,17 @@ NR_PHP_WRAPPER_END
 NR_PHP_WRAPPER(nr_predis_aggregateconnection_getConnection) {
   zval** retval_ptr = NR_GET_RETURN_VALUE_PTR;
 
+  if (NULL == retval_ptr) {
+    nrl_verbosedebug(NRL_INSTRUMENT,
+                     "%s: error retrieving return value pointer", __func__);
+    return;
+  }
+
   (void)wraprec;
 
   NR_PHP_WRAPPER_CALL;
 
-  if (NULL == retval_ptr) {
-    nrl_verbosedebug(NRL_INSTRUMENT,
-                     "%s: error retrieving return value pointer", __func__);
-  } else if (!nr_predis_is_node_connection(*retval_ptr TSRMLS_CC)) {
+  if (!nr_predis_is_node_connection(*retval_ptr TSRMLS_CC)) {
     nrl_verbosedebug(NRL_INSTRUMENT,
                      "%s: got an unexpected value that is not a "
                      "NodeConnectionInterface",

--- a/agent/lib_zend_http.c
+++ b/agent/lib_zend_http.c
@@ -399,6 +399,7 @@ NR_PHP_WRAPPER_START(nr_zend_http_client_request) {
     nrl_verbosedebug(NRL_FRAMEWORK,
                      "%s: unable to obtain return value from request",
                      library_name);
+    return;
   }
 
   if (NRPRG(txn) && NRTXN(special_flags.debug_cat)) {


### PR DESCRIPTION
fix the issue null check for `retval_ptr` should be moved before any dereference of `retval_ptr`. Specifically:
1. Move the null check (`if (retval_ptr)`) to precede the dereference of `retval_ptr` in line {tag}.
2. Ensure that the logic inside the null check block remains unchanged.
3. This change will prevent undefined behavior or crashes if `retval_ptr` is null.

This rule finds comparisons of a pointer to null that occur after a reference of that pointer. It's likely either the check is not required and can be removed, or it should be moved to before the dereference so that a null pointer dereference does not occur.

### References
[Null Dereference](https://www.owasp.org/index.php/Null_Dereference)