### PR TITLE
fix(agent): fix table naming for queries with `EXTRACT` function

### DIFF
--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -604,7 +604,7 @@ static void test_real_world_things(void) {
       "should return correct table name",
       sql, "select", "baz_table");
 
-  sql = " SELECT foo,bar FROM baz_table WHERE (MONTH FROM event_date) = 10";
+  sql = " SELECT foo,bar FROM baz_table WHERE EXTRACT(MONTH FROM event_date) = 10";
   test_get_operation_and_table(
       "Valid EXTRACT function at the end of the query string should return "
       "correct table name",

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -600,9 +600,14 @@ static void test_real_world_things(void) {
       = " SELECT foo, EXTRACT(EPOCH FROM(content.creation)::timestamptz) as "
         "creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(
-      "Valid EXTRACT function with no whitespace before parenthesis in select "
-      "should return correct table name",
+      "Valid EXTRACT function at the end of the query string should return "
+      "correct table name",
       sql, "select", "baz_table");
+
+  sql = " SELECT foo,bar FROM baz_table WHERE (MONTH FROM event_date) = 10";
+  test_get_operation_and_table(
+      "Valid EXTRACT function in select should return correct table name", sql,
+      "select", "baz_table");
 
   sql = " SELECT foo, EXTRACT as creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -600,14 +600,15 @@ static void test_real_world_things(void) {
       = " SELECT foo, EXTRACT(EPOCH FROM(content.creation)::timestamptz) as "
         "creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(
-      "Valid EXTRACT function at the end of the query string should return "
-      "correct table name",
+      "Valid EXTRACT function with no whitespace before parenthesis in select "
+      "should return correct table name",
       sql, "select", "baz_table");
 
   sql = " SELECT foo,bar FROM baz_table WHERE (MONTH FROM event_date) = 10";
   test_get_operation_and_table(
-      "Valid EXTRACT function in select should return correct table name", sql,
-      "select", "baz_table");
+      "Valid EXTRACT function at the end of the query string should return "
+      "correct table name",
+      sql, "select", "baz_table");
 
   sql = " SELECT foo, EXTRACT as creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -618,25 +618,47 @@ static void test_real_world_things(void) {
       sql, "select", NULL);
 
   sql
+      = " SELECT foo, EXTRACT() as "
+        "creation_timestamp,bar FROM baz_table ";
+  test_get_operation_and_table(
+      "invalid EXTRACT function with nothing in parenthesis in SELECT "
+      "but this parser isn't detecting sql correctness so should still return "
+      "correct table name which is same as functionality now and the important "
+      "thing here is that we don't try to parse the FROM inside anyway so for "
+      "that we are good",
+      sql, "select", "baz_table");
+
+  sql = " DELETE from baz_table WHERE EXTRACT(MONTH FROM event_date) = 10";
+  test_get_operation_and_table(
+      "Valid EXTRACT function at the end of the query string should return "
+      "correct table name",
+      sql, "delete", "baz_table");
+
+  sql
       = " DELETE foo, EXTRACT(EPOCH FROM (content.creation)::timestamptz) as "
         "creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(
-      "Valid EXTRACT function in DELETE should return correct table name", sql,
-      "delete", "baz_table");
+      "Valid EXTRACT function in invalid DELETE should return correct table "
+      "name but this parser isn't detecting sql correctness so should still "
+      "return the correct table name which is same as functionality now and "
+      "the important thing here is that we don't try to parse the FROM inside "
+      "anyway so for that we are good",
+      sql, "delete", "baz_table");
 
   sql
       = " DELETE foo, EXTRACT(EPOCH FROM(content.creation)::timestamptz) as "
         "creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(
-      "Valid EXTRACT function with no whitespace before parenthesis in DELETE "
-      "should return correct table name",
+      "Valid EXTRACT function with no whitespace before parenthesis in invalid "
+      "DELETE but this parser isn't detecting sql correctness so should still "
+      "return the correct table name which is same as functionality now and "
+      "the important thing here is that we don't try to parse the FROM inside "
+      "anyway so for that we are good and should return correct table name",
       sql, "delete", "baz_table");
 
-  sql
-      = " DELETE foo, EXTRACT() as "
-        "creation_timestamp,bar FROM baz_table ";
+  sql = " DELETE foo, EXTRACT() as creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(
-      "invalid EXTRACT function with nothing in parenthesis in DELETE "
+      "invalid EXTRACT function with nothing in parenthesis in invalid DELETE "
       "but this parser isn't detecting sql correctness so should still return "
       "correct table name which is same as functionality now and the important "
       "thing here is that we don't try to parse the FROM inside anyway so for "
@@ -645,8 +667,10 @@ static void test_real_world_things(void) {
 
   sql = " DELETE foo, EXTRACT as creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(
-      "Invalid EXTRACT function with DELETE should return null table name", sql,
-      "delete", NULL);
+      "Invalid EXTRACT function with invalid DELETE should return null table "
+      "name as this parser isn't detecting sql correctness but still verifies "
+      "don't try to parse the FROM inside anyway so for that we are good",
+      sql, "delete", NULL);
 }
 
 /*

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -573,6 +573,41 @@ static void test_real_world_things(void) {
         "n.locale_id = :locale_id AND n.is_active = ? LIMIT ? ";
   test_get_operation_and_table("_from in alias", sql, "select",
                                "notifications");
+
+  /*
+   * Sometimes you can get a `FROM` in the EXTRACT function.
+   * https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
+   * The EXTRACT function retrieves subfields such as year or hour from
+   * date/time values. source must be a value expression of type timestamp,
+   * date, time, or interval. Ex: SELECT EXTRACT(CENTURY FROM TIMESTAMP
+   * '2000-12-16 12:21:13'); Result: 20 This FROM is NOT followed by a table
+   * name but a timestamp and therefore when we are trying to NR_SQL_PARSE_FROM,
+   * the whole EXTRACT(...) clause should be ignored to avoid keying off of the
+   * FROM value contained inside.
+   *
+   * The following are the real world case followed by valid and invalid
+   * variations
+   */
+
+  sql
+      = " SELECT foo, EXTRACT(EPOCH FROM (content.creation)::timestamptz) as "
+        "creation_timestamp,bar FROM baz_table ";
+  test_get_operation_and_table(
+      "Valid EXTRACT function in select should return correct table name", sql,
+      "select", "baz_table");
+
+  sql
+      = " SELECT foo, EXTRACT(EPOCH FROM(content.creation)::timestamptz) as "
+        "creation_timestamp,bar FROM baz_table ";
+  test_get_operation_and_table(
+      "Valid EXTRACT function with no whitespace before parenthesis in select "
+      "should return correct table name",
+      sql, "select", "baz_table");
+
+  sql = " SELECT foo, EXTRACT as creation_timestamp,bar FROM baz_table ";
+  test_get_operation_and_table(
+      "Invalid EXTRACT function with in select should return null table name",
+      sql, "select", NULL);
 }
 
 /*

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -604,7 +604,9 @@ static void test_real_world_things(void) {
       "should return correct table name",
       sql, "select", "baz_table");
 
-  sql = " SELECT foo,bar FROM baz_table WHERE EXTRACT(MONTH FROM event_date) = 10";
+  sql
+      = " SELECT foo,bar FROM baz_table WHERE EXTRACT(MONTH FROM event_date) = "
+        "10";
   test_get_operation_and_table(
       "Valid EXTRACT function at the end of the query string should return "
       "correct table name",
@@ -614,6 +616,37 @@ static void test_real_world_things(void) {
   test_get_operation_and_table(
       "Invalid EXTRACT function with in select should return null table name",
       sql, "select", NULL);
+
+  sql
+      = " DELETE foo, EXTRACT(EPOCH FROM (content.creation)::timestamptz) as "
+        "creation_timestamp,bar FROM baz_table ";
+  test_get_operation_and_table(
+      "Valid EXTRACT function in DELETE should return correct table name", sql,
+      "delete", "baz_table");
+
+  sql
+      = " DELETE foo, EXTRACT(EPOCH FROM(content.creation)::timestamptz) as "
+        "creation_timestamp,bar FROM baz_table ";
+  test_get_operation_and_table(
+      "Valid EXTRACT function with no whitespace before parenthesis in DELETE "
+      "should return correct table name",
+      sql, "delete", "baz_table");
+
+  sql
+      = " DELETE foo, EXTRACT() as "
+        "creation_timestamp,bar FROM baz_table ";
+  test_get_operation_and_table(
+      "invalid EXTRACT function with nothing in parenthesis in DELETE "
+      "but this parser isn't detecting sql correctness so should still return "
+      "correct table name which is same as functionality now and the important "
+      "thing here is that we don't try to parse the FROM inside anyway so for "
+      "that we are good",
+      sql, "delete", "baz_table");
+
+  sql = " DELETE foo, EXTRACT as creation_timestamp,bar FROM baz_table ";
+  test_get_operation_and_table(
+      "Invalid EXTRACT function with DELETE should return null table name", sql,
+      "delete", NULL);
 }
 
 /*

--- a/axiom/util_sql.c
+++ b/axiom/util_sql.c
@@ -385,7 +385,7 @@ void nr_sql_get_operation_and_table(const char* sql,
   static sql_parse_expectation_t operations[]
       = {/*
           * In the future, we could match additional sql statements, e.g.,
-          * create, alter, drop, etc. We could also expand on the show to parse
+          * alter, etc. We could also expand on the show to parse
           * the table name from "show columns in", etc.
           */
          {"select", sizeof("select") - 1, NR_SQL_PARSE_FROM},
@@ -498,6 +498,43 @@ void nr_sql_get_operation_and_table(const char* sql,
           x += 5;
           break;
         }
+      }
+
+      /*
+       * Sometimes you can get a `FROM` in the EXTRACT function.
+       * https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
+       * The EXTRACT function retrieves subfields such as year or hour from
+       * date/time values. source must be a value expression of type timestamp,
+       * date, time, or interval. Ex: SELECT EXTRACT(CENTURY FROM TIMESTAMP
+       * '2000-12-16 12:21:13'); Result: 20 This FROM is NOT followed by a table
+       * name but a timestamp and therefore when we are trying to
+       * NR_SQL_PARSE_FROM, the whole EXTRACT(...) clause should be ignored to
+       * avoid keying off of the FROM value contained inside.
+       */
+      if ((NR_SQL_PARSE_FROM == operations[i].opflag)
+          && ('e' == nr_tolower(x[0])) && ('x' == nr_tolower(x[1]))
+          && ('t' == nr_tolower(x[2])) && ('r' == nr_tolower(x[3]))
+          && ('a' == nr_tolower(x[4])) && ('c' == nr_tolower(x[5]))
+          && ('t' == nr_tolower(x[6]))
+          && (NULL != nr_strchr(NR_SQL_DELIMITER_CHARS, x[7]))) {
+        x += 7;
+
+        /* process any whitespace before the () block */
+        x = nr_sql_whitespace_comment_prefix(x, show_sql_parsing);
+        if (NULL == x) {
+          return;
+        }
+
+        /* Remove the parentheses block */
+        if ('(' == *x) {
+          x = nr_sql_parse_over(x + 1, ')', show_sql_parsing);
+          if (NULL == x) {
+            return;
+          }
+          continue;
+        }
+        /* We only get here if there weren't parentheses which isn't valid */
+        return;
       }
 
       if ((NR_SQL_PARSE_FROM == operations[i].opflag)


### PR DESCRIPTION
Sometimes you can get a `FROM` in the EXTRACT function. 

https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT The EXTRACT function retrieves subfields such as year or hour from date/time values. source must be a value expression of type timestamp, date, time, or interval 
 Ex: SELECT EXTRACT(CENTURY FROM TIMESTAMP '2000-12-16 12:21:13');
 Result: 20
This FROM is NOT followed by a table name but a timestamp and therefore when we are trying to NR_SQL_PARSE_FROM, the whole EXTRACT(...) clause should be ignored to avoid keying off of the FROM value contained inside.

This PR:
1) updates agent's SQL the parser to skip/parse over `EXTRACT(field FROM source)` function
2) adds unit tests