### PR TITLE
fix(agent): do not call 'get' directly on Symfony requests

### DIFF
--- a/agent/fw_symfony4.c
+++ b/agent/fw_symfony4.c
@@ -130,9 +130,9 @@ NR_PHP_WRAPPER_END
 NR_PHP_WRAPPER(nr_symfony4_name_the_wt) {
   zval* event = NULL;
   zval* request = NULL;
-  zval* request_attrs;
-  zval* route_rval;
-  zval* controller_rval;
+  zval* request_attrs = NULL;
+  zval* route_rval = NULL;
+  zval* controller_rval = NULL;
 
   /* Warning avoidance */
   (void)wraprec;


### PR DESCRIPTION
Calling `get` on a request object is not best practice, and has been deprecated. It is advised to instead call get on the proper member, in our case, `attributes`.

closes https://github.com/newrelic/newrelic-php-agent/issues/1148