### PR TITLE
feat(test): Enhance integration_runner to extract env vars for EXPECT

### DIFF
--- a/daemon/cmd/integration_runner/main.go
+++ b/daemon/cmd/integration_runner/main.go
@@ -578,6 +578,15 @@ func runTest(t *integration.Test) {
 		fmt.Printf("Test output:\n%s\n", body)
 	}
 
+	//
+	// Extract and remove from the output any env vars from the output that
+	// we want to add to t.Env for use with EXPECT blocks.
+	// The env vars will be proceeded with the
+	// NR_EXPECT_ENV_VAR prefix followed by the env var name and value.
+	// ex: NR_EXPECT_ENV_VAR[NEW_VAR_FROM_TEST]=1234567
+	//
+
+	body = t.GetEnvVarsFromBody(body)
 	// Always save the test output. If an error occurred it may contain
 	// critical information regarding the cause. Currently, it may also
 	// contain valgrind commentary which we want to display.

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -282,6 +282,32 @@ func (t *Test) MakeSkipIf(ctx *Context) (Tx, error) {
 	return PhpTx(src, t.Env, settings, ctx)
 }
 
+//
+// Extract and remove from the output any env vars from the output that
+// we want to add to t.Env for use with EXPECT blocks.
+// The env vars will be proceeded with the
+// NR_EXPECT_ENV_VAR prefix followed by the env var name and value.
+// ex: NR_EXPECT_ENV_VAR[NEW_VAR_FROM_TEST]=1234567 followed by a newline
+// Be aware this will overwrite any previously existing env vars with the same name.
+//
+
+func (t *Test) GetEnvVarsFromBody(body []byte) []byte {
+
+	nrExpectEnvVarRE := regexp.MustCompile(`^NR_EXPECT_ENV_VAR\[(.+?)\]=(.*)$`)
+
+	lines := bytes.Split(body, []byte("\n"))
+	filteredLines := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		matches := nrExpectEnvVarRE.FindSubmatch(line)
+		if matches != nil {
+			t.Env[string(matches[1])] = string(matches[2])
+			continue
+		}
+		filteredLines = append(filteredLines, line)
+	}
+	return bytes.Join(filteredLines, []byte("\n"))
+}
+
 type Scrub struct {
 	re          *regexp.Regexp
 	replacement []byte

--- a/daemon/internal/newrelic/integration/test_test.go
+++ b/daemon/internal/newrelic/integration/test_test.go
@@ -8,10 +8,59 @@ package integration
 import (
 	"bytes"
 	"maps"
+	"reflect"
 	"testing"
 
 	"github.com/newrelic/newrelic-php-agent/daemon/internal/newrelic/sysinfo"
 )
+
+func TestGetEnvVarsFromBody_RemovesEnvLinesAndSetsEnv(t *testing.T) {
+	test := &Test{Env: make(map[string]string)}
+	input := []byte("starting it out\nNR_EXPECT_ENV_VAR[BLUE]=apricot\nrandomoutputpart 1\nNR_EXPECT_ENV_VAR[YELLOW]=kiwi\nsome other random output")
+	expectedOutput := []byte("starting it out\nrandomoutputpart 1\nsome other random output")
+	expectedEnv := map[string]string{"BLUE": "apricot", "YELLOW": "kiwi"}
+
+	output := test.GetEnvVarsFromBody(input)
+
+	if !bytes.Equal(output, expectedOutput) {
+		t.Errorf("Expected output:\n%q\ngot:\n%q", expectedOutput, output)
+	}
+	if !reflect.DeepEqual(test.Env, expectedEnv) {
+		t.Errorf("Expected Env: %+v, got: %+v", expectedEnv, test.Env)
+	}
+}
+
+func TestGetEnvVarsFromBody_NoEnvLines(t *testing.T) {
+	test := &Test{Env: make(map[string]string)}
+	input := []byte("starting it out\nand continuing on\neaching the end")
+	expectedOutput := []byte("starting it out\nand continuing on\neaching the end")
+	expectedEnv := map[string]string{}
+
+	output := test.GetEnvVarsFromBody(input)
+
+	if !bytes.Equal(output, expectedOutput) {
+		t.Errorf("Expected output:\n%q\ngot:\n%q", expectedOutput, output)
+	}
+	if !reflect.DeepEqual(test.Env, expectedEnv) {
+		t.Errorf("Expected Env: %+v, got: %+v", expectedEnv, test.Env)
+	}
+}
+
+func TestGetEnvVarsFromBody_EmptyInput(t *testing.T) {
+	test := &Test{Env: make(map[string]string)}
+	input := []byte("")
+	expectedOutput := []byte("")
+	expectedEnv := map[string]string{}
+
+	output := test.GetEnvVarsFromBody(input)
+
+	if !bytes.Equal(output, expectedOutput) {
+		t.Errorf("Expected output:\n%q\ngot:\n%q", expectedOutput, output)
+	}
+	if !reflect.DeepEqual(test.Env, expectedEnv) {
+		t.Errorf("Expected Env: %+v, got: %+v", expectedEnv, test.Env)
+	}
+}
 
 func TestScrubHost(t *testing.T) {
 	host, err := sysinfo.Hostname()

--- a/tests/include/helpers.php
+++ b/tests/include/helpers.php
@@ -36,3 +36,13 @@ function force_error() {
 function force_transaction_trace() {
   error_reporting(error_reporting()); time_nanosleep(0, 50000); // 50usec should be enough
 }
+
+/*
+ * Formats an env var to pass back to integration_runner for use with EXPECT blocks.
+ * Note: integration_runner will use vars set via this method to overwrite previously 
+ * existing vars of the same name.
+ */
+function env_var_for_expects($name, $value) {
+  echo "NR_EXPECT_ENV_VAR[" . $name . "]=" . $value . "\n";
+}
+

--- a/tests/integration/span_events/test_nested_span_parenting.php
+++ b/tests/integration/span_events/test_nested_span_parenting.php
@@ -13,8 +13,6 @@ newrelic.distributed_tracing_enabled=1
 newrelic.transaction_tracer.threshold = 0
 newrelic.span_events_enabled=1
 newrelic.cross_application_tracer.enabled = false
-newrelic.fibers.disabled = true
-newrelic.special = show_executes, show_execute_params, show_execute_stack, show_execute_returns, show_executes_untrimmed
 */
 
 /*EXPECT_ERROR_EVENTS

--- a/tests/integration/span_events/test_nested_span_parenting.php
+++ b/tests/integration/span_events/test_nested_span_parenting.php
@@ -1,0 +1,186 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the nested spans are all parented correctly.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.fibers.disabled = true
+newrelic.special = show_executes, show_execute_params, show_execute_stack, show_execute_returns, show_executes_untrimmed
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "ENV[GUID_FRACTION]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_C]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id']);
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();


### PR DESCRIPTION
Updated integration runner to:
Extract and remove from the test output any env vars from the output that will then be used with EXPECT blocks.
The env vars will be proceeded with the format:
NR_EXPECT_ENV_VAR[NEW_ENV_VAR]=new_env_value.

Added a helper script to ensure proper formatting.

Added a sample test case that utilizes the new feature.

Among other uses, this will allow integration tests for proper span parenting.