### PR TITLE
fix(agent): fix legacy package detection issues

### DIFF
--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -69,23 +69,26 @@ static int nr_execute_handle_autoload_composer_init(const char* vendor_path) {
   return NR_SUCCESS;
 }
 
-static bool nr_execute_handle_autoload_composer_get_packages_information(
+static nr_composer_api_call_result_t
+nr_execute_handle_autoload_composer_get_packages_information(
     const char* vendor_path) {
   zval retval;  // This is used as a return value for zend_eval_string.
                 // It will only be set if the result of the eval is SUCCESS.
   int result = FAILURE;
+  nr_composer_api_call_result_t api_call_result
+      = NR_COMPOSER_API_CALL_RESULT_UNSET;
 
   // nrunlikely because this should alredy be ensured by the caller
   if (nrunlikely(!NRINI(vulnerability_management_package_detection_enabled))) {
     // do nothing when collecting package information for vulnerability
     // management is disabled
-    return false;
+    return NR_COMPOSER_API_CALL_RESULT_INVALID_USE;
   }
 
   // nrunlikely because this should alredy be ensured by the caller
   if (nrunlikely(!NRINI(vulnerability_management_composer_api_enabled))) {
     // do nothing when use of composer to collect package info is disabled
-    return false;
+    return NR_COMPOSER_API_CALL_RESULT_INVALID_USE;
   }
 
   // clang-format off
@@ -124,7 +127,7 @@ static bool nr_execute_handle_autoload_composer_get_packages_information(
               "%s - unable to initialize Composer runtime API - package info "
               "unavailable",
               __func__);
-    return false;
+    return NR_COMPOSER_API_CALL_RESULT_INIT_FAILURE;
   }
 
   nrl_verbosedebug(NRL_INSTRUMENT, "%s - Composer runtime API available",
@@ -135,7 +138,7 @@ static bool nr_execute_handle_autoload_composer_get_packages_information(
   if (SUCCESS != result) {
     nrl_verbosedebug(NRL_INSTRUMENT, "%s - composer_getallrawdata.php failed",
                      __func__);
-    return false;
+    return NR_COMPOSER_API_CALL_RESULT_CALL_FAILURE;
   }
 
   if (IS_ARRAY == Z_TYPE(retval)) {
@@ -156,15 +159,17 @@ static bool nr_execute_handle_autoload_composer_get_packages_information(
       }
     }
     ZEND_HASH_FOREACH_END();
+    api_call_result = NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED;
   } else {
     char strbuf[80];
     nr_format_zval_for_debug(&retval, strbuf, 0, sizeof(strbuf) - 1, 0);
     nrl_verbosedebug(NRL_INSTRUMENT,
                      "%s - installed packages is: " NRP_FMT ", not an array",
                      __func__, NRP_ARGSTR(strbuf));
+    api_call_result = NR_COMPOSER_API_CALL_RESULT_INVALID_RESULT;
   }
   zval_dtor(&retval);
-  return true;
+  return api_call_result;
 }
 
 static char* nr_execute_handle_autoload_composer_get_vendor_path(
@@ -269,7 +274,7 @@ void nr_composer_handle_autoload(const char* filename) {
   NRPRG(txn)->composer_info.composer_detected = true;
   nr_fw_support_add_library_supportability_metric(NRPRG(txn), "Composer");
 
-  NRTXN(composer_info.packages_detected)
+  NRTXN(composer_info.api_call_result)
       = nr_execute_handle_autoload_composer_get_packages_information(
           vendor_path);
 leave:

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -875,12 +875,13 @@ static void nr_execute_handle_autoload(const char* filename,
     return;
   }
 
-  if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)
-      && NR_COMPOSER_API_CALL_RESULT_UNSET
-             != NR_PHP_PROCESS_GLOBALS(composer_api_call_result)) {
-    // do nothing if per-process detection is enabled and api was already called
+  // clang-format off
+  if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection) &&
+      NR_COMPOSER_API_STATUS_UNSET != NR_PHP_PROCESS_GLOBALS(composer_api_status)) {
+    // do nothing if per-process detection is enabled and composer api status is set
     return;
   }
+  // clang-format on
 
   if (!nr_striendswith(STR_AND_LEN(filename), AUTOLOAD_MAGIC_FILE,
                        AUTOLOAD_MAGIC_FILE_LEN)) {

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -876,7 +876,7 @@ static void nr_execute_handle_autoload(const char* filename,
   }
 
   if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)
-      && NR_PHP_PROCESS_GLOBALS(composer_api_per_process_called)) {
+      && NR_PHP_PROCESS_GLOBALS(composer_packages_detected)) {
     // do nothing if per-process detection is enabled and the flag to track
     // detection is true
     return;

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -876,9 +876,9 @@ static void nr_execute_handle_autoload(const char* filename,
   }
 
   if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)
-      && NR_PHP_PROCESS_GLOBALS(composer_packages_detected)) {
-    // do nothing if per-process detection is enabled and the flag to track
-    // detection is true
+      && NR_COMPOSER_API_CALL_RESULT_UNSET
+             != NR_PHP_PROCESS_GLOBALS(composer_api_call_result)) {
+    // do nothing if per-process detection is enabled and api was already called
     return;
   }
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -876,7 +876,7 @@ static void nr_execute_handle_autoload(const char* filename,
   }
 
   if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)
-      && NR_PHP_PROCESS_GLOBALS(composer_packages_detected)) {
+      && NR_PHP_PROCESS_GLOBALS(composer_api_per_process_called)) {
     // do nothing if per-process detection is enabled and the flag to track
     // detection is true
     return;

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -78,10 +78,6 @@ typedef struct _nrphpglobals_t {
   int composer_api_per_process_detection;  /* Enables per-process VM package
                                               detection when Composer API is also
                                               enabled */
-  int composer_api_per_process_called; /* Flag to indicate that Composer API was
-                                    called by current process to detect packages
-                                    and succeeded. Used in conjunction with
-                                    composer_api_per_process_detection. */
   int composer_packages_detected;      /* Flag to indicate that Composer API was
                                          called to detect packages and succeeded. */
   char* docker_id; /* 64 byte hex docker ID parsed from /proc/self/mountinfo */

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -78,9 +78,12 @@ typedef struct _nrphpglobals_t {
   int composer_api_per_process_detection;  /* Enables per-process VM package
                                               detection when Composer API is also
                                               enabled */
-  int composer_packages_detected; /* Flag to indicate that Composer package
-                                    detection has run. Used in conjunction with
+  int composer_api_per_process_called; /* Flag to indicate that Composer API was
+                                    called by current process to detect packages
+                                    and succeeded. Used in conjunction with
                                     composer_api_per_process_detection. */
+  int composer_packages_detected;      /* Flag to indicate that Composer API was
+                                         called to detect packages and succeeded. */
   char* docker_id; /* 64 byte hex docker ID parsed from /proc/self/mountinfo */
 
   /* Original PHP callback pointer contents */

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -78,8 +78,7 @@ typedef struct _nrphpglobals_t {
   int composer_api_per_process_detection;  /* Enables per-process VM package
                                               detection when Composer API is also
                                               enabled */
-  nr_composer_api_call_result_t
-      composer_api_call_result; /* Composer API's call result */
+  nr_composer_api_status_t composer_api_status; /* Composer API's status */
   char* docker_id; /* 64 byte hex docker ID parsed from /proc/self/mountinfo */
 
   /* Original PHP callback pointer contents */

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -78,8 +78,8 @@ typedef struct _nrphpglobals_t {
   int composer_api_per_process_detection;  /* Enables per-process VM package
                                               detection when Composer API is also
                                               enabled */
-  int composer_packages_detected;      /* Flag to indicate that Composer API was
-                                         called to detect packages and succeeded. */
+  nr_composer_api_call_result_t
+      composer_api_call_result; /* Composer API's call result */
   char* docker_id; /* 64 byte hex docker ID parsed from /proc/self/mountinfo */
 
   /* Original PHP callback pointer contents */

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -456,8 +456,7 @@ PHP_MINIT_FUNCTION(newrelic) {
       = nr_php_check_for_upgrade_license_key();
   NR_PHP_PROCESS_GLOBALS(high_security) = 0;
   NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection) = 1;
-  NR_PHP_PROCESS_GLOBALS(composer_api_call_result)
-      = NR_COMPOSER_API_CALL_RESULT_UNSET;
+  NR_PHP_PROCESS_GLOBALS(composer_api_status) = NR_COMPOSER_API_STATUS_UNSET;
   nr_php_populate_apache_process_globals();
   nr_php_api_distributed_trace_register_userland_class(TSRMLS_C);
   /*

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -456,7 +456,8 @@ PHP_MINIT_FUNCTION(newrelic) {
       = nr_php_check_for_upgrade_license_key();
   NR_PHP_PROCESS_GLOBALS(high_security) = 0;
   NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection) = 1;
-  NR_PHP_PROCESS_GLOBALS(composer_packages_detected) = 0;
+  NR_PHP_PROCESS_GLOBALS(composer_api_call_result)
+      = NR_COMPOSER_API_CALL_RESULT_UNSET;
   nr_php_populate_apache_process_globals();
   nr_php_api_distributed_trace_register_userland_class(TSRMLS_C);
   /*

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1151,8 +1151,8 @@ nr_status_t nr_php_txn_begin(const char* appnames,
     }
   }
 
-  NRTXN(composer_info.packages_detected)
-      = NR_PHP_PROCESS_GLOBALS(composer_packages_detected);
+  NRTXN(composer_info.api_call_result)
+      = NR_PHP_PROCESS_GLOBALS(composer_api_call_result);
 
   return NR_SUCCESS;
 }
@@ -1343,8 +1343,8 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
       if (NR_FAILURE == ret) {
         nrl_debug(NRL_TXN, "failed to send txn");
       }
-      NR_PHP_PROCESS_GLOBALS(composer_packages_detected)
-          = NRTXN(composer_info.packages_detected);
+      NR_PHP_PROCESS_GLOBALS(composer_api_call_result)
+          = NRTXN(composer_info.api_call_result);
     }
   }
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1343,12 +1343,6 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
       if (NR_FAILURE == ret) {
         nrl_debug(NRL_TXN, "failed to send txn");
       }
-      if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)) {
-        // set the per-process flag to true to avoid re-running composer api
-        // detection when the per-process detection is enabled.
-        NR_PHP_PROCESS_GLOBALS(composer_api_per_process_called)
-            = NRTXN(composer_info.packages_detected);
-      }
       NR_PHP_PROCESS_GLOBALS(composer_packages_detected)
           = NRTXN(composer_info.packages_detected);
     }

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1151,8 +1151,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
     }
   }
 
-  NRTXN(composer_info.api_call_result)
-      = NR_PHP_PROCESS_GLOBALS(composer_api_call_result);
+  NRTXN(composer_info.api_status) = NR_PHP_PROCESS_GLOBALS(composer_api_status);
 
   return NR_SUCCESS;
 }
@@ -1343,8 +1342,8 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
       if (NR_FAILURE == ret) {
         nrl_debug(NRL_TXN, "failed to send txn");
       }
-      NR_PHP_PROCESS_GLOBALS(composer_api_call_result)
-          = NRTXN(composer_info.api_call_result);
+      NR_PHP_PROCESS_GLOBALS(composer_api_status)
+          = NRTXN(composer_info.api_status);
     }
   }
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1346,9 +1346,11 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
       if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)) {
         // set the per-process flag to true to avoid re-running composer api
         // detection when the per-process detection is enabled.
-        NR_PHP_PROCESS_GLOBALS(composer_packages_detected)
+        NR_PHP_PROCESS_GLOBALS(composer_api_per_process_called)
             = NRTXN(composer_info.packages_detected);
       }
+      NR_PHP_PROCESS_GLOBALS(composer_packages_detected)
+          = NRTXN(composer_info.packages_detected);
     }
   }
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1151,6 +1151,9 @@ nr_status_t nr_php_txn_begin(const char* appnames,
     }
   }
 
+  NRTXN(composer_info.packages_detected)
+      = NR_PHP_PROCESS_GLOBALS(composer_packages_detected);
+
   return NR_SUCCESS;
 }
 
@@ -1339,6 +1342,12 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
       ret = nr_cmd_txndata_tx(nr_get_daemon_fd(), txn);
       if (NR_FAILURE == ret) {
         nrl_debug(NRL_TXN, "failed to send txn");
+      }
+      if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)) {
+        // set the per-process flag to true to avoid re-running composer api
+        // detection when the per-process detection is enabled.
+        NR_PHP_PROCESS_GLOBALS(composer_packages_detected)
+            = NRTXN(composer_info.packages_detected);
       }
     }
   }

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3540,8 +3540,8 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
   }
 
   if (NR_PHP_PACKAGE_SOURCE_LEGACY == source
-      && NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED
-             == txn->composer_info.api_call_result) {
+      && NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED
+             == txn->composer_info.api_status) {
     // don't add packages from legacy source if packages have been detected
     // using composer runtime api
     return NULL;

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3546,6 +3546,14 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
 nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
                                          char* package_name,
                                          char* package_version) {
+  if (nrunlikely(NULL == txn)) {
+    return NULL;
+  }
+  if (txn->composer_info.packages_detected) {
+    // don't add packages from legacy source if packages have been detected
+    // using composer runtime api
+    return NULL;
+  }
   return nr_txn_add_php_package_from_source(txn, package_name, package_version,
                                             NR_PHP_PACKAGE_SOURCE_LEGACY);
 }

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3540,7 +3540,8 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
   }
 
   if (NR_PHP_PACKAGE_SOURCE_LEGACY == source
-      && txn->composer_info.packages_detected) {
+      && NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED
+             == txn->composer_info.api_call_result) {
     // don't add packages from legacy source if packages have been detected
     // using composer runtime api
     return NULL;

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3539,6 +3539,13 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
     return NULL;
   }
 
+  if (NR_PHP_PACKAGE_SOURCE_LEGACY == source
+      && txn->composer_info.packages_detected) {
+    // don't add packages from legacy source if packages have been detected
+    // using composer runtime api
+    return NULL;
+  }
+
   p = nr_php_package_create_with_source(package_name, package_version, source);
   return nr_php_packages_add_package(txn->php_packages, p);
 }
@@ -3546,14 +3553,6 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
 nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
                                          char* package_name,
                                          char* package_version) {
-  if (nrunlikely(NULL == txn)) {
-    return NULL;
-  }
-  if (txn->composer_info.packages_detected) {
-    // don't add packages from legacy source if packages have been detected
-    // using composer runtime api
-    return NULL;
-  }
   return nr_txn_add_php_package_from_source(txn, package_name, package_version,
                                             NR_PHP_PACKAGE_SOURCE_LEGACY);
 }

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -210,6 +210,7 @@ typedef enum _nr_cpu_usage_t {
 typedef struct _nr_composer_info_t {
   bool autoload_detected;
   bool composer_detected;
+  bool packages_detected;
 } nr_composer_info_t;
 
 /*

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -208,18 +208,18 @@ typedef enum _nr_cpu_usage_t {
 } nr_cpu_usage_t;
 
 typedef enum {
-  NR_COMPOSER_API_CALL_RESULT_UNSET = 0,
-  NR_COMPOSER_API_CALL_RESULT_INVALID_USE = 1,
-  NR_COMPOSER_API_CALL_RESULT_INIT_FAILURE = 2,
-  NR_COMPOSER_API_CALL_RESULT_CALL_FAILURE = 3,
-  NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED = 4,
-  NR_COMPOSER_API_CALL_RESULT_INVALID_RESULT = 5,
-} nr_composer_api_call_result_t;
+  NR_COMPOSER_API_STATUS_UNSET = 0,
+  NR_COMPOSER_API_STATUS_INVALID_USE = 1,
+  NR_COMPOSER_API_STATUS_INIT_FAILURE = 2,
+  NR_COMPOSER_API_STATUS_CALL_FAILURE = 3,
+  NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED = 4,
+  NR_COMPOSER_API_STATUS_INVALID_RESULT = 5,
+} nr_composer_api_status_t;
 
 typedef struct _nr_composer_info_t {
   bool autoload_detected;
   bool composer_detected;
-  nr_composer_api_call_result_t api_call_result;
+  nr_composer_api_status_t api_status;
 } nr_composer_info_t;
 
 /*

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -207,10 +207,19 @@ typedef enum _nr_cpu_usage_t {
   NR_CPU_USAGE_COUNT = 2
 } nr_cpu_usage_t;
 
+typedef enum {
+  NR_COMPOSER_API_CALL_RESULT_UNSET = 0,
+  NR_COMPOSER_API_CALL_RESULT_INVALID_USE = 1,
+  NR_COMPOSER_API_CALL_RESULT_INIT_FAILURE = 2,
+  NR_COMPOSER_API_CALL_RESULT_CALL_FAILURE = 3,
+  NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED = 4,
+  NR_COMPOSER_API_CALL_RESULT_INVALID_RESULT = 5,
+} nr_composer_api_call_result_t;
+
 typedef struct _nr_composer_info_t {
   bool autoload_detected;
   bool composer_detected;
-  bool packages_detected;
+  nr_composer_api_call_result_t api_call_result;
 } nr_composer_info_t;
 
 /*

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8668,8 +8668,7 @@ static void test_nr_txn_add_php_package(void) {
 
   txn = new_txn(0);
   // simulate composer api was successfully used
-  txn->composer_info.api_call_result
-      = NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED;
+  txn->composer_info.api_status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
   p1 = nr_txn_add_php_package(txn, package_name1, package_version1);
   tlib_pass_if_null(
       "legacy package information not added to transaction after composer api "
@@ -8744,8 +8743,7 @@ static void test_nr_txn_add_php_package_from_source(void) {
 
   txn = new_txn(0);
   // simulate composer api was successfully used
-  txn->composer_info.api_call_result
-      = NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED;
+  txn->composer_info.api_status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
   p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
                                           NR_PHP_PACKAGE_SOURCE_LEGACY);
   tlib_pass_if_null(

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8668,7 +8668,8 @@ static void test_nr_txn_add_php_package(void) {
 
   txn = new_txn(0);
   // simulate composer api was successfully used
-  txn->composer_info.packages_detected = true;
+  txn->composer_info.api_call_result
+      = NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED;
   p1 = nr_txn_add_php_package(txn, package_name1, package_version1);
   tlib_pass_if_null(
       "legacy package information not added to transaction after composer api "
@@ -8743,7 +8744,8 @@ static void test_nr_txn_add_php_package_from_source(void) {
 
   txn = new_txn(0);
   // simulate composer api was successfully used
-  txn->composer_info.packages_detected = true;
+  txn->composer_info.api_call_result
+      = NR_COMPOSER_API_CALL_RESULT_PACKAGES_COLLECTED;
   p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
                                           NR_PHP_PACKAGE_SOURCE_LEGACY);
   tlib_pass_if_null(

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8665,6 +8665,16 @@ static void test_nr_txn_add_php_package(void) {
   tlib_pass_if_ptr_equal(
       "same package name, different version, add returns same pointer", p1, p2);
   nr_txn_destroy(&txn);
+
+  txn = new_txn(0);
+  // simulate composer api was successfully used
+  txn->composer_info.packages_detected = true;
+  p1 = nr_txn_add_php_package(txn, package_name1, package_version1);
+  tlib_pass_if_null(
+      "legacy package information not added to transaction after composer api "
+      "was called successfully",
+      p1);
+  nr_txn_destroy(&txn);
 }
 
 static void test_nr_txn_add_php_package_from_source(void) {
@@ -8729,6 +8739,29 @@ static void test_nr_txn_add_php_package_from_source(void) {
   tlib_pass_if_str_equal("composer version used", package_version2,
                          p2->package_version);
 
+  nr_txn_destroy(&txn);
+
+  txn = new_txn(0);
+  // simulate composer api was successfully used
+  txn->composer_info.packages_detected = true;
+  p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                          NR_PHP_PACKAGE_SOURCE_LEGACY);
+  tlib_pass_if_null(
+      "legacy package information not added to transaction after composer api "
+      "was called successfully",
+      p1);
+  p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                          NR_PHP_PACKAGE_SOURCE_SUGGESTION);
+  tlib_pass_if_not_null(
+      "suggestion package information added to transaction even after composer "
+      "api was called successfully",
+      p1);
+  p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                          NR_PHP_PACKAGE_SOURCE_COMPOSER);
+  tlib_pass_if_not_null(
+      "composer package information added to transaction even after composer "
+      "api was called successfully",
+      p1);
   nr_txn_destroy(&txn);
 }
 


### PR DESCRIPTION
When Composer runtime API is used to get packages information, the
agent should not generate packages information using legacy methods.
This solves the problem of package data detected with the help of
Composer's runtime API not to be sent to the backend in environments
using “once-per-process” setting. The reason for is that the first 
request generates package information using Composer's runtime API
but every next request only generates package information using legacy
method. This in conjunction with the fact that daemon is only sending
the last package information received from the daemon leads to a
situation that package information returned by Composer runtime API
is lost and never makes it to the backend.