### PR TITLE
feat(agent): update instrumentation to be compatible with MongoDB 2.x

### DIFF
--- a/agent/lib_mongodb.c
+++ b/agent/lib_mongodb.c
@@ -190,7 +190,6 @@ NR_PHP_WRAPPER(nr_mongodb_operation_before) {
 NR_PHP_WRAPPER_END
 
 NR_PHP_WRAPPER(nr_mongodb_operation_after) {
-  const char* this_klass = "MongoDB\\Operation\\Executable";
   zval* collection = NULL;
   zval* database = NULL;
   zval* server = NULL;
@@ -218,18 +217,8 @@ NR_PHP_WRAPPER(nr_mongodb_operation_after) {
     },
   };
 #pragma GCC diagnostic pop
-  /*
-   * We check for the interface all Collection operations extend, rather than
-   * their specific class. Not all operations have the properties we need but
-   * the ones we hook do (as of mongo-php-library v.1.1).
-   */
+
   this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS);
-  if (!nr_php_object_instanceof_class(this_var, this_klass)) {
-    nrl_verbosedebug(NRL_FRAMEWORK, "%s: operation is not %s", __func__,
-                     this_klass);
-    discard_segment = true;
-    goto leave;
-  }
 
   collection = nr_php_get_zval_object_property(this_var, "collectionName");
   if (nr_php_is_zval_valid_string(collection)) {

--- a/agent/lib_mongodb.c
+++ b/agent/lib_mongodb.c
@@ -194,7 +194,6 @@ NR_PHP_WRAPPER(nr_mongodb_operation_after) {
   zval* database = NULL;
   zval* server = NULL;
   zval* this_var = NULL;
-  bool discard_segment = false;
   nr_datastore_instance_t instance = {
       .host = NULL,
       .port_path_or_id = NULL,
@@ -235,11 +234,7 @@ NR_PHP_WRAPPER(nr_mongodb_operation_after) {
                                           &instance.port_path_or_id);
 
 leave:
-  if (discard_segment) {
-    nr_segment_discard(&auto_segment);
-  } else {
-    nr_segment_datastore_end(&auto_segment, &params);
-  }
+  nr_segment_datastore_end(&auto_segment, &params);
   nr_php_arg_release(&server);
   nr_php_scope_release(&this_var);
   nr_free(instance.host);

--- a/agent/lib_mongodb.c
+++ b/agent/lib_mongodb.c
@@ -233,7 +233,6 @@ NR_PHP_WRAPPER(nr_mongodb_operation_after) {
   nr_mongodb_get_host_and_port_path_or_id(server, &instance.host,
                                           &instance.port_path_or_id);
 
-leave:
   nr_segment_datastore_end(&auto_segment, &params);
   nr_php_arg_release(&server);
   nr_php_scope_release(&this_var);


### PR DESCRIPTION
This PR removes redundant `Executable` interface check which caused instrumentation to break for MongoDB 2.x because the `Executable` interface has been removed. This check is not needed because for all operations we implement, they will only be instrumented if `execute` method is called, so this makes current check for `Executable` interface redundant as this interface only defined `execute` method.

closes #1147