### PR TITLE
chore(build): force golang toolchain from daemon/go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ GCOV  ?= gcov
 SHELL = /bin/bash
 GCOVR ?= gcovr
 GIT   ?= git
+GOTOOLCHAIN=auto # make sure go toolchain defined in daemon/go.mod is always used
 
 include make/config.mk
 include make/vendor.mk

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ GCOV  ?= gcov
 SHELL = /bin/bash
 GCOVR ?= gcovr
 GIT   ?= git
-GOTOOLCHAIN=auto # make sure go toolchain defined in daemon/go.mod is always used
+# make sure go toolchain defined in daemon/go.mod is always used
+GOTOOLCHAIN=auto
 
 include make/config.mk
 include make/vendor.mk


### PR DESCRIPTION
Set `GOTOOLCHAIN` to `auto` to ensure go toolchain from `daemon/go.mod` will always be used.