### PR TITLE
fix(agent): improve SQL parsing logic

### DIFF
--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -771,6 +771,7 @@ static void test_nested_parentheticals(void) {
       "`nested_table`",
       sql, "delete", "my_table");
 }
+// clang-format on
 
 /*
  * Read the section on identifiers and comments carefully:

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -724,6 +724,91 @@ static void test_nested_parentheticals(void) {
       "`nested_table`",
       sql, "select", "my_table");
 
+  sql = "                   \
+    SELECT                  \
+      label,                \
+      (                     \
+        SELECT              \
+          COUNT(1,          \
+          (                 \
+            SELECT          \
+              nested        \
+            FROM            \
+              nested_table  \
+          )                 \
+        FROM                \
+          my_table_event    \
+        WHERE               \
+          my_table_id = my_table.my_table_id \
+      ) AS event_count      \
+    FROM                    \
+      my_table              \
+    ";
+  test_get_operation_and_table(
+      "Invalid SQL SELECT operation missing a closing parenthesis should return"
+    " NULL table name",
+    sql, "select", NULL);
+
+  sql = "                   \
+    SELECT                  \
+      label,                \
+      (                     \
+        SELECT              \
+          COUNT 1),         \
+          (                 \
+            SELECT          \
+              nested        \
+            FROM            \
+              nested_table  \
+          )                 \
+        FROM                \
+          my_table_event    \
+        WHERE               \
+          my_table_id = my_table.my_table_id \
+      ) AS event_count      \
+    FROM                    \
+      my_table              \
+    ";
+  test_get_operation_and_table(
+    "Invalid SQL SELECT operation missing an opening parenthesis should not "
+    "cause agent to crash",
+      sql, "select", "my_table_event");
+
+  sql = "         \
+    SELECT        \
+      id          \
+    FROM          \
+      records     \
+    WHERE         \
+      CONCAT(     \
+        '(',      \
+        name,     \
+        suffix    \
+      ) = '(test' \
+    ";
+  test_get_operation_and_table(
+      "Valid SQL SELECT operation should skip parenthesis in quotations and "
+    "return correct table name",
+      sql, "select", "records");
+
+  sql = "           \
+    SELECT          \
+      id(           \
+        SELECT      \
+          COUNT(*)  \
+        FROM        \
+          events    \
+        WHERE       \
+          note = 'Started (' \
+      ) AS COUNT    \
+    FROM            \
+      orders        \
+    ";
+  test_get_operation_and_table(
+      "Valid SQL SELECT operation with nested SELECT statement should skip "
+    "parenthesis in quotations and return correct table name",
+      sql, "select", "orders");
+
   sql = "                 \
     DELETE                \
       (label),            \

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -614,8 +614,9 @@ static void test_real_world_things(void) {
 
   sql = " SELECT foo, EXTRACT as creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(
-      "Invalid EXTRACT function with in select should return null table name",
-      sql, "select", NULL);
+      "Invalid EXTRACT function in SELECT should return table name as this "
+      "parser isn't detecting sql correctness",
+      sql, "select", "baz_table");
 
   sql
       = " SELECT foo, EXTRACT() as "
@@ -667,17 +668,17 @@ static void test_real_world_things(void) {
 
   sql = " DELETE foo, EXTRACT as creation_timestamp,bar FROM baz_table ";
   test_get_operation_and_table(
-      "Invalid EXTRACT function with invalid DELETE should return null table "
-      "name as this parser isn't detecting sql correctness but still verifies "
-      "don't try to parse the FROM inside anyway so for that we are good",
-      sql, "delete", NULL);
+      "Invalid EXTRACT function with DELETE should return table "
+      "name as this parser isn't detecting sql correctness",
+      sql, "delete", "baz_table");
 }
 
 static void test_nested_parentheticals(void) {
   const char* sql;
 
   sql
-      = "SELECT label, (SELECT COUNT(1) FROM my_table_event WHERE my_table_id "
+      = "SELECT (label), (SELECT COUNT(1) FROM my_table_event WHERE "
+        "my_table_id "
         "= my_table.my_table_id) as event_count FROM my_table";
   test_get_operation_and_table(
       "Valid SQL SELECT operation with nested SELECT statement should "

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -855,6 +855,34 @@ static void test_nested_parentheticals(void) {
       "`my_table` rather than the nested table names `my_table_event` or "
       "`nested_table`",
       sql, "delete", "my_table");
+
+  sql = "CREATE TABLE IF NOT EXISTS birthdays";
+  test_get_operation_and_table(
+      "Valid SQL CREATE TABLE operation with [IF NOT EXISTS] clause should "
+      "correctly identify "
+      "`birthdays` rather than the operator name `IF`",
+      sql, "create", "birthdays");
+
+  sql = "DROP TABLE IF EXISTS birthdays";
+  test_get_operation_and_table(
+      "Valid SQL DROP TABLE operation with [IF EXISTS] clause should "
+      "correctly identify "
+      "`birthdays` rather than the operator name `IF`",
+      sql, "drop", "birthdays");
+
+  sql = "CREATE DATABASE IF NOT EXISTS birthdays";
+  test_get_operation_and_table(
+      "Valid SQL CREATE DATABASE operation with [IF NOT EXISTS] clause should "
+      "correctly identify "
+      "`birthdays` rather than the operator name `IF`",
+      sql, "create", "birthdays");
+
+  sql = "DROP DATABASE IF EXISTS birthdays";
+  test_get_operation_and_table(
+      "Valid SQL DROP DATABASE operation with [IF EXISTS] clause should "
+      "correctly identify "
+      "`birthdays` rather than the operator name `IF`",
+      sql, "drop", "birthdays");
 }
 // clang-format on
 

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -676,30 +676,47 @@ static void test_real_world_things(void) {
 static void test_nested_parentheticals(void) {
   const char* sql;
 
-  sql
-      = "SELECT (label), (SELECT COUNT(1) FROM my_table_event WHERE "
-        "my_table_id "
-        "= my_table.my_table_id) as event_count FROM my_table";
+  // clang-format off
+  sql = "                 \
+    SELECT                \
+      (label),            \
+      (                   \
+        SELECT            \
+          COUNT(1)        \
+        FROM              \
+          my_table_event  \
+        WHERE             \
+          my_table_id = my_table.my_table_id \
+      ) AS event_count    \
+    FROM                  \
+      my_table            \
+    ";
   test_get_operation_and_table(
       "Valid SQL SELECT operation with nested SELECT statement should "
       "correctly identify "
       "`my_table` rather than the nested table name `my_table_event`",
       sql, "select", "my_table");
 
-  sql
-      = "SELECT label, ( SELECT COUNT(1) FROM my_table_event WHERE my_table_id "
-        "= my_table.my_table_id) as event_count FROM my_table";
-  test_get_operation_and_table(
-      "Valid SQL SELECT operation with nested SELECT statement containing "
-      "whitespace between "
-      "the parenthesis and the SELECT keyword should correctly identify "
-      "`my_table` rather than the nested table name `my_table_event`",
-      sql, "select", "my_table");
-
-  sql
-      = "SELECT label, (SELECT COUNT(1), (SELECT nested FROM nested_table) "
-        "FROM my_table_event WHERE my_table_id "
-        "= my_table.my_table_id) as event_count FROM my_table";
+  sql = "                   \
+    SELECT                  \
+      label,                \
+      (                     \
+        SELECT              \
+          COUNT(1),         \
+          (                 \
+            SELECT          \
+              nested        \
+            FROM            \
+              nested_table  \
+          )                 \
+        FROM                \
+          my_table_event    \
+        WHERE               \
+          my_table_id = my_table.my_table_id \
+      ) AS event_count      \
+    FROM                    \
+      my_table              \
+    ";
   test_get_operation_and_table(
       "Valid SQL SELECT operation with double nested SELECT statement should "
       "correctly identify "
@@ -707,29 +724,46 @@ static void test_nested_parentheticals(void) {
       "`nested_table`",
       sql, "select", "my_table");
 
-  sql
-      = "DELETE label, (SELECT COUNT(1) FROM my_table_event WHERE my_table_id "
-        "= my_table.my_table_id) as event_count FROM my_table";
+  sql = "                 \
+    DELETE                \
+      (label),            \
+      (                   \
+        SELECT            \
+          COUNT(1)        \
+        FROM              \
+          my_table_event  \
+        WHERE             \
+          my_table_id = my_table.my_table_id \
+      ) AS event_count    \
+    FROM                  \
+      my_table            \
+    ";
   test_get_operation_and_table(
       "Valid SQL DELETE operation with nested SELECT statement should "
       "correctly identify "
       "`my_table` rather than the nested table name `my_table_event`",
       sql, "delete", "my_table");
 
-  sql
-      = "DELETE label, ( SELECT COUNT(1) FROM my_table_event WHERE my_table_id "
-        "= my_table.my_table_id) as event_count FROM my_table";
-  test_get_operation_and_table(
-      "Valid SQL DELETE operation with nested SELECT statement containing "
-      "whitespace between "
-      "the parenthesis and the SELECT keyword should correctly identify "
-      "`my_table` rather than the nested table name `my_table_event`",
-      sql, "delete", "my_table");
-
-  sql
-      = "DELETE label, (SELECT COUNT(1), (SELECT nested FROM nested_table) "
-        "FROM my_table_event WHERE my_table_id "
-        "= my_table.my_table_id) as event_count FROM my_table";
+  sql = "                   \
+    DELETE                  \
+      label,                \
+      (                     \
+        SELECT              \
+          COUNT(1),         \
+          (                 \
+            SELECT          \
+              nested        \
+            FROM            \
+              nested_table  \
+          )                 \
+        FROM                \
+          my_table_event    \
+        WHERE               \
+          my_table_id = my_table.my_table_id \
+      ) AS event_count      \
+    FROM                    \
+      my_table              \
+    ";
   test_get_operation_and_table(
       "Valid SQL DELETE operation with double nested SELECT statement should "
       "correctly identify "
@@ -737,6 +771,7 @@ static void test_nested_parentheticals(void) {
       "`nested_table`",
       sql, "delete", "my_table");
 }
+
 /*
  * Read the section on identifiers and comments carefully:
  *   https://dev.mysql.com/doc/refman/5.0/en/identifiers.html

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -856,6 +856,11 @@ static void test_nested_parentheticals(void) {
       "`nested_table`",
       sql, "delete", "my_table");
 
+}
+// clang-format on
+
+static void test_replication_clause(void) {
+  const char* sql;
   sql = "CREATE TABLE IF NOT EXISTS birthdays";
   test_get_operation_and_table(
       "Valid SQL CREATE TABLE operation with [IF NOT EXISTS] clause should "
@@ -884,7 +889,6 @@ static void test_nested_parentheticals(void) {
       "`birthdays` rather than the operator name `IF`",
       sql, "drop", "birthdays");
 }
-// clang-format on
 
 /*
  * Read the section on identifiers and comments carefully:
@@ -1210,6 +1214,7 @@ void test_main(void* p NRUNUSED) {
   test_find_table_with_from();
   test_real_world_things();
   test_nested_parentheticals();
+  test_replication_clause();
   test_diabolical_quoting();
   test_get_operation_and_table_in_sql_with_info();
   test_weird_and_wonderful();

--- a/axiom/tests/test_sql.c
+++ b/axiom/tests/test_sql.c
@@ -673,6 +673,69 @@ static void test_real_world_things(void) {
       sql, "delete", NULL);
 }
 
+static void test_nested_parentheticals(void) {
+  const char* sql;
+
+  sql
+      = "SELECT label, (SELECT COUNT(1) FROM my_table_event WHERE my_table_id "
+        "= my_table.my_table_id) as event_count FROM my_table";
+  test_get_operation_and_table(
+      "Valid SQL SELECT operation with nested SELECT statement should "
+      "correctly identify "
+      "`my_table` rather than the nested table name `my_table_event`",
+      sql, "select", "my_table");
+
+  sql
+      = "SELECT label, ( SELECT COUNT(1) FROM my_table_event WHERE my_table_id "
+        "= my_table.my_table_id) as event_count FROM my_table";
+  test_get_operation_and_table(
+      "Valid SQL SELECT operation with nested SELECT statement containing "
+      "whitespace between "
+      "the parenthesis and the SELECT keyword should correctly identify "
+      "`my_table` rather than the nested table name `my_table_event`",
+      sql, "select", "my_table");
+
+  sql
+      = "SELECT label, (SELECT COUNT(1), (SELECT nested FROM nested_table) "
+        "FROM my_table_event WHERE my_table_id "
+        "= my_table.my_table_id) as event_count FROM my_table";
+  test_get_operation_and_table(
+      "Valid SQL SELECT operation with double nested SELECT statement should "
+      "correctly identify "
+      "`my_table` rather than the nested table names `my_table_event` or "
+      "`nested_table`",
+      sql, "select", "my_table");
+
+  sql
+      = "DELETE label, (SELECT COUNT(1) FROM my_table_event WHERE my_table_id "
+        "= my_table.my_table_id) as event_count FROM my_table";
+  test_get_operation_and_table(
+      "Valid SQL DELETE operation with nested SELECT statement should "
+      "correctly identify "
+      "`my_table` rather than the nested table name `my_table_event`",
+      sql, "delete", "my_table");
+
+  sql
+      = "DELETE label, ( SELECT COUNT(1) FROM my_table_event WHERE my_table_id "
+        "= my_table.my_table_id) as event_count FROM my_table";
+  test_get_operation_and_table(
+      "Valid SQL DELETE operation with nested SELECT statement containing "
+      "whitespace between "
+      "the parenthesis and the SELECT keyword should correctly identify "
+      "`my_table` rather than the nested table name `my_table_event`",
+      sql, "delete", "my_table");
+
+  sql
+      = "DELETE label, (SELECT COUNT(1), (SELECT nested FROM nested_table) "
+        "FROM my_table_event WHERE my_table_id "
+        "= my_table.my_table_id) as event_count FROM my_table";
+  test_get_operation_and_table(
+      "Valid SQL DELETE operation with double nested SELECT statement should "
+      "correctly identify "
+      "`my_table` rather than the nested table names `my_table_event` or "
+      "`nested_table`",
+      sql, "delete", "my_table");
+}
 /*
  * Read the section on identifiers and comments carefully:
  *   https://dev.mysql.com/doc/refman/5.0/en/identifiers.html
@@ -996,6 +1059,7 @@ tlib_parallel_info_t parallel_info = {.suggested_nthreads = 2, .state_size = 0};
 void test_main(void* p NRUNUSED) {
   test_find_table_with_from();
   test_real_world_things();
+  test_nested_parentheticals();
   test_diabolical_quoting();
   test_get_operation_and_table_in_sql_with_info();
   test_weird_and_wonderful();

--- a/axiom/util_sql.c
+++ b/axiom/util_sql.c
@@ -6,6 +6,7 @@
 #include "nr_axiom.h"
 
 #include <stddef.h>
+#include <stdio.h>
 
 #include "util_hash.h"
 #include "util_logging.h"
@@ -368,11 +369,25 @@ static char* nr_sql_parse_over(const char* str,
   return cend + 1; /* Character is consumed */
 }
 
+static bool nr_parse_sql_keyword(const char* sql, const char* keyword) {
+  int i;
+  for (i = 0; i < nr_strlen(keyword); i++) {
+    if (keyword[i] != nr_tolower(sql[i])) {
+      return false;
+    }
+  }
+  if (NULL == nr_strchr(NR_SQL_DELIMITER_CHARS, sql[i])) {
+    return false;
+  }
+  return true;
+}
+
 void nr_sql_get_operation_and_table(const char* sql,
                                     const char** operation_ptr,
                                     char** table_ptr,
                                     int show_sql_parsing) {
   int i;
+  bool nested = false;
   const char* start = 0;
   const char* end = 0;
   const char* x;
@@ -475,6 +490,10 @@ void nr_sql_get_operation_and_table(const char* sql,
         continue;
       }
 
+      if ('(' == nr_tolower(x[0])) {
+        nested = true;
+      }
+
       if ((NR_SQL_PARSE_CREATE == operations[i].opflag)
           || (NR_SQL_PARSE_DROP == operations[i].opflag)) {
         /*
@@ -535,6 +554,35 @@ void nr_sql_get_operation_and_table(const char* sql,
         }
         /* We only get here if there weren't parentheses which isn't valid */
         return;
+      }
+
+      /*
+       * Handle the edge case of a nested SELECT parenthetical causing
+       * misidentification of the main table name.
+       * If we've detected an open parenthetical above, check the index of the
+       * next '(' character and compare it to the index of the next ')'
+       * character. If '(' exists and precedes the ')' character, advance the
+       * sql string  to the position of the next ')'+1 and check again.
+       * Once the next ')' character precedes the next '(' character or the next
+       * '(' character does not exist, break out of the loop and advance one
+       * final time to reach the end of the highest nested statement.
+       */
+      if ((NR_SQL_PARSE_FROM == operations[i].opflag) && nested
+          && (nr_parse_sql_keyword(x, "select")
+              || nr_parse_sql_keyword(x, "(select"))) {
+        while (nr_stridx(x, "(") != -1
+               && (nr_stridx(x, "(") < nr_stridx(x, ")"))) {
+          x = nr_sql_parse_over(x, ')', show_sql_parsing);
+          if (NULL == x) {
+            return;
+          }
+        }
+        x = nr_sql_parse_over(x, ')', show_sql_parsing);
+        nested = false;
+        if (NULL == x) {
+          return;
+        }
+        continue;
       }
 
       if ((NR_SQL_PARSE_FROM == operations[i].opflag)

--- a/axiom/util_sql.c
+++ b/axiom/util_sql.c
@@ -499,7 +499,7 @@ void nr_sql_get_operation_and_table(const char* sql,
         continue;
       }
 
-      if ('(' == nr_tolower(x[0])) {
+      if ('(' == x[0]) {
         nest_level++;
         x++;
         if (NULL == x) {
@@ -508,7 +508,7 @@ void nr_sql_get_operation_and_table(const char* sql,
         continue;
       }
 
-      if (')' == nr_tolower(x[0])) {
+      if (')' == x[0]) {
         nest_level--;
         x++;
         if (NULL == x) {

--- a/axiom/util_sql.c
+++ b/axiom/util_sql.c
@@ -404,6 +404,7 @@ void nr_sql_get_operation_and_table(const char* sql,
   const char* end = 0;
   const char* x;
   int sl;
+  bool check_replication_stmt = false;
   typedef struct _sql_parse_expectation {
     const char* opname;
     int oplength;
@@ -486,6 +487,23 @@ void nr_sql_get_operation_and_table(const char* sql,
         return;
       }
 
+      if (check_replication_stmt) {
+        if (nr_parse_sql_keyword(x, NR_PSTR("if"))) {
+          x += 2;
+          continue;
+        } else if (nr_parse_sql_keyword(x, NR_PSTR("not"))) {
+          x += 3;
+          continue;
+        } else if (nr_parse_sql_keyword(x, NR_PSTR("exists"))) {
+          x += 6;
+          check_replication_stmt = false;
+          break;
+        } else {
+          check_replication_stmt = false;
+          break;
+        }
+      }
+
       if ('\'' == *x) {
         x = nr_sql_parse_over(x + 1, '\'', show_sql_parsing);
         if (NULL == x) {
@@ -531,11 +549,13 @@ void nr_sql_get_operation_and_table(const char* sql,
            */
           if (nr_parse_sql_keyword(x, NR_PSTR("database"))) {
             x += 8;
-            break;
+            check_replication_stmt = true;
+            continue;
 
           } else if (nr_parse_sql_keyword(x, NR_PSTR("table"))) {
             x += 5;
-            break;
+            check_replication_stmt = true;
+            continue;
           }
         }
 

--- a/axiom/util_sql.c
+++ b/axiom/util_sql.c
@@ -368,6 +368,16 @@ static char* nr_sql_parse_over(const char* str,
   return cend + 1; /* Character is consumed */
 }
 
+/*
+ * Purpose: Determine whether the provided keyword is the next token in an SQL
+ * statement
+ *
+ * @param sql     The SQL statement to parse
+ * @param keyword The SQL keyword to compare
+ *
+ * @return bool
+ *
+ */
 static bool nr_parse_sql_keyword(const char* sql, const char* keyword) {
   int i;
   for (i = 0; i < nr_strlen(keyword); i++) {
@@ -386,7 +396,7 @@ void nr_sql_get_operation_and_table(const char* sql,
                                     char** table_ptr,
                                     int show_sql_parsing) {
   int i;
-  bool nested = false;
+  int nest_level = 0;
   const char* start = 0;
   const char* end = 0;
   const char* x;
@@ -490,117 +500,59 @@ void nr_sql_get_operation_and_table(const char* sql,
       }
 
       if ('(' == nr_tolower(x[0])) {
-        nested = true;
-      }
-
-      if ((NR_SQL_PARSE_CREATE == operations[i].opflag)
-          || (NR_SQL_PARSE_DROP == operations[i].opflag)) {
-        /*
-         * If this is a `CREATE` or `DROP` statement then it will be followed by
-         * `DATABASE` or `TABLE` (ignoring whitespace and comments). Since
-         * 'create' is the first word, we merely advance to the second word to
-         * see if it is DATABASE OR TABLE then advance to the db/table name.
-         */
-        if (('d' == nr_tolower(x[0])) && ('a' == nr_tolower(x[1]))
-            && ('t' == nr_tolower(x[2])) && ('a' == nr_tolower(x[3]))
-            && ('b' == nr_tolower(x[4])) && ('a' == nr_tolower(x[5]))
-            && ('s' == nr_tolower(x[6])) && ('e' == nr_tolower(x[7]))
-            && (NULL != nr_strchr(NR_SQL_DELIMITER_CHARS, x[8]))) {
-          x += 8;
-          break;
-
-        } else if (('t' == nr_tolower(x[0])) && ('a' == nr_tolower(x[1]))
-                   && ('b' == nr_tolower(x[2])) && ('l' == nr_tolower(x[3]))
-                   && ('e' == nr_tolower(x[4]))
-                   && (NULL != nr_strchr(NR_SQL_DELIMITER_CHARS, x[5]))) {
-          x += 5;
-          break;
-        }
-      }
-
-      /*
-       * Sometimes you can get a `FROM` in the EXTRACT function.
-       * https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
-       * The EXTRACT function retrieves subfields such as year or hour from
-       * date/time values. source must be a value expression of type timestamp,
-       * date, time, or interval. Ex: SELECT EXTRACT(CENTURY FROM TIMESTAMP
-       * '2000-12-16 12:21:13'); Result: 20 This FROM is NOT followed by a table
-       * name but a timestamp and therefore when we are trying to
-       * NR_SQL_PARSE_FROM, the whole EXTRACT(...) clause should be ignored to
-       * avoid keying off of the FROM value contained inside.
-       */
-      if ((NR_SQL_PARSE_FROM == operations[i].opflag)
-          && ('e' == nr_tolower(x[0])) && ('x' == nr_tolower(x[1]))
-          && ('t' == nr_tolower(x[2])) && ('r' == nr_tolower(x[3]))
-          && ('a' == nr_tolower(x[4])) && ('c' == nr_tolower(x[5]))
-          && ('t' == nr_tolower(x[6]))
-          && (NULL != nr_strchr(NR_SQL_DELIMITER_CHARS, x[7]))) {
-        x += 7;
-
-        /* process any whitespace before the () block */
-        x = nr_sql_whitespace_comment_prefix(x, show_sql_parsing);
-        if (NULL == x) {
-          return;
-        }
-
-        /* Remove the parentheses block */
-        if ('(' == *x) {
-          x = nr_sql_parse_over(x + 1, ')', show_sql_parsing);
-          if (NULL == x) {
-            return;
-          }
-          continue;
-        }
-        /* We only get here if there weren't parentheses which isn't valid */
-        return;
-      }
-
-      /*
-       * Handle the edge case of a nested SELECT parenthetical causing
-       * misidentification of the main table name.
-       * If we've detected an open parenthetical above, check the index of the
-       * next '(' character and compare it to the index of the next ')'
-       * character. If '(' exists and precedes the ')' character, advance the
-       * sql string  to the position of the next ')'+1 and check again.
-       * Once the next ')' character precedes the next '(' character or the next
-       * '(' character does not exist, break out of the loop and advance one
-       * final time to reach the end of the outermost nested statement.
-       */
-      if ((NR_SQL_PARSE_FROM == operations[i].opflag) && nested
-          && (nr_parse_sql_keyword(x, "select")
-              || nr_parse_sql_keyword(x, "(select"))) {
-        while (nr_stridx(x, "(") != -1
-               && (nr_stridx(x, "(") < nr_stridx(x, ")"))) {
-          x = nr_sql_parse_over(x, ')', show_sql_parsing);
-          if (NULL == x) {
-            return;
-          }
-        }
-        x = nr_sql_parse_over(x, ')', show_sql_parsing);
-        nested = false;
+        nest_level++;
+        x++;
         if (NULL == x) {
           return;
         }
         continue;
       }
 
-      if ((NR_SQL_PARSE_FROM == operations[i].opflag)
-          && ('f' == nr_tolower(x[0])) && ('r' == nr_tolower(x[1]))
-          && ('o' == nr_tolower(x[2])) && ('m' == nr_tolower(x[3]))
-          && (NULL != nr_strchr(NR_SQL_DELIMITER_CHARS, x[4]))) {
-        x += 4;
-        break;
+      if (')' == nr_tolower(x[0])) {
+        nest_level--;
+        x++;
+        if (NULL == x) {
+          return;
+        }
+        continue;
       }
 
-      if ((NR_SQL_PARSE_INTO == operations[i].opflag)
-          && ('i' == nr_tolower(x[0])) && ('n' == nr_tolower(x[1]))
-          && ('t' == nr_tolower(x[2])) && ('o' == nr_tolower(x[3]))
-          && (NULL != nr_strchr(NR_SQL_DELIMITER_CHARS, x[4]))) {
-        x += 4;
-        break;
+      if (0 == nest_level) {
+        if (NR_SQL_PARSE_CREATE == operations[i].opflag
+            || NR_SQL_PARSE_DROP == operations[i].opflag) {
+          /*
+           * If this is a `CREATE` or `DROP` statement then it will be followed
+           * by `DATABASE` or `TABLE` (ignoring whitespace and comments). Since
+           * 'create' is the first word, we merely advance to the second word to
+           * see if it is DATABASE OR TABLE then advance to the db/table name.
+           */
+          if (nr_parse_sql_keyword(x, "database")) {
+            x += 8;
+            break;
+
+          } else if (nr_parse_sql_keyword(x, "table")) {
+            x += 5;
+            break;
+          }
+        }
+
+        if (NR_SQL_PARSE_FROM == operations[i].opflag
+            && nr_parse_sql_keyword(x, "from")) {
+          x += 4;
+          break;
+        }
+
+        if (NR_SQL_PARSE_INTO == operations[i].opflag
+            && nr_parse_sql_keyword(x, "into")) {
+          x += 4;
+          break;
+        }
       }
 
-      sl = nr_strcspn(x, NR_SQL_WHITESPACE_CHARS "'\"");
+      sl = nr_strcspn(x, NR_SQL_WHITESPACE_CHARS
+                      "'\""
+                      "("
+                      ")");
       x += sl;
     }
   }

--- a/axiom/util_sql.c
+++ b/axiom/util_sql.c
@@ -6,7 +6,6 @@
 #include "nr_axiom.h"
 
 #include <stddef.h>
-#include <stdio.h>
 
 #include "util_hash.h"
 #include "util_logging.h"

--- a/axiom/util_sql.c
+++ b/axiom/util_sql.c
@@ -564,7 +564,7 @@ void nr_sql_get_operation_and_table(const char* sql,
        * sql string  to the position of the next ')'+1 and check again.
        * Once the next ')' character precedes the next '(' character or the next
        * '(' character does not exist, break out of the loop and advance one
-       * final time to reach the end of the highest nested statement.
+       * final time to reach the end of the outermost nested statement.
        */
       if ((NR_SQL_PARSE_FROM == operations[i].opflag) && nested
           && (nr_parse_sql_keyword(x, "select")

--- a/axiom/util_sql.c
+++ b/axiom/util_sql.c
@@ -374,13 +374,16 @@ static char* nr_sql_parse_over(const char* str,
  *
  * @param sql     The SQL statement to parse
  * @param keyword The SQL keyword to compare
+ * @param len     Length of the SQL keyword
  *
  * @return bool
  *
  */
-static bool nr_parse_sql_keyword(const char* sql, const char* keyword) {
+static bool nr_parse_sql_keyword(const char* sql,
+                                 const char* keyword,
+                                 int len) {
   int i;
-  for (i = 0; i < nr_strlen(keyword); i++) {
+  for (i = 0; i < len; i++) {
     if (keyword[i] != nr_tolower(sql[i])) {
       return false;
     }
@@ -526,24 +529,24 @@ void nr_sql_get_operation_and_table(const char* sql,
            * 'create' is the first word, we merely advance to the second word to
            * see if it is DATABASE OR TABLE then advance to the db/table name.
            */
-          if (nr_parse_sql_keyword(x, "database")) {
+          if (nr_parse_sql_keyword(x, NR_PSTR("database"))) {
             x += 8;
             break;
 
-          } else if (nr_parse_sql_keyword(x, "table")) {
+          } else if (nr_parse_sql_keyword(x, NR_PSTR("table"))) {
             x += 5;
             break;
           }
         }
 
         if (NR_SQL_PARSE_FROM == operations[i].opflag
-            && nr_parse_sql_keyword(x, "from")) {
+            && nr_parse_sql_keyword(x, NR_PSTR("from"))) {
           x += 4;
           break;
         }
 
         if (NR_SQL_PARSE_INTO == operations[i].opflag
-            && nr_parse_sql_keyword(x, "into")) {
+            && nr_parse_sql_keyword(x, NR_PSTR("into"))) {
           x += 4;
           break;
         }


### PR DESCRIPTION
### With this change the following problems are addressed: 
1. Broken SQL parsing behavior when attempting to extract table name from statements with nested subqueries in `SELECT` and `DELETE` statements.
#### Example: 
```sql
SELECT (label), (SELECT COUNT(1) FROM my_nested_table WHERE my_table_id = my_table.my_table_id) AS event_count) FROM my_table
```

Should return `my_table`, not `my_nested_table`.

2. Failure to properly handle replication safeguard logic in `CREATE` and `DROP` statements.
#### Example:
```sql
CREATE TABLE IF NOT EXISTS birthdays
```

Should return `birthdays`, not `IF`

```sql
DROP TABLE IF EXISTS birthdays
```

Should return `birthdays`, not `IF`.

### Solutions:
1. Track the nesting level of an SQL query while parsing. Do not attempt to parse the table name of a valid statement unless the nesting level is 0.
2. Add logic to check for and parse over keywords `IF`, `NOT` and `EXISTS` if we know we are parsing a `CREATE` or `DROP` statement