### PR TITLE
security(daemon): bump go version to 1.26.1

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -1,7 +1,7 @@
 module github.com/newrelic/newrelic-php-agent/daemon
 
 go 1.24.0
-toolchain go1.25.7
+toolchain go1.26.1
 
 require (
 	github.com/golang/protobuf v1.5.3


### PR DESCRIPTION
Address daemon security vulnerabilities by bumping go toolchain required to build the daemon to 1.26.1.

Fixes #1173 