### PR TITLE
feat(agent): add supportability metric for laravel horizon and queue

### DIFF
--- a/agent/fw_laravel.c
+++ b/agent/fw_laravel.c
@@ -1228,7 +1228,7 @@ NR_PHP_WRAPPER(nr_laravel_horizon_is_used) {
   NR_UNUSED_SPECIALFN;
   (void)wraprec;
 
-  NR_PHP_PROCESS_GLOBALS(is_horizon_used) = true;
+  NR_PHP_PROCESS_GLOBALS(laravel_horizon_worker_used) = true;
 }
 NR_PHP_WRAPPER_END
 

--- a/agent/fw_laravel_queue.c
+++ b/agent/fw_laravel_queue.c
@@ -295,7 +295,7 @@ NR_PHP_WRAPPER(nr_laravel_queue_worker_raiseBeforeJobEvent_before) {
   nr_txn_set_path("Laravel", NRPRG(txn), txn_name, NR_PATH_TYPE_CUSTOM,
                   NR_OK_TO_OVERWRITE);
 
-  if (NR_PHP_PROCESS_GLOBALS(is_horizon_used)) {
+  if (NR_PHP_PROCESS_GLOBALS(laravel_horizon_worker_used)) {
     nrm_force_add(NRPRG(txn) ? NRPRG(txn)->unscoped_metrics : 0,
                   "Supportability/library/Laravel/Horizon/used", 0);
   } else {

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -80,7 +80,7 @@ typedef struct _nrphpglobals_t {
                                               enabled */
   nr_composer_api_status_t composer_api_status; /* Composer API's status */
   char* docker_id; /* 64 byte hex docker ID parsed from /proc/self/mountinfo */
-  bool is_horizon_used; /* Set to true if Laravel Horizon is used */
+  bool laravel_horizon_worker_used; /* Set to true if Laravel Horizon is used */
 
   /* Original PHP callback pointer contents */
   nrphperrfn_t orig_error_cb;


### PR DESCRIPTION
This PR does the following:

- Wrap `Laravel\Horizon\Console\WorkCommand` to check if Laravel Horizon is being used and if it is, then set `is_horizon_used` global flag to `true`.
- Check value of `is_horizon_used` flag which will determine what supportability metric is sent. (`Supportability/library/Laravel/Horizon/used` or `Supportability/library/Laravel/Queue/used`)