### PR TITLE
fix: install newrelic.ini into mods-available on Debian/Ubuntu

### DIFF
--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -931,6 +931,15 @@ set_daemon_location() {
 #   what we detect.
 # pi_php8
 #   True if PHP version is 8.0+
+# pi_mods_avail
+#   On Debian/Ubuntu systems, the path to the mods-available directory
+#   (e.g. /etc/php/8.4/mods-available). Empty if the system does not use
+#   the Debian PHP module management layout.
+# pi_sapi_confdirs
+#   Space-separated list of SAPI conf.d directories found under the same
+#   PHP configuration prefix as pi_mods_avail (e.g. /etc/php/8.4/cli/conf.d
+#   /etc/php/8.4/fpm/conf.d). Used to create symlinks after installing the
+#   INI file into mods-available. Empty if pi_mods_avail is empty.
 #
 # For installation, 4 things are important:
 # the extension API version, the extension load directory, and whether or not
@@ -1089,6 +1098,8 @@ to view compatibilty requirements for the the New Relic PHP agent.
   pi_extdir=
   pi_inidir_cli=
   pi_inifile_cli=
+  pi_mods_avail=
+  pi_sapi_confdirs=
   pi_arch="${NR_INSTALL_ARCH}"
   if [ -n "${havebin}" ]; then
     #
@@ -1391,22 +1402,23 @@ EOF
       fi
 
       #
-      # Debian can use a mods-available directory to store the ini files.
-      # It creates a symlink from the ini file in the conf.d directory that
-      # our installer can fail to find (because the symlink is prefixed with
-      # "20-" (notably the number can change based on configurations).
-      # While this install script will not install into the mods-available
-      # directory, our .deb installer can. Therefore, we want to detect if
-      # newrelic has previously been installed in the mods-available directory
-      # so that we do not create an additional ini file -- which would result in
-      # the conf.d directory having both newrelic.ini and 20-newrelic.ini.
+      # Debian/Ubuntu systems can use a mods-available directory to manage
+      # PHP module INI files. When the mods-available directory exists, we
+      # install the newrelic.ini file there and create symlinks in each
+      # SAPI's conf.d directory. This is consistent with how the Debian
+      # phpenmod/phpdismod tools work.
       #
 
-      if [ -d "${cfg_pfx}/mods-available" -a -f "${cfg_pfx}/mods-available/newrelic.ini" ]; then
+      if [ -d "${cfg_pfx}/mods-available" ]; then
+        pi_mods_avail="${cfg_pfx}/mods-available"
+        pi_sapi_confdirs=""
+        for sapi_dir in "${cfg_pfx}"/*/conf.d; do
+          if [ -d "${sapi_dir}" ]; then
+            pi_sapi_confdirs="${pi_sapi_confdirs} ${sapi_dir}"
+          fi
+        done
         pi_inidir_cli="${cfg_pfx}/mods-available"
-        if [ -n "${pi_inidir_dso}" ]; then
-          pi_inidir_dso="${cfg_pfx}/mods-available"
-        fi
+        pi_inidir_dso=""
       fi
     fi
   done
@@ -1514,6 +1526,28 @@ install_agent_here() {
         log "${pdir}: copy ini template to ${pi_inidir_dso}/newrelic.ini failed"
       fi
     fi
+  fi
+
+  #
+  # If we installed to mods-available, create symlinks in each SAPI conf.d
+  # directory so PHP picks up the module configuration. This follows the
+  # Debian convention used by phpenmod/phpdismod with a "20-" priority prefix.
+  #
+  if [ -n "${pi_mods_avail}" -a -f "${pi_mods_avail}/newrelic.ini" ]; then
+    for sapi_confdir in ${pi_sapi_confdirs}; do
+      if [ -d "${sapi_confdir}" ]; then
+        if [ ! -e "${sapi_confdir}/newrelic.ini" -a ! -e "${sapi_confdir}/20-newrelic.ini" ]; then
+          if logcmd ln -sf "${pi_mods_avail}/newrelic.ini" "${sapi_confdir}/20-newrelic.ini"; then
+            if [ -z "${NR_INSTALL_SILENT}" ]; then
+              echo "      Install Status : ${sapi_confdir}/20-newrelic.ini symlinked"
+            fi
+            log "${pdir}: created symlink ${sapi_confdir}/20-newrelic.ini -> ${pi_mods_avail}/newrelic.ini"
+          else
+            log "${pdir}: failed to create symlink ${sapi_confdir}/20-newrelic.ini"
+          fi
+        fi
+      fi
+    done
   fi
 
   if [ -n "${pi_inidir_cli}" -a -f "${pi_inidir_cli}/newrelic.ini" ]; then

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1410,15 +1410,31 @@ EOF
       #
 
       if [ -d "${cfg_pfx}/mods-available" ]; then
-        pi_mods_avail="${cfg_pfx}/mods-available"
-        pi_sapi_confdirs=""
+        #
+        # If a previous install placed a plain newrelic.ini directly in a
+        # SAPI conf.d directory, skip the mods-available redirect to avoid
+        # creating a duplicate INI with default settings. The user's
+        # existing customized files in conf.d will continue to be used.
+        #
+        pi_has_confd_ini=
         for sapi_dir in "${cfg_pfx}"/*/conf.d; do
-          if [ -d "${sapi_dir}" ]; then
-            pi_sapi_confdirs="${pi_sapi_confdirs} ${sapi_dir}"
+          if [ -f "${sapi_dir}/newrelic.ini" -a ! -L "${sapi_dir}/newrelic.ini" ]; then
+            pi_has_confd_ini=1
+            break
           fi
         done
-        pi_inidir_cli="${cfg_pfx}/mods-available"
-        pi_inidir_dso=""
+
+        if [ -z "${pi_has_confd_ini}" ]; then
+          pi_mods_avail="${cfg_pfx}/mods-available"
+          pi_sapi_confdirs=""
+          for sapi_dir in "${cfg_pfx}"/*/conf.d; do
+            if [ -d "${sapi_dir}" ]; then
+              pi_sapi_confdirs="${pi_sapi_confdirs} ${sapi_dir}"
+            fi
+          done
+          pi_inidir_cli="${cfg_pfx}/mods-available"
+          pi_inidir_dso=""
+        fi
       fi
     fi
   done

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1559,6 +1559,7 @@ install_agent_here() {
             fi
             log "${pdir}: created symlink ${sapi_confdir}/20-newrelic.ini -> ${pi_mods_avail}/newrelic.ini"
           else
+            istat="failed"
             log "${pdir}: failed to create symlink ${sapi_confdir}/20-newrelic.ini"
           fi
         fi

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -1975,6 +1975,19 @@ remove_from_here() {
   if [ -n "${pi_inidir_dso}" -a -f "${pi_inidir_dso}/newrelic.ini" ]; then
     remove_if_unchanged "${pi_inidir_dso}/newrelic.ini" "${ilibdir}/scripts/newrelic.ini.template"
   fi
+
+  #
+  # Remove symlinks created in SAPI conf.d directories when the INI file
+  # was installed into mods-available.
+  #
+  if [ -n "${pi_mods_avail}" ]; then
+    for sapi_confdir in ${pi_sapi_confdirs}; do
+      if [ -L "${sapi_confdir}/20-newrelic.ini" ]; then
+        logcmd rm -f "${sapi_confdir}/20-newrelic.ini"
+        log "removed symlink ${sapi_confdir}/20-newrelic.ini"
+      fi
+    done
+  fi
 }
 
 do_uninstall() {


### PR DESCRIPTION
On Debian/Ubuntu systems, the tarball installer placed newrelic.ini directly
into each SAPI's conf.d directory, bypassing the mods-available module
management layout. This made phpenmod/phpdismod unable to manage the newrelic
module.

The installer now detects when a mods-available directory exists, installs
newrelic.ini there, and creates 20-newrelic.ini symlinks in each SAPI's conf.d
directory. This new behavior makes tarball install method consistent with deb
package install method, which is consistent with Debian PHP module conventions.

Fixes #1168 