### PR TITLE
feat(agent): Add sampling control based on upstream sampling decisions

### DIFF
--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -491,6 +491,19 @@ nrinibool_t span_events_enabled; /* newrelic.span_events_enabled */
 nriniuint_t
     span_events_max_samples_stored; /* newrelic.span_events.max_samples_stored
                                      */
+
+nrinistr_t dt_remote_parent_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_sampled */
+nrinistr_t
+    dt_remote_parent_not_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_not_sampled */
+/* decoding of newrelic.distributed_tracing.sampler.remote_parent_sampled and
+ * newrelic.distributed_tracing.sampler.remote_parent_not_sampled.
+ * 0 = "default"
+ * 1 = "always_on"
+ * -1 = "always_off"
+ */
+int dt_sampler_parent_sampled;
+int dt_sampler_parent_not_sampled;
+
 nrinistr_t
     trace_observer_host; /* newrelic.infinite_tracing.trace_observer.host */
 nriniuint_t

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1970,6 +1970,55 @@ static PHP_INI_MH(nr_wordpress_hooks_options_mh) {
   return SUCCESS;
 }
 
+static PHP_INI_MH(nr_dt_sampler_remote_parent_mh) {
+  nrinistr_t* p;
+
+  char* base = (char*)mh_arg2;
+  p = (nrinistr_t*)(base + (size_t)mh_arg1);
+  bool parent_sampled = false;
+
+  (void)mh_arg3;
+  NR_UNUSED_TSRMLS;
+
+  p->where = 0;
+
+  if (0 == nr_strcmp(ZEND_STRING_VALUE(entry->name),
+                     "newrelic.distributed_tracing.sampler.remote_parent_sampled")) {
+    parent_sampled = true;
+  }
+
+  if (0 == nr_strcmp(NEW_VALUE, "default")) {
+    if (parent_sampled) {
+      NRPRG(dt_sampler_parent_sampled) = 0;
+    } else {
+      NRPRG(dt_sampler_parent_not_sampled) = 0;
+    }
+  } else if (0 == nr_strcmp(NEW_VALUE, "always_on")) {
+    if (parent_sampled) {
+      NRPRG(dt_sampler_parent_sampled) = 1;
+    } else {
+      NRPRG(dt_sampler_parent_not_sampled) = 1;
+    }
+  } else if (0 == nr_strcmp(NEW_VALUE, "always_off")) {
+    if (parent_sampled) {
+      NRPRG(dt_sampler_parent_sampled) = -1;
+    } else {
+      NRPRG(dt_sampler_parent_not_sampled) = -1;
+    }
+  } else {
+    nrl_warning(NRL_INIT, "Invalid %s value \"%s\"; using \"%s\" instead.",
+                ZEND_STRING_VALUE(entry->name), NEW_VALUE,
+                DEFAULT_WORDPRESS_HOOKS_OPTIONS);
+    /* This will cause PHP to call the handler again with default value */
+    return FAILURE;
+  }
+
+  p->where = stage;
+  p->value = NEW_VALUE;
+
+  return SUCCESS;
+}
+
 /*
  * Now for the actual INI entry table. Please note there are two types of INI
  * entry specification used.
@@ -2926,6 +2975,24 @@ STD_PHP_INI_ENTRY_EX("newrelic.distributed_tracing_exclude_newrelic_header",
                      NR_PHP_REQUEST,
                      nr_boolean_mh,
                      distributed_tracing_exclude_newrelic_header,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     0)
+
+
+STD_PHP_INI_ENTRY_EX("newrelic.distributed_tracing.sampler.remote_parent_sampled",
+                     "default",
+                     NR_PHP_REQUEST,
+                     nr_dt_sampler_remote_parent_mh,
+                     dt_remote_parent_sampled,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     0)
+STD_PHP_INI_ENTRY_EX("newrelic.distributed_tracing.sampler.remote_parent_not_sampled",
+                     "default",
+                     NR_PHP_REQUEST,
+                     nr_dt_sampler_remote_parent_mh,
+                     dt_remote_parent_not_sampled,
                      zend_newrelic_globals,
                      newrelic_globals,
                      0)

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -942,6 +942,10 @@ nr_status_t nr_php_txn_begin(const char* appnames,
       = is_cli ? NRINI(tt_max_segments_cli) : NRINI(tt_max_segments_web);
   opts.span_queue_batch_size = NRINI(agent_span_queue_size);
   opts.span_queue_batch_timeout = NRINI(agent_span_queue_timeout);
+  opts.dt_sampler_parent_sampled
+      = NRPRG(dt_sampler_parent_sampled);
+  opts.dt_sampler_parent_not_sampled
+      = NRPRG(dt_sampler_parent_not_sampled);
   opts.logging_enabled = NRINI(logging_enabled);
   opts.log_decorating_enabled = NRINI(log_decorating_enabled);
   opts.log_forwarding_enabled = NRINI(log_forwarding_enabled);

--- a/agent/scripts/newrelic.ini.template
+++ b/agent/scripts/newrelic.ini.template
@@ -911,6 +911,36 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;
 ;newrelic.distributed_tracing_exclude_newrelic_header = false
 
+; Setting: newrelic.distributed_tracing.sampler.remote_parent_sampled
+; Type   : string
+; Scope  : per-directory
+; Default: "default"
+; Info   : This option defines how the agent should handle sampling spans when
+;          their parent span from an upstream entity was sampled. For example,
+;          setting remote_parent_sampled: always_on means the agent will sample
+;          anything if the upstream entity sampled the parent.
+;          The possible values are:
+;          - "default": Use New Relic's standard sampling rules.
+;          - "always_on": Always sample spans whose upstream parent was not sampled.
+;          - "always_off": Always skip sampling spans whose upstream parent was not sampled.
+;
+;newrelic.distributed_tracing.sampler.remote_parent_sampled = "default"
+
+; Setting: newrelic.distributed_tracing.sampler.remote_parent_not_sampled
+; Type   : string
+; Scope  : per-directory
+; Default: "default"
+; Info   : This option defines how the agent should handle sampling spans when
+;          their parent span from an upstream entity was not sampled. For example,
+;          setting remote_parent_not_sampled: always_off means the agent will not
+;          try to sample anything if the upstream entity did not sample the parent.
+;          The possible values are:
+;          - "default": Use New Relic's standard sampling rules.
+;          - "always_on": Always sample spans whose upstream parent was not sampled.
+;          - "always_off": Always skip sampling spans whose upstream parent was not sampled.
+;
+;newrelic.distributed_tracing.sampler.remote_parent_sampled = "default"
+
 ; Setting: newrelic.span_events_enabled
 ; Type   : boolean
 ; Scope  : per-directory

--- a/axiom/nr_distributed_trace.h
+++ b/axiom/nr_distributed_trace.h
@@ -409,4 +409,22 @@ bool nr_distributed_trace_accept_inbound_w3c_payload(
     const char* transport_type,
     const char** error);
 
+/*
+ * Purpose : Handle upstream w3c sampled flag according to settings
+ *
+ * Params : 1. The distributed trace object
+ *          2. Setting for if the upstream trace is sampled
+ *          3. Setting for if the upstream trace is not sampled
+ *
+ * Notes : The setting objects should follow this specification:
+ *         1 = always keep
+ *         0 = ignore upstream sampled flag
+ *         -1 = always toss
+ */
+void nr_distributed_trace_handle_inbound_w3c_sampled_flag(
+    nr_distributed_trace_t* dt,
+    const nrobj_t* trace_headers,
+    int remote_parent_sampled,
+    int remote_parent_not_sampled);
+
 #endif /* NR_DISTRIBUTED_TRACE_HDR */

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -2972,6 +2972,14 @@ static bool nr_txn_accept_w3c_trace_context_headers(
   nr_distributed_trace_accept_inbound_w3c_payload(
       txn->distributed_trace, trace_headers, transport_type, &error_metrics);
 
+  /* Depending on the user's INI settings, we may or may not want to
+   * consider the traceparent's sampled field */
+  nr_distributed_trace_handle_inbound_w3c_sampled_flag(
+      txn->distributed_trace,
+      trace_headers,
+      txn->options.dt_sampler_parent_sampled,
+      txn->options.dt_sampler_parent_not_sampled);
+
   if (error_metrics) {
     nr_txn_force_single_count(txn, error_metrics);
   }

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -100,6 +100,18 @@ typedef struct _nrtxnopt_t {
                                                        headers in favor of only
                                                        W3C trace context headers
                                                      */
+  int dt_sampler_parent_sampled; /* how to sample spans when non-
+                                    New Relic upstream did sample.
+                                    1 - always keep
+                                    0 - use default sampling
+                                    -1 - always toss
+                                  */
+  int dt_sampler_parent_not_sampled; /* how to sample spans when non-
+                                        New Relic upstream didn't sample.
+                                        1 - always keep
+                                        0 - use default sampling
+                                        -1 - always toss
+                                      */
   int span_events_enabled; /* Whether span events are enabled */
   size_t
       span_events_max_samples_stored; /* The maximum number of span events per

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -6299,6 +6299,206 @@ static void test_txn_accept_distributed_trace_payload_metrics(void) {
   nrm_table_destroy(&txn.unscoped_metrics);
 }
 
+static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
+  nrtxn_t txn = {0};
+  nr_hashmap_t* headers;
+  bool rv = true;
+  nrtime_t payload_timestamp_ms = 1529445826000;
+  nrtime_t txn_timestamp_us = 15214458260000 * NR_TIME_DIVISOR_MS;
+  nrtime_t delta_timestamp_us = nr_time_duration(
+      (payload_timestamp_ms * NR_TIME_DIVISOR_MS), txn_timestamp_us);
+
+  tlib_fail_if_int64_t_equal("Zero duration", 0, delta_timestamp_us);
+
+  nr_memset(&txn, 0, sizeof(nrtxn_t));
+  txn.app_connect_reply = nro_new_hash();
+  txn.unscoped_metrics = nrm_table_create(0);
+  nro_set_hash_string(txn.app_connect_reply, "trusted_account_key", "123");
+  // default value for padding can be used for this test, because other
+  // test (test_distributed_trace_create_trace_parent_header) already
+  // covers using trace_id of different lengths when w3c header is created.
+  txn.options.distributed_tracing_pad_trace_id = false;
+  txn.options.distributed_tracing_enabled = true;
+
+#define TEST_TXN_ACCEPT_DT_PAYLOAD_RESET    \
+  txn.distributed_trace->inbound.set = 0;   \
+  nrm_table_destroy(&txn.unscoped_metrics); \
+  txn.unscoped_metrics = nrm_table_create(0);
+
+  headers = nr_hashmap_create(NULL);
+
+  /*
+   * Test : DT traceparent sampled flag INI settings
+   */
+  // 1: upstream not sampled, agent discard
+  txn.options.dt_sampler_parent_not_sampled = -1;
+  txn.options.dt_sampler_parent_sampled = 0;
+  nr_distributed_trace_destroy(&txn.distributed_trace);
+  txn.distributed_trace = nr_distributed_trace_create();
+  nr_hashmap_update(headers, NR_PSTR("traceparent"),
+                    "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-00");
+  nr_hashmap_update(headers, NR_PSTR("tracestate"),
+                    "123@nr=0-2-account-app-span-transaction-1-1.1273-"
+                    "1529445826000");
+  rv = nr_txn_accept_distributed_trace_payload(&txn, headers, "HTTP");
+  tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
+                    (int)rv);
+  tlib_pass_if_false("Sampled should be set to false",
+                    txn.distributed_trace->sampled, "sampled flag = %d",
+                    (int)txn.distributed_trace->sampled);
+  tlib_pass_if_true("Priority should not be overwritten",
+                    2.0 != txn.distributed_trace->priority,
+                    "priority is 2.0");
+
+  // 2: upstream not sampled, agent keep
+  TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
+  txn.options.dt_sampler_parent_not_sampled = 1;
+  txn.options.dt_sampler_parent_sampled = 0;
+  nr_distributed_trace_destroy(&txn.distributed_trace);
+  txn.distributed_trace = nr_distributed_trace_create();
+  nr_hashmap_update(headers, NR_PSTR("traceparent"),
+                    "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-00");
+  nr_hashmap_update(headers, NR_PSTR("tracestate"),
+                    "123@nr=0-2-account-app-span-transaction-0-1.1273-"
+                    "1529445826000");
+  rv = nr_txn_accept_distributed_trace_payload(&txn, headers, "HTTP");
+  tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
+                    (int)rv);
+  tlib_pass_if_true("Sampled should be set to true",
+                    txn.distributed_trace->sampled, "sampled flag = %d",
+                    (int)txn.distributed_trace->sampled);
+  tlib_pass_if_double_equal("Priority should be set to max", 2.0,
+                            txn.distributed_trace->priority);
+
+  // 3: upstream not sampled, agent default (keep)
+  TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
+  txn.options.dt_sampler_parent_not_sampled = 0;
+  txn.options.dt_sampler_parent_sampled = 0;
+  nr_distributed_trace_destroy(&txn.distributed_trace);
+  txn.distributed_trace = nr_distributed_trace_create();
+  nr_hashmap_update(headers, NR_PSTR("traceparent"),
+                    "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-00");
+  nr_hashmap_update(headers, NR_PSTR("tracestate"),
+                    "123@nr=0-2-account-app-span-transaction-1-1.1273-"
+                    "1529445826000");
+  rv = nr_txn_accept_distributed_trace_payload(&txn, headers, "HTTP");
+  tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
+                    (int)rv);
+  tlib_pass_if_true("Sampled should be set to true",
+                    txn.distributed_trace->sampled, "sampled flag = %d",
+                    (int)txn.distributed_trace->sampled);
+  tlib_pass_if_true("Priority should not be overwritten",
+                    2.0 != txn.distributed_trace->priority,
+                    "priority is 2.0");
+
+  // 4: upstream not sampled, agent default (toss)
+  TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
+  txn.options.dt_sampler_parent_not_sampled = 0;
+  txn.options.dt_sampler_parent_sampled = 0;
+  nr_distributed_trace_destroy(&txn.distributed_trace);
+  txn.distributed_trace = nr_distributed_trace_create();
+  nr_hashmap_update(headers, NR_PSTR("traceparent"),
+                    "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-00");
+  nr_hashmap_update(headers, NR_PSTR("tracestate"),
+                    "123@nr=0-2-account-app-span-transaction-0-1.1273-"
+                    "1529445826000");
+  rv = nr_txn_accept_distributed_trace_payload(&txn, headers, "HTTP");
+  tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
+                    (int)rv);
+  tlib_pass_if_false("Sampled should be set to false",
+                    txn.distributed_trace->sampled, "sampled flag = %d",
+                    (int)txn.distributed_trace->sampled);
+  tlib_pass_if_true("Priority should not be overwritten",
+                    2.0 != txn.distributed_trace->priority,
+                    "priority is 2.0");
+
+  // 5: upstream sampled, agent discard
+  TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
+  txn.options.dt_sampler_parent_not_sampled = 0;
+  txn.options.dt_sampler_parent_sampled = -1;
+  nr_distributed_trace_destroy(&txn.distributed_trace);
+  txn.distributed_trace = nr_distributed_trace_create();
+  nr_hashmap_update(headers, NR_PSTR("traceparent"),
+                    "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-01");
+  nr_hashmap_update(headers, NR_PSTR("tracestate"),
+                    "123@nr=0-2-account-app-span-transaction-1-1.1273-"
+                    "1529445826000");
+  rv = nr_txn_accept_distributed_trace_payload(&txn, headers, "HTTP");
+  tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
+                    (int)rv);
+  tlib_pass_if_false("Sampled should be set to false",
+                    txn.distributed_trace->sampled, "sampled flag = %d",
+                    (int)txn.distributed_trace->sampled);
+  tlib_pass_if_true("Priority should not be overwritten",
+                    2.0 != txn.distributed_trace->priority,
+                    "priority is 2.0");
+
+  // 6: upstream sampled, agent keep
+  TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
+  txn.options.dt_sampler_parent_not_sampled = 0;
+  txn.options.dt_sampler_parent_sampled = 1;
+  nr_distributed_trace_destroy(&txn.distributed_trace);
+  txn.distributed_trace = nr_distributed_trace_create();
+  nr_hashmap_update(headers, NR_PSTR("traceparent"),
+                    "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-01");
+  nr_hashmap_update(headers, NR_PSTR("tracestate"),
+                    "123@nr=0-2-account-app-span-transaction-0-1.1273-"
+                    "1529445826000");
+  rv = nr_txn_accept_distributed_trace_payload(&txn, headers, "HTTP");
+  tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
+                    (int)rv);
+  tlib_pass_if_true("Sampled should be set to true",
+                    txn.distributed_trace->sampled, "sampled flag = %d",
+                    (int)txn.distributed_trace->sampled);
+  tlib_pass_if_double_equal("Priority should be set to max", 2.0,
+                            txn.distributed_trace->priority);
+
+  // 7: upstream sampled, agent default (keep)
+  TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
+  txn.options.dt_sampler_parent_not_sampled = 0;
+  txn.options.dt_sampler_parent_sampled = 0;
+  nr_distributed_trace_destroy(&txn.distributed_trace);
+  txn.distributed_trace = nr_distributed_trace_create();
+  nr_hashmap_update(headers, NR_PSTR("traceparent"),
+                    "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-01");
+  nr_hashmap_update(headers, NR_PSTR("tracestate"),
+                    "123@nr=0-2-account-app-span-transaction-1-1.1273-"
+                    "1529445826000");
+  rv = nr_txn_accept_distributed_trace_payload(&txn, headers, "HTTP");
+  tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
+                    (int)rv);
+  tlib_pass_if_true("Sampled should be set to true",
+                    txn.distributed_trace->sampled, "sampled flag = %d",
+                    (int)txn.distributed_trace->sampled);
+  tlib_pass_if_true("Priority should not be overwritten",
+                    2.0 != txn.distributed_trace->priority,
+                    "priority is 2.0");
+
+  // 8: upstream sampled, agent default (toss)
+  TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
+  txn.options.dt_sampler_parent_not_sampled = 0;
+  txn.options.dt_sampler_parent_sampled = 0;
+  nr_distributed_trace_destroy(&txn.distributed_trace);
+  txn.distributed_trace = nr_distributed_trace_create();
+  nr_hashmap_update(headers, NR_PSTR("traceparent"),
+                    "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-01");
+  nr_hashmap_update(headers, NR_PSTR("tracestate"),
+                    "123@nr=0-2-account-app-span-transaction-0-1.1273-"
+                    "1529445826000");
+  rv = nr_txn_accept_distributed_trace_payload(&txn, headers, "HTTP");
+  tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
+                    (int)rv);
+  tlib_pass_if_false("Sampled should be set to false",
+                    txn.distributed_trace->sampled, "sampled flag = %d",
+                    (int)txn.distributed_trace->sampled);
+  tlib_pass_if_true("Priority should not be overwritten",
+                    2.0 != txn.distributed_trace->priority,
+                    "priority is 2.0");
+
+  nr_txn_destroy_fields(&txn);
+  nr_hashmap_destroy(&headers);
+}
+
 static void test_txn_accept_distributed_trace_payload_w3c(void) {
   nrtxn_t txn = {0};
   nr_hashmap_t* headers;
@@ -8879,6 +9079,7 @@ void test_main(void* p NRUNUSED) {
   test_create_w3c_traceparent_header();
   test_create_w3c_tracestate_header();
   test_txn_accept_distributed_trace_payload_w3c();
+  test_txn_accept_distributed_trace_payload_w3c_sample_flags();
   test_txn_accept_distributed_trace_payload_w3c_and_nr();
   test_span_queue();
   test_segment_record_error();

--- a/tests/integration/distributed_tracing/w3c/test_force_keep_headers_not_sampled.php
+++ b/tests/integration/distributed_tracing/w3c/test_force_keep_headers_not_sampled.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Tests the Supportability metric "Supportability/DistributedTrace/AcceptPayload/Success"
+when the payload is correct.
+ */
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.cross_application_tracer.enabled = false
+newrelic.distributed_tracing.sampler.remote_parent_not_sampled = 'always_on'
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": 2.00000,
+        "sampled": true,
+        "nr.entryPoint": true,
+        "tracingVendors": "123@nr",
+        "parentId": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "parent.transportType": "Unknown"
+      }
+    ]
+  ]
+
+]
+*/
+
+
+
+
+$payload = array(
+  'traceparent' => "00-74be672b84ddc4e4b28be285632bbc0a-27ddd2d8890283b4-00",
+  'tracestate' => "123@nr=0-0-1349956-41346604-27ddd2d8890283b4-b28be285632bbc0a-0-1.1273-1569367663277"
+);
+
+newrelic_accept_distributed_trace_headers($payload);

--- a/tests/integration/distributed_tracing/w3c/test_force_keep_headers_sampled.php
+++ b/tests/integration/distributed_tracing/w3c/test_force_keep_headers_sampled.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Tests the Supportability metric "Supportability/DistributedTrace/AcceptPayload/Success"
+when the payload is correct.
+ */
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.cross_application_tracer.enabled = false
+newrelic.distributed_tracing.sampler.remote_parent_sampled = 'always_on'
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": 2.00000,
+        "sampled": true,
+        "nr.entryPoint": true,
+        "tracingVendors": "123@nr",
+        "parentId": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {
+        "parent.transportType": "Unknown"
+      }
+    ]
+  ]
+
+]
+*/
+
+
+
+
+$payload = array(
+  'traceparent' => "00-74be672b84ddc4e4b28be285632bbc0a-27ddd2d8890283b4-01",
+  'tracestate' => "123@nr=0-0-1349956-41346604-27ddd2d8890283b4-b28be285632bbc0a-0-1.1273-1569367663277"
+);
+
+newrelic_accept_distributed_trace_headers($payload);

--- a/tests/integration/distributed_tracing/w3c/test_force_toss_headers_not_sampled.php
+++ b/tests/integration/distributed_tracing/w3c/test_force_toss_headers_not_sampled.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Tests the Supportability metric "Supportability/DistributedTrace/AcceptPayload/Success"
+when the payload is correct.
+ */
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.cross_application_tracer.enabled = false
+newrelic.distributed_tracing.sampler.remote_parent_not_sampled = 'always_off'
+*/
+
+/*EXPECT_SPAN_EVENTS
+null
+*/
+
+
+
+
+$payload = array(
+  'traceparent' => "00-74be672b84ddc4e4b28be285632bbc0a-27ddd2d8890283b4-00",
+  'tracestate' => "123@nr=0-0-1349956-41346604-27ddd2d8890283b4-b28be285632bbc0a-1-1.1273-1569367663277"
+);
+
+newrelic_accept_distributed_trace_headers($payload);

--- a/tests/integration/distributed_tracing/w3c/test_force_toss_headers_sampled.php
+++ b/tests/integration/distributed_tracing/w3c/test_force_toss_headers_sampled.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Tests the Supportability metric "Supportability/DistributedTrace/AcceptPayload/Success"
+when the payload is correct.
+ */
+
+/*INI
+newrelic.distributed_tracing_enabled = true
+newrelic.cross_application_tracer.enabled = false
+newrelic.distributed_tracing.sampler.remote_parent_sampled = 'always_off'
+*/
+
+/*EXPECT_SPAN_EVENTS
+null
+*/
+
+
+
+
+$payload = array(
+  'traceparent' => "00-74be672b84ddc4e4b28be285632bbc0a-27ddd2d8890283b4-01",
+  'tracestate' => "123@nr=0-0-1349956-41346604-27ddd2d8890283b4-b28be285632bbc0a-1-1.1273-1569367663277"
+);
+
+newrelic_accept_distributed_trace_headers($payload);


### PR DESCRIPTION
This implements the sampling spec to allow control over the agent sampling decisions based on the value in the sampled flag of an inbound traceparent header.