### PR TITLE
feat: add zts build and install support

### DIFF
--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -279,7 +279,7 @@ tests/test_txn.o: ../VERSION
 #
 # Used when linking test binaries.
 #
-TEST_LIBS := $(PHP_EMBED_LIBRARY) $(shell $(PHP_CONFIG) --libs)
+TEST_LIBS := $(PHP_EMBED_LIBRARY) $(shell $(PHP_CONFIG) --libs) -lrt
 TEST_LDFLAGS := $(shell $(PHP_CONFIG) --ldflags) $(EXPORT_DYNAMIC)
 TEST_LDFLAGS += $(USER_LDFLAGS)
 CROSS_AGENT_DIR := $(CURDIR)/../axiom/tests/cross_agent_tests

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -931,6 +931,8 @@ set_daemon_location() {
 #   what we detect.
 # pi_php8
 #   True if PHP version is 8.0+
+# pi_php82
+#   True if PHP version is 8.2+
 # pi_mods_avail
 #   On Debian/Ubuntu systems, the path to the mods-available directory
 #   (e.g. /etc/php/8.4/mods-available). Empty if the system does not use
@@ -993,6 +995,7 @@ gather_info() {
   havebin=
   pi_bin=
   pi_php8=
+  pi_php82=
 
   #
   # Get the path to the binary.
@@ -1065,18 +1068,22 @@ for this copy of PHP. We apologize for the inconvenience.
 
     8.2.*)
       pi_php8="yes"
+      pi_php82="yes"
       ;;
 
     8.3.*)
       pi_php8="yes"
+      pi_php82="yes"
       ;;  
 
     8.4.*)
       pi_php8="yes"
+      pi_php82="yes"
       ;;          
 
     8.5.*)
       pi_php8="yes"
+      pi_php82="yes"
       ;;
 
     *)
@@ -1305,8 +1312,8 @@ does not exist. This particular instance of PHP will be skipped.
   fi
   log "${pdir}: pi_zts=${pi_zts}"
 
-# zts installs are no longer supported
-  if [ "${pi_zts}" = "yes" ]; then
+# zts installs are only supported for PHPs 8.2+
+  if [ "${pi_zts}" = "yes" ] && [ "${pi_php82}" != "yes" ]; then
     msg=$(
     cat << EOF
 
@@ -1476,11 +1483,6 @@ install_agent_here() {
   istat=
   if [ "${pi_zts}" = "yes" ]; then
     zts="-zts"
-
-    # Force copy of zts files as it is EOL so this will
-    # prevent future eraseure of linked to file from
-    # leading to a dangling symlink
-    NR_INSTALL_USE_CP_NOT_LN=1
   fi
   srcf="${ilibdir}/agent/${pi_arch}/newrelic-${pi_modver}${zts}.so"
   destf="${pi_extdir}/newrelic.so"

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1940,7 +1940,11 @@ static PHP_INI_MH(nr_custom_events_max_samples_stored_mh) {
 static PHP_INI_MH(nr_wordpress_hooks_options_mh) {
   nrinistr_t* p;
 
+#ifndef ZTS
   char* base = (char*)mh_arg2;
+#else
+  char* base = (char*)ts_resource(*((int*)mh_arg2));
+#endif
 
   p = (nrinistr_t*)(base + (size_t)mh_arg1);
 
@@ -1973,7 +1977,11 @@ static PHP_INI_MH(nr_wordpress_hooks_options_mh) {
 static PHP_INI_MH(nr_dt_sampler_remote_parent_mh) {
   nrinistr_t* p;
 
+#ifndef ZTS
   char* base = (char*)mh_arg2;
+#else
+  char* base = (char*)ts_resource(*((int*)mh_arg2));
+#endif
   p = (nrinistr_t*)(base + (size_t)mh_arg1);
   bool parent_sampled = false;
 

--- a/agent/tests/test_fw_support.c
+++ b/agent/tests/test_fw_support.c
@@ -215,6 +215,8 @@ static void test_fw_supportability_metrics_with_vm_enabled(void) {
 }
 
 void test_main(void* p NRUNUSED) {
+  tlib_php_engine_create("");
   test_fw_supportability_metrics_with_vm_disabled();
   test_fw_supportability_metrics_with_vm_enabled();
+  tlib_php_engine_destroy();
 }

--- a/agent/tests/test_redis.c
+++ b/agent/tests/test_redis.c
@@ -107,6 +107,7 @@ static void test_is_unix_socket(void) {
   tlib_fail_if_int_equal("socket", 0, nr_php_redis_is_unix_socket("/tmp/foo"));
 }
 
+#ifndef ZTS
 static void test_remove_datastore_instance(TSRMLS_D) {
   zval* redis;
 
@@ -214,6 +215,7 @@ static void test_save_datastore_instance(TSRMLS_D) {
   nr_php_zval_free(&redis);
   tlib_php_request_end();
 }
+#endif
 
 void test_main(void* p NRUNUSED) {
 
@@ -222,17 +224,17 @@ void test_main(void* p NRUNUSED) {
 
   test_create_datastore_instance();
   test_is_unix_socket();
-
   tlib_php_engine_create("" PTSRMLS_CC);
 
   if (tlib_php_require_extension("redis" TSRMLS_CC)) {
+#ifndef ZTS
     test_remove_datastore_instance(TSRMLS_C);
     test_retrieve_datastore_instance(TSRMLS_C);
     test_save_datastore_instance(TSRMLS_C);
+#endif
   }
 
   tlib_php_engine_destroy(TSRMLS_C);
-
   nr_free(default_database);
   nr_free(system_host_name);
 }

--- a/agent/tests/test_redis.c
+++ b/agent/tests/test_redis.c
@@ -107,7 +107,6 @@ static void test_is_unix_socket(void) {
   tlib_fail_if_int_equal("socket", 0, nr_php_redis_is_unix_socket("/tmp/foo"));
 }
 
-#ifndef ZTS
 static void test_remove_datastore_instance(TSRMLS_D) {
   zval* redis;
 
@@ -215,26 +214,26 @@ static void test_save_datastore_instance(TSRMLS_D) {
   nr_php_zval_free(&redis);
   tlib_php_request_end();
 }
-#endif
 
 void test_main(void* p NRUNUSED) {
+#define REQUIRED_EXTENSION "redis"
 
   default_database = nr_strdup(nr_php_redis_default_database);
   system_host_name = nr_system_get_hostname();
 
   test_create_datastore_instance();
   test_is_unix_socket();
-  tlib_php_engine_create("" PTSRMLS_CC);
 
-  if (tlib_php_require_extension("redis" TSRMLS_CC)) {
-#ifndef ZTS
+  tlib_php_engine_create("extension=" REQUIRED_EXTENSION PTSRMLS_CC);
+
+  if (nr_php_extension_loaded(REQUIRED_EXTENSION)) {
     test_remove_datastore_instance(TSRMLS_C);
     test_retrieve_datastore_instance(TSRMLS_C);
     test_save_datastore_instance(TSRMLS_C);
-#endif
   }
 
   tlib_php_engine_destroy(TSRMLS_C);
+
   nr_free(default_database);
   nr_free(system_host_name);
 }

--- a/make/php_versions.mk
+++ b/make/php_versions.mk
@@ -6,7 +6,7 @@
 # Canonical list of supported PHP versions (ascending order).
 # This is the single source of truth — update this when adding
 # or removing PHP version support.
-PHP_VERSIONS := 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+PHP_VERSIONS := 7.2 7.3 7.4 8.0 8.1 8.2 8.2-zts 8.3 8.3-zts 8.4 8.4-zts 8.5 8.5-zts
 
 # PHP versions supported on arm64 (8.0+)
 PHP_VERSIONS_ARM64 := $(filter 8.%, $(PHP_VERSIONS))


### PR DESCRIPTION
Allow to build and install for thread safe PHP (8.2+ only). Following changes were required:
- Add `-lrt` to `TEST_LIBS` - ZTS builds have zend-max-execution-timers enabled and POSIX timer symbols (timer_create, timer_settime, timer_delete) used by zend_max_execution_timer from libphp.a for PHP 8.1+ are unresolved when `-lrt` appears in `LDFLAGS` before `libphp.a` on the link line. Moving `-lrt` to `TEST_LIBS` ensures it is processed after `libphp.a`, satisfying the GNU linker's left-to-right symbol resolution.
- Fix fw_support unit test - Underlying functions rely on INI settings being available and that requires Zend Engine to be created.
- Fix ZTS-incompatible INI modify handlers - Make `newrelic.distributed_tracing.sampler.remote_parent_sampled` and `newrelic.framework.wordpress.hooks.options` INI modify handlers use ts_resource() in ZTS builds. Without this, mh_arg2 is used as a raw pointer instead of a TSRM resource ID, corrupting memory and causing a segfault in ts_free_id() during module shutdown.
- Fix test_redis segfault on ZTS builds - Implement a workaround of loading redis extension via INI at PHP engine startup because dynamic loading with php_load_extension in ZTS doesn't work and causes segfault.