### PR TITLE
feat(agent): Functionality to disable instrumentation on fiber detection

### DIFF
--- a/agent/php_api.c
+++ b/agent/php_api.c
@@ -58,30 +58,33 @@ void nr_php_api_add_supportability_metric(const char* name TSRMLS_DC) {
 
 /*
  * Purpose : (New Relic API) Pretend that there is an error at this exact spot.
- *           Useful for business logic errors. 
+ *           Useful for business logic errors.
  *              - newrelic_notice_error($errstr)
  *                   - $errstr : string : The error message to record
  *              - newrelic_notice_error($exception)
- *                   - $exception : object : The exception to use to record the exception
- *                  NOTE: This version is compatible with being a callback for set_exception_handler()
+ *                   - $exception : object : The exception to use to record the
+ * exception NOTE: This version is compatible with being a callback for
+ * set_exception_handler()
  *              - newrelic_notice_error($errstr,$exception)
  *                   - $errstr : string : The error message to record
- *                   - $exception : object : The exception to use to record the exception 
- *                  NOTE: The $errstr value is ignored!  Started with agent version 4.23
+ *                   - $exception : object : The exception to use to record the
+ * exception NOTE: The $errstr value is ignored!  Started with agent
+ * version 4.23
  *              - newrelic_notice_error($errno,$errstr,$fname,$line_nr)
  *                   - $errno : int : The error number
  *                   - $errstr : string : The error message
  *                   - $fname : string : The filename where the error occurred
  *                   - $line_nr : int : The line number where the error occurred
- *                  NOTE: This version is compatible with being a callback for set_error_handler() for PHP 8+
+ *                  NOTE: This version is compatible with being a callback for
+ * set_error_handler() for PHP 8+
  *              - newrelic_notice_error($errno,$errstr,$fname,$line_nr,$ctx)
  *                   - $errno : int : The error number
  *                   - $errstr : string : The error message
  *                   - $fname : string : The filename where the error occurred
  *                   - $line_nr : int : The line number where the error occurred
- *                   - $ctx : array : The context of the error  
- *                  NOTE: This version is compatible with being a callback for set_error_handler() for PHP < 8
- *                        The $ctx is ignored!
+ *                   - $ctx : array : The context of the error
+ *                  NOTE: This version is compatible with being a callback for
+ * set_error_handler() for PHP < 8 The $ctx is ignored!
  */
 #ifdef TAGS
 void zif_newrelic_notice_error(void); /* ctags landing pad only */
@@ -163,7 +166,7 @@ PHP_FUNCTION(newrelic_notice_error) {
 
     case 4:
     case 5:
-      /* PHP 8+ will only pass the first 4 parameters so the 5th parameter is 
+      /* PHP 8+ will only pass the first 4 parameters so the 5th parameter is
        * declared to be optional.  Also this parameter is completely ignored
        * so it doesn't matter if it is passed or not.
        */
@@ -178,14 +181,17 @@ PHP_FUNCTION(newrelic_notice_error) {
       break;
 
     default:
-      nrl_debug(NRL_API, "newrelic_notice_error: invalid number of arguments: %d", ZEND_NUM_ARGS());
+      nrl_debug(NRL_API,
+                "newrelic_notice_error: invalid number of arguments: %d",
+                ZEND_NUM_ARGS());
       RETURN_NULL();
   }
 
   if (exc) {
     if (NR_SUCCESS
-        == nr_php_error_record_exception(
-            NRPRG(txn), exc, priority, true, "Noticed exception ", NULL TSRMLS_CC)) {
+        == nr_php_error_record_exception(NRPRG(txn), exc, priority, true,
+                                         "Noticed exception ",
+                                         NULL TSRMLS_CC)) {
       RETURN_TRUE;
     } else {
       nrl_debug(NRL_API, "newrelic_notice_error: invalid exception argument");
@@ -1557,7 +1563,7 @@ PHP_FUNCTION(newrelic_get_trace_metadata) {
 }
 
 /*
- * Purpose      Allows a caller to add a user id string to agent attributes in 
+ * Purpose      Allows a caller to add a user id string to agent attributes in
                 transaction event, transaction trace, error and span.
  *
  */

--- a/agent/php_error.c
+++ b/agent/php_error.c
@@ -272,8 +272,8 @@ PHP_FUNCTION(newrelic_exception_handler) {
    */
 
   nr_php_error_record_exception(
-      NRPRG(txn), exception, NR_PHP_ERROR_PRIORITY_UNCAUGHT_EXCEPTION,
-      true, "Uncaught exception ", &NRPRG(exception_filters) TSRMLS_CC);
+      NRPRG(txn), exception, NR_PHP_ERROR_PRIORITY_UNCAUGHT_EXCEPTION, true,
+      "Uncaught exception ", &NRPRG(exception_filters) TSRMLS_CC);
   /*
    * Finally, we need to generate an E_ERROR to match what PHP would have done
    * if this handler wasn't installed. Happily, PHP exposes an API function
@@ -313,7 +313,7 @@ int nr_php_error_get_priority(int type) {
     case E_USER_DEPRECATED:
       return 30;
     case E_STRICT: /* Included for backward compatibility */
-      return 10;      
+      return 10;
     case E_USER_NOTICE:
       return 0;
     case E_NOTICE:
@@ -449,7 +449,8 @@ static long nr_php_error_exception_line(zval* exception TSRMLS_DC) {
  *           will need to free, or NULL if no message could be extracted.
  */
 static char* nr_php_error_exception_message(zval* exception TSRMLS_DC) {
-  zval* message_zv = nr_php_get_zval_base_exception_property(exception, "message");
+  zval* message_zv
+      = nr_php_get_zval_base_exception_property(exception, "message");
   char* message = NULL;
 
   if (nr_php_is_zval_valid_string(message_zv)) {
@@ -547,18 +548,20 @@ static int nr_php_should_record_error(int type, const char* format TSRMLS_DC) {
    * For a the following error types:
    * E_WARNING || E_CORE_WARNING || E_COMPILE_WARNING || E_USER_WARNING
    * PHP triggers an exception if EH_THROW is toggled on and then immediately
-   * returns after throwing the exception. PHP 7 additionally triggers an exception 
-   * for E_RECOVERABLE_ERROR.
-   * See for more info:
+   * returns after throwing the exception. PHP 7 additionally triggers an
+   * exception for E_RECOVERABLE_ERROR. See for more info:
    * https://github.com/php/php-src/blob/master/main/main.c In that case, we
    * should not handle it, but we should exit and let the exception handler
    * deal with it; otherwise, we could record an error even if an exception is
    * caught.
    */
 #if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
-#define E_ERRORS_THROWING_EXCEPTIONS (E_WARNING | E_CORE_WARNING | E_COMPILE_WARNING | E_USER_WARNING | E_RECOVERABLE_ERROR)
+#define E_ERRORS_THROWING_EXCEPTIONS                               \
+  (E_WARNING | E_CORE_WARNING | E_COMPILE_WARNING | E_USER_WARNING \
+   | E_RECOVERABLE_ERROR)
 #else
-#define E_ERRORS_THROWING_EXCEPTIONS (E_WARNING | E_CORE_WARNING | E_COMPILE_WARNING | E_USER_WARNING)
+#define E_ERRORS_THROWING_EXCEPTIONS \
+  (E_WARNING | E_CORE_WARNING | E_COMPILE_WARNING | E_USER_WARNING)
 #endif
 
 #define E_THROWS_EXCEPTION(e) ((E_ERRORS_THROWING_EXCEPTIONS & e) == e)
@@ -631,8 +634,8 @@ void nr_php_error_cb(int type,
 
     stack_json = nr_php_backtrace_to_json(0 TSRMLS_CC);
     errclass = nr_php_error_get_type_string(type);
-    nr_txn_record_error(NRPRG(txn), nr_php_error_get_priority(type), true,
-                        msg, errclass, stack_json);
+    nr_txn_record_error(NRPRG(txn), nr_php_error_get_priority(type), true, msg,
+                        errclass, stack_json);
 
     /*
      * Error Fingerprinting Callback
@@ -742,8 +745,7 @@ nr_status_t nr_php_error_record_exception(nrtxn_t* txn,
                                            stack_json);
   }
 
-  nr_txn_record_error(NRPRG(txn), priority,
-                      add_to_current_segment,
+  nr_txn_record_error(NRPRG(txn), priority, add_to_current_segment,
                       error_message, klass, stack_json);
 
   nr_free(error_message);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -326,18 +326,18 @@ static const nr_framework_table_t all_frameworks[] = {
      * specifically a problem for Expression Engine (look for expression_engine,
      * below.)
      */
-    {"CodeIgniter", "codeigniter", NR_PSTR("codeigniter.php"), 0, nr_codeigniter_enable,
-     NR_FW_CODEIGNITER},
+    {"CodeIgniter", "codeigniter", NR_PSTR("codeigniter.php"), 0,
+     nr_codeigniter_enable, NR_FW_CODEIGNITER},
 
-    {"Drupal8", "drupal8", NR_PSTR("core/includes/bootstrap.inc"), 0, nr_drupal8_enable,
-     NR_FW_DRUPAL8},
+    {"Drupal8", "drupal8", NR_PSTR("core/includes/bootstrap.inc"), 0,
+     nr_drupal8_enable, NR_FW_DRUPAL8},
     {"Drupal", "drupal", NR_PSTR("includes/common.inc"), 0, nr_drupal_enable,
      NR_FW_DRUPAL},
 
     {"Joomla", "joomla", NR_PSTR("joomla/import.php"), 0, nr_joomla_enable,
      NR_FW_JOOMLA}, /* <= Joomla 1.5 */
-    {"Joomla", "joomla", NR_PSTR("libraries/joomla/factory.php"), 0, nr_joomla_enable,
-     NR_FW_JOOMLA}, /* >= Joomla 1.6, including 2.5 and 3.2 */
+    {"Joomla", "joomla", NR_PSTR("libraries/joomla/factory.php"), 0,
+     nr_joomla_enable, NR_FW_JOOMLA}, /* >= Joomla 1.6, including 2.5 and 3.2 */
 
     /* See below: Zend, the legacy project of Laminas, which shares much
        of the instrumentation implementation with Laminas */
@@ -348,25 +348,25 @@ static const nr_framework_table_t all_frameworks[] = {
 
     {"Laravel", "laravel", NR_PSTR("illuminate/foundation/application.php"), 0,
      nr_laravel_enable, NR_FW_LARAVEL},
-    {"Laravel", "laravel", NR_PSTR("bootstrap/compiled.php"), 0, nr_laravel_enable,
-     NR_FW_LARAVEL}, /* 4.x */
+    {"Laravel", "laravel", NR_PSTR("bootstrap/compiled.php"), 0,
+     nr_laravel_enable, NR_FW_LARAVEL}, /* 4.x */
     {"Laravel", "laravel", NR_PSTR("storage/framework/compiled.php"), 0,
      nr_laravel_enable, NR_FW_LARAVEL}, /* 5.0.0-14 */
     {"Laravel", "laravel", NR_PSTR("vendor/compiled.php"), 0, nr_laravel_enable,
      NR_FW_LARAVEL}, /* 5.0.15-5.0.x */
-    {"Laravel", "laravel", NR_PSTR("bootstrap/cache/compiled.php"), 0, nr_laravel_enable,
-     NR_FW_LARAVEL}, /* 5.1.0-x */
+    {"Laravel", "laravel", NR_PSTR("bootstrap/cache/compiled.php"), 0,
+     nr_laravel_enable, NR_FW_LARAVEL}, /* 5.1.0-x */
 
-    {"Lumen", "lumen", NR_PSTR("lumen-framework/src/helpers.php"), 0, nr_lumen_enable,
-     NR_FW_LUMEN},
+    {"Lumen", "lumen", NR_PSTR("lumen-framework/src/helpers.php"), 0,
+     nr_lumen_enable, NR_FW_LUMEN},
 
     {"Magento", "magento", NR_PSTR("app/mage.php"), 0, nr_magento1_enable,
      NR_FW_MAGENTO1},
     {"Magento2", "magento2", NR_PSTR("magento/framework/registration.php"), 0,
      nr_magento2_enable, NR_FW_MAGENTO2},
 
-    {"MediaWiki", "mediawiki", NR_PSTR("includes/webstart.php"), 0, nr_mediawiki_enable,
-     NR_FW_MEDIAWIKI},
+    {"MediaWiki", "mediawiki", NR_PSTR("includes/webstart.php"), 0,
+     nr_mediawiki_enable, NR_FW_MEDIAWIKI},
 
     {"Slim", "slim", NR_PSTR("slim/slim/app.php"), 0, nr_slim_enable,
      NR_FW_SLIM}, /* 3.x */
@@ -380,17 +380,19 @@ static const nr_framework_table_t all_frameworks[] = {
      NR_FW_WORDPRESS},
 
     {"Yii", "yii", NR_PSTR("framework/yii.php"), 0, nr_yii1_enable, NR_FW_YII1},
-    {"Yii", "yii", NR_PSTR("framework/yiilite.php"), 0, nr_yii1_enable, NR_FW_YII1},
-    {"Yii2", "yii2", NR_PSTR("yii2/baseyii.php"), 0, nr_yii2_enable, NR_FW_YII2},
+    {"Yii", "yii", NR_PSTR("framework/yiilite.php"), 0, nr_yii1_enable,
+     NR_FW_YII1},
+    {"Yii2", "yii2", NR_PSTR("yii2/baseyii.php"), 0, nr_yii2_enable,
+     NR_FW_YII2},
 
     /* See above: Laminas, the successor to Zend, which shares much
        of the instrumentation implementation with Zend */
     // treating zend2 as zend3 for backwards compatibility
-    {"Zend3", "zend2", NULL, 0, 0, nr_fw_zend3_enable, NR_FW_ZEND3}, 
-    {"Zend3", "zend3", NR_PSTR("zend/mvc/application.php"), 0, nr_fw_zend3_enable,
-     NR_FW_ZEND3},
-    {"Zend3", "zend3", NR_PSTR("zend-mvc/src/application.php"), 0, nr_fw_zend3_enable,
-     NR_FW_ZEND3},
+    {"Zend3", "zend2", NULL, 0, 0, nr_fw_zend3_enable, NR_FW_ZEND3},
+    {"Zend3", "zend3", NR_PSTR("zend/mvc/application.php"), 0,
+     nr_fw_zend3_enable, NR_FW_ZEND3},
+    {"Zend3", "zend3", NR_PSTR("zend-mvc/src/application.php"), 0,
+     nr_fw_zend3_enable, NR_FW_ZEND3},
 };
 // clang-format: on
 static const int num_all_frameworks
@@ -449,7 +451,8 @@ typedef struct _nr_library_table_t {
 // clang-format: off
 static nr_library_table_t libraries[] = {
     /* AWS-SDK-PHP 3 */
-    {"AWS-SDK-PHP", NR_PSTR("aws-sdk-php/src/awsclient.php"), nr_aws_sdk_php_enable},
+    {"AWS-SDK-PHP", NR_PSTR("aws-sdk-php/src/awsclient.php"),
+     nr_aws_sdk_php_enable},
 
     /* Doctrine < 2.18 */
     {"Doctrine 2", NR_PSTR("doctrine/orm/query.php"), nr_doctrine2_enable},
@@ -457,14 +460,15 @@ static nr_library_table_t libraries[] = {
     {"Doctrine 2", NR_PSTR("doctrine/orm/src/query.php"), nr_doctrine2_enable},
 
     {"Guzzle 4-5", NR_PSTR("hasemitterinterface.php"), nr_guzzle4_enable},
-    {"Guzzle 6", NR_PSTR("guzzle/src/functions_include.php"), nr_guzzle6_enable},
+    {"Guzzle 6", NR_PSTR("guzzle/src/functions_include.php"),
+     nr_guzzle6_enable},
 
     {"MongoDB", NR_PSTR("mongodb/src/client.php"), nr_mongodb_enable},
 
     /* php-amqplib RabbitMQ; PHP Agent supports php-amqplib >= 3.7 */
     {"php-amqplib", NR_PSTR("phpamqplib/connection/abstractconnection.php"),
      nr_php_amqplib_enable},
-    
+
     /*
      * The first path is for Composer installs, the second is for
      * /usr/local/bin.
@@ -488,7 +492,8 @@ static nr_library_table_t libraries[] = {
      * framework. This allows Laminas_Http_Client to be instrumented when used
      * with other frameworks or even without a framework at all.
      */
-    {"Laminas_Http", NR_PSTR("laminas-http/src/client.php"), nr_laminas_http_enable},
+    {"Laminas_Http", NR_PSTR("laminas-http/src/client.php"),
+     nr_laminas_http_enable},
 };
 // clang-format: on
 
@@ -520,7 +525,8 @@ typedef struct _nr_vuln_mgmt_table_t {
 /* Note that all paths should be in lowercase. */
 // clang-format: off
 static const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
-    {"Drupal", NR_PSTR("drupal/component/dependencyinjection/container.php"), nr_drupal_version},
+    {"Drupal", NR_PSTR("drupal/component/dependencyinjection/container.php"),
+     nr_drupal_version},
     {"Wordpress", NR_PSTR("wp-includes/version.php"), nr_wordpress_version},
 };
 // clang-format: on
@@ -579,13 +585,13 @@ void nr_php_show_exec(const char* context, NR_EXECUTE_PROTO TSRMLS_DC) {
     nrl_verbosedebug(
         NRL_AGENT,
         NRP_FMT_UQ ": %.*s scope={%.*s} function={" NRP_FMT_UQ
-        "}"
-        " params={" NRP_FMT_UQ
-        "}"
-        " %.5s"
-        "@ " NRP_FMT_UQ ":%d",
-        NRP_SHOW_EXEC_CONTEXT(ctx),
-        nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces,
+                   "}"
+                   " params={" NRP_FMT_UQ
+                   "}"
+                   " %.5s"
+                   "@ " NRP_FMT_UQ ":%d",
+        NRP_SHOW_EXEC_CONTEXT(ctx), nr_php_show_exec_indentation(TSRMLS_C),
+        nr_php_indentation_spaces,
         NRSAFELEN(nr_php_class_entry_name_length(NR_OP_ARRAY->scope)),
         nr_php_class_entry_name(NR_OP_ARRAY->scope),
         NRP_PHP(function_name ? function_name : "?"), NRP_ARGSTR(argstr),
@@ -603,14 +609,13 @@ void nr_php_show_exec(const char* context, NR_EXECUTE_PROTO TSRMLS_DC) {
     nrl_verbosedebug(
         NRL_AGENT,
         NRP_FMT_UQ ": %.*s function={" NRP_FMT_UQ
-        "}"
-        " params={" NRP_FMT_UQ
-        "}"
-        " %.5s"
-        "@ " NRP_FMT_UQ ":%d",
-        NRP_SHOW_EXEC_CONTEXT(ctx),
-        nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces,
-        NRP_PHP(function_name), NRP_ARGSTR(argstr),
+                   "}"
+                   " params={" NRP_FMT_UQ
+                   "}"
+                   " %.5s"
+                   "@ " NRP_FMT_UQ ":%d",
+        NRP_SHOW_EXEC_CONTEXT(ctx), nr_php_show_exec_indentation(TSRMLS_C),
+        nr_php_indentation_spaces, NRP_PHP(function_name), NRP_ARGSTR(argstr),
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
         nr_php_op_array_get_wraprec(NR_OP_ARRAY TSRMLS_CC) ? " *" : "",
 #else
@@ -629,9 +634,9 @@ void nr_php_show_exec(const char* context, NR_EXECUTE_PROTO TSRMLS_DC) {
     /*
      * unknown
      */
-    nrl_verbosedebug(NRL_AGENT, NRP_FMT_UQ ": %.*s ?",
-                     NRP_SHOW_EXEC_CONTEXT(ctx),
-                     nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces);
+    nrl_verbosedebug(
+        NRL_AGENT, NRP_FMT_UQ ": %.*s ?", NRP_SHOW_EXEC_CONTEXT(ctx),
+        nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces);
   }
 }
 
@@ -862,14 +867,14 @@ static void nr_execute_handle_autoload(const char* filename,
     return;
   }
 
-  /* 
-  *  There is a possibility of the txn being NULL if nr_php_end_txn has been called. 
-  *  Verify txn is not null before dereferencing and continuing on.
-  */  
+  /*
+   *  There is a possibility of the txn being NULL if nr_php_end_txn has been
+   * called. Verify txn is not null before dereferencing and continuing on.
+   */
   if (NULL == NRPRG(txn)) {
     return;
   }
-  
+
   if (NRPRG(txn)->composer_info.autoload_detected) {
     // autoload already handled
     return;
@@ -972,7 +977,7 @@ static void nr_php_user_instrumentation_from_file(const char* filename,
 #define METRIC_NAME_MAX_LEN 512
 
 void nr_php_execute_file(const zend_op_array* op_array,
-                                NR_EXECUTE_PROTO TSRMLS_DC) {
+                         NR_EXECUTE_PROTO TSRMLS_DC) {
   const char* filename = nr_php_op_array_file_name(op_array);
   size_t filename_len = nr_php_op_array_file_name_len(op_array);
 
@@ -1210,7 +1215,6 @@ static void nr_php_execute_metadata_metric(
  */
 static inline void nr_php_execute_metadata_release(
     nr_php_execute_metadata_t* metadata) {
-
   if (NULL != metadata->scope) {
     zend_string_release(metadata->scope);
     metadata->scope = NULL;
@@ -1233,7 +1237,7 @@ static inline void nr_php_execute_segment_add_metric(
     bool create_metric) {
   char buf[METRIC_NAME_MAX_LEN];
 
-/*
+  /*
    * If the name is not already set, use the metadata to get the class and
    * function name to name the metric and the segment.
    *
@@ -1288,14 +1292,13 @@ static inline void nr_php_execute_segment_end(
   if (create_metric || (duration >= NR_PHP_PROCESS_GLOBALS(expensive_min))
       || nr_vector_size(stacked->metrics) || stacked->id || stacked->attributes
       || stacked->error) {
-
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
     // There are no stacked segments for OAPI.
     nr_segment_t* s = stacked;
 #else
     nr_segment_t* s = nr_php_stacked_segment_move_to_heap(stacked TSRMLS_CC);
-#endif // OAPI
+#endif  // OAPI
     nr_php_execute_segment_add_metric(s, metadata, create_metric);
 
     /*
@@ -1314,7 +1317,7 @@ static inline void nr_php_execute_segment_end(
     nr_segment_discard(&stacked);
 #else
     nr_php_stacked_segment_deinit(stacked TSRMLS_CC);
-#endif // OAPI
+#endif  // OAPI
   }
 }
 
@@ -1493,7 +1496,7 @@ static void nr_php_execute_show(NR_EXECUTE_PROTO TSRMLS_DC) {
     nr_php_show_exec_return(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
   }
 }
-#endif // not OAPI
+#endif  // not OAPI
 
 static void nr_php_max_nesting_level_reached(TSRMLS_D) {
   /*
@@ -1577,7 +1580,7 @@ void nr_php_execute(NR_EXECUTE_PROTO_OVERWRITE TSRMLS_DC) {
 
   return;
 }
-#endif // not OAPI
+#endif  // not OAPI
 
 static void nr_php_show_exec_internal(NR_EXECUTE_PROTO_OVERWRITE,
                                       const zend_function* func TSRMLS_DC) {
@@ -1601,8 +1604,7 @@ static void nr_php_show_exec_internal(NR_EXECUTE_PROTO_OVERWRITE,
   (NR_PHP_PROCESS_GLOBALS(orig_execute_internal)(execute_data, return_value))
 
 void nr_php_execute_internal(zend_execute_data* execute_data,
-                             zval* return_value NRUNUSED)
-{
+                             zval* return_value NRUNUSED) {
   nrtime_t duration = 0;
   zend_function* func = NULL;
   nr_segment_t* segment;
@@ -1936,15 +1938,16 @@ static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
     return;
   }
   if (nrunlikely(NRPRG(txn)->segment_root == segment)) {
-/*
+    /*
      * There should be no fcall_end associated with the segment root, If we are
      * here, it is most likely due to an API call to newrelic_end_transaction.
      * However, there's a special case here, if we call nr_php_txn_end
-     * and then call nr_php_txn_start from within a wrapped call inside the agent,
-     * then there will be an fcall associated with the segment root.
-     * We may or may not need to do anything with this so we check if a wraprec exists.
-     * If a wraprec exists, we proceed so we can use the _after and _clean callbacks
-     * if they exist. If it doesn't exist, we exit as nothing needs to be done.
+     * and then call nr_php_txn_start from within a wrapped call inside the
+     * agent, then there will be an fcall associated with the segment root. We
+     * may or may not need to do anything with this so we check if a wraprec
+     * exists. If a wraprec exists, we proceed so we can use the _after and
+     * _clean callbacks if they exist. If it doesn't exist, we exit as nothing
+     * needs to be done.
      */
 
     if (NULL == segment->wraprec) {
@@ -1977,8 +1980,7 @@ static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
     zval exception;
     ZVAL_OBJ(&exception, EG(exception));
     nr_status_t status = nr_php_error_record_exception_segment(
-      NRPRG(txn), &exception,
-      &NRPRG(exception_filters));
+        NRPRG(txn), &exception, &NRPRG(exception_filters));
 
     if (NR_FAILURE == status) {
       nrl_verbosedebug(NRL_AGENT, "%s: unable to record exception on segment",
@@ -2009,7 +2011,7 @@ static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
      */
     if (NULL != nr_php_get_return_value(NR_EXECUTE_ORIG_ARGS)) {
       zcaught = nr_zend_call_orig_execute_special(wraprec, segment,
-                                                NR_EXECUTE_ORIG_ARGS);
+                                                  NR_EXECUTE_ORIG_ARGS);
     } else {
       zcaught = nr_zend_call_oapi_special_clean(wraprec, segment,
                                                 NR_EXECUTE_ORIG_ARGS);

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -46,7 +46,7 @@ extern zend_module_entry newrelic_module_entry;
  * instrumentation. When checking in, leave this toggled on to have the CI work
  * as long as possible until the handler functionality is implemented.*/
 
-//#define OVERWRITE_ZEND_EXECUTE_DATA true
+// #define OVERWRITE_ZEND_EXECUTE_DATA true
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP 8.0+ and OAPI */
@@ -262,12 +262,13 @@ nrinibool_t drupal_modules;  /* newrelic.framework.drupal.modules */
 nrinibool_t wordpress_hooks; /* newrelic.framework.wordpress.hooks */
 nrinistr_t
     wordpress_hooks_options; /* newrelic.framework.wordpress.hooks.options */
-nrinitime_t wordpress_hooks_threshold; /* newrelic.framework.wordpress.hooks.threshold
-                                        */
-bool wordpress_plugins;                /* set based on
-                                                 newrelic.framework.wordpress.hooks.options */
-bool wordpress_core;                   /* set based on
-                                                 newrelic.framework.wordpress.hooks.options */
+nrinitime_t
+    wordpress_hooks_threshold; /* newrelic.framework.wordpress.hooks.threshold
+                                */
+bool wordpress_plugins;        /* set based on
+                                         newrelic.framework.wordpress.hooks.options */
+bool wordpress_core;           /* set based on
+                                         newrelic.framework.wordpress.hooks.options */
 nrinistr_t
     wordpress_hooks_skip_filename; /* newrelic.framework.wordpress.hooks_skip_filename
                                     */
@@ -313,9 +314,10 @@ nr_php_ini_attribute_config_t
                                   */
 
 nrinibool_t custom_events_enabled; /* newrelic.custom_insights_events.enabled */
-nriniuint_t custom_events_max_samples_stored; /* newrelic.custom_events.max_samples_stored
-                                               */
-nrinibool_t synthetics_enabled;               /* newrelic.synthetics.enabled */
+nriniuint_t
+    custom_events_max_samples_stored; /* newrelic.custom_events.max_samples_stored
+                                       */
+nrinibool_t synthetics_enabled;       /* newrelic.synthetics.enabled */
 
 nrinibool_t phpunit_events_enabled; /* newrelic.phpunit_events.enabled */
 
@@ -328,8 +330,7 @@ nrinibool_t
 /*
  * Cloud relationship settings
  */
-nrinistr_t
-    aws_account_id; /* newrelic.cloud.aws.account_id */
+nrinistr_t aws_account_id; /* newrelic.cloud.aws.account_id */
 
 /*
  * Deprecated settings that control request parameter capture.
@@ -374,11 +375,11 @@ nrframework_t
 int framework_version; /* Current framework version */
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
-     && !defined OVERWRITE_ZEND_EXECUTE_DATA
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
 /* Without OAPI, we are able to utilize the call stack to keep track
  * of the previous hooks. With OAPI, we can no longer do this so
  * we track the stack manually */
-nr_stack_t drupal_invoke_all_hooks; /* stack of Drupal hooks */
+nr_stack_t drupal_invoke_all_hooks;  /* stack of Drupal hooks */
 nr_stack_t drupal_invoke_all_states; /* stack of bools indicating
                                                whether the current hook
                                                needs to be released */
@@ -386,7 +387,7 @@ nr_stack_t drupal_invoke_all_states; /* stack of bools indicating
 char* drupal_invoke_all_hook;      /* The current Drupal hook */
 size_t drupal_invoke_all_hook_len; /* The length of the current Drupal
                                              hook */
-#endif //OAPI
+#endif                            // OAPI
 size_t drupal_http_request_depth; /* The current depth of drupal_http_request()
                                      calls */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
@@ -395,7 +396,7 @@ nr_segment_t* drupal_http_request_segment;
 #endif
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
-     && !defined OVERWRITE_ZEND_EXECUTE_DATA
+    && !defined OVERWRITE_ZEND_EXECUTE_DATA
 bool check_cufa;
 /* Without OAPI, we are able to utilize the call stack to keep track
  * of the previous tags. With OAPI, we can no longer do this so
@@ -405,18 +406,18 @@ nr_stack_t wordpress_tag_states; /* stack of bools indicating
                                     whether the current tag
                                     needs to be released */
 #else
-bool check_cufa; /* Whether we need to check cufa because we are
-                    instrumenting hooks, or whether we can skip cufa */
-char* wordpress_tag;                    /* The current WordPress tag */
+bool check_cufa;     /* Whether we need to check cufa because we are
+                        instrumenting hooks, or whether we can skip cufa */
+char* wordpress_tag; /* The current WordPress tag */
 
-#endif //OAPI
+#endif  // OAPI
 
-nr_matcher_t* wordpress_plugin_matcher; /* Matcher for plugin filenames */
-nr_matcher_t* wordpress_theme_matcher;  /* Matcher for theme filenames */
-nr_matcher_t* wordpress_core_matcher;   /* Matcher for plugin filenames */
-nr_hashmap_t* wordpress_file_metadata;  /* Metadata for plugin and theme names
-                                           given a filename */
-nr_hashmap_t* wordpress_clean_tag_cache; /* Cached clean tags */                                           
+nr_matcher_t* wordpress_plugin_matcher;  /* Matcher for plugin filenames */
+nr_matcher_t* wordpress_theme_matcher;   /* Matcher for theme filenames */
+nr_matcher_t* wordpress_core_matcher;    /* Matcher for plugin filenames */
+nr_hashmap_t* wordpress_file_metadata;   /* Metadata for plugin and theme names
+                                            given a filename */
+nr_hashmap_t* wordpress_clean_tag_cache; /* Cached clean tags */
 
 char* doctrine_dql; /* The current Doctrine DQL. Only non-NULL while a Doctrine
                        object is on the stack. */
@@ -489,16 +490,17 @@ nrinibool_t
 nrinibool_t
     distributed_tracing_exclude_newrelic_header; /* newrelic.distributed_tracing_exclude_newrelic_header
                                                   */
-nrinibool_t
-    distributed_tracing_pad_trace_id; /* newrelic.distributed_tracing.pad_trace_id */
-nrinibool_t span_events_enabled; /* newrelic.span_events_enabled */
+nrinibool_t distributed_tracing_pad_trace_id; /* newrelic.distributed_tracing.pad_trace_id
+                                               */
+nrinibool_t span_events_enabled;              /* newrelic.span_events_enabled */
 nriniuint_t
     span_events_max_samples_stored; /* newrelic.span_events.max_samples_stored
                                      */
 
-nrinistr_t dt_remote_parent_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_sampled */
-nrinistr_t
-    dt_remote_parent_not_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_not_sampled */
+nrinistr_t dt_remote_parent_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_sampled
+                                      */
+nrinistr_t dt_remote_parent_not_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_not_sampled
+                                          */
 /* decoding of newrelic.distributed_tracing.sampler.remote_parent_sampled and
  * newrelic.distributed_tracing.sampler.remote_parent_not_sampled.
  */
@@ -537,12 +539,11 @@ nrinibool_t
 nriniuint_t
     log_forwarding_log_level; /* newrelic.application_logging.forwarding.log_level
                                */
-nrinibool_t
-    log_forwarding_labels_enabled; /* newrelic.application_logging.forwarding.labels.enabled */
+nrinibool_t log_forwarding_labels_enabled; /* newrelic.application_logging.forwarding.labels.enabled
+                                            */
 
-nrinistr_t
-    log_forwarding_labels_exclude; /* newrelic.application_logging.forwarding.labels.exclude */
-
+nrinistr_t log_forwarding_labels_exclude; /* newrelic.application_logging.forwarding.labels.exclude
+                                           */
 
 /*
  * Configuration option to toggle code level metrics collection.
@@ -551,19 +552,20 @@ nrinibool_t
     code_level_metrics_enabled; /* newrelic.code_level_metrics.enabled */
 
 /*
- * Configuration option to enable or disable package detection for vulnerability management
+ * Configuration option to enable or disable package detection for vulnerability
+ * management
  */
 nrinibool_t
     vulnerability_management_package_detection_enabled; /* newrelic.vulnerability_management.package_detection.enabled
                                                          */
-nrinibool_t
-    vulnerability_management_composer_api_enabled; /* newrelic.vulnerability_management.composer_api.enabled */
+nrinibool_t vulnerability_management_composer_api_enabled; /* newrelic.vulnerability_management.composer_api.enabled
+                                                            */
 
 /*
  * Configuration options for recording Messaging APIs
  */
-nrinibool_t
-    message_tracer_segment_parameters_enabled; /* newrelic.segment_tracer.segment_parameters.enabled */
+nrinibool_t message_tracer_segment_parameters_enabled; /* newrelic.segment_tracer.segment_parameters.enabled
+                                                        */
 
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
 /*
@@ -655,7 +657,7 @@ static inline int nr_php_recording(TSRMLS_D) {
 }
 
 static inline bool is_error_callback_set() {
-    return NRPRG(error_group_user_callback).is_set;
+  return NRPRG(error_group_user_callback).is_set;
 }
 
 /*

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -363,6 +363,7 @@ nrinistr_t file_name_list;            /* newrelic.webtransaction.name.files */
 nrinibool_t
     tt_inputquery;        /* newrelic.transaction_tracer.gather_input_queries */
 nriniuint_t tt_recordsql; /* newrelic.transaction_tracer.record_sql */
+nrinibool_t fibers_disabled; /* newrelic.fibers.disabled */
 #define NR_PHP_RECORDSQL_OFF NR_SQL_NONE
 #define NR_PHP_RECORDSQL_RAW NR_SQL_RAW
 #define NR_PHP_RECORDSQL_OBFUSCATED NR_SQL_OBFUSCATED

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1982,8 +1982,10 @@ static PHP_INI_MH(nr_dt_sampler_remote_parent_mh) {
 
   p->where = 0;
 
-  if (0 == nr_strcmp(ZEND_STRING_VALUE(entry->name),
-                     "newrelic.distributed_tracing.sampler.remote_parent_sampled")) {
+  if (0
+      == nr_strcmp(
+          ZEND_STRING_VALUE(entry->name),
+          "newrelic.distributed_tracing.sampler.remote_parent_sampled")) {
     parent_sampled = true;
   }
 
@@ -2636,14 +2638,15 @@ STD_PHP_INI_ENTRY_EX("newrelic.error_collector.ignore_user_exception_handler",
                      zend_newrelic_globals,
                      newrelic_globals,
                      nr_yes_no_dh)
-STD_PHP_INI_ENTRY_EX("newrelic.error_collector.ignore_framework_error_exception_handler",
-                     "0",
-                     NR_PHP_REQUEST,
-                     nr_boolean_mh,
-                     ignore_framework_error_exception_handler,
-                     zend_newrelic_globals,
-                     newrelic_globals,
-                     nr_yes_no_dh)
+STD_PHP_INI_ENTRY_EX(
+    "newrelic.error_collector.ignore_framework_error_exception_handler",
+    "0",
+    NR_PHP_REQUEST,
+    nr_boolean_mh,
+    ignore_framework_error_exception_handler,
+    zend_newrelic_globals,
+    newrelic_globals,
+    nr_yes_no_dh)
 STD_PHP_INI_ENTRY_EX("newrelic.error_collector.ignore_errors",
                      "",
                      NR_PHP_REQUEST,
@@ -2987,23 +2990,24 @@ STD_PHP_INI_ENTRY_EX("newrelic.distributed_tracing_exclude_newrelic_header",
                      newrelic_globals,
                      0)
 
-
-STD_PHP_INI_ENTRY_EX("newrelic.distributed_tracing.sampler.remote_parent_sampled",
-                     "default",
-                     NR_PHP_REQUEST,
-                     nr_dt_sampler_remote_parent_mh,
-                     dt_remote_parent_sampled,
-                     zend_newrelic_globals,
-                     newrelic_globals,
-                     0)
-STD_PHP_INI_ENTRY_EX("newrelic.distributed_tracing.sampler.remote_parent_not_sampled",
-                     "default",
-                     NR_PHP_REQUEST,
-                     nr_dt_sampler_remote_parent_mh,
-                     dt_remote_parent_not_sampled,
-                     zend_newrelic_globals,
-                     newrelic_globals,
-                     0)
+STD_PHP_INI_ENTRY_EX(
+    "newrelic.distributed_tracing.sampler.remote_parent_sampled",
+    "default",
+    NR_PHP_REQUEST,
+    nr_dt_sampler_remote_parent_mh,
+    dt_remote_parent_sampled,
+    zend_newrelic_globals,
+    newrelic_globals,
+    0)
+STD_PHP_INI_ENTRY_EX(
+    "newrelic.distributed_tracing.sampler.remote_parent_not_sampled",
+    "default",
+    NR_PHP_REQUEST,
+    nr_dt_sampler_remote_parent_mh,
+    dt_remote_parent_not_sampled,
+    zend_newrelic_globals,
+    newrelic_globals,
+    0)
 
 /*
  * This setting is not documented and affects the length of the interally used
@@ -3180,30 +3184,33 @@ STD_PHP_INI_ENTRY_EX("newrelic.application_logging.metrics.enabled",
                      zend_newrelic_globals,
                      newrelic_globals,
                      nr_enabled_disabled_dh)
-STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.context_data.enabled",
-                     "0",
-                     NR_PHP_REQUEST,
-                     nr_boolean_mh,
-                     log_context_data_attributes.enabled,
-                     zend_newrelic_globals,
-                     newrelic_globals,
-                     nr_enabled_disabled_dh)
-STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.context_data.include",
-                     "",
-                     NR_PHP_REQUEST,
-                     nr_string_mh,
-                     log_context_data_attributes.include,
-                     zend_newrelic_globals,
-                     newrelic_globals,
-                     0)
-STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.context_data.exclude",
-                     "",
-                     NR_PHP_REQUEST,
-                     nr_string_mh,
-                     log_context_data_attributes.exclude,
-                     zend_newrelic_globals,
-                     newrelic_globals,
-                     0)
+STD_PHP_INI_ENTRY_EX(
+    "newrelic.application_logging.forwarding.context_data.enabled",
+    "0",
+    NR_PHP_REQUEST,
+    nr_boolean_mh,
+    log_context_data_attributes.enabled,
+    zend_newrelic_globals,
+    newrelic_globals,
+    nr_enabled_disabled_dh)
+STD_PHP_INI_ENTRY_EX(
+    "newrelic.application_logging.forwarding.context_data.include",
+    "",
+    NR_PHP_REQUEST,
+    nr_string_mh,
+    log_context_data_attributes.include,
+    zend_newrelic_globals,
+    newrelic_globals,
+    0)
+STD_PHP_INI_ENTRY_EX(
+    "newrelic.application_logging.forwarding.context_data.exclude",
+    "",
+    NR_PHP_REQUEST,
+    nr_string_mh,
+    log_context_data_attributes.exclude,
+    zend_newrelic_globals,
+    newrelic_globals,
+    0)
 STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.labels.enabled",
                      "0",
                      NR_PHP_REQUEST,
@@ -3224,14 +3231,15 @@ STD_PHP_INI_ENTRY_EX("newrelic.application_logging.forwarding.labels.exclude",
 /*
  * Vulnerability Management
  */
-STD_PHP_INI_ENTRY_EX("newrelic.vulnerability_management.package_detection.enabled",
-                     "1",
-                     NR_PHP_REQUEST,
-                     nr_boolean_mh,
-                     vulnerability_management_package_detection_enabled,
-                     zend_newrelic_globals,
-                     newrelic_globals,
-                     nr_enabled_disabled_dh)
+STD_PHP_INI_ENTRY_EX(
+    "newrelic.vulnerability_management.package_detection.enabled",
+    "1",
+    NR_PHP_REQUEST,
+    nr_boolean_mh,
+    vulnerability_management_package_detection_enabled,
+    zend_newrelic_globals,
+    newrelic_globals,
+    nr_enabled_disabled_dh)
 
 STD_PHP_INI_ENTRY_EX("newrelic.vulnerability_management.composer_api.enabled",
                      "1",

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -3265,6 +3265,21 @@ STD_PHP_INI_ENTRY_EX("newrelic.message_tracer.segment_parameters.enabled",
                      zend_newrelic_globals,
                      newrelic_globals,
                      nr_enabled_disabled_dh)
+
+/*
+ * This setting is not documented.  If enabled, on fiber detection, it will end
+ * the current transaction and disable instrumentation for the remainder of the
+ * request.
+ */
+STD_PHP_INI_ENTRY_EX("newrelic.fibers.disabled",
+                     "1",  // default will eventually be false
+                     NR_PHP_REQUEST,
+                     nr_boolean_mh,
+                     fibers_disabled,
+                     zend_newrelic_globals,
+                     newrelic_globals,
+                     nr_enabled_disabled_dh)
+
 PHP_INI_END() /* } */
 
 void nr_php_register_ini_entries(int module_number TSRMLS_DC) {

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -111,12 +111,18 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
     return handlers;
   }
 
-  if (!ZEND_OP_ARRAY_EXTENSION(NR_OP_ARRAY, NR_PHP_PROCESS_GLOBALS(op_array_extension_handle))) {
+  if (!ZEND_OP_ARRAY_EXTENSION(
+          NR_OP_ARRAY, NR_PHP_PROCESS_GLOBALS(op_array_extension_handle))) {
     zend_string* func_name = NR_OP_ARRAY->function_name;
-    zend_string* scope_name = OP_ARRAY_IS_A_METHOD(NR_OP_ARRAY)? NR_OP_ARRAY->scope->name : NULL;
-    nruserfn_t* wr = nr_php_user_instrument_wraprec_hashmap_get(func_name, scope_name);
-    // store the wraprec in the op_array extension for the duration of the request for later lookup
-    ZEND_OP_ARRAY_EXTENSION(NR_OP_ARRAY, NR_PHP_PROCESS_GLOBALS(op_array_extension_handle)) = wr;
+    zend_string* scope_name
+        = OP_ARRAY_IS_A_METHOD(NR_OP_ARRAY) ? NR_OP_ARRAY->scope->name : NULL;
+    nruserfn_t* wr
+        = nr_php_user_instrument_wraprec_hashmap_get(func_name, scope_name);
+    // store the wraprec in the op_array extension for the duration of the
+    // request for later lookup
+    ZEND_OP_ARRAY_EXTENSION(NR_OP_ARRAY,
+                            NR_PHP_PROCESS_GLOBALS(op_array_extension_handle))
+        = wr;
   }
 
   handlers.begin = nr_php_observer_fcall_begin;
@@ -130,7 +136,8 @@ static void nr_fiber_disable(zend_fiber_context* fiber_context) {
     /* Fiber init/destroy detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
                 "Transaction is truncated because PHP Fiber use is detected.");
-    nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used", 0);
+    nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used",
+                  0);
     nr_php_txn_end(0, 0 TSRMLS_CC);
   }
 }
@@ -141,13 +148,14 @@ static void nr_fiber_switch_disable(zend_fiber_context* from,
     /* Fiber switch detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
                 "Transaction is truncated because PHP Fiber use is detected.");
-    nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used", 0);
+    nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used",
+                  0);
     nr_php_txn_end(0, 0 TSRMLS_CC);
   }
 }
 #endif /* PHP 8.1+ */
 
-void nr_php_observer_no_op(zend_execute_data* execute_data NRUNUSED){};
+void nr_php_observer_no_op(zend_execute_data* execute_data NRUNUSED) {};
 
 void nr_php_observer_minit() {
   /*
@@ -162,22 +170,20 @@ void nr_php_observer_minit() {
    */
   NR_PHP_PROCESS_GLOBALS(orig_execute) = nr_php_observer_no_op;
 
-
 #if ZEND_MODULE_API_NO > ZEND_8_0_X_API_NO /* PHP 8.1+ */
 
   /*
    * Register the Observer API fiber handlers.
    */
 
-   /* Currently only register if we are disabling instrumentation. */
-   if (NRINI(fibers_disabled)) {
-     zend_observer_fiber_init_register(nr_fiber_disable);
-     zend_observer_fiber_switch_register(nr_fiber_switch_disable);
-     zend_observer_fiber_destroy_register(nr_fiber_disable);
-   }
+  /* Currently only register if we are disabling instrumentation. */
+  if (NRINI(fibers_disabled)) {
+    zend_observer_fiber_init_register(nr_fiber_disable);
+    zend_observer_fiber_switch_register(nr_fiber_switch_disable);
+    zend_observer_fiber_destroy_register(nr_fiber_disable);
+  }
 
 #endif /* PHP 8.1+ */
-
 }
 
 #endif

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -124,11 +124,34 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
   return handlers;
 }
 
+#if ZEND_MODULE_API_NO > ZEND_8_0_X_API_NO /* PHP8.1+ */
+static void nr_fiber_disable(zend_fiber_context* fiber_context) {
+  if (NULL != NRPRG(txn)) {
+    /* Fiber init/destroy detected, end and keep the transaction. */
+    nrl_warning(NRL_INSTRUMENT,
+                "Transaction is truncated because PHP Fiber use is detected.");
+    nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used", 0);
+    nr_php_txn_end(0, 0 TSRMLS_CC);
+  }
+}
+
+static void nr_fiber_switch_disable(zend_fiber_context* from,
+                                    zend_fiber_context* to) {
+  if (NULL != NRPRG(txn)) {
+    /* Fiber switch detected, end and keep the transaction. */
+    nrl_warning(NRL_INSTRUMENT,
+                "Transaction is truncated because PHP Fiber use is detected.");
+    nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used", 0);
+    nr_php_txn_end(0, 0 TSRMLS_CC);
+  }
+}
+#endif /* PHP 8.1+ */
+
 void nr_php_observer_no_op(zend_execute_data* execute_data NRUNUSED){};
 
 void nr_php_observer_minit() {
   /*
-   * Register the Observer API handlers.
+   * Register the Observer API function handlers.
    */
   zend_observer_fcall_register(nr_php_fcall_register_handlers);
 
@@ -138,6 +161,23 @@ void nr_php_observer_minit() {
    * turn it into a no_op when using OAPI.
    */
   NR_PHP_PROCESS_GLOBALS(orig_execute) = nr_php_observer_no_op;
+
+
+#if ZEND_MODULE_API_NO > ZEND_8_0_X_API_NO /* PHP 8.1+ */
+
+  /*
+   * Register the Observer API fiber handlers.
+   */
+
+   /* Currently only register if we are disabling instrumentation. */
+   if (NRINI(fibers_disabled)) {
+     zend_observer_fiber_init_register(nr_fiber_disable);
+     zend_observer_fiber_switch_register(nr_fiber_switch_disable);
+     zend_observer_fiber_destroy_register(nr_fiber_disable);
+   }
+
+#endif /* PHP 8.1+ */
+
 }
 
 #endif

--- a/agent/php_observer.h
+++ b/agent/php_observer.h
@@ -75,7 +75,6 @@ void nr_php_observer_fcall_begin(zend_execute_data* execute_data);
 void nr_php_observer_fcall_end(zend_execute_data* execute_data,
                                zval* func_return_value);
 
-
 #endif /* PHP8+ */
 
 #endif  // NEWRELIC_PHP_AGENT_PHP_OBSERVER_H

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -27,7 +27,7 @@ static void nr_php_datastore_instance_destroy(
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-/* OAPI global stacks (as opposed to call stack used previously) 
+/* OAPI global stacks (as opposed to call stack used previously)
  * need to have a dtor set so that when we free it
  * during rshutdown, all elements are properly freed */
 static void str_stack_dtor(void* e, NRUNUSED void* d) {

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -84,11 +84,11 @@ static void nr_php_set_initial_path(nrtxn_t* txn TSRMLS_DC) {
                != (uri = nr_php_zend_hash_find(Z_ARRVAL_P(server),
                                                "SCRIPT_NAME"))) {
       whence = "WT_IS_FILENAME & SCRIPT_NAME";
-/* uri has a zval with the name of the script */
+      /* uri has a zval with the name of the script */
     } else if (CG(active_op_array)) {
       whence = "WT_IS_FILENAME & op_array";
       suri = nr_php_op_array_file_name(CG(active_op_array));
-/* suri has a char* to the name of the script */
+      /* suri has a char* to the name of the script */
     }
 
     if ((NULL == uri) && (NULL == suri)) {
@@ -242,11 +242,11 @@ static int nr_php_capture_request_parameter(zval* element,
       break;
 #endif /* PHP < 7.3 */
 
-/*
- * PHP 5.6.0 beta 2 replaced IS_CONSTANT_ARRAY and IS_CONSTANT_INDEX with
- * IS_CONSTANT_AST. For the purposes of this function, it can be
- * considered the same thing.
- */
+      /*
+       * PHP 5.6.0 beta 2 replaced IS_CONSTANT_ARRAY and IS_CONSTANT_INDEX with
+       * IS_CONSTANT_AST. For the purposes of this function, it can be
+       * considered the same thing.
+       */
     case IS_CONSTANT_AST:
       nr_strcpy(datastr, "[constants]");
       break;
@@ -942,10 +942,8 @@ nr_status_t nr_php_txn_begin(const char* appnames,
       = is_cli ? NRINI(tt_max_segments_cli) : NRINI(tt_max_segments_web);
   opts.span_queue_batch_size = NRINI(agent_span_queue_size);
   opts.span_queue_batch_timeout = NRINI(agent_span_queue_timeout);
-  opts.dt_sampler_parent_sampled
-      = NRPRG(dt_sampler_parent_sampled);
-  opts.dt_sampler_parent_not_sampled
-      = NRPRG(dt_sampler_parent_not_sampled);
+  opts.dt_sampler_parent_sampled = NRPRG(dt_sampler_parent_sampled);
+  opts.dt_sampler_parent_not_sampled = NRPRG(dt_sampler_parent_not_sampled);
   opts.logging_enabled = NRINI(logging_enabled);
   opts.log_decorating_enabled = NRINI(log_decorating_enabled);
   opts.log_forwarding_enabled = NRINI(log_forwarding_enabled);

--- a/agent/scripts/newrelic.ini.private.template
+++ b/agent/scripts/newrelic.ini.private.template
@@ -210,7 +210,7 @@
 ; Type   : bool
 ; Scope  : per-directory
 ; Default: true
-; Info   : If set to true, the agent, on detecting fiber activity, will end the txn
-;          and disable instrumentation for the remainder of the request.
+; Info   : If set to true, the agent, on detecting fiber activity, will end the txn,
+;          send the recorded telementry, and disable instrumentation for the remainder of the request.
 ;
 ;newrelic.fibers.disabled = true

--- a/agent/scripts/newrelic.ini.private.template
+++ b/agent/scripts/newrelic.ini.private.template
@@ -204,3 +204,13 @@
 ;          the amount of data sent to New Relic.
 ;
 ;newrelic.distributed_tracing.pad_trace_id = false
+
+
+; Setting: newrelic.fibers.disabled
+; Type   : bool
+; Scope  : per-directory
+; Default: true
+; Info   : If set to true, the agent, on detecting fiber activity, will end the txn
+;          and disable instrumentation for the remainder of the request.
+;
+;newrelic.fibers.disabled = true

--- a/agent/tests/valgrind-suppressions
+++ b/agent/tests/valgrind-suppressions
@@ -1,4 +1,26 @@
 {
+   <PHP 8.1 Fiber Defect #1>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:__zend_malloc
+   fun:zend_llist_add_element
+   fun:zend_observer_fiber_init_register
+   ...
+}
+
+{
+   <PHP 8.1 Fiber Defect #2>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:__zend_malloc
+   fun:zend_llist_add_element
+   fun:zend_observer_fiber_destroy_register
+   ... 
+}
+
+{
    agent-32bit-debian-invalid-read
    Memcheck:Addr4
    fun:check_free

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -263,7 +263,7 @@ static void nr_populate_datastore_spans(nr_span_event_t* span_event,
                               component);
 
   nr_span_event_set_datastore(span_event, NR_SPAN_DATASTORE_DB_SYSTEM,
-                              segment->typed_attributes->datastore.db_system);                            
+                              segment->typed_attributes->datastore.db_system);
 
   host = segment->typed_attributes->datastore.instance.host;
   nr_span_event_set_datastore(span_event, NR_SPAN_DATASTORE_PEER_HOSTNAME,

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -2975,8 +2975,7 @@ static bool nr_txn_accept_w3c_trace_context_headers(
   /* Depending on the user's INI settings, we may or may not want to
    * consider the traceparent's sampled field */
   nr_distributed_trace_handle_inbound_w3c_sampled_flag(
-      txn->distributed_trace,
-      trace_headers,
+      txn->distributed_trace, trace_headers,
       txn->options.dt_sampler_parent_sampled,
       txn->options.dt_sampler_parent_not_sampled);
 

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -101,14 +101,14 @@ typedef struct _nrtxnopt_t {
                                                        W3C trace context headers
                                                      */
   nr_upstream_parent_sampling_control_t
-    dt_sampler_parent_sampled; /* how to sample spans when non-
-                                  New Relic upstream did sample.
-                                */
+      dt_sampler_parent_sampled; /* how to sample spans when non-
+                                    New Relic upstream did sample.
+                                  */
   nr_upstream_parent_sampling_control_t
-    dt_sampler_parent_not_sampled; /* how to sample spans when non-
-                                      New Relic upstream didn't sample.
-                                    */
-  int span_events_enabled; /* Whether span events are enabled */
+      dt_sampler_parent_not_sampled; /* how to sample spans when non-
+                                        New Relic upstream didn't sample.
+                                      */
+  int span_events_enabled;           /* Whether span events are enabled */
   size_t
       span_events_max_samples_stored; /* The maximum number of span events per
                                          transaction. When set to 0, the default
@@ -313,8 +313,8 @@ typedef struct _nrtxn_t {
   nr_php_packages_t*
       php_package_major_version_metrics_suggestions; /* Suggested packages for
                                   major metric creation */
-  nrtime_t user_cpu[NR_CPU_USAGE_COUNT]; /* User CPU usage */
-  nrtime_t sys_cpu[NR_CPU_USAGE_COUNT];  /* System CPU usage */
+  nrtime_t user_cpu[NR_CPU_USAGE_COUNT];             /* User CPU usage */
+  nrtime_t sys_cpu[NR_CPU_USAGE_COUNT];              /* System CPU usage */
 
   char* license;     /* License copied from application for RUM encoding use. */
   char* request_uri; /* Request URI */

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -6303,10 +6303,14 @@ static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
   nrtxn_t txn = {0};
   nr_hashmap_t* headers;
   bool rv = true;
-  char* TRACEPARENT_SAMPLED = "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-01";
-  char* TRACEPARENT_NOT_SAMPLED = "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-00";
-  char* TRACESTATE_SAMPLED = "123@nr=0-2-account-app-span-transaction-1-1.1273-1529445826000";
-  char* TRACESTATE_NOT_SAMPLED = "123@nr=0-2-account-app-span-transaction-0-1.1273-1529445826000";
+  char* TRACEPARENT_SAMPLED
+      = "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-01";
+  char* TRACEPARENT_NOT_SAMPLED
+      = "00-87b1c9a429205b25e5b687d890d4821f-7d3efb1b173fecfa-00";
+  char* TRACESTATE_SAMPLED
+      = "123@nr=0-2-account-app-span-transaction-1-1.1273-1529445826000";
+  char* TRACESTATE_NOT_SAMPLED
+      = "123@nr=0-2-account-app-span-transaction-0-1.1273-1529445826000";
   nrtime_t payload_timestamp_ms = 1529445826000;
   nrtime_t txn_timestamp_us = 15214458260000 * NR_TIME_DIVISOR_MS;
   nrtime_t delta_timestamp_us = nr_time_duration(
@@ -6324,10 +6328,10 @@ static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
   txn.options.distributed_tracing_pad_trace_id = false;
   txn.options.distributed_tracing_enabled = true;
 
-#define TEST_TXN_ACCEPT_DT_PAYLOAD_RESET         \
-  txn.distributed_trace->inbound.set = 0;        \
-  nrm_table_destroy(&txn.unscoped_metrics);      \
-  txn.unscoped_metrics = nrm_table_create(0);    \
+#define TEST_TXN_ACCEPT_DT_PAYLOAD_RESET               \
+  txn.distributed_trace->inbound.set = 0;              \
+  nrm_table_destroy(&txn.unscoped_metrics);            \
+  txn.unscoped_metrics = nrm_table_create(0);          \
   txn.options.dt_sampler_parent_not_sampled = DEFAULT; \
   txn.options.dt_sampler_parent_sampled = DEFAULT;
 
@@ -6346,11 +6350,10 @@ static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
   tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
                     (int)rv);
   tlib_pass_if_false("Sampled should be set to false",
-                    txn.distributed_trace->sampled, "sampled flag = %d",
-                    (int)txn.distributed_trace->sampled);
+                     txn.distributed_trace->sampled, "sampled flag = %d",
+                     (int)txn.distributed_trace->sampled);
   tlib_pass_if_true("Priority should not be overwritten",
-                    2.0 != txn.distributed_trace->priority,
-                    "priority is 2.0");
+                    2.0 != txn.distributed_trace->priority, "priority is 2.0");
 
   // 2: upstream not sampled, agent keep
   TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
@@ -6382,8 +6385,7 @@ static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
                     txn.distributed_trace->sampled, "sampled flag = %d",
                     (int)txn.distributed_trace->sampled);
   tlib_pass_if_true("Priority should not be overwritten",
-                    2.0 != txn.distributed_trace->priority,
-                    "priority is 2.0");
+                    2.0 != txn.distributed_trace->priority, "priority is 2.0");
 
   // 4: upstream not sampled, agent default (toss)
   TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
@@ -6396,11 +6398,10 @@ static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
   tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
                     (int)rv);
   tlib_pass_if_false("Sampled should be set to false",
-                    txn.distributed_trace->sampled, "sampled flag = %d",
-                    (int)txn.distributed_trace->sampled);
+                     txn.distributed_trace->sampled, "sampled flag = %d",
+                     (int)txn.distributed_trace->sampled);
   tlib_pass_if_true("Priority should not be overwritten",
-                    2.0 != txn.distributed_trace->priority,
-                    "priority is 2.0");
+                    2.0 != txn.distributed_trace->priority, "priority is 2.0");
 
   // 5: upstream sampled, agent discard
   TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
@@ -6413,11 +6414,10 @@ static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
   tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
                     (int)rv);
   tlib_pass_if_false("Sampled should be set to false",
-                    txn.distributed_trace->sampled, "sampled flag = %d",
-                    (int)txn.distributed_trace->sampled);
+                     txn.distributed_trace->sampled, "sampled flag = %d",
+                     (int)txn.distributed_trace->sampled);
   tlib_pass_if_true("Priority should not be overwritten",
-                    2.0 != txn.distributed_trace->priority,
-                    "priority is 2.0");
+                    2.0 != txn.distributed_trace->priority, "priority is 2.0");
 
   // 6: upstream sampled, agent keep
   TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
@@ -6449,8 +6449,7 @@ static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
                     txn.distributed_trace->sampled, "sampled flag = %d",
                     (int)txn.distributed_trace->sampled);
   tlib_pass_if_true("Priority should not be overwritten",
-                    2.0 != txn.distributed_trace->priority,
-                    "priority is 2.0");
+                    2.0 != txn.distributed_trace->priority, "priority is 2.0");
 
   // 8: upstream sampled, agent default (toss)
   TEST_TXN_ACCEPT_DT_PAYLOAD_RESET
@@ -6463,11 +6462,10 @@ static void test_txn_accept_distributed_trace_payload_w3c_sample_flags(void) {
   tlib_pass_if_true("The header should be accepted", rv, "Return value = %d",
                     (int)rv);
   tlib_pass_if_false("Sampled should be set to false",
-                    txn.distributed_trace->sampled, "sampled flag = %d",
-                    (int)txn.distributed_trace->sampled);
+                     txn.distributed_trace->sampled, "sampled flag = %d",
+                     (int)txn.distributed_trace->sampled);
   tlib_pass_if_true("Priority should not be overwritten",
-                    2.0 != txn.distributed_trace->priority,
-                    "priority is 2.0");
+                    2.0 != txn.distributed_trace->priority, "priority is 2.0");
 
   nr_txn_destroy_fields(&txn);
   nr_hashmap_destroy(&headers);

--- a/daemon/cmd/integration_runner/main.go
+++ b/daemon/cmd/integration_runner/main.go
@@ -581,7 +581,7 @@ func runTest(t *integration.Test) {
 	//
 	// Extract and remove from the output any env vars from the output that
 	// we want to add to t.Env for use with EXPECT blocks.
-	// The env vars will be proceeded with the
+	// The env vars will be preceded by the
 	// NR_EXPECT_ENV_VAR prefix followed by the env var name and value.
 	// ex: NR_EXPECT_ENV_VAR[NEW_VAR_FROM_TEST]=1234567
 	//

--- a/daemon/cmd/integration_runner/main.go
+++ b/daemon/cmd/integration_runner/main.go
@@ -578,6 +578,15 @@ func runTest(t *integration.Test) {
 		fmt.Printf("Test output:\n%s\n", body)
 	}
 
+	//
+	// Extract and remove from the output any env vars from the output that
+	// we want to add to t.Env for use with EXPECT blocks.
+	// The env vars will be proceeded with the
+	// NR_EXPECT_ENV_VAR prefix followed by the env var name and value.
+	// ex: NR_EXPECT_ENV_VAR[NEW_VAR_FROM_TEST]=1234567
+	//
+
+	body = t.GetEnvVarsFromBody(body)
 	// Always save the test output. If an error occurred it may contain
 	// critical information regarding the cause. Currently, it may also
 	// contain valgrind commentary which we want to display.

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -282,6 +282,32 @@ func (t *Test) MakeSkipIf(ctx *Context) (Tx, error) {
 	return PhpTx(src, t.Env, settings, ctx)
 }
 
+//
+// Extract and remove from the output any env vars from the output that
+// we want to add to t.Env for use with EXPECT blocks.
+// The env vars will be proceeded with the
+// NR_EXPECT_ENV_VAR prefix followed by the env var name and value.
+// ex: NR_EXPECT_ENV_VAR[NEW_VAR_FROM_TEST]=1234567 followed by a newline
+// Be aware this will overwrite any previously existing env vars with the same name.
+//
+
+func (t *Test) GetEnvVarsFromBody(body []byte) []byte {
+
+	nrExpectEnvVarRE := regexp.MustCompile(`^NR_EXPECT_ENV_VAR\[(.+?)\]=(.*)$`)
+
+	lines := bytes.Split(body, []byte("\n"))
+	filteredLines := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		matches := nrExpectEnvVarRE.FindSubmatch(line)
+		if matches != nil {
+			t.Env[string(matches[1])] = string(matches[2])
+			continue
+		}
+		filteredLines = append(filteredLines, line)
+	}
+	return bytes.Join(filteredLines, []byte("\n"))
+}
+
 type Scrub struct {
 	re          *regexp.Regexp
 	replacement []byte

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -285,7 +285,7 @@ func (t *Test) MakeSkipIf(ctx *Context) (Tx, error) {
 //
 // Extract and remove from the output any env vars from the output that
 // we want to add to t.Env for use with EXPECT blocks.
-// The env vars will be proceeded with the
+// The env vars will be preceded by the
 // NR_EXPECT_ENV_VAR prefix followed by the env var name and value.
 // ex: NR_EXPECT_ENV_VAR[NEW_VAR_FROM_TEST]=1234567 followed by a newline
 // Be aware this will overwrite any previously existing env vars with the same name.

--- a/daemon/internal/newrelic/integration/test_test.go
+++ b/daemon/internal/newrelic/integration/test_test.go
@@ -8,10 +8,59 @@ package integration
 import (
 	"bytes"
 	"maps"
+	"reflect"
 	"testing"
 
 	"github.com/newrelic/newrelic-php-agent/daemon/internal/newrelic/sysinfo"
 )
+
+func TestGetEnvVarsFromBody_RemovesEnvLinesAndSetsEnv(t *testing.T) {
+	test := &Test{Env: make(map[string]string)}
+	input := []byte("starting it out\nNR_EXPECT_ENV_VAR[BLUE]=apricot\nrandomoutputpart 1\nNR_EXPECT_ENV_VAR[YELLOW]=kiwi\nsome other random output")
+	expectedOutput := []byte("starting it out\nrandomoutputpart 1\nsome other random output")
+	expectedEnv := map[string]string{"BLUE": "apricot", "YELLOW": "kiwi"}
+
+	output := test.GetEnvVarsFromBody(input)
+
+	if !bytes.Equal(output, expectedOutput) {
+		t.Errorf("Expected output:\n%q\ngot:\n%q", expectedOutput, output)
+	}
+	if !reflect.DeepEqual(test.Env, expectedEnv) {
+		t.Errorf("Expected Env: %+v, got: %+v", expectedEnv, test.Env)
+	}
+}
+
+func TestGetEnvVarsFromBody_NoEnvLines(t *testing.T) {
+	test := &Test{Env: make(map[string]string)}
+	input := []byte("starting it out\nand continuing on\neaching the end")
+	expectedOutput := []byte("starting it out\nand continuing on\neaching the end")
+	expectedEnv := map[string]string{}
+
+	output := test.GetEnvVarsFromBody(input)
+
+	if !bytes.Equal(output, expectedOutput) {
+		t.Errorf("Expected output:\n%q\ngot:\n%q", expectedOutput, output)
+	}
+	if !reflect.DeepEqual(test.Env, expectedEnv) {
+		t.Errorf("Expected Env: %+v, got: %+v", expectedEnv, test.Env)
+	}
+}
+
+func TestGetEnvVarsFromBody_EmptyInput(t *testing.T) {
+	test := &Test{Env: make(map[string]string)}
+	input := []byte("")
+	expectedOutput := []byte("")
+	expectedEnv := map[string]string{}
+
+	output := test.GetEnvVarsFromBody(input)
+
+	if !bytes.Equal(output, expectedOutput) {
+		t.Errorf("Expected output:\n%q\ngot:\n%q", expectedOutput, output)
+	}
+	if !reflect.DeepEqual(test.Env, expectedEnv) {
+		t.Errorf("Expected Env: %+v, got: %+v", expectedEnv, test.Env)
+	}
+}
 
 func TestScrubHost(t *testing.T) {
 	host, err := sysinfo.Hostname()

--- a/tests/include/helpers.php
+++ b/tests/include/helpers.php
@@ -36,3 +36,13 @@ function force_error() {
 function force_transaction_trace() {
   error_reporting(error_reporting()); time_nanosleep(0, 50000); // 50usec should be enough
 }
+
+/*
+ * Formats an env var to pass back to integration_runner for use with EXPECT blocks.
+ * Note: integration_runner will use vars set via this method to overwrite previously 
+ * existing vars of the same name.
+ */
+function env_var_for_expects($name, $value) {
+  echo "NR_EXPECT_ENV_VAR[" . $name . "]=" . $value . "\n";
+}
+

--- a/tests/integration/span_events/fibers/test_fiber_disable_nested1.php
+++ b/tests/integration/span_events/fibers/test_fiber_disable_nested1.php
@@ -1,0 +1,129 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Test that the txn is ended if PHP fiber use is detected. 
+Fiber action detected on root span so only root span will exist and be named.
+
+Output should show that PHP functionality should continue to work 
+as expected.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.fibers.disabled = true
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/Fiber/used
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+Ending Func 'a'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    Fiber::suspend();
+    echo "Ending Func 'a'\n";
+};
+
+$fiber = new Fiber('a');
+$fiber->start();
+
+b();
+$fiber->resume();

--- a/tests/integration/span_events/fibers/test_fiber_disable_nested2.php
+++ b/tests/integration/span_events/fibers/test_fiber_disable_nested2.php
@@ -1,0 +1,164 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Test that the txn is ended if PHP fiber use is detected. 
+Fiber action detected in a function `b` called from root span after the successful
+completion of another non-fiber function `a`.
+Root span and `a` span should be named.  `b` span will be named <unknown>.
+
+Output should show that PHP functionality should continue to work 
+as expected.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.fibers.disabled = true
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/Fiber/used
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    Fiber::suspend();
+    time_nanosleep(0, 100000000);
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    $fiber = new Fiber('c');
+    try {
+        $fiber->start();
+        $fiber->resume();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();

--- a/tests/integration/span_events/fibers/test_fiber_disable_nested3.php
+++ b/tests/integration/span_events/fibers/test_fiber_disable_nested3.php
@@ -1,0 +1,180 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Test that the txn is ended if PHP fiber use is detected. 
+Fiber action detected in a function `c` called `b` called from root span after the successful
+completion of another non-fiber function `a`.
+Root span and `a` span should be named.  `b` and `c` span will be named <unknown>.
+
+Output should show that PHP functionality should continue to work 
+as expected.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.fibers.disabled = true
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/Fiber/used
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 4
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    $fiber = new Fiber('fraction');
+    echo $fiber->start(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    try {
+      c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();

--- a/tests/integration/span_events/fibers/test_fiber_disable_nested4.php
+++ b/tests/integration/span_events/fibers/test_fiber_disable_nested4.php
@@ -1,0 +1,236 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Test that the txn is ended if PHP fiber use is detected. 
+Fiber action detected in a function `c` called `b` called from root span after the successful
+completion of another non-fiber function `a`.
+Root span and `a` span should be named.  `b` and `c` span will be named <unknown>.
+
+The calling function doesn't call fiber->resume, and a new txn is started before
+the calling function ends.
+
+Detect the fiber activity and end the txn. Because the txn starts in a function 
+that then has fiber activity that ends that txn, 
+only a root span is created for the new txn.
+
+Output should show that PHP functionality should continue to work 
+as expected.
+
+Note: 
+Fiber activity is defined as:
+1) fiber->start which triggers 
+ a) fiber init 
+ b) fiber switch from calling context to fiber context
+2) fiber->resume which triggers
+ a) fiber switch from calling context to fiber context
+3) fiber->suspend which triggers
+ a) fiber switch from fiber context to calling context
+4) fiber exits/completes which triggers
+ a) fiber switch from fiber context to calling context
+ b) fiber destroy
+5) calling function exits without calling fiber->resume which triggers
+ a) fiber switch from calling context to fiber context
+ b) fiber switch from fiber context to calling context
+ c) fiber destroy
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.fibers.disabled = true
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/Fiber/used
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/Custom\/manual_txn",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/Custom\/manual_txn"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Ending Func 'c'
+Ending Func 'b'
+Ending Func 'endit'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    $fiber = new Fiber('fraction');
+    time_nanosleep(0, 100000000);
+    $fiber->start(1);
+
+    newrelic_start_transaction(ini_get("newrelic.appname"));
+    newrelic_name_transaction("manual_txn");
+
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    try {
+      c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    Fiber::suspend();
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+function endit()
+{
+    echo "Ending Func 'endit'\n";
+    env_var_for_expects("GUID_ENDIT", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+}
+
+a();
+b();
+endit();

--- a/tests/integration/span_events/fibers/test_fiber_disable_nested5.php
+++ b/tests/integration/span_events/fibers/test_fiber_disable_nested5.php
@@ -1,0 +1,227 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Test that the txn is ended if PHP fiber use is detected. 
+Fiber action detected in a function `c` called `b` called from root span after the successful
+completion of another non-fiber function `a`.
+Root span and `a` span should be named.  `b` and `c` span will be named <unknown>.
+
+Then a new txn is started before a fiber resumes in the caller.
+
+Detect the fiber activity and end the txn. Because the txn starts in a function 
+that then has fiber activity that ends that txn, 
+only a root span is created for the new txn.
+
+Output should show that PHP functionality should continue to work 
+as expected.
+
+Note: 
+Fiber activity is defined as:
+1) fiber->start which triggers 
+ a) fiber init 
+ b) fiber switch from calling context to fiber context
+2) fiber->resume which triggers
+ a) fiber switch from calling context to fiber context
+3) fiber->suspend which triggers
+ a) fiber switch from fiber context to calling context
+4) fiber exits/completes which triggers
+ a) fiber switch from fiber context to calling context
+ b) fiber destroy
+5) calling function exits without calling fiber->resume which triggers
+ a) fiber switch from calling context to fiber context
+ b) fiber switch from fiber context to calling context
+ c) fiber destroy
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.fibers.disabled = true
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/Fiber/used
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/Custom\/manual_txn",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/Custom\/manual_txn"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    $fiber = new Fiber('fraction');
+    $fiber->start(0);
+
+    newrelic_start_transaction(ini_get("newrelic.appname"));
+    newrelic_name_transaction("manual_txn");
+    
+    $fiber->resume();
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    try {
+      c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    Fiber::suspend();
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();

--- a/tests/integration/span_events/fibers/test_fiber_disable_nested6.php
+++ b/tests/integration/span_events/fibers/test_fiber_disable_nested6.php
@@ -1,0 +1,228 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the txn is ended if PHP fiber use is detected. 
+Fiber action detected in a function `c` called `b` called from root span after the successful
+completion of another non-fiber function `a`.
+Root span and `a` span should be named.  `b` and `c` span will be named <unknown>.
+
+Then a new txn is started within a fiber before a fiber suspends.
+
+Detect the fiber activity and end the txn. Because the txn starts in a function 
+that then has fiber activity that ends that txn, 
+only a root span is created for the new txn.
+
+Output should show that PHP functionality should continue to work 
+as expected.
+
+Note: 
+Fiber activity is defined as:
+1) fiber->start which triggers 
+ a) fiber init 
+ b) fiber switch from calling context to fiber context
+2) fiber->resume which triggers
+ a) fiber switch from calling context to fiber context
+3) fiber->suspend which triggers
+ a) fiber switch from fiber context to calling context
+4) fiber exits/completes which triggers
+ a) fiber switch from fiber context to calling context
+ b) fiber destroy
+5) calling function exits without calling fiber->resume which triggers
+ a) fiber switch from calling context to fiber context
+ b) fiber switch from fiber context to calling context
+ c) fiber destroy
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.fibers.disabled = true
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/Fiber/used
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/Custom\/manual_txn",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/Custom\/manual_txn"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    $fiber = new Fiber('fraction');
+    $fiber->start(0);
+    $fiber->resume();
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    try {
+      c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+    newrelic_start_transaction(ini_get("newrelic.appname"));
+    newrelic_name_transaction("manual_txn");
+    
+    Fiber::suspend();
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();

--- a/tests/integration/span_events/fibers/test_fiber_disable_nested7.php
+++ b/tests/integration/span_events/fibers/test_fiber_disable_nested7.php
@@ -1,0 +1,235 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*DESCRIPTION
+Test that the txn is ended if PHP fiber use is detected. 
+Fiber action detected in a function `c` called `b` called from root span after the successful
+completion of another non-fiber function `a`.
+Root span and `a` span should be named.  `b` and `c` span will be named <unknown>.
+
+Then a new txn is started in a fiber after the fiber has resumed from a suspension.
+
+Detect the fiber activity and end the txn. Because the txn starts in a function 
+that then has fiber activity that ends that txn on fiber exit, 
+only a root span is created for the new txn.
+
+Output should show that PHP functionality should continue to work 
+as expected.
+
+Note: 
+Fiber activity is defined as:
+1) fiber->start which triggers 
+ a) fiber init 
+ b) fiber switch from calling context to fiber context
+2) fiber->resume which triggers
+ a) fiber switch from calling context to fiber context
+3) fiber->suspend which triggers
+ a) fiber switch from fiber context to calling context
+4) fiber exits/completes which triggers
+ a) fiber switch from fiber context to calling context
+ b) fiber destroy
+5) calling function exits without calling fiber->resume which triggers
+ a) fiber switch from calling context to fiber context
+ b) fiber switch from fiber context to calling context
+ c) fiber destroy
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+newrelic.fibers.disabled = true
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/Fiber/used
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/Custom\/manual_txn",
+        "guid": "??",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/Custom\/manual_txn"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+Ending Func 'endit'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    $fiber = new Fiber('fraction');
+    $fiber->start(0);
+    $fiber->resume();
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    try {
+      c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    Fiber::suspend();
+
+    newrelic_start_transaction(ini_get("newrelic.appname"));
+    newrelic_name_transaction("manual_txn");
+    
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+function endit()
+{
+    echo "Ending Func 'endit'\n";
+    env_var_for_expects("GUID_ENDIT", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+}
+
+a();
+b();
+endit();

--- a/tests/integration/span_events/test_nested_span_endstarttxn.php
+++ b/tests/integration/span_events/test_nested_span_endstarttxn.php
@@ -1,0 +1,213 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Demonstrates the behavior when ending a txn within nested function calls.
+The nested spans are all parented correctly, but the functions that started but did not
+complete before the end txn are named <unknown>.  Because all open segments were discarded, 
+any subsequent child spans are parented to main.
+
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: Only for PHP 8.0+\n");
+}
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 6
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_NEW_TXN]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "ENV[GUID_FRACTION]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_NEW_TXN]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id']);
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    newrelic_end_transaction();
+    newrelic_start_transaction(ini_get("newrelic.appname"));
+    env_var_for_expects("GUID_NEW_TXN", newrelic_get_linking_metadata()['span.id']);
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();

--- a/tests/integration/span_events/test_nested_span_endtxn.php
+++ b/tests/integration/span_events/test_nested_span_endtxn.php
@@ -1,0 +1,171 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Demonstrates the behavior when ending a txn within nested function calls.
+The nested spans are all parented correctly, but the functions that started but did not 
+complete before the end txn are named <unknown>.
+As the txn ended before the error, there will be no error recorded.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: Only for PHP 8.0+\n");
+}
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 4
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "<unknown>",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id']);
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    newrelic_end_transaction();
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();

--- a/tests/integration/span_events/test_nested_span_parenting.php
+++ b/tests/integration/span_events/test_nested_span_parenting.php
@@ -1,0 +1,184 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test that the nested spans are all parented correctly.
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.span_events_enabled=1
+newrelic.cross_application_tracer.enabled = false
+*/
+
+/*EXPECT_ERROR_EVENTS
+null
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "ENV[GUID_FRACTION]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_C]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id']);
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id']);
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();


### PR DESCRIPTION
By default, disables instrumentation per request when detecting PHP Fibers activity.

Has configurable INI setting to toggle the behavior which defaults to disabling.

Integration tests added to demonstrate behavior.