### PR TITLE
ci: dynamically generate list of phps

### DIFF
--- a/.github/workflows/get-php-versions.yml
+++ b/.github/workflows/get-php-versions.yml
@@ -1,0 +1,32 @@
+name: _get-php-versions
+
+on:
+  workflow_call:
+    outputs:
+      php-versions:
+        description: 'JSON array of all supported PHP versions'
+        value: ${{ jobs.parse.outputs.php-versions }}
+      php-versions-arm64:
+        description: 'JSON array of PHP versions supported on arm64 (8.0+)'
+        value: ${{ jobs.parse.outputs.php-versions-arm64 }}
+
+jobs:
+  parse:
+    runs-on: ubuntu-latest
+    outputs:
+      php-versions: ${{ steps.parse.outputs.php-versions }}
+      php-versions-arm64: ${{ steps.parse.outputs.php-versions-arm64 }}
+    steps:
+      - name: Checkout php_versions.mk
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: make/php_versions.mk
+          path: php-agent
+      - name: Parse PHP versions from make/php_versions.mk
+        id: parse
+        run: |
+          versions=$(sed -n 's/.*:-\(.*\)}/\1/p' php-agent/make/php_versions.mk)
+          json="[$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | sed 's/.*/"&"/' | paste -sd,)]"
+          echo "php-versions=$json" >> $GITHUB_OUTPUT
+          json_arm="[$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | awk -F. '$1>=8' | sed 's/.*/"&"/' | paste -sd,)]"
+          echo "php-versions-arm64=$json_arm" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-php-versions.yml
+++ b/.github/workflows/get-php-versions.yml
@@ -1,5 +1,7 @@
 name: _get-php-versions
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/get-php-versions.yml
+++ b/.github/workflows/get-php-versions.yml
@@ -25,6 +25,8 @@ jobs:
           path: php-agent
       - name: Get PHP versions
         id: get-php-versions
+        env:
+          ARCH: ${{ inputs.arch }}
         run: |
-          json=$(make -f php-agent/make/php_versions.mk php-versions-json ARCH=${{ inputs.arch }})
+          json=$(make -f php-agent/make/php_versions.mk php-versions-json ARCH=$ARCH)
           echo "php-versions=$json" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-php-versions.yml
+++ b/.github/workflows/get-php-versions.yml
@@ -10,21 +10,21 @@ on:
     outputs:
       php-versions:
         description: 'JSON array of supported PHP versions for the given architecture'
-        value: ${{ jobs.parse.outputs.php-versions }}
+        value: ${{ jobs.get-php-versions.outputs.php-versions }}
 
 jobs:
-  parse:
+  get-php-versions:
     runs-on: ubuntu-latest
     outputs:
-      php-versions: ${{ steps.parse.outputs.php-versions }}
+      php-versions: ${{ steps.get-php-versions.outputs.php-versions }}
     steps:
       - name: Checkout php_versions.mk
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: make/php_versions.mk
           path: php-agent
       - name: Get PHP versions
-        id: parse
+        id: get-php-versions
         run: |
           json=$(make -f php-agent/make/php_versions.mk php-versions-json ARCH=${{ inputs.arch }})
           echo "php-versions=$json" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-php-versions.yml
+++ b/.github/workflows/get-php-versions.yml
@@ -2,20 +2,21 @@ name: _get-php-versions
 
 on:
   workflow_call:
+    inputs:
+      arch:
+        description: 'Target architecture (amd64, arm64)'
+        required: true
+        type: string
     outputs:
       php-versions:
-        description: 'JSON array of all supported PHP versions'
+        description: 'JSON array of supported PHP versions for the given architecture'
         value: ${{ jobs.parse.outputs.php-versions }}
-      php-versions-arm64:
-        description: 'JSON array of PHP versions supported on arm64 (8.0+)'
-        value: ${{ jobs.parse.outputs.php-versions-arm64 }}
 
 jobs:
   parse:
     runs-on: ubuntu-latest
     outputs:
       php-versions: ${{ steps.parse.outputs.php-versions }}
-      php-versions-arm64: ${{ steps.parse.outputs.php-versions-arm64 }}
     steps:
       - name: Checkout php_versions.mk
         uses: actions/checkout@v4
@@ -26,7 +27,9 @@ jobs:
         id: parse
         run: |
           versions=$(sed -n 's/.*:-\(.*\)}/\1/p' php-agent/make/php_versions.mk)
-          json="[$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | sed 's/.*/"&"/' | paste -sd,)]"
+          sorted=$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n)
+          if [[ "${{ inputs.arch }}" == "arm64" ]]; then
+            sorted=$(echo "$sorted" | awk -F. '$1>=8')
+          fi
+          json="[$(echo "$sorted" | sed 's/.*/"&"/' | paste -sd,)]"
           echo "php-versions=$json" >> $GITHUB_OUTPUT
-          json_arm="[$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | awk -F. '$1>=8' | sed 's/.*/"&"/' | paste -sd,)]"
-          echo "php-versions-arm64=$json_arm" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-php-versions.yml
+++ b/.github/workflows/get-php-versions.yml
@@ -23,13 +23,8 @@ jobs:
         with:
           sparse-checkout: make/php_versions.mk
           path: php-agent
-      - name: Parse PHP versions from make/php_versions.mk
+      - name: Get PHP versions
         id: parse
         run: |
-          versions=$(sed -n 's/.*:-\(.*\)}/\1/p' php-agent/make/php_versions.mk)
-          sorted=$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n)
-          if [[ "${{ inputs.arch }}" == "arm64" ]]; then
-            sorted=$(echo "$sorted" | awk -F. '$1>=8')
-          fi
-          json="[$(echo "$sorted" | sed 's/.*/"&"/' | paste -sd,)]"
+          json=$(make -f php-agent/make/php_versions.mk php-versions-json ARCH=${{ inputs.arch }})
           echo "php-versions=$json" >> $GITHUB_OUTPUT

--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -1,5 +1,7 @@
 name: _make-agent
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -24,6 +24,8 @@ on:
 jobs:
   get-php-versions:
     uses: ./.github/workflows/get-php-versions.yml
+    with:
+      arch: ${{ inputs.arch }}
   build-agent:
     needs: [get-php-versions]
     name: make agent (${{ matrix.platform }}, ${{ inputs.arch }}, ${{ matrix.php }})
@@ -35,7 +37,7 @@ jobs:
     strategy:
       matrix:
         platform: [gnu, musl]
-        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions-arm64) }}
+        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/make-agent.yml
+++ b/.github/workflows/make-agent.yml
@@ -22,7 +22,10 @@ on:
         type: string
 
 jobs:
+  get-php-versions:
+    uses: ./.github/workflows/get-php-versions.yml
   build-agent:
+    needs: [get-php-versions]
     name: make agent (${{ matrix.platform }}, ${{ inputs.arch }}, ${{ matrix.php }})
     runs-on: ${{inputs.runs-on}}
     env:
@@ -32,7 +35,7 @@ jobs:
     strategy:
       matrix:
         platform: [gnu, musl]
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions-arm64) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -30,7 +30,10 @@ on:
         type: boolean
 
 jobs:
+  get-php-versions:
+    uses: ./.github/workflows/get-php-versions.yml
   test-agent:
+    needs: [get-php-versions]
     name: test agent (${{ matrix.platform }}, ${{ inputs.arch }}, ${{ matrix.php }})
     runs-on: ${{inputs.runs-on}}
     continue-on-error: ${{inputs.continue-on-error}}
@@ -38,7 +41,7 @@ jobs:
       fail-fast: true
       matrix:
         platform: [gnu, musl]
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions-arm64) }}
     steps:
       - name: Checkout integration tests
         uses: actions/checkout@v4

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -1,5 +1,7 @@
 name: _make-integration-tests
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/make-integration-tests.yml
+++ b/.github/workflows/make-integration-tests.yml
@@ -32,6 +32,8 @@ on:
 jobs:
   get-php-versions:
     uses: ./.github/workflows/get-php-versions.yml
+    with:
+      arch: ${{ inputs.arch }}
   test-agent:
     needs: [get-php-versions]
     name: test agent (${{ matrix.platform }}, ${{ inputs.arch }}, ${{ matrix.php }})
@@ -41,7 +43,7 @@ jobs:
       fail-fast: true
       matrix:
         platform: [gnu, musl]
-        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions-arm64) }}
+        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions) }}
     steps:
       - name: Checkout integration tests
         uses: actions/checkout@v4

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -19,8 +19,14 @@ on:
   pull_request:
 
 jobs:
-  get-php-versions:
+  get-php-versions-amd64:
     uses: ./.github/workflows/get-php-versions.yml
+    with:
+      arch: amd64
+  get-php-versions-arm64:
+    uses: ./.github/workflows/get-php-versions.yml
+    with:
+      arch: arm64
 
   gofmt-check:
     runs-on: ubuntu-latest
@@ -158,7 +164,7 @@ jobs:
           path: php-agent/bin/integration_runner
 
   agent-unit-test-amd64:
-    needs: [get-php-versions]
+    needs: [get-php-versions-amd64]
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: newrelic/nr-php-agent-builder
@@ -168,7 +174,7 @@ jobs:
       matrix:
         platform: [gnu, musl]
         arch: [amd64]
-        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions) }}
+        php: ${{ fromJson(needs.get-php-versions-amd64.outputs.php-versions) }}
         include:
           - codecov: 0
           - platform: gnu
@@ -249,7 +255,7 @@ jobs:
           path: php-agent/agent/.libs/*.gc*
 
   agent-unit-test-arm64:
-    needs: [get-php-versions]
+    needs: [get-php-versions-arm64]
     runs-on: ubuntu-24.04-arm
     env:
       IMAGE_NAME: newrelic/nr-php-agent-builder
@@ -259,7 +265,7 @@ jobs:
       matrix:
         platform: [gnu, musl]
         arch: [arm64]
-        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions-arm64) }}
+        php: ${{ fromJson(needs.get-php-versions-arm64.outputs.php-versions) }}
         include:
           - codecov: 0
     steps:
@@ -320,14 +326,14 @@ jobs:
           path: php-agent/agent/modules/newrelic.so
 
   integration-tests-amd64:
-    needs: [daemon-unit-tests-amd64, agent-unit-test-amd64, get-php-versions]
+    needs: [daemon-unit-tests-amd64, agent-unit-test-amd64, get-php-versions-amd64]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         platform: [gnu, musl]
         arch: [amd64]
-        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions) }}
+        php: ${{ fromJson(needs.get-php-versions-amd64.outputs.php-versions) }}
         include:
           - codecov: 0
           - platform: gnu
@@ -437,14 +443,14 @@ jobs:
           make test-services-stop
 
   integration-tests-arm64:
-    needs: [daemon-unit-tests-arm64, agent-unit-test-arm64, get-php-versions]
+    needs: [daemon-unit-tests-arm64, agent-unit-test-arm64, get-php-versions-arm64]
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         platform: [gnu, musl]
         arch: [arm64]
-        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions-arm64) }}
+        php: ${{ fromJson(needs.get-php-versions-arm64.outputs.php-versions) }}
     steps:
       - name: Checkout integration tests
         uses: actions/checkout@v4

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -19,6 +19,26 @@ on:
   pull_request:
 
 jobs:
+  get-php-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      php-versions: ${{ steps.parse.outputs.php-versions }}
+      php-versions-arm64: ${{ steps.parse.outputs.php-versions-arm64 }}
+    steps:
+      - name: Checkout php_versions.mk
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: make/php_versions.mk
+          path: php-agent
+      - name: Parse PHP versions from make/php_versions.mk
+        id: parse
+        run: |
+          versions=$(sed -n 's/.*:-\(.*\)}/\1/p' php-agent/make/php_versions.mk)
+          json="[$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | sed 's/.*/"&"/' | paste -sd,)]"
+          echo "php-versions=$json" >> $GITHUB_OUTPUT
+          json_arm="[$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | awk -F. '$1>=8' | sed 's/.*/"&"/' | paste -sd,)]"
+          echo "php-versions-arm64=$json_arm" >> $GITHUB_OUTPUT
+
   gofmt-check:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -155,6 +175,7 @@ jobs:
           path: php-agent/bin/integration_runner
 
   agent-unit-test-amd64:
+    needs: [get-php-versions]
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: newrelic/nr-php-agent-builder
@@ -164,7 +185,7 @@ jobs:
       matrix:
         platform: [gnu, musl]
         arch: [amd64]
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions) }}
         include:
           - codecov: 0
           - platform: gnu
@@ -245,6 +266,7 @@ jobs:
           path: php-agent/agent/.libs/*.gc*
 
   agent-unit-test-arm64:
+    needs: [get-php-versions]
     runs-on: ubuntu-24.04-arm
     env:
       IMAGE_NAME: newrelic/nr-php-agent-builder
@@ -254,7 +276,7 @@ jobs:
       matrix:
         platform: [gnu, musl]
         arch: [arm64]
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions-arm64) }}
         include:
           - codecov: 0
     steps:
@@ -315,14 +337,14 @@ jobs:
           path: php-agent/agent/modules/newrelic.so
 
   integration-tests-amd64:
-    needs: [daemon-unit-tests-amd64, agent-unit-test-amd64]
+    needs: [daemon-unit-tests-amd64, agent-unit-test-amd64, get-php-versions]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         platform: [gnu, musl]
         arch: [amd64]
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions) }}
         include:
           - codecov: 0
           - platform: gnu
@@ -432,14 +454,14 @@ jobs:
           make test-services-stop
 
   integration-tests-arm64:
-    needs: [daemon-unit-tests-arm64, agent-unit-test-arm64]
+    needs: [daemon-unit-tests-arm64, agent-unit-test-arm64, get-php-versions]
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         platform: [gnu, musl]
         arch: [arm64]
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ${{ fromJson(needs.get-php-versions.outputs.php-versions-arm64) }}
     steps:
       - name: Checkout integration tests
         uses: actions/checkout@v4

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -20,24 +20,7 @@ on:
 
 jobs:
   get-php-versions:
-    runs-on: ubuntu-latest
-    outputs:
-      php-versions: ${{ steps.parse.outputs.php-versions }}
-      php-versions-arm64: ${{ steps.parse.outputs.php-versions-arm64 }}
-    steps:
-      - name: Checkout php_versions.mk
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: make/php_versions.mk
-          path: php-agent
-      - name: Parse PHP versions from make/php_versions.mk
-        id: parse
-        run: |
-          versions=$(sed -n 's/.*:-\(.*\)}/\1/p' php-agent/make/php_versions.mk)
-          json="[$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | sed 's/.*/"&"/' | paste -sd,)]"
-          echo "php-versions=$json" >> $GITHUB_OUTPUT
-          json_arm="[$(echo $versions | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | awk -F. '$1>=8' | sed 's/.*/"&"/' | paste -sd,)]"
-          echo "php-versions-arm64=$json_arm" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/get-php-versions.yml
 
   gofmt-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -4,6 +4,8 @@
 
 name: test-pull-request
 
+permissions: {}
+
 #
 # Controls when the action will run. 
 #

--- a/make/php_versions.mk
+++ b/make/php_versions.mk
@@ -14,9 +14,12 @@ PHP_VERSIONS_ARM64 := $(filter 8.%, $(PHP_VERSIONS))
 # Shell-friendly version list with PHPS env var override.
 PHP_VERSION_LIST=$${PHPS:-$(PHP_VERSIONS)}
 
-# ARCH is already set by config.mk. This fallback exists for standalone use
-# (e.g., GHA workflow running make -f php_versions.mk directly without the
-# top-level Makefile that includes config.mk).
+# ARCH can come from several sources:
+#   - config.mk (top-level Makefile): x64, x86, arm64, aarch64
+#   - GHA workflow input:             amd64, arm64
+#   - uname -m fallback (standalone): x86_64, aarch64, arm64
+# The php-versions-json recipe only checks for ARM variants (arm64, aarch64);
+# any other value returns the full version list.
 ARCH ?= $(shell uname -m)
 
 # Output a JSON array of supported PHP versions for the given ARCH.

--- a/make/php_versions.mk
+++ b/make/php_versions.mk
@@ -3,4 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-PHP_VERSION_LIST=$${PHPS:-8.5 8.4 8.3 8.2 8.1 8.0 7.4 7.3 7.2}
+# Canonical list of supported PHP versions (ascending order).
+# This is the single source of truth — update this when adding
+# or removing PHP version support.
+PHP_VERSIONS := 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+
+# PHP versions supported on arm64 (8.0+)
+PHP_VERSIONS_ARM64 := $(filter 8.%, $(PHP_VERSIONS))
+
+# Shell-friendly version list with PHPS env var override.
+PHP_VERSION_LIST=$${PHPS:-$(PHP_VERSIONS)}
+
+# ARCH is already set by config.mk. This fallback exists for standalone use
+# (e.g., GHA workflow running make -f php_versions.mk directly without the
+# top-level Makefile that includes config.mk).
+ARCH ?= $(shell uname -m)
+
+# Output a JSON array of supported PHP versions for the given ARCH.
+# Usage: make php-versions-json ARCH=arm64
+.PHONY: php-versions-json
+php-versions-json:
+	@versions="$(if $(filter arm64 aarch64,$(ARCH)),$(PHP_VERSIONS_ARM64),$(PHP_VERSIONS))"; \
+	json=""; sep=""; \
+	for v in $$versions; do json="$${json}$${sep}\"$$v\""; sep=","; done; \
+	echo "[$${json}]"

--- a/make/release.mk
+++ b/make/release.mk
@@ -10,8 +10,6 @@
 # the top-level of the project.
 #
 
-include make/php_versions.mk
-
 RELEASE_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 RELEASE_OS := $(RELEASE_OS:darwin=osx)
 RELEASE_OS := $(RELEASE_OS:sunos=solaris)


### PR DESCRIPTION
Use make/php_versions.mk as source of truth about which PHP versions are
supported instead of hardcoding this in GitHub Actions workflows. This
makes GitHub Actions workflows more dynamic and adding support for new
PHP version requires update in a single file.