### PR TITLE
feat(agent): end transaction for laravel horizon

### DIFF
--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -1204,7 +1204,7 @@ NR_PHP_WRAPPER(nr_laravel_horizon_end_txn) {
 
   nr_php_txn_end(1, 0 TSRMLS_CC);
 
-  nrl_verbosedebug(NRL_TXN, "Ending Laravel Horizon Transaction");
+  nrl_verbosedebug(NRL_FRAMEWORK, "Ending Laravel Horizon Transaction");
 }
 NR_PHP_WRAPPER_END
 

--- a/agent/fw_laravel_queue.c
+++ b/agent/fw_laravel_queue.c
@@ -873,6 +873,14 @@ end:
 }
 NR_PHP_WRAPPER_END
 
+NR_PHP_WRAPPER(nr_laravel_horizon_end) {
+  NR_UNUSED_SPECIALFN;
+  (void)wraprec;
+
+  nr_php_txn_end(1, 0 TSRMLS_CC);
+}
+NR_PHP_WRAPPER_END
+
 void nr_laravel_queue_enable(TSRMLS_D) {
   /*
    * Hook the command class that implements Laravel's queue:work command so
@@ -975,6 +983,13 @@ void nr_laravel_queue_enable(TSRMLS_D) {
       nr_laravel_queue_workcommand_handle TSRMLS_CC);
 #endif
 
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("Laravel\\Horizon\\Console\\HorizonCommand::handle"),
+      nr_laravel_horizon_end, NULL, NULL);
+
+  nr_php_wrap_user_function_before_after_clean(
+      NR_PSTR("Laravel\\Horizon\\Console\\SupervisorCommand::handle"),
+      nr_laravel_horizon_end, NULL, NULL);
   /*
    * Hook the method that creates the JSON payloads for queued jobs so that we
    * can add our metadata for CATMQ.

--- a/agent/fw_laravel_queue.c
+++ b/agent/fw_laravel_queue.c
@@ -873,14 +873,6 @@ end:
 }
 NR_PHP_WRAPPER_END
 
-NR_PHP_WRAPPER(nr_laravel_horizon_end) {
-  NR_UNUSED_SPECIALFN;
-  (void)wraprec;
-
-  nr_php_txn_end(1, 0 TSRMLS_CC);
-}
-NR_PHP_WRAPPER_END
-
 void nr_laravel_queue_enable(TSRMLS_D) {
   /*
    * Hook the command class that implements Laravel's queue:work command so
@@ -983,13 +975,6 @@ void nr_laravel_queue_enable(TSRMLS_D) {
       nr_laravel_queue_workcommand_handle TSRMLS_CC);
 #endif
 
-  nr_php_wrap_user_function_before_after_clean(
-      NR_PSTR("Laravel\\Horizon\\Console\\HorizonCommand::handle"),
-      nr_laravel_horizon_end, NULL, NULL);
-
-  nr_php_wrap_user_function_before_after_clean(
-      NR_PSTR("Laravel\\Horizon\\Console\\SupervisorCommand::handle"),
-      nr_laravel_horizon_end, NULL, NULL);
   /*
    * Hook the method that creates the JSON payloads for queued jobs so that we
    * can add our metadata for CATMQ.

--- a/tests/integration/frameworks/laravel/mock_horizon_error_path.php
+++ b/tests/integration/frameworks/laravel/mock_horizon_error_path.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Mock enough bits of Laravel framework to test the HorizonCommand */
+
+namespace Laravel\Horizon\Console {
+    class HorizonCommand {
+        public function handle() {
+            echo "handle function\n";
+            throw new \Error("Error occurred");
+        }
+    }
+}

--- a/tests/integration/frameworks/laravel/mock_horizon_error_path.php
+++ b/tests/integration/frameworks/laravel/mock_horizon_error_path.php
@@ -10,7 +10,7 @@
 namespace Laravel\Horizon\Console {
     class HorizonCommand {
         public function handle() {
-            echo "handle function\n";
+            echo "Error handle function\n";
             throw new \Error("Error occurred");
         }
     }

--- a/tests/integration/frameworks/laravel/mock_horizon_exception_path.php
+++ b/tests/integration/frameworks/laravel/mock_horizon_exception_path.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Mock enough bits of Laravel framework to test the HorizonCommand */
+
+namespace Laravel\Horizon\Console {
+    class HorizonCommand {
+        public function handle() {
+            echo "handle function\n";
+            throw new \Exception("Error occurred");
+        }
+    }
+}

--- a/tests/integration/frameworks/laravel/mock_horizon_exception_path.php
+++ b/tests/integration/frameworks/laravel/mock_horizon_exception_path.php
@@ -11,7 +11,7 @@ namespace Laravel\Horizon\Console {
     class HorizonCommand {
         public function handle() {
             echo "handle function\n";
-            throw new \Exception("Error occurred");
+            throw new \Exception("Exception occurred");
         }
     }
 }

--- a/tests/integration/frameworks/laravel/mock_horizon_exception_path.php
+++ b/tests/integration/frameworks/laravel/mock_horizon_exception_path.php
@@ -10,7 +10,7 @@
 namespace Laravel\Horizon\Console {
     class HorizonCommand {
         public function handle() {
-            echo "handle function\n";
+            echo "Exception handle function\n";
             throw new \Exception("Exception occurred");
         }
     }

--- a/tests/integration/frameworks/laravel/mock_horizon_happy_path.php
+++ b/tests/integration/frameworks/laravel/mock_horizon_happy_path.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Mock enough bits of Laravel framework to test the HorizonCommand */
+
+namespace Laravel\Horizon\Console {
+    class HorizonCommand {
+        public function handle() {
+            echo "handle function\n";
+        }
+    }
+}

--- a/tests/integration/frameworks/laravel/mock_supervisor_error_path.php
+++ b/tests/integration/frameworks/laravel/mock_supervisor_error_path.php
@@ -10,7 +10,7 @@
 namespace Laravel\Horizon\Console {
     class SupervisorCommand {
         public function handle() {
-            echo "handle function\n";
+            echo "Error handle function\n";
             throw new \Error("Error occurred");
         }
     }

--- a/tests/integration/frameworks/laravel/mock_supervisor_error_path.php
+++ b/tests/integration/frameworks/laravel/mock_supervisor_error_path.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Mock enough bits of Laravel framework to test the SupervisorCommand */
+
+namespace Laravel\Horizon\Console {
+    class SupervisorCommand {
+        public function handle() {
+            echo "handle function\n";
+            throw new \Error("Error occurred");
+        }
+    }
+}

--- a/tests/integration/frameworks/laravel/mock_supervisor_exception_path.php
+++ b/tests/integration/frameworks/laravel/mock_supervisor_exception_path.php
@@ -10,7 +10,7 @@
 namespace Laravel\Horizon\Console {
     class SupervisorCommand {
         public function handle() {
-            echo "handle function\n";
+            echo "Exception handle function\n";
             throw new \Exception("Exception occurred");
         }
     }

--- a/tests/integration/frameworks/laravel/mock_supervisor_exception_path.php
+++ b/tests/integration/frameworks/laravel/mock_supervisor_exception_path.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Mock enough bits of Laravel framework to test the SupervisorCommand */
+
+namespace Laravel\Horizon\Console {
+    class SupervisorCommand {
+        public function handle() {
+            echo "handle function\n";
+            throw new \Exception("Error occurred");
+        }
+    }
+}

--- a/tests/integration/frameworks/laravel/mock_supervisor_exception_path.php
+++ b/tests/integration/frameworks/laravel/mock_supervisor_exception_path.php
@@ -11,7 +11,7 @@ namespace Laravel\Horizon\Console {
     class SupervisorCommand {
         public function handle() {
             echo "handle function\n";
-            throw new \Exception("Error occurred");
+            throw new \Exception("Exception occurred");
         }
     }
 }

--- a/tests/integration/frameworks/laravel/mock_supervisor_happy_path.php
+++ b/tests/integration/frameworks/laravel/mock_supervisor_happy_path.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Mock enough bits of Laravel framework to test the SupervisorCommand */
+
+namespace Laravel\Horizon\Console {
+    class SupervisorCommand {
+        public function handle() {
+            echo "handle function\n";
+        }
+    }
+}

--- a/tests/integration/frameworks/laravel/test_horizon_disable_laravel_queue.php
+++ b/tests/integration/frameworks/laravel/test_horizon_disable_laravel_queue.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+This test ensures that when the newrelic.special = disable_laravel_queue INI setting
+is set, the transaction is still properly stopped when HorizonCommand::handle is executed.
+This test verifies this behavior by first making sure the transaction exists and the
+transaction trace is not empty. Then it calls the HorizonCommand::handle method and
+verifies that the transaction has been stopped by checking that there was no harvest received.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
+/*INI
+newrelic.framework = laravel
+newrelic.special = disable_laravel_queue
+*/
+
+/*EXPECT_HARVEST
+no
+*/
+
+/*EXPECT
+foobar
+Custom/foobar
+handle function
+foobar
+*/
+
+require_once(__DIR__ . '/mock_horizon_happy_path.php');
+require_once(__DIR__.'/../../../include/integration.php');
+
+use Laravel\Horizon\Console\HorizonCommand;
+use NewRelic\Integration\Transaction;
+
+function foobar() {
+    echo "foobar\n";
+}
+function get_txn() {
+    return new Transaction;
+}
+
+newrelic_add_custom_tracer('foobar');
+foobar();
+
+$txn = get_txn();
+foreach ($txn->getTrace()->findSegmentsByName('Custom/foobar') as $segment) {
+    echo $segment->name;
+    echo "\n";
+}
+
+$horizon = new HorizonCommand();
+$horizon->handle();
+foobar();

--- a/tests/integration/frameworks/laravel/test_horizon_error_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_error_path.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Ensure that when HorizonCommand::handle is executed, the transaction is properly stopped.
+*/
+
+/*INI
+newrelic.framework = laravel
+*/
+
+/*EXPECT_HARVEST
+no
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+require_once(__DIR__ . '/mock_horizon_error_path.php');
+require_once(__DIR__.'/../../../include/integration.php');
+
+use Laravel\Horizon\Console\HorizonCommand;
+use NewRelic\Integration\Transaction;
+
+function foobar() {
+    echo "foobar\n";
+}
+function get_txn() {
+    return new Transaction;
+}
+
+newrelic_add_custom_tracer('foobar');
+foobar();
+
+$txn = get_txn();
+foreach ($txn->getTrace()->findSegmentsByName('Custom/foobar') as $segment) {
+    echo $segment->name;
+    echo "\n";
+}
+
+$horizon = new HorizonCommand();
+$horizon->handle();
+foobar();

--- a/tests/integration/frameworks/laravel/test_horizon_error_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_error_path.php
@@ -12,6 +12,13 @@ verifies that the transaction has been stopped by checking that there was no har
 It also verifies that no traced errors and no error events were recorded.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
 /*INI
 newrelic.framework = laravel
 */

--- a/tests/integration/frameworks/laravel/test_horizon_error_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_error_path.php
@@ -6,6 +6,10 @@
 
 /*DESCRIPTION
 Ensure that when HorizonCommand::handle is executed, the transaction is properly stopped.
+This test verifies this behavior by first making sure the transaction exists and the
+transaction trace is not empty. Then it calls the HorizonCommand::handle method and
+verifies that the transaction has been stopped by checking that there was no harvest received.
+It also verifies that no traced errors and no error events were recorded.
 */
 
 /*INI

--- a/tests/integration/frameworks/laravel/test_horizon_error_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_error_path.php
@@ -35,6 +35,14 @@ null
 null
 */
 
+/*EXPECT_REGEX
+foobar
+Custom/foobar
+Error handle function
+
+Fatal error: Uncaught Error: Error occurred in .*mock_horizon_error_path.php:.*
+*/
+
 require_once(__DIR__ . '/mock_horizon_error_path.php');
 require_once(__DIR__.'/../../../include/integration.php');
 

--- a/tests/integration/frameworks/laravel/test_horizon_exception_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_exception_path.php
@@ -35,6 +35,14 @@ null
 null
 */
 
+/*EXPECT_REGEX
+foobar
+Custom/foobar
+Exception handle function
+
+Fatal error: Uncaught Exception: Exception occurred in .*mock_horizon_exception_path.php:.*
+*/
+
 require_once(__DIR__ . '/mock_horizon_exception_path.php');
 require_once(__DIR__.'/../../../include/integration.php');
 

--- a/tests/integration/frameworks/laravel/test_horizon_exception_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_exception_path.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Ensure that when HorizonCommand::handle is executed, the transaction is properly stopped.
+*/
+
+/*INI
+newrelic.framework = laravel
+*/
+
+/*EXPECT_HARVEST
+no
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+require_once(__DIR__ . '/mock_horizon_exception_path.php');
+require_once(__DIR__.'/../../../include/integration.php');
+
+use Laravel\Horizon\Console\HorizonCommand;
+use NewRelic\Integration\Transaction;
+
+function foobar() {
+    echo "foobar\n";
+}
+function get_txn() {
+    return new Transaction;
+}
+
+newrelic_add_custom_tracer('foobar');
+foobar();
+
+$txn = get_txn();
+foreach ($txn->getTrace()->findSegmentsByName('Custom/foobar') as $segment) {
+    echo $segment->name;
+    echo "\n";
+}
+
+$horizon = new HorizonCommand();
+$horizon->handle();
+foobar();

--- a/tests/integration/frameworks/laravel/test_horizon_exception_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_exception_path.php
@@ -12,6 +12,13 @@ verifies that the transaction has been stopped by checking that there was no har
 It also verifies that no traced errors and no error events were recorded.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
 /*INI
 newrelic.framework = laravel
 */

--- a/tests/integration/frameworks/laravel/test_horizon_exception_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_exception_path.php
@@ -6,6 +6,10 @@
 
 /*DESCRIPTION
 Ensure that when HorizonCommand::handle is executed, the transaction is properly stopped.
+This test verifies this behavior by first making sure the transaction exists and the
+transaction trace is not empty. Then it calls the HorizonCommand::handle method and
+verifies that the transaction has been stopped by checking that there was no harvest received.
+It also verifies that no traced errors and no error events were recorded.
 */
 
 /*INI

--- a/tests/integration/frameworks/laravel/test_horizon_happy_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_happy_path.php
@@ -11,6 +11,13 @@ transaction trace is not empty. Then it calls the HorizonCommand::handle method 
 verifies that the transaction has been stopped by checking that there was no harvest received.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
 /*INI
 newrelic.framework = laravel
 */

--- a/tests/integration/frameworks/laravel/test_horizon_happy_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_happy_path.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Ensure that when HorizonCommand::handle is executed, the transaction is properly stopped.
+*/
+
+/*INI
+newrelic.framework = laravel
+*/
+
+/*EXPECT_HARVEST
+no
+*/
+
+/*EXPECT
+foobar
+Custom/foobar
+handle function
+foobar
+*/
+
+require_once(__DIR__ . '/mock_horizon_happy_path.php');
+require_once(__DIR__.'/../../../include/integration.php');
+
+use Laravel\Horizon\Console\HorizonCommand;
+use NewRelic\Integration\Transaction;
+
+function foobar() {
+    echo "foobar\n";
+}
+function get_txn() {
+    return new Transaction;
+}
+
+newrelic_add_custom_tracer('foobar');
+foobar();
+
+$txn = get_txn();
+foreach ($txn->getTrace()->findSegmentsByName('Custom/foobar') as $segment) {
+    echo $segment->name;
+    echo "\n";
+}
+
+$horizon = new HorizonCommand();
+$horizon->handle();
+foobar();

--- a/tests/integration/frameworks/laravel/test_horizon_happy_path.php
+++ b/tests/integration/frameworks/laravel/test_horizon_happy_path.php
@@ -6,6 +6,9 @@
 
 /*DESCRIPTION
 Ensure that when HorizonCommand::handle is executed, the transaction is properly stopped.
+This test verifies this behavior by first making sure the transaction exists and the
+transaction trace is not empty. Then it calls the HorizonCommand::handle method and
+verifies that the transaction has been stopped by checking that there was no harvest received.
 */
 
 /*INI

--- a/tests/integration/frameworks/laravel/test_supervisor_error_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_error_path.php
@@ -35,6 +35,14 @@ null
 null
 */
 
+/*EXPECT_REGEX
+foobar
+Custom/foobar
+Error handle function
+
+Fatal error: Uncaught Error: Error occurred in .*mock_supervisor_error_path.php:.*
+*/
+
 require_once(__DIR__ . '/mock_supervisor_error_path.php');
 require_once(__DIR__.'/../../../include/integration.php');
 

--- a/tests/integration/frameworks/laravel/test_supervisor_error_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_error_path.php
@@ -12,6 +12,13 @@ verifies that the transaction has been stopped by checking that there was no har
 It also verifies that no traced errors and no error events were recorded.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
 /*INI
 newrelic.framework = laravel
 */

--- a/tests/integration/frameworks/laravel/test_supervisor_error_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_error_path.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Ensure that when SupervisorCommand::handle is executed, the transaction is properly stopped.
+*/
+
+/*INI
+newrelic.framework = laravel
+*/
+
+/*EXPECT_HARVEST
+no
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+require_once(__DIR__ . '/mock_supervisor_error_path.php');
+require_once(__DIR__.'/../../../include/integration.php');
+
+use Laravel\Horizon\Console\SupervisorCommand;
+use NewRelic\Integration\Transaction;
+
+function foobar() {
+    echo "foobar\n";
+}
+function get_txn() {
+    return new Transaction;
+}
+
+newrelic_add_custom_tracer('foobar');
+foobar();
+
+$txn = get_txn();
+foreach ($txn->getTrace()->findSegmentsByName('Custom/foobar') as $segment) {
+    echo $segment->name;
+    echo "\n";
+}
+
+$supervisor = new SupervisorCommand();
+$supervisor->handle();
+foobar();

--- a/tests/integration/frameworks/laravel/test_supervisor_error_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_error_path.php
@@ -6,6 +6,10 @@
 
 /*DESCRIPTION
 Ensure that when SupervisorCommand::handle is executed, the transaction is properly stopped.
+This test verifies this behavior by first making sure the transaction exists and the
+transaction trace is not empty. Then it calls the SupervisorCommand::handle method and
+verifies that the transaction has been stopped by checking that there was no harvest received.
+It also verifies that no traced errors and no error events were recorded.
 */
 
 /*INI

--- a/tests/integration/frameworks/laravel/test_supervisor_exception_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_exception_path.php
@@ -12,6 +12,13 @@ verifies that the transaction has been stopped by checking that there was no har
 It also verifies that no traced errors and no error events were recorded.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
 /*INI
 newrelic.framework = laravel
 */

--- a/tests/integration/frameworks/laravel/test_supervisor_exception_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_exception_path.php
@@ -6,6 +6,10 @@
 
 /*DESCRIPTION
 Ensure that when SupervisorCommand::handle is executed, the transaction is properly stopped.
+This test verifies this behavior by first making sure the transaction exists and the
+transaction trace is not empty. Then it calls the SupervisorCommand::handle method and
+verifies that the transaction has been stopped by checking that there was no harvest received.
+It also verifies that no traced errors and no error events were recorded.
 */
 
 /*INI

--- a/tests/integration/frameworks/laravel/test_supervisor_exception_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_exception_path.php
@@ -35,6 +35,14 @@ null
 null
 */
 
+/*EXPECT_REGEX
+foobar
+Custom/foobar
+Exception handle function
+
+Fatal error: Uncaught Exception: Exception occurred in .*mock_supervisor_exception_path.php:.*
+*/
+
 require_once(__DIR__ . '/mock_supervisor_exception_path.php');
 require_once(__DIR__.'/../../../include/integration.php');
 

--- a/tests/integration/frameworks/laravel/test_supervisor_exception_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_exception_path.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Ensure that when SupervisorCommand::handle is executed, the transaction is properly stopped.
+*/
+
+/*INI
+newrelic.framework = laravel
+*/
+
+/*EXPECT_HARVEST
+no
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+require_once(__DIR__ . '/mock_supervisor_exception_path.php');
+require_once(__DIR__.'/../../../include/integration.php');
+
+use Laravel\Horizon\Console\SupervisorCommand;
+use NewRelic\Integration\Transaction;
+
+function foobar() {
+    echo "foobar\n";
+}
+function get_txn() {
+    return new Transaction;
+}
+
+newrelic_add_custom_tracer('foobar');
+foobar();
+
+$txn = get_txn();
+foreach ($txn->getTrace()->findSegmentsByName('Custom/foobar') as $segment) {
+    echo $segment->name;
+    echo "\n";
+}
+
+$supervisor = new SupervisorCommand();
+$supervisor->handle();
+foobar();

--- a/tests/integration/frameworks/laravel/test_supervisor_happy_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_happy_path.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Ensure that when SupervisorCommand::handle is executed, the transaction is properly stopped.
+*/
+
+/*INI
+newrelic.framework = laravel
+*/
+
+/*EXPECT_HARVEST
+no
+*/
+
+/*EXPECT
+foobar
+Custom/foobar
+handle function
+foobar
+*/
+
+require_once(__DIR__ . '/mock_supervisor_happy_path.php');
+require_once(__DIR__.'/../../../include/integration.php');
+
+use Laravel\Horizon\Console\SupervisorCommand;
+use NewRelic\Integration\Transaction;
+
+function foobar() {
+    echo "foobar\n";
+}
+function get_txn() {
+    return new Transaction;
+}
+
+newrelic_add_custom_tracer('foobar');
+foobar();
+
+$txn = get_txn();
+foreach ($txn->getTrace()->findSegmentsByName('Custom/foobar') as $segment) {
+    echo $segment->name;
+    echo "\n";
+}
+
+$supervisor = new SupervisorCommand();
+$supervisor->handle();
+foobar();

--- a/tests/integration/frameworks/laravel/test_supervisor_happy_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_happy_path.php
@@ -11,6 +11,13 @@ transaction trace is not empty. Then it calls the HorizonCommand::handle method 
 verifies that the transaction has been stopped by checking that there was no harvest received.
 */
 
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
 /*INI
 newrelic.framework = laravel
 */

--- a/tests/integration/frameworks/laravel/test_supervisor_happy_path.php
+++ b/tests/integration/frameworks/laravel/test_supervisor_happy_path.php
@@ -6,6 +6,9 @@
 
 /*DESCRIPTION
 Ensure that when SupervisorCommand::handle is executed, the transaction is properly stopped.
+This test verifies this behavior by first making sure the transaction exists and the
+transaction trace is not empty. Then it calls the HorizonCommand::handle method and
+verifies that the transaction has been stopped by checking that there was no harvest received.
 */
 
 /*INI


### PR DESCRIPTION
This PR does the following:

- Adds instrumentation that ensures the transaction is properly stopped for laravel horizon.
- Adds integration tests verifying the transaction is properly stopped.