### PR TITLE
feat(agent): Base to build upon for fiber implementation

### DIFF
--- a/agent/php_api.c
+++ b/agent/php_api.c
@@ -1241,9 +1241,15 @@ static nr_status_t nr_php_api_add_custom_span_attribute(const char* keystr,
                                                             TSRMLS_DC) {
   bool rv;
   char* key = NULL;
-  nr_segment_t* current;
+  nr_segment_t* current = NULL;
+  nrtxn_t* txn = NULL;
 
-  current = nr_txn_get_current_segment(NRPRG(txn), NULL);
+  txn = NRPRG(txn);
+  if (NULL == txn) {
+    return NR_FAILURE;
+  }
+
+  current = nr_txn_get_current_segment(txn, nr_txn_get_current_context(txn));
   if (!current) {
     return NR_FAILURE;
   }
@@ -1482,6 +1488,8 @@ PHP_FUNCTION(newrelic_get_linking_metadata) {
   NR_UNUSED_RETURN_VALUE_USED;
   NR_UNUSED_THIS_PTR;
 
+  nrtxn_t* txn = NULL;
+
   nr_php_api_add_supportability_metric("get_linking_metadata" TSRMLS_CC);
 
   array_init(return_value);
@@ -1494,6 +1502,8 @@ PHP_FUNCTION(newrelic_get_linking_metadata) {
     return;
   }
 
+  txn = NRPRG(txn);
+
   if (nrlikely(NRPRG(app))) {
     nr_php_add_assoc_string_const(return_value, "entity.name",
                                   nr_app_get_entity_name(NRPRG(app)));
@@ -1505,10 +1515,9 @@ PHP_FUNCTION(newrelic_get_linking_metadata) {
                                   nr_app_get_host_name(NRPRG(app)));
   }
 
-  if (nrlikely(NRPRG(txn))) {
-    trace_id = nr_txn_get_current_trace_id(NRPRG(txn));
-    span_id = nr_txn_get_current_span_id(NRPRG(txn));
-
+  if (nrlikely(txn)) {
+    trace_id = nr_txn_get_current_trace_id(txn);
+    span_id = nr_txn_get_current_span_id(txn, nr_txn_get_current_context(txn));
     if (trace_id) {
       nr_php_add_assoc_string(return_value, "trace.id", trace_id);
     }
@@ -1535,6 +1544,8 @@ PHP_FUNCTION(newrelic_get_trace_metadata) {
   NR_UNUSED_RETURN_VALUE_USED;
   NR_UNUSED_THIS_PTR;
 
+  nrtxn_t* txn = NULL;
+
   nr_php_api_add_supportability_metric("get_trace_metadata" TSRMLS_CC);
 
   array_init(return_value);
@@ -1547,14 +1558,15 @@ PHP_FUNCTION(newrelic_get_trace_metadata) {
     return;
   }
 
-  if (nrlikely(NRPRG(txn))) {
-    trace_id = nr_txn_get_current_trace_id(NRPRG(txn));
+  txn = NRPRG(txn);
+
+  if (nrlikely(txn)) {
+    trace_id = nr_txn_get_current_trace_id(txn);
     if (trace_id) {
       nr_php_add_assoc_string(return_value, "trace_id", trace_id);
     }
     nr_free(trace_id);
-
-    span_id = nr_txn_get_current_span_id(NRPRG(txn));
+    span_id = nr_txn_get_current_span_id(txn, nr_txn_get_current_context(txn));
     if (span_id) {
       nr_php_add_assoc_string(return_value, "span_id", span_id);
     }
@@ -1564,7 +1576,7 @@ PHP_FUNCTION(newrelic_get_trace_metadata) {
 
 /*
  * Purpose      Allows a caller to add a user id string to agent attributes in
-                transaction event, transaction trace, error and span.
+ *              transaction event, transaction trace, error and span.
  *
  */
 #ifdef TAGS

--- a/agent/php_api.c
+++ b/agent/php_api.c
@@ -1244,6 +1244,8 @@ static nr_status_t nr_php_api_add_custom_span_attribute(const char* keystr,
   nr_segment_t* current = NULL;
   nrtxn_t* txn = NULL;
 
+  txn = NRPRG(txn);
+
   current = nr_txn_get_current_segment(txn, nr_txn_get_current_context(txn));
   if (!current) {
     return NR_FAILURE;

--- a/agent/php_api.c
+++ b/agent/php_api.c
@@ -1244,11 +1244,6 @@ static nr_status_t nr_php_api_add_custom_span_attribute(const char* keystr,
   nr_segment_t* current = NULL;
   nrtxn_t* txn = NULL;
 
-  txn = NRPRG(txn);
-  if (NULL == txn) {
-    return NR_FAILURE;
-  }
-
   current = nr_txn_get_current_segment(txn, nr_txn_get_current_context(txn));
   if (!current) {
     return NR_FAILURE;

--- a/agent/php_error.c
+++ b/agent/php_error.c
@@ -812,8 +812,9 @@ nr_status_t nr_php_error_record_exception_segment(nrtxn_t* txn,
     error_message = nr_formatf("%s'%s'", prefix, klass);
   }
 
-  nr_segment_record_exception(nr_txn_get_current_segment(NRPRG(txn), NULL),
-                              error_message, klass);
+  nr_segment_record_exception(
+      nr_txn_get_current_segment(txn, nr_txn_get_current_context(txn)),
+      error_message, klass);
 
   nr_free(file);
   nr_free(error_message);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1714,93 +1714,93 @@ end:
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP8+ and OAPI */
 
-#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO    
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
 void nr_fiber_show_fiber(zend_fiber_context* zfc, const char* fiber_action) {
-  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers)) {
-    zend_fiber* zfc_fiber = NULL;
-    char* zfc_status = NULL;
-    char* fiber_destroy_flag = NULL;
-    char* fiber_threw_flag = NULL;
-    char* fiber_bailout_flag = NULL;
-    char* fiber_func_name = NULL;
-    char* label = "  fiber";
-
-    if (NULL == zfc) {
-      nrl_warning(NRL_AGENT,
-                  "PHP Issue: %s Fiber context is unexpectedly NULL.",
-                  fiber_action);
-      return;
-    }
-
-    switch (zfc->status) {
-      case ZEND_FIBER_STATUS_INIT:
-        zfc_status = "ZEND_FIBER_STATUS_INIT";
-        break;
-      case ZEND_FIBER_STATUS_RUNNING:
-        zfc_status = "ZEND_FIBER_STATUS_RUNNING";
-        break;
-      case ZEND_FIBER_STATUS_SUSPENDED:
-        zfc_status = "ZEND_FIBER_STATUS_SUSPENDED";
-        break;
-      case ZEND_FIBER_STATUS_DEAD:
-        zfc_status = "ZEND_FIBER_STATUS_DEAD";
-        break;
-      default:
-        zfc_status = "UNKNOWN STATUS";
-    }
-
-    if (zend_ce_fiber != zfc->kind) {
-      /*
-       * Return with what we have since we can't extract a fiber from the main
-       * context for any additional info.
-       */
-      nrl_verbosedebug(
-          NRL_AGENT, "%s: %.*s %s:`main` context ctx={%p} status{%s}", label,
-          nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces,
-          NRSAFESTR(fiber_action), zfc, zfc_status);
-      return;
-    }
-    zfc_fiber = zend_fiber_from_context(zfc);
-
-    if (NULL == zfc_fiber) {
-      nrl_verbosedebug(
-          NRL_INSTRUMENT,
-          "PHP Issue: The Fiber associated with %p is unexpectedly NULL.", zfc);
-      return;
-    }
-    if (zfc_fiber->flags & ZEND_FIBER_FLAG_DESTROYED) {
-      fiber_destroy_flag = "destroyed";
-    }
-
-    if (zfc_fiber->flags & ZEND_FIBER_FLAG_THREW) {
-      fiber_threw_flag = "threw";
-    }
-
-    if (zfc_fiber->flags & ZEND_FIBER_FLAG_BAILOUT) {
-      fiber_bailout_flag = "bailout";
-    }
-
-    /*
-     * Use fci_cache vs fci since fci.function_name will be set to undef in PHP
-     * when the fiber is dead and cannot be depended on.
-     */
-    zend_fcall_info_cache zfc_fci_cache = zfc_fiber->fci_cache;
-    if (NULL != zfc_fci_cache.function_handler) {
-      fiber_func_name
-          = nr_php_function_debug_name(zfc_fci_cache.function_handler);
-    }
-
-    nrl_verbosedebug(
-        NRL_AGENT,
-        "%s: %.*s %s: fiber context ctx={%p} function={%s} status{%s}"
-        "flags={%s|%s|%s}",
-        label, nr_php_show_exec_indentation(TSRMLS_C),
-        nr_php_indentation_spaces, NRSAFESTR(fiber_action), zfc,
-        NRSAFESTR(fiber_func_name), NRSAFESTR(zfc_status),
-        NRSAFESTR(fiber_destroy_flag), NRSAFESTR(fiber_threw_flag),
-        NRSAFESTR(fiber_bailout_flag));
-    nr_free(fiber_func_name);
+  if (nrlikely(0 == NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers)) {
+    return;
   }
+
+  zend_fiber* zfc_fiber = NULL;
+  char* zfc_status = NULL;
+  char* fiber_destroy_flag = NULL;
+  char* fiber_threw_flag = NULL;
+  char* fiber_bailout_flag = NULL;
+  char* fiber_func_name = NULL;
+  char* label = "  fiber";
+
+  if (NULL == zfc) {
+    nrl_warning(NRL_AGENT, "PHP Issue: %s Fiber context is unexpectedly NULL.",
+                fiber_action);
+    return;
+  }
+
+  switch (zfc->status) {
+    case ZEND_FIBER_STATUS_INIT:
+      zfc_status = "ZEND_FIBER_STATUS_INIT";
+      break;
+    case ZEND_FIBER_STATUS_RUNNING:
+      zfc_status = "ZEND_FIBER_STATUS_RUNNING";
+      break;
+    case ZEND_FIBER_STATUS_SUSPENDED:
+      zfc_status = "ZEND_FIBER_STATUS_SUSPENDED";
+      break;
+    case ZEND_FIBER_STATUS_DEAD:
+      zfc_status = "ZEND_FIBER_STATUS_DEAD";
+      break;
+    default:
+      zfc_status = "UNKNOWN STATUS";
+  }
+
+  if (zend_ce_fiber != zfc->kind) {
+    /*
+     * Return with what we have since we can't extract a fiber from the main
+     * context for any additional info.
+     */
+    nrl_verbosedebug(
+        NRL_AGENT, "%s: %.*s %s:`main` context ctx={%p} status{%s}", label,
+        nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces,
+        NRSAFESTR(fiber_action), zfc, zfc_status);
+    return;
+  }
+  zfc_fiber = zend_fiber_from_context(zfc);
+
+  if (NULL == zfc_fiber) {
+    nrl_verbosedebug(
+        NRL_INSTRUMENT,
+        "PHP Issue: The Fiber associated with %p is unexpectedly NULL.", zfc);
+    return;
+  }
+  if (zfc_fiber->flags & ZEND_FIBER_FLAG_DESTROYED) {
+    fiber_destroy_flag = "destroyed";
+  }
+
+  if (zfc_fiber->flags & ZEND_FIBER_FLAG_THREW) {
+    fiber_threw_flag = "threw";
+  }
+
+  if (zfc_fiber->flags & ZEND_FIBER_FLAG_BAILOUT) {
+    fiber_bailout_flag = "bailout";
+  }
+
+  /*
+   * Use fci_cache vs fci since fci.function_name will be set to undef in PHP
+   * when the fiber is dead and cannot be depended on.
+   */
+  zend_fcall_info_cache zfc_fci_cache = zfc_fiber->fci_cache;
+  if (NULL != zfc_fci_cache.function_handler) {
+    fiber_func_name
+        = nr_php_function_debug_name(zfc_fci_cache.function_handler);
+  }
+
+  nrl_verbosedebug(
+      NRL_AGENT,
+      "%s: %.*s %s: fiber context ctx={%p} function={%s} status{%s}"
+      "flags={%s|%s|%s}",
+      label, nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces,
+      NRSAFESTR(fiber_action), zfc, NRSAFESTR(fiber_func_name),
+      NRSAFESTR(zfc_status), NRSAFESTR(fiber_destroy_flag),
+      NRSAFESTR(fiber_threw_flag), NRSAFESTR(fiber_bailout_flag));
+  nr_free(fiber_func_name);
 }
 #endif /* PHP 8.1+ */
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -634,13 +634,6 @@ static void nr_framework_log(const char* log_prefix,
   nrl_debug(NRL_FRAMEWORK, "%s = '%s'", log_prefix, framework_name);
 }
 
-/*
- * Return the parent segment.
- * This will only be non-null when creating a segment for a new fiber context
- * that needs to be a child of another fiber context. If it is non-null, it will
- * be set to NULL after being used. The helper function will ensure the fiber
- * parent segment is only used once.
- */
 static nr_segment_t* nr_use_fiber_parent() {
   if (NULL == NRPRG(fiber_parent_segment)) {
     return NULL;

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -368,6 +368,7 @@ static const nr_framework_table_t all_frameworks[] = {
      NR_FW_YII1},
     {"Yii2", "yii2", NR_PSTR("yii2/baseyii.php"), 0, nr_yii2_enable,
      NR_FW_YII2},
+
 };
 // clang-format: on
 static const int num_all_frameworks
@@ -443,7 +444,7 @@ static nr_library_table_t libraries[] = {
     /* php-amqplib RabbitMQ; PHP Agent supports php-amqplib >= 3.7 */
     {"php-amqplib", NR_PSTR("phpamqplib/connection/abstractconnection.php"),
      nr_php_amqplib_enable},
-    
+
     {"Predis", NR_PSTR("predis/src/client.php"), nr_predis_enable},
     {"Predis", NR_PSTR("predis/client.php"), nr_predis_enable},
 
@@ -632,6 +633,22 @@ static nrframework_t nr_try_force_framework(
 static void nr_framework_log(const char* log_prefix,
                              const char* framework_name) {
   nrl_debug(NRL_FRAMEWORK, "%s = '%s'", log_prefix, framework_name);
+}
+
+/*
+ * Return the parent segment.
+ * This will only be non-null when creating a segment for a new fiber context
+ * that needs to be a child of another fiber context. If it is non-null, it will
+ * be set to NULL after being used. The helper function will ensure the fiber
+ * parent segment is only used once.
+ */
+static nr_segment_t* nr_use_fiber_parent() {
+  if (NULL == NRPRG(fiber_parent_segment)) {
+    return NULL;
+  }
+  nr_segment_t* ret_segment = NRPRG(fiber_parent_segment);
+  NRPRG(fiber_parent_segment) = NULL;
+  return ret_segment;
 }
 
 void nr_framework_create_metric(TSRMLS_D) {
@@ -1599,7 +1616,10 @@ void nr_php_execute_internal(zend_execute_data* execute_data,
   if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_executes)) {
     nr_php_show_exec_internal(NR_EXECUTE_ORIG_ARGS_OVERWRITE, func TSRMLS_CC);
   }
-  segment = nr_segment_start(NRPRG(txn), NULL, NULL);
+  segment = nr_segment_start(NRPRG(txn), NRPRG(fiber_parent_segment),
+                             NRPRG(current_php_context));
+  NRPRG(fiber_parent_segment) = NULL;
+
   CALL_ORIGINAL;
 
   duration = nr_time_duration(segment->start_time, nr_txn_now_rel(NRPRG(txn)));
@@ -1610,7 +1630,7 @@ void nr_php_execute_internal(zend_execute_data* execute_data,
 
     nr_php_execute_metadata_init(&metadata, (zend_op_array*)func);
 
-    nr_php_execute_segment_add_metric(segment, &metadata, false);
+    nr_php_execute_segment_add_metric(segment, &metadata645, false);
 
     nr_php_execute_metadata_release(&metadata);
   }
@@ -1694,6 +1714,96 @@ end:
  */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA /* PHP8+ and OAPI */
+
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO    
+void nr_fiber_show_fiber(zend_fiber_context* zfc, const char* fiber_action) {
+  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers)) {
+    zend_fiber* zfc_fiber = NULL;
+    char* zfc_status = NULL;
+    char* fiber_destroy_flag = NULL;
+    char* fiber_threw_flag = NULL;
+    char* fiber_bailout_flag = NULL;
+    char* fiber_func_name = NULL;
+    char* label = "  fiber";
+
+    if (NULL == zfc) {
+      nrl_warning(NRL_AGENT,
+                  "PHP Issue: %s Fiber context is unexpectedly NULL.",
+                  fiber_action);
+      return;
+    }
+
+    switch (zfc->status) {
+      case ZEND_FIBER_STATUS_INIT:
+        zfc_status = "ZEND_FIBER_STATUS_INIT";
+        break;
+      case ZEND_FIBER_STATUS_RUNNING:
+        zfc_status = "ZEND_FIBER_STATUS_RUNNING";
+        break;
+      case ZEND_FIBER_STATUS_SUSPENDED:
+        zfc_status = "ZEND_FIBER_STATUS_SUSPENDED";
+        break;
+      case ZEND_FIBER_STATUS_DEAD:
+        zfc_status = "ZEND_FIBER_STATUS_DEAD";
+        break;
+      default:
+        zfc_status = "UNKNOWN STATUS";
+    }
+
+    if (zend_ce_fiber != zfc->kind) {
+      /*
+       * Return with what we have since we can't extract a fiber from the main
+       * context for any additional info.
+       */
+      nrl_verbosedebug(
+          NRL_AGENT, "%s: %.*s %s:`main` context ctx={%p} status{%s}", label,
+          nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces,
+          NRSAFESTR(fiber_action), zfc, zfc_status);
+      return;
+    }
+    zfc_fiber = zend_fiber_from_context(zfc);
+
+    if (NULL == zfc_fiber) {
+      nrl_verbosedebug(
+          NRL_INSTRUMENT,
+          "PHP Issue: The Fiber associated with %p is unexpectedly NULL.", zfc);
+      return;
+    }
+    if (zfc_fiber->flags & ZEND_FIBER_FLAG_DESTROYED) {
+      fiber_destroy_flag = "destroyed";
+    }
+
+    if (zfc_fiber->flags & ZEND_FIBER_FLAG_THREW) {
+      fiber_threw_flag = "threw";
+    }
+
+    if (zfc_fiber->flags & ZEND_FIBER_FLAG_BAILOUT) {
+      fiber_bailout_flag = "bailout";
+    }
+
+    /*
+     * Use fci_cache vs fci since fci.function_name will be set to undef in PHP
+     * when the fiber is dead and cannot be depended on.
+     */
+    zend_fcall_info_cache zfc_fci_cache = zfc_fiber->fci_cache;
+    if (NULL != zfc_fci_cache.function_handler) {
+      fiber_func_name
+          = nr_php_function_debug_name(zfc_fci_cache.function_handler);
+    }
+
+    nrl_verbosedebug(
+        NRL_AGENT,
+        "%s: %.*s %s: fiber context ctx={%p} function={%s} status{%s}"
+        "flags={%s|%s|%s}",
+        label, nr_php_show_exec_indentation(TSRMLS_C),
+        nr_php_indentation_spaces, NRSAFESTR(fiber_action), zfc,
+        NRSAFESTR(fiber_func_name), NRSAFESTR(zfc_status),
+        NRSAFESTR(fiber_destroy_flag), NRSAFESTR(fiber_threw_flag),
+        NRSAFESTR(fiber_bailout_flag));
+    nr_free(fiber_func_name);
+  }
+}
+#endif /* PHP 8.1+ */
 
 static void nr_php_observer_attempt_call_cufa_handler(NR_EXECUTE_PROTO) {
   NR_UNUSED_FUNC_RETURN_VALUE;
@@ -1816,7 +1926,9 @@ static void nr_php_instrument_func_begin(NR_EXECUTE_PROTO) {
   }
   wraprec = nr_php_get_wraprec(execute_data->func);
 
-  segment = nr_segment_start(NRPRG(txn), NULL, NULL);
+  segment = nr_segment_start(NRPRG(txn), NRPRG(fiber_parent_segment),
+                             NRPRG(current_php_context));
+  NRPRG(fiber_parent_segment) = NULL;
 
   if (nrunlikely(NULL == segment)) {
     nrl_verbosedebug(NRL_AGENT, "Error starting segment.");
@@ -1889,7 +2001,7 @@ static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
   /*
    * Get the current segment and return if null.
    */
-  segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
+  segment = nr_txn_get_current_segment(NRPRG(txn), NRPRG(current_php_context));
   if (nrunlikely(NULL == segment)) {
     /*
      * Most likely caused by txn ending prematurely and closing all segments. We
@@ -1909,7 +2021,6 @@ static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
      * _clean callbacks if they exist. If it doesn't exist, we exit as nothing
      * needs to be done.
      */
-
     if (NULL == segment->wraprec) {
       return;
     }
@@ -2010,7 +2121,8 @@ static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
    * start and then stop a segment. If that happened, we want to ensure we
    * get the now-current segment
    */
-  segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
+  //  segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
+  segment = nr_txn_get_current_segment(NRPRG(txn), NRPRG(current_php_context));
   nr_php_execute_metadata_init(&metadata, NR_OP_ARRAY);
   nr_php_execute_segment_end(segment, &metadata, create_metric);
   nr_php_execute_metadata_release(&metadata);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -2120,7 +2120,6 @@ static void nr_php_instrument_func_end(NR_EXECUTE_PROTO) {
    * start and then stop a segment. If that happened, we want to ensure we
    * get the now-current segment
    */
-  //  segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
   segment = nr_txn_get_current_segment(NRPRG(txn), NRPRG(current_php_context));
   nr_php_execute_metadata_init(&metadata, NR_OP_ARRAY);
   nr_php_execute_segment_end(segment, &metadata, create_metric);

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -634,15 +634,6 @@ static void nr_framework_log(const char* log_prefix,
   nrl_debug(NRL_FRAMEWORK, "%s = '%s'", log_prefix, framework_name);
 }
 
-static nr_segment_t* nr_use_fiber_parent() {
-  if (NULL == NRPRG(fiber_parent_segment)) {
-    return NULL;
-  }
-  nr_segment_t* ret_segment = NRPRG(fiber_parent_segment);
-  NRPRG(fiber_parent_segment) = NULL;
-  return ret_segment;
-}
-
 void nr_framework_create_metric(TSRMLS_D) {
   char* metric_name = NULL;
   const char* framework_name = "None";

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -368,7 +368,6 @@ static const nr_framework_table_t all_frameworks[] = {
      NR_FW_YII1},
     {"Yii2", "yii2", NR_PSTR("yii2/baseyii.php"), 0, nr_yii2_enable,
      NR_FW_YII2},
-
 };
 // clang-format: on
 static const int num_all_frameworks
@@ -1630,7 +1629,7 @@ void nr_php_execute_internal(zend_execute_data* execute_data,
 
     nr_php_execute_metadata_init(&metadata, (zend_op_array*)func);
 
-    nr_php_execute_segment_add_metric(segment, &metadata645, false);
+    nr_php_execute_segment_add_metric(segment, &metadata, false);
 
     nr_php_execute_metadata_release(&metadata);
   }

--- a/agent/php_execute.h
+++ b/agent/php_execute.h
@@ -30,6 +30,13 @@
 extern void nr_php_execute_file(const zend_op_array* op_array,
                                 NR_EXECUTE_PROTO TSRMLS_DC);
 
+#if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO
+/*
+ * Purpose: Log information about the fiber for a given fiber context
+ */
+extern void nr_fiber_show_fiber(zend_fiber_context* zfc,
+                                const char* fiber_action);
+#endif /* PHP 8.1+ */
 /*
  * Purpose: Log information about the execute data in a given execution
  * context - either 'execute' (zend_execute) or 'observe' (fcall_init).

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -50,10 +50,11 @@ typedef struct _nrphpglobals_t {
 #if ZEND_MODULE_API_NO >= ZEND_8_1_X_API_NO /* PHP 8.1+ */
   zend_long zend_offset;                    /* Zend extension offset */
 #else
-  int zend_offset;          /* Zend extension offset */
+  int zend_offset; /* Zend extension offset */
 #endif
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP 8.0+ */
-  int op_array_extension_handle; /* Zend op_array extension handle to attach agent's data to function */
+  int op_array_extension_handle; /* Zend op_array extension handle to attach
+                                    agent's data to function */
 #endif
   int done_instrumentation;  /* Set to true if we have installed instrumentation
                                 handlers */
@@ -100,6 +101,7 @@ typedef struct _nrphpglobals_t {
     uint8_t show_execute_stack;
     uint8_t show_execute_returns;
     uint8_t show_executes_untrimmed;
+    uint8_t show_fibers;
     uint8_t no_exception_handler;
     uint8_t no_signal_handler;
     uint8_t debug_autorum;

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -484,17 +484,20 @@ nrinibool_t
 nrinibool_t
     distributed_tracing_exclude_newrelic_header; /* newrelic.distributed_tracing_exclude_newrelic_header
                                                   */
-nrinibool_t distributed_tracing_pad_trace_id; /* newrelic.distributed_tracing.pad_trace_id
-                                               */
-nrinibool_t span_events_enabled;              /* newrelic.span_events_enabled */
+nrinibool_t
+    distributed_tracing_pad_trace_id; /* newrelic.distributed_tracing.pad_trace_id
+                                       */
+nrinibool_t span_events_enabled;      /* newrelic.span_events_enabled */
 nriniuint_t
     span_events_max_samples_stored; /* newrelic.span_events.max_samples_stored
                                      */
 
-nrinistr_t dt_remote_parent_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_sampled
-                                      */
-nrinistr_t dt_remote_parent_not_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_not_sampled
-                                          */
+nrinistr_t
+    dt_remote_parent_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_sampled
+                               */
+nrinistr_t
+    dt_remote_parent_not_sampled; /* newrelic.distributed_tracing.sampler.remote_parent_not_sampled
+                                   */
 /* decoding of newrelic.distributed_tracing.sampler.remote_parent_sampled and
  * newrelic.distributed_tracing.sampler.remote_parent_not_sampled.
  */
@@ -533,11 +536,13 @@ nrinibool_t
 nriniuint_t
     log_forwarding_log_level; /* newrelic.application_logging.forwarding.log_level
                                */
-nrinibool_t log_forwarding_labels_enabled; /* newrelic.application_logging.forwarding.labels.enabled
-                                            */
+nrinibool_t
+    log_forwarding_labels_enabled; /* newrelic.application_logging.forwarding.labels.enabled
+                                    */
 
-nrinistr_t log_forwarding_labels_exclude; /* newrelic.application_logging.forwarding.labels.exclude
-                                           */
+nrinistr_t
+    log_forwarding_labels_exclude; /* newrelic.application_logging.forwarding.labels.exclude
+                                    */
 
 /*
  * Configuration option to toggle code level metrics collection.
@@ -552,14 +557,16 @@ nrinibool_t
 nrinibool_t
     vulnerability_management_package_detection_enabled; /* newrelic.vulnerability_management.package_detection.enabled
                                                          */
-nrinibool_t vulnerability_management_composer_api_enabled; /* newrelic.vulnerability_management.composer_api.enabled
-                                                            */
+nrinibool_t
+    vulnerability_management_composer_api_enabled; /* newrelic.vulnerability_management.composer_api.enabled
+                                                    */
 
 /*
  * Configuration options for recording Messaging APIs
  */
-nrinibool_t message_tracer_segment_parameters_enabled; /* newrelic.segment_tracer.segment_parameters.enabled
-                                                        */
+nrinibool_t
+    message_tracer_segment_parameters_enabled; /* newrelic.segment_tracer.segment_parameters.enabled
+                                                */
 
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
 /*
@@ -588,6 +595,22 @@ nr_hashmap_t* predis_commands;
 
 nrcallbackfn_t error_group_user_callback; /* The user defined callback for
                                               error group naming */
+
+/*
+ * Pointer to the current context string.
+ * If NULL, execution is occuring in the main PHP Process.
+ * Otherwise it will point to the fiber context string.
+ */
+const char* current_php_context;
+
+/* Contains the fiber address as a string to use as the async_context.*/
+char fiber_context_string[32];
+/*
+ * Contains the parent segment of a fiber only when starting a fiber within a
+ * fiber. For all other cases will be null which indicates that the main PHP
+ * process is the parent.
+ */
+nr_segment_t* fiber_parent_segment;
 
 /*
  * The globals below all refer to a transaction. Those globals contain

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -943,6 +943,10 @@ static void foreach_special_control_flag(const char* str,
     NR_PHP_PROCESS_GLOBALS(special_flags).show_executes_untrimmed = 1;
     return;
   }
+  if (0 == nr_strcmp(str, "show_fibers")) {
+    NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers = 1;
+    return;
+  }
   if (0 == nr_strcmp(str, "no_exception_handler")) {
     NR_PHP_PROCESS_GLOBALS(special_flags).no_exception_handler = 1;
     return;

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -210,7 +210,7 @@ static inline void nr_fiber_set_fiber_parent_segment(zend_fiber_context* zfc) {
     /* Main process is the parent, set to NULL. */
     NRPRG(fiber_parent_segment) = NULL;
   } else {
-    const char* parent_fiber_context_string = nr_formatf("%p", zfc);
+    char* parent_fiber_context_string = nr_formatf("%p", zfc);
     NRPRG(fiber_parent_segment)
         = nr_txn_get_current_segment(NRPRG(txn), parent_fiber_context_string);
     nr_free(parent_fiber_context_string);

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -130,7 +130,9 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
 }
 
 #if ZEND_MODULE_API_NO > ZEND_8_0_X_API_NO /* PHP8.1+ */
+
 static void nr_fiber_disable(zend_fiber_context* fiber_context) {
+  nr_fiber_show_fiber(fiber_context, "init/destroy");
   if (NULL != NRPRG(txn)) {
     /* Fiber init/destroy detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
@@ -143,6 +145,8 @@ static void nr_fiber_disable(zend_fiber_context* fiber_context) {
 
 static void nr_fiber_switch_disable(zend_fiber_context* from,
                                     zend_fiber_context* to) {
+  nr_fiber_show_fiber(from, "switch from");
+  nr_fiber_show_fiber(to, "switch to");
   if (NULL != NRPRG(txn)) {
     /* Fiber switch detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
@@ -152,6 +156,82 @@ static void nr_fiber_switch_disable(zend_fiber_context* from,
     nr_php_txn_end(0, 0 TSRMLS_CC);
   }
 }
+
+static void nr_fiber_init_observe(zend_fiber_context* zfc) {
+  nr_fiber_show_fiber(zfc, "init");
+}
+
+static void nr_fiber_destroy_observe(zend_fiber_context* zfc) {
+  nr_fiber_show_fiber(zfc, "destroy");
+}
+
+static inline void nr_fiber_set_contexts(zend_fiber_context* zfc) {
+  nr_segment_t* current_segment = NULL;
+
+  if (zfc->kind != zend_ce_fiber) {
+    /* Fiber context is the Main PHP Process */
+    NRPRG(current_php_context) = NULL;
+    NRPRG(fiber_context_string)[0] = '\0';
+  } else {
+    snprintf(NRPRG(fiber_context_string), sizeof(NRPRG(fiber_context_string)),
+             "%p", zfc);
+    NRPRG(current_php_context) = NRPRG(fiber_context_string);
+  }
+
+  current_segment
+      = nr_txn_get_current_segment(NRPRG(txn), NRPRG(current_php_context));
+  if (current_segment) {
+    nr_txn_set_current_segment(NRPRG(txn), current_segment);
+  }
+}
+
+/*
+ * The fiber_parent_segment is only set to non-NULL when starting a fiber within
+ a fiber.
+ * For all other cases it will be null which indicates that the main PHP process
+ is the parent.
+ * In the case of end/start txn happening within fibers, this can also be null
+ due to the following
+ * current agent behavior when a txn ends/starts:
+ * 1) when a segment is discarded, its children get re-parented to its parent
+ * 2) when a txn is ended, all segments (even those that haven't completed yet)
+ are closed
+ * 3) For subsequent children of a calling segment that was closed by the txn
+ end, since the calling segment no longer exists, the main process becomes the
+ parent.
+ *
+ */
+static inline void nr_fiber_set_fiber_parent_segment(zend_fiber_context* zfc) {
+  if (zfc->kind != zend_ce_fiber) {
+    /* Main process is the parent, set to NULL. */
+    NRPRG(fiber_parent_segment) = NULL;
+  } else {
+    const char* parent_fiber_context_string = nr_formatf("%p", zfc);
+    NRPRG(fiber_parent_segment)
+        = nr_txn_get_current_segment(NRPRG(txn), parent_fiber_context_string);
+    nr_free(parent_fiber_context_string);
+  }
+}
+
+static void nr_fiber_switch_observe(zend_fiber_context* from,
+                                    zend_fiber_context* to) {
+  nr_fiber_show_fiber(from, "switch from");
+  nr_fiber_show_fiber(to, "switch to");
+
+  /*
+   * If kind != zend_ce_fiber that means the fiber context is the MAIN php
+   * context not an actual fiber.
+   */
+
+  nr_fiber_set_contexts(to);
+
+  /* If we are starting a new fiber.  We need to ensure it is properly parented
+   * to the "from" context. */
+  if (ZEND_FIBER_STATUS_INIT == to->status) {
+    nr_fiber_set_fiber_parent_segment(from);
+  }
+}
+
 #endif /* PHP 8.1+ */
 
 void nr_php_observer_no_op(zend_execute_data* execute_data NRUNUSED) {};
@@ -175,11 +255,31 @@ void nr_php_observer_minit() {
    * Register the Observer API fiber handlers.
    */
 
-  /* Currently only register if we are disabling instrumentation. */
+  /*
+   * Life cycle of a fiber:
+   * 1) fiber->start which triggers
+   *    a) fiber init
+   *    b) fiber switch from calling context to fiber context
+   * 2) fiber->resume which triggers
+   *    a) fiber switch from calling context to fiber context
+   * 3) fiber->suspend which triggers
+   *    a) fiber switch from fiber context to calling context
+   * 4) fiber exits/completes which triggers
+   *    a) fiber switch from fiber context to calling context
+   *    b) fiber destroy
+   * 5) calling function exits without calling fiber->resume which triggers
+   *    a) fiber switch from calling context to fiber context
+   *    b) fiber switch from fiber context to calling context
+   *    c) fiber destroy
+   */
   if (NRINI(fibers_disabled)) {
     zend_observer_fiber_init_register(nr_fiber_disable);
     zend_observer_fiber_switch_register(nr_fiber_switch_disable);
     zend_observer_fiber_destroy_register(nr_fiber_disable);
+  } else {
+    zend_observer_fiber_init_register(nr_fiber_init_observe);
+    zend_observer_fiber_switch_register(nr_fiber_switch_observe);
+    zend_observer_fiber_destroy_register(nr_fiber_destroy_observe);
   }
 
 #endif /* PHP 8.1+ */

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -136,7 +136,9 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
                 0);
 
 static void nr_fiber_disable(zend_fiber_context* fiber_context) {
-  nr_fiber_show_fiber(fiber_context, "init/destroy");
+  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers)) {
+    nr_fiber_show_fiber(fiber_context, "init/destroy");
+  }
   if (NULL != NRPRG(txn)) {
     /* Fiber init/destroy detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
@@ -148,8 +150,10 @@ static void nr_fiber_disable(zend_fiber_context* fiber_context) {
 
 static void nr_fiber_switch_disable(zend_fiber_context* from,
                                     zend_fiber_context* to) {
-  nr_fiber_show_fiber(from, "switch from");
-  nr_fiber_show_fiber(to, "switch to");
+  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers)) {
+    nr_fiber_show_fiber(from, "switch from");
+    nr_fiber_show_fiber(to, "switch to");
+  }
   if (NULL != NRPRG(txn)) {
     /* Fiber switch detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
@@ -161,12 +165,16 @@ static void nr_fiber_switch_disable(zend_fiber_context* from,
 
 static void nr_fiber_init_observe(zend_fiber_context* zfc) {
   NR_FIBER_USED_CREATE_METRIC
-  nr_fiber_show_fiber(zfc, "init");
+  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers)) {
+    nr_fiber_show_fiber(zfc, "init");
+  }
 }
 
 static void nr_fiber_destroy_observe(zend_fiber_context* zfc) {
   NR_FIBER_USED_CREATE_METRIC
-  nr_fiber_show_fiber(zfc, "destroy");
+  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers)) {
+    nr_fiber_show_fiber(zfc, "destroy");
+  }
 }
 
 static inline void nr_fiber_set_contexts(zend_fiber_context* zfc) {
@@ -220,8 +228,10 @@ static inline void nr_fiber_set_fiber_parent_segment(zend_fiber_context* zfc) {
 static void nr_fiber_switch_observe(zend_fiber_context* from,
                                     zend_fiber_context* to) {
   NR_FIBER_USED_CREATE_METRIC
-  nr_fiber_show_fiber(from, "switch from");
-  nr_fiber_show_fiber(to, "switch to");
+  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_fibers)) {
+    nr_fiber_show_fiber(from, "switch from");
+    nr_fiber_show_fiber(to, "switch to");
+  }
 
   /*
    * If kind != zend_ce_fiber that means the fiber context is the MAIN php

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -131,14 +131,17 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
 
 #if ZEND_MODULE_API_NO > ZEND_8_0_X_API_NO /* PHP8.1+ */
 
+#define NR_FIBER_USED_CREATE_METRIC                                            \
+  nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used", \
+                0);
+
 static void nr_fiber_disable(zend_fiber_context* fiber_context) {
   nr_fiber_show_fiber(fiber_context, "init/destroy");
   if (NULL != NRPRG(txn)) {
     /* Fiber init/destroy detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
                 "Transaction is truncated because PHP Fiber use is detected.");
-    nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used",
-                  0);
+    NR_FIBER_USED_CREATE_METRIC;
     nr_php_txn_end(0, 0 TSRMLS_CC);
   }
 }
@@ -151,17 +154,18 @@ static void nr_fiber_switch_disable(zend_fiber_context* from,
     /* Fiber switch detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
                 "Transaction is truncated because PHP Fiber use is detected.");
-    nrm_force_add(NRPRG(txn)->unscoped_metrics, "Supportability/PHP/Fiber/used",
-                  0);
+    NR_FIBER_USED_CREATE_METRIC;
     nr_php_txn_end(0, 0 TSRMLS_CC);
   }
 }
 
 static void nr_fiber_init_observe(zend_fiber_context* zfc) {
+  NR_FIBER_USED_CREATE_METRIC;
   nr_fiber_show_fiber(zfc, "init");
 }
 
 static void nr_fiber_destroy_observe(zend_fiber_context* zfc) {
+  NR_FIBER_USED_CREATE_METRIC;
   nr_fiber_show_fiber(zfc, "destroy");
 }
 
@@ -215,6 +219,7 @@ static inline void nr_fiber_set_fiber_parent_segment(zend_fiber_context* zfc) {
 
 static void nr_fiber_switch_observe(zend_fiber_context* from,
                                     zend_fiber_context* to) {
+  NR_FIBER_USED_CREATE_METRIC;
   nr_fiber_show_fiber(from, "switch from");
   nr_fiber_show_fiber(to, "switch to");
 

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -141,7 +141,7 @@ static void nr_fiber_disable(zend_fiber_context* fiber_context) {
     /* Fiber init/destroy detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
                 "Transaction is truncated because PHP Fiber use is detected.");
-    NR_FIBER_USED_CREATE_METRIC;
+    NR_FIBER_USED_CREATE_METRIC
     nr_php_txn_end(0, 0 TSRMLS_CC);
   }
 }
@@ -154,18 +154,18 @@ static void nr_fiber_switch_disable(zend_fiber_context* from,
     /* Fiber switch detected, end and keep the transaction. */
     nrl_warning(NRL_INSTRUMENT,
                 "Transaction is truncated because PHP Fiber use is detected.");
-    NR_FIBER_USED_CREATE_METRIC;
+    NR_FIBER_USED_CREATE_METRIC
     nr_php_txn_end(0, 0 TSRMLS_CC);
   }
 }
 
 static void nr_fiber_init_observe(zend_fiber_context* zfc) {
-  NR_FIBER_USED_CREATE_METRIC;
+  NR_FIBER_USED_CREATE_METRIC
   nr_fiber_show_fiber(zfc, "init");
 }
 
 static void nr_fiber_destroy_observe(zend_fiber_context* zfc) {
-  NR_FIBER_USED_CREATE_METRIC;
+  NR_FIBER_USED_CREATE_METRIC
   nr_fiber_show_fiber(zfc, "destroy");
 }
 
@@ -219,7 +219,7 @@ static inline void nr_fiber_set_fiber_parent_segment(zend_fiber_context* zfc) {
 
 static void nr_fiber_switch_observe(zend_fiber_context* from,
                                     zend_fiber_context* to) {
-  NR_FIBER_USED_CREATE_METRIC;
+  NR_FIBER_USED_CREATE_METRIC
   nr_fiber_show_fiber(from, "switch from");
   nr_fiber_show_fiber(to, "switch to");
 

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -113,6 +113,9 @@ PHP_RINIT_FUNCTION(newrelic) {
 
   NRPRG(check_cufa) = false;
 
+  NRPRG(current_php_context) = NULL;
+  NRPRG(fiber_parent_segment) = NULL;
+
   /*
    * Pre-OAPI, this variables were kept on the call stack and
    * therefore had no need to be in an nr_stack

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1268,11 +1268,7 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO \
     && !defined OVERWRITE_ZEND_EXECUTE_DATA
-  nr_segment_t* segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
-  while (NULL != segment && segment != NRTXN(segment_root)) {
-    nr_segment_end(&segment);
-    segment = nr_txn_get_current_segment(NRPRG(txn), NULL);
-  }
+  nr_txn_finalize_parent_stacks(NRPRG(txn));
 #else
   nr_php_stacked_segment_unwind(TSRMLS_C);
 #endif

--- a/agent/scripts/newrelic.ini.private.template
+++ b/agent/scripts/newrelic.ini.private.template
@@ -44,6 +44,7 @@
 ;            show_execute_stack
 ;            show_execute_returns
 ;            show_executes_untrimmed
+;            show_fibers
 ;            no_exception_handler
 ;            no_signal_handler
 ;            debug_autorum

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -218,6 +218,25 @@ bool nr_segment_init(nr_segment_t* segment,
   if (parent) {
     segment->parent = parent;
     nr_segment_children_add(&parent->children, segment);
+    /*
+     * Special case: if the new async context stack does not exist and the async
+     * context is not NULL, then this indicates that the new segment is the root
+     * of a new async context. In that case, we'll parent it to the requested
+     * parent and set it as current for that async context. (Users who want to
+     * have their new context be parented to current on main should not provide
+     * a parent which handles that case.) */
+    if (NULL != async_context
+        && NULL
+               == (nr_stack_t*)nr_hashmap_index_get(txn->parent_stacks,
+                                                    segment->async_context)) {
+      /*
+       * This means this IS the first segment in the async context that is the
+       * child of a parent of another async context and so it will need to be
+       * set as current on the new context.
+       */
+      nr_txn_set_current_segment(txn, segment);
+    }
+
   } /* Otherwise, the parent of this new segment is the current segment on the
        transaction */
   else {

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -237,9 +237,11 @@ bool nr_segment_init(nr_segment_t* segment,
       nr_txn_set_current_segment(txn, segment);
     }
 
-  } /* Otherwise, the parent of this new segment is the current segment on the
-       transaction */
-  else {
+  } else {
+    /*
+     * Otherwise, the parent of this new segment is the current segment on the
+     * transaction
+     */
     nr_segment_t* current_segment
         = nr_txn_get_current_segment(txn, async_context);
 

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -571,11 +571,12 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nt->abs_start_time = nr_get_time();
 
   /*
-   * Allocate the stacks to manage segment parenting
+   * Allocate the stacks to manage segment parenting and set context to default
    */
   nr_stack_init(&nt->default_parent_stack, NR_STACK_DEFAULT_CAPACITY);
   nt->parent_stacks
       = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_txn_destroy_parent_stack);
+  nt->current_async_context = 0;
 
   /*
    * Install the root segment
@@ -1598,7 +1599,8 @@ void nr_txn_record_error(nrtxn_t* txn,
   /* Only try to get a span_id in cases where we know spans should be created.
    */
   if (nr_txn_should_create_span_events(txn)) {
-    span_id = nr_txn_get_current_span_id(txn);
+    span_id = nr_txn_get_current_span_id(
+        txn, nr_string_get(txn->trace_strings, txn->current_async_context));
 
     /*
      * The specification says span_id MUST be included so if span events are
@@ -3190,6 +3192,16 @@ void nr_txn_finalize_parent_stacks(nrtxn_t* txn) {
   nr_txn_end_segments_in_stack(&txn->default_parent_stack, txn);
 }
 
+const char* nr_txn_get_current_context(nrtxn_t* txn) {
+  if (NULL == txn) {
+    return NULL;
+  }
+  if (0 == txn->current_async_context) {
+    return NULL;
+  }
+  return nr_string_get(txn->trace_strings, txn->current_async_context);
+}
+
 nr_segment_t* nr_txn_get_current_segment(nrtxn_t* txn,
                                          const char* async_context) {
   if (nrunlikely(NULL == txn)) {
@@ -3231,15 +3243,20 @@ void nr_txn_set_current_segment(nrtxn_t* txn, nr_segment_t* segment) {
 
       if (NR_SUCCESS
           != nr_hashmap_index_set(txn->parent_stacks, key, (void*)stack)) {
-        // If we can't add the stack to the hashmap, then we should free it to
-        // avoid a memory leak.
+        /*
+         * If we can't add the stack to the hashmap, then we should free it to
+         * avoid a memory leak.
+         */
         nr_stack_destroy_fields(stack);
         nr_free(stack);
         return;
       }
     }
+    txn->current_async_context = segment->async_context;
   } else {
     stack = &txn->default_parent_stack;
+
+    txn->current_async_context = 0;
   }
 
   nr_stack_push(stack, (void*)segment);
@@ -3255,6 +3272,13 @@ void nr_txn_retire_current_segment(nrtxn_t* txn, nr_segment_t* segment) {
         (nr_stack_t*)nr_hashmap_index_get(txn->parent_stacks,
                                           (uint64_t)segment->async_context),
         segment);
+
+    if (NULL != segment->parent) {
+      txn->current_async_context = segment->parent->async_context;
+    } else {
+      txn->current_async_context = 0;
+    }
+
   } else {
     nr_stack_remove_topmost(&txn->default_parent_stack, segment);
   }
@@ -3284,7 +3308,7 @@ char* nr_txn_get_current_trace_id(nrtxn_t* txn) {
   return nr_strdup(trace_id);
 }
 
-char* nr_txn_get_current_span_id(nrtxn_t* txn) {
+char* nr_txn_get_current_span_id(nrtxn_t* txn, const char* async_context) {
   nr_segment_t* segment;
   char* span_id;
 
@@ -3292,7 +3316,7 @@ char* nr_txn_get_current_span_id(nrtxn_t* txn) {
     return NULL;
   }
 
-  segment = nr_txn_get_current_segment(txn, NULL);
+  segment = nr_txn_get_current_segment(txn, async_context);
   if (NULL == segment) {
     return NULL;
   }
@@ -3422,7 +3446,8 @@ static void log_event_set_linking_metadata(nr_log_event_t* e,
     nr_log_event_set_trace_id(e, trace_id);
     nr_free(trace_id);
 
-    span_id = nr_txn_get_current_span_id(txn);
+    span_id = nr_txn_get_current_span_id(
+        txn, nr_string_get(txn->trace_strings, txn->current_async_context));
     nr_log_event_set_span_id(e, span_id);
     nr_free(span_id);
 

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3309,8 +3309,8 @@ char* nr_txn_get_current_trace_id(nrtxn_t* txn) {
 }
 
 char* nr_txn_get_current_span_id(nrtxn_t* txn, const char* async_context) {
-  nr_segment_t* segment;
-  char* span_id;
+  nr_segment_t* segment = NULL;
+  char* span_id = NULL;
 
   if (NULL == txn) {
     return NULL;

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -287,6 +287,8 @@ typedef struct _nrtxn_t {
                             * all segment start and end times are relative to
                             * this field */
 
+  int current_async_context; /* Execution context (pooled string index) */
+
   nr_error_t* error;            /* Captured error */
   nr_slowsqls_t* slowsqls;      /* Slow SQL statements */
   nrpool_t* datastore_products; /* Datastore products seen */
@@ -1059,6 +1061,16 @@ char* nr_txn_create_w3c_tracestate_header(const nrtxn_t* txn,
 extern bool nr_txn_should_create_span_events(const nrtxn_t* txn);
 
 /*
+ * Purpose : Get a the string value of the current txn context
+ *
+ * Params  : 1. The transaction.
+ *
+ * Note    : This will be NULL for default/main, and a string context for async
+ * Returns : A pointer to string context.
+ */
+extern const char* nr_txn_get_current_context(nrtxn_t* txn);
+
+/*
  * Purpose : Get a pointer to the currently-executing segment for a given
  *           async context.
  *
@@ -1149,12 +1161,13 @@ extern char* nr_txn_get_current_trace_id(nrtxn_t* txn);
  * Purpose : Return the current span ID or create it if doesn't have one yet.
  *
  * Params  : 1. The transaction.
- *
+ *           2. The async context.
  * Note    : The string returned has to be freed by the caller.
  *
  * Returns : current span ID if the segment is valid, otherwise NULL.
  */
-extern char* nr_txn_get_current_span_id(nrtxn_t* txn);
+extern char* nr_txn_get_current_span_id(nrtxn_t* txn,
+                                        const char* async_context);
 
 /*
  * Purpose : End all currently active segments.

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -7908,7 +7908,6 @@ static void test_get_current_span_id(void) {
    * Test : default segment and async segment are different.
    * And span ids are also different.
    */
-  //  nr_txn_set_current_segment(txn, segment_async);
   span_id_async = nr_txn_get_current_span_id(txn, async_context);
   span_id = nr_txn_get_current_span_id(txn, NULL);
   tlib_pass_if_str_equal(

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -7807,10 +7807,16 @@ static void test_get_current_trace_id(void) {
 static void test_get_current_span_id(void) {
   nrapp_t app;
   nrtxnopt_t opts;
-  nr_segment_t* segment;
-  char* span_id;
-  nrtxn_t* txn;
+  nr_segment_t* segment = NULL;
+  nr_segment_t* segment_async = NULL;
+  char* span_id = NULL;
+  char* span_id_async = NULL;
+  nrtxn_t* txn = NULL;
   uint32_t priority;
+  const char* async_context = "sunshine";
+  nr_segment_t* parent;
+  nr_segment_t* first_born;
+  nr_segment_t* async_grandchild;
 
   /* start txn and segment */
   nr_memset(&app, 0, sizeof(app));
@@ -7819,27 +7825,66 @@ static void test_get_current_span_id(void) {
   opts.distributed_tracing_enabled = 1;
   txn = nr_txn_begin(&app, &opts, NULL, NULL);
   segment = nr_segment_start(txn, txn->segment_root, NULL);
+  segment_async = nr_segment_start(txn, segment, async_context);
   nr_distributed_trace_set_sampled(txn->distributed_trace, true);
-  nr_txn_set_current_segment(txn, segment);
 
+  parent = nr_segment_start(txn, NULL, NULL);
+  first_born = nr_segment_start(txn, NULL, NULL);
+  tlib_pass_if_not_null("parent should not be null", parent);
+
+  async_grandchild = nr_segment_start(txn, first_born, "another_async");
+  tlib_pass_if_not_null(
+      "Starting a segment on a valid txn and an implicit parent must succeed",
+      async_grandchild);
+
+  tlib_pass_if_int_equal(
+      "grandchild segment has initialized async context",
+      first_grandchild->async_context,
+      nr_string_find(first_grandchild->txn->trace_strings, "another_async"));
+
+  tlib_pass_if_int_equal(
+      "grandchild has initialized async context",
+      nr_string_find(txn->trace_strings, "another_async"),
+      nr_string_find(first_grandchild->txn->trace_strings, "another_async"));
+
+  tlib_pass_if_ptr_equal(
+      "The most recently started, implicitly-parented segment must not alter "
+      "the NULL context's current segment",
+      nr_txn_get_current_segment(txn, NULL), first_born);
+
+  tlib_pass_if_ptr_equal(
+      "The most recently started, implicitly-parented segment must set the "
+      "current segment for the new context",
+      nr_txn_get_current_segment(txn, "another_async"), async_grandchild);
+
+  tlib_pass_if_not_null("Default Segment should not be null", segment);
+  tlib_pass_if_not_null("Async Segment should not be null", segment_async);
+  tlib_pass_if_int_equal(
+      "Async segment has initialized async context",
+      segment_async->async_context,
+      nr_string_find(segment_async->txn->trace_strings, async_context));
+  tlib_pass_if_ptr_equal(
+      "should be able to retrieve current of an async context",
+      nr_txn_get_current_segment(txn, async_context), segment_async);
   /*
    * Test : Bad parameters
    */
   tlib_pass_if_null("no span id. txn is null",
-                    nr_txn_get_current_span_id(NULL));
+                    nr_txn_get_current_span_id(NULL, NULL));
 
   /*
    * Test : disabled span events
    */
   txn->options.span_events_enabled = 0;
-  tlib_pass_if_null("span events disabled", nr_txn_get_current_span_id(txn));
+  tlib_pass_if_null("span events disabled",
+                    nr_txn_get_current_span_id(txn, NULL));
 
   /*
-   * Test : span id is created
+   * Test : span id is created for default (NULL) context
    */
   txn->options.span_events_enabled = 1;
-  span_id = nr_txn_get_current_span_id(txn);
-  tlib_fail_if_null("span id is created", span_id);
+  span_id = nr_txn_get_current_span_id(txn, NULL);
+  tlib_fail_if_null("span id is created for default (NULL) context", span_id);
   nr_free(span_id);
 
   /*
@@ -7848,6 +7893,27 @@ static void test_get_current_span_id(void) {
   priority = segment->priority;
   tlib_pass_if_true("log segment priority", priority & NR_SEGMENT_PRIORITY_LOG,
                     "priority=0x%08x", priority);
+
+  /*
+   * Test : span id is created for a segment with async context
+   */
+  span_id_async = nr_txn_get_current_span_id(txn, async_context);
+  tlib_fail_if_null("span id is created for segment with async context",
+                    span_id_async);
+  nr_free(span_id_async);
+
+  /*
+   * Test : default segment and async segment are different.
+   * And span ids are also different.
+   */
+  //  nr_txn_set_current_segment(txn, segment_async);
+  span_id_async = nr_txn_get_current_span_id(txn, async_context);
+  span_id = nr_txn_get_current_span_id(txn, NULL);
+  tlib_pass_if_str_equal(
+      "async current span id should not equal default current span id",
+      span_id_async, span_id);
+  nr_free(span_id);
+  nr_free(span_id_async);
 
   nr_txn_destroy(&txn);
 }

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -7824,48 +7824,9 @@ static void test_get_current_span_id(void) {
   app.state = NR_APP_OK;
   opts.distributed_tracing_enabled = 1;
   txn = nr_txn_begin(&app, &opts, NULL, NULL);
-  segment = nr_segment_start(txn, txn->segment_root, NULL);
-  segment_async = nr_segment_start(txn, segment, async_context);
+  segment = nr_segment_start(txn, NULL, NULL);
   nr_distributed_trace_set_sampled(txn->distributed_trace, true);
 
-  parent = nr_segment_start(txn, NULL, NULL);
-  first_born = nr_segment_start(txn, NULL, NULL);
-  tlib_pass_if_not_null("parent should not be null", parent);
-
-  async_grandchild = nr_segment_start(txn, first_born, "another_async");
-  tlib_pass_if_not_null(
-      "Starting a segment on a valid txn and an implicit parent must succeed",
-      async_grandchild);
-
-  tlib_pass_if_int_equal(
-      "grandchild segment has initialized async context",
-      first_grandchild->async_context,
-      nr_string_find(first_grandchild->txn->trace_strings, "another_async"));
-
-  tlib_pass_if_int_equal(
-      "grandchild has initialized async context",
-      nr_string_find(txn->trace_strings, "another_async"),
-      nr_string_find(first_grandchild->txn->trace_strings, "another_async"));
-
-  tlib_pass_if_ptr_equal(
-      "The most recently started, implicitly-parented segment must not alter "
-      "the NULL context's current segment",
-      nr_txn_get_current_segment(txn, NULL), first_born);
-
-  tlib_pass_if_ptr_equal(
-      "The most recently started, implicitly-parented segment must set the "
-      "current segment for the new context",
-      nr_txn_get_current_segment(txn, "another_async"), async_grandchild);
-
-  tlib_pass_if_not_null("Default Segment should not be null", segment);
-  tlib_pass_if_not_null("Async Segment should not be null", segment_async);
-  tlib_pass_if_int_equal(
-      "Async segment has initialized async context",
-      segment_async->async_context,
-      nr_string_find(segment_async->txn->trace_strings, async_context));
-  tlib_pass_if_ptr_equal(
-      "should be able to retrieve current of an async context",
-      nr_txn_get_current_segment(txn, async_context), segment_async);
   /*
    * Test : Bad parameters
    */
@@ -7897,6 +7858,47 @@ static void test_get_current_span_id(void) {
   /*
    * Test : span id is created for a segment with async context
    */
+
+  segment_async = nr_segment_start(txn, segment, async_context);
+  parent = nr_segment_start(txn, NULL, NULL);
+  first_born = nr_segment_start(txn, NULL, NULL);
+  tlib_pass_if_not_null("parent should not be null", parent);
+
+  async_grandchild = nr_segment_start(txn, first_born, "another_async");
+  tlib_pass_if_not_null(
+      "Starting a segment on a valid txn and an implicit parent must succeed",
+      async_grandchild);
+
+  tlib_pass_if_int_equal(
+      "grandchild segment has initialized async context",
+      async_grandchild->async_context,
+      nr_string_find(async_grandchild->txn->trace_strings, "another_async"));
+
+  tlib_pass_if_int_equal(
+      "grandchild has initialized async context",
+      nr_string_find(txn->trace_strings, "another_async"),
+      nr_string_find(async_grandchild->txn->trace_strings, "another_async"));
+
+  tlib_pass_if_ptr_equal(
+      "The most recently started, implicitly-parented segment must not alter "
+      "the NULL context's current segment",
+      nr_txn_get_current_segment(txn, NULL), first_born);
+
+  tlib_pass_if_ptr_equal(
+      "The most recently started, implicitly-parented segment must set the "
+      "current segment for the new context",
+      nr_txn_get_current_segment(txn, "another_async"), async_grandchild);
+
+  tlib_pass_if_not_null("Default Segment should not be null", segment);
+  tlib_pass_if_not_null("Async Segment should not be null", segment_async);
+  tlib_pass_if_int_equal(
+      "Async segment has initialized async context",
+      segment_async->async_context,
+      nr_string_find(segment_async->txn->trace_strings, async_context));
+  tlib_pass_if_ptr_equal(
+      "should be able to retrieve current of an async context",
+      nr_txn_get_current_segment(txn, async_context), segment_async);
+
   span_id_async = nr_txn_get_current_span_id(txn, async_context);
   tlib_fail_if_null("span id is created for segment with async context",
                     span_id_async);

--- a/tests/integration/span_events/fibers/test_fiber_nested1.php
+++ b/tests/integration/span_events/fibers/test_fiber_nested1.php
@@ -1,0 +1,194 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test should show proper parentage of txns with fiber activity.
+
+Output should show that PHP functionality should continue to work as expected.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.fibers.disabled = false
+*/
+
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "ENV[GUID_FRACTION]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_C]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+Ending Func 'a'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    Fiber::suspend();
+    echo "Ending Func 'a'\n";
+};
+
+$fiber = new Fiber('a');
+$fiber->start();
+
+b();
+
+$fiber->resume();

--- a/tests/integration/span_events/fibers/test_fiber_nested2.php
+++ b/tests/integration/span_events/fibers/test_fiber_nested2.php
@@ -1,0 +1,198 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test should show proper parentage of txns with fiber activity.
+
+Output should show that PHP functionality should continue to work as expected.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.fibers.disabled = false
+newrelic.loglevel = "verbosedebug"
+*/
+
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "ENV[GUID_FRACTION]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_C]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/Fiber/used
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    Fiber::suspend();
+    try {
+        c();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+$fiber = new Fiber('b');
+a();
+$fiber->start();
+
+$fiber->resume();

--- a/tests/integration/span_events/fibers/test_fiber_nested3.php
+++ b/tests/integration/span_events/fibers/test_fiber_nested3.php
@@ -1,0 +1,193 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test should show proper parentage of txns with fiber activity.
+
+Output should show that PHP functionality should continue to work as expected.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.fibers.disabled = false
+*/
+
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "ENV[GUID_FRACTION]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_C]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Ending Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    Fiber::suspend();
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    $fiber = new Fiber('c');
+    try {
+        $fiber->start();
+        time_nanosleep(0, 100000000);
+        $fiber->resume();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+a();
+b();

--- a/tests/integration/span_events/fibers/test_fiber_nested4.php
+++ b/tests/integration/span_events/fibers/test_fiber_nested4.php
@@ -1,0 +1,199 @@
+<?php
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Test should show proper parentage of txns with fiber activity.
+
+Output should show that PHP functionality should continue to work as expected.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.1", "<")) {
+  die("skip: PHP 8.1+ required\n");
+}
+*/
+
+/*INI
+newrelic.distributed_tracing_enabled=1
+newrelic.transaction_tracer.threshold = 0
+newrelic.fibers.disabled = false
+*/
+
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 5
+  },
+  [
+    [
+      {
+        "traceId": "??",
+        "duration": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "guid": "ENV[GUID_ROOT]",
+        "type": "Span",
+        "category": "generic",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "timestamp": "??",
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+       "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/a",
+        "guid": "ENV[GUID_A]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/b",
+        "guid": "ENV[GUID_B]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_ROOT]"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/c",
+        "guid": "ENV[GUID_C]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_B]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ],
+    [
+      {
+        "type": "Span",
+        "traceId": "??",
+        "transactionId": "??",
+        "sampled": true,
+        "priority": "??",
+        "name": "Custom\/fraction",
+        "guid": "ENV[GUID_FRACTION]",
+        "timestamp": "??",
+        "duration": "??",
+        "category": "generic",
+        "parentId": "ENV[GUID_C]"
+      },
+      {},
+      {
+        "error.message": "Uncaught exception 'RuntimeException' with message 'Division by zero' in __FILE__:??",
+        "error.class": "RuntimeException"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT
+Starting Func 'a'
+Starting Func 'b'
+Starting Func 'c'
+Starting Func 'fraction'
+Caught exception: Division by zero
+Ending Func 'b'
+Ending Func 'a'
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../../include/helpers.php');
+
+
+env_var_for_expects("GUID_ROOT", newrelic_get_linking_metadata()['span.id'] ?? '');
+
+function c()
+{
+    echo "Starting Func 'c'\n";
+    env_var_for_expects("GUID_C", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    Fiber::suspend();
+    echo fraction(0) . "\n";
+    echo "Ending Func 'c'\n";
+}
+
+function b()
+{
+    echo "Starting Func 'b'\n";
+    env_var_for_expects("GUID_B", newrelic_get_linking_metadata()['span.id'] ?? '');
+    $fiberc = new Fiber('c');
+    Fiber::suspend();
+    try {
+        $fiberc->start();
+        time_nanosleep(0, 100000000);
+        $fiberc->resume();
+    } catch (RuntimeException $e) {
+        echo("Caught exception: " . $e->getMessage() . "\n");
+    }
+    echo "Ending Func 'b'\n";
+}
+
+function fraction($x) {
+    echo "Starting Func 'fraction'\n";
+    env_var_for_expects("GUID_FRACTION", newrelic_get_linking_metadata()['span.id'] ?? '');
+    time_nanosleep(0, 100000000);
+    if (!$x) {
+        throw new RuntimeException('Division by zero');
+    }
+    echo "Ending Func 'fraction'\n";
+    return 1/$x;
+}
+
+function a()
+{
+    echo "Starting Func 'a'\n";
+    env_var_for_expects("GUID_A", newrelic_get_linking_metadata()['span.id'] ?? '');
+    Fiber::suspend();
+    time_nanosleep(0, 100000000);
+    echo "Ending Func 'a'\n";
+};
+
+$fibera = new Fiber('a');
+$fiberb = new Fiber('b');
+
+$fibera->start();
+$fiberb->start();
+$fiberb->resume();
+$fibera->resume();


### PR DESCRIPTION
* show_fiber functionality; indentations align with show_execs; the special keyword is "show_fibers"
* basic user function fiber usage - does not include anything with special instrumentation.  Instrumentation of internal functions have not been tested; although the show_fibers properly detects them.
* a few basic tests
* some get_current_segment, start_segment have been updated
* added values to track global asynchronous context (the actual context we are in) and txn context (the context the txn is currently working with which can be modified with set_current_segment)
* modified nr_txn_get_current_span_id for context to be passed
* added nr_txn_get_current_context
* added a few axiom unit tests

This is not the complete implementation, but will provide a base for other PRs to iterate on.