### PR TITLE
ci: fix run-integration-tests-workflow on arm64

### DIFF
--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -65,6 +65,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Enable amd64 emulation
+        if: ${{ inputs.arch == 'arm64' }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
+          platforms: amd64
       - name: Start services
         env:
           PHP: ${{matrix.php}}


### PR DESCRIPTION
Enable amd64 emulation for integration tests on arm64 runners

MySQL 5.6 only provides amd64 images. Without QEMU emulation, the container crashes immediately on arm64 runners, causing test-services-start to fail with "container is unhealthy", which in turns causes integration tests not to run at all. The emulation is only used to run `mysqldb` service container.