### PR TITLE
fix(agent): don't try to instrument anything when not recording

### DIFF
--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -84,6 +84,10 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
     return handlers;
   }
 
+  if (0 == nr_php_recording()) {
+    return handlers;
+  }
+
   if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_executes)) {
     nr_php_show_exec("observe", execute_data, NULL);
   }


### PR DESCRIPTION
When agent is not recording, Observer API fcall_init callback shouldn't do anything, including framework detection. This is how the agent operated before it used Observer API to hook into Zend Engine.