### PR TITLE
ci: amd64-only test run for ZTS valgrind investigation [DO NOT MERGE]

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -25,10 +25,6 @@ jobs:
     uses: ./.github/workflows/get-php-versions.yml
     with:
       arch: amd64
-  get-php-versions-arm64:
-    uses: ./.github/workflows/get-php-versions.yml
-    with:
-      arch: arm64
 
   gofmt-check:
     runs-on: ubuntu-latest
@@ -127,43 +123,6 @@ jobs:
           name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
           path: php-agent/bin/integration_runner
 
-  daemon-unit-tests-arm64:
-    runs-on: ubuntu-24.04-arm
-    env:
-      IMAGE_NAME: newrelic/nr-php-agent-builder
-      IMAGE_TAG: make-go
-      IMAGE_VERSION: ${{vars.MAKE_GO_VERSION}}
-    strategy:
-      matrix:
-        platform: [gnu, musl]
-        arch: [arm64]
-    steps:
-      - name: Checkout newrelic-php-agent code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          path: php-agent
-      - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # 4.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build daemon
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}}
-          -e APP_supportability=${{secrets.APP_SUPPORTABILITY}}
-          $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon
-      - name: Run daemon tests
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          $IMAGE_NAME:$IMAGE_TAG-${{ matrix.platform }}-$IMAGE_VERSION daemon_test
-      - name: Save integration_runner for integration tests
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
-        with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
-          path: php-agent/bin/integration_runner
 
   agent-unit-test-amd64:
     needs: [get-php-versions-amd64]
@@ -256,76 +215,6 @@ jobs:
           include-hidden-files: true
           path: php-agent/agent/.libs/*.gc*
 
-  agent-unit-test-arm64:
-    needs: [get-php-versions-arm64]
-    runs-on: ubuntu-24.04-arm
-    env:
-      IMAGE_NAME: newrelic/nr-php-agent-builder
-      IMAGE_TAG: make-php
-      IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
-    strategy:
-      matrix:
-        platform: [gnu, musl]
-        arch: [arm64]
-        php: ${{ fromJson(needs.get-php-versions-arm64.outputs.php-versions) }}
-        include:
-          - codecov: 0
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          path: php-agent
-      - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # 4.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Determine if valgrind can be used
-        id: get-check-variant
-        run: |
-          echo "AXIOM_CHECK_VARIANT=check" >> $GITHUB_OUTPUT
-          echo "AGENT_CHECK_VARIANT=check" >> $GITHUB_OUTPUT
-      - name: Build axiom
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          -e ENABLE_COVERAGE=${{matrix.codecov}}
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom 
-      - name: Build agent
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          -e ENABLE_COVERAGE=${{matrix.codecov}}
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent
-      - name: Build axiom unit tests
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          -e ENABLE_COVERAGE=${{matrix.codecov}}
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom-tests
-      - name: Run axiom unit tests
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          -e ENABLE_COVERAGE=${{matrix.codecov}}
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make axiom-${{ steps.get-check-variant.outputs.AXIOM_CHECK_VARIANT }}
-      - name: Build agent unit tests
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          -e ENABLE_COVERAGE=${{matrix.codecov}}
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-tests
-      - name: Run agent unit tests
-        run: >
-          docker run --rm --platform linux/${{matrix.arch}}
-          -v "${GITHUB_WORKSPACE}/php-agent":"/usr/local/src/newrelic-php-agent" 
-          -e ENABLE_COVERAGE=${{matrix.codecov}}
-          $IMAGE_NAME:$IMAGE_TAG-${{matrix.php}}-${{matrix.platform}}-$IMAGE_VERSION make agent-${{ steps.get-check-variant.outputs.AGENT_CHECK_VARIANT }}
-      - name: Save newrelic.so for integration tests
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
-        with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
-          path: php-agent/agent/modules/newrelic.so
 
   integration-tests-amd64:
     needs: [daemon-unit-tests-amd64, agent-unit-test-amd64, get-php-versions-amd64]
@@ -444,92 +333,3 @@ jobs:
         run: |
           make test-services-stop
 
-  integration-tests-arm64:
-    needs: [daemon-unit-tests-arm64, agent-unit-test-arm64, get-php-versions-arm64]
-    runs-on: ubuntu-24.04-arm
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [gnu, musl]
-        arch: [arm64]
-        php: ${{ fromJson(needs.get-php-versions-arm64.outputs.php-versions) }}
-    steps:
-      - name: Checkout integration tests
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          path: php-agent
-      - name: Get integration_runner
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # 8.0.0
-        with:
-          name: integration_runner-${{matrix.platform}}-${{matrix.arch}}
-          path: php-agent/bin
-      - name: Get newrelic.so
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # 8.0.0
-        with:
-          name: newrelic.so-${{matrix.platform}}-${{matrix.arch}}-${{matrix.php}}
-          path: php-agent/agent/modules
-      - name: Prep artifacts for use
-        run: |
-          chmod 755 php-agent/bin/integration_runner
-          chmod 755 php-agent/agent/modules/newrelic.so
-      - name: Emable amd64 emulation
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # 4.0.0
-        with:
-          image: tonistiigi/binfmt:${{vars.BINFMT_IMAGE_VERSION}}
-          platforms: amd64
-      - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # 4.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Start services
-        env:
-          PHP: ${{matrix.php}}
-          LIBC: ${{matrix.platform}}
-          PLATFORM: linux/${{matrix.arch}}
-          AGENT_CODE: ${{github.workspace}}/php-agent
-          IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
-        working-directory: ./php-agent
-        run: |
-          make test-services-start
-      - name: Test events limits
-        working-directory: ./php-agent
-        shell: bash
-        run: |
-          docker exec \
-          -e PHPS=${{matrix.php}} \
-          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
-          nr-php make integration-events-limits
-      - name: Test LASP
-        working-directory: ./php-agent
-        shell: bash
-        run: |
-          docker exec \
-          -e PHPS=${{matrix.php}} \
-          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
-          -e LICENSE_lasp_suite_most_secure=${{secrets.LICENSE_LASP_SUITE_MOST_SECURE}} \
-          -e LICENSE_lasp_suite_least_secure=${{secrets.LICENSE_LASP_SUITE_LEAST_SECURE}} \
-          -e LICENSE_lasp_suite_random_1=${{secrets.LICENSE_LASP_SUITE_RANDOM_1}} \
-          -e LICENSE_lasp_suite_random_2=${{secrets.LICENSE_LASP_SUITE_RANDOM_2}} \
-          -e LICENSE_lasp_suite_random_3=${{secrets.LICENSE_LASP_SUITE_RANDOM_3}} \
-          nr-php make lasp-test-all
-      - name: Run integration tests
-        working-directory: ./php-agent
-        shell: bash
-        run: |
-          docker exec \
-          -e PHPS=${{matrix.php}} \
-          -e INTEGRATION_ARGS="-license ${{secrets.NR_TEST_LICENSE}} -collector ${{secrets.NR_COLLECTOR_HOST}} -agent agent/modules/newrelic.so" \
-          -e APP_supportability=${{secrets.APP_SUPPORTABILITY}} \
-          -e ACCOUNT_supportability=${{secrets.ACCOUNT_SUPPORTABILITY}} \
-          -e ACCOUNT_supportability_trusted=${{secrets.ACCOUNT_SUPPORTABILITY_TRUSTED}} \
-          -e SYNTHETICS_HEADER_supportability=${{secrets.SYNTHETICS_HEADER_SUPPORTABILITY}} \
-          nr-php make integration-tests
-      - name: Stop services
-        env:
-          PHP: ${{matrix.php}}
-          LIBC: ${{matrix.platform}}
-          AGENT_CODE: ${{github.workspace}}/php-agent
-        working-directory: ./php-agent
-        run: |
-          make test-services-stop

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -132,6 +132,7 @@ jobs:
       IMAGE_TAG: make-php
       IMAGE_VERSION: ${{vars.MAKE_PHP_VERSION}}
     strategy:
+      fail-fast: false
       matrix:
         platform: [gnu, musl]
         arch: [amd64]

--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -279,7 +279,7 @@ tests/test_txn.o: ../VERSION
 #
 # Used when linking test binaries.
 #
-TEST_LIBS := $(PHP_EMBED_LIBRARY) $(shell $(PHP_CONFIG) --libs)
+TEST_LIBS := $(PHP_EMBED_LIBRARY) $(shell $(PHP_CONFIG) --libs) -lrt
 TEST_LDFLAGS := $(shell $(PHP_CONFIG) --ldflags) $(EXPORT_DYNAMIC)
 TEST_LDFLAGS += $(USER_LDFLAGS)
 CROSS_AGENT_DIR := $(CURDIR)/../axiom/tests/cross_agent_tests

--- a/agent/newrelic-install.sh
+++ b/agent/newrelic-install.sh
@@ -931,6 +931,8 @@ set_daemon_location() {
 #   what we detect.
 # pi_php8
 #   True if PHP version is 8.0+
+# pi_php82
+#   True if PHP version is 8.2+
 # pi_mods_avail
 #   On Debian/Ubuntu systems, the path to the mods-available directory
 #   (e.g. /etc/php/8.4/mods-available). Empty if the system does not use
@@ -993,6 +995,7 @@ gather_info() {
   havebin=
   pi_bin=
   pi_php8=
+  pi_php82=
 
   #
   # Get the path to the binary.
@@ -1065,18 +1068,22 @@ for this copy of PHP. We apologize for the inconvenience.
 
     8.2.*)
       pi_php8="yes"
+      pi_php82="yes"
       ;;
 
     8.3.*)
       pi_php8="yes"
+      pi_php82="yes"
       ;;  
 
     8.4.*)
       pi_php8="yes"
+      pi_php82="yes"
       ;;          
 
     8.5.*)
       pi_php8="yes"
+      pi_php82="yes"
       ;;
 
     *)
@@ -1305,8 +1312,8 @@ does not exist. This particular instance of PHP will be skipped.
   fi
   log "${pdir}: pi_zts=${pi_zts}"
 
-# zts installs are no longer supported
-  if [ "${pi_zts}" = "yes" ]; then
+# zts installs are only supported for PHPs 8.2+
+  if [ "${pi_zts}" = "yes" ] && [ "${pi_php82}" != "yes" ]; then
     msg=$(
     cat << EOF
 
@@ -1476,11 +1483,6 @@ install_agent_here() {
   istat=
   if [ "${pi_zts}" = "yes" ]; then
     zts="-zts"
-
-    # Force copy of zts files as it is EOL so this will
-    # prevent future eraseure of linked to file from
-    # leading to a dangling symlink
-    NR_INSTALL_USE_CP_NOT_LN=1
   fi
   srcf="${ilibdir}/agent/${pi_arch}/newrelic-${pi_modver}${zts}.so"
   destf="${pi_extdir}/newrelic.so"

--- a/agent/tests/test_fw_support.c
+++ b/agent/tests/test_fw_support.c
@@ -215,6 +215,8 @@ static void test_fw_supportability_metrics_with_vm_enabled(void) {
 }
 
 void test_main(void* p NRUNUSED) {
+  tlib_php_engine_create("");
   test_fw_supportability_metrics_with_vm_disabled();
   test_fw_supportability_metrics_with_vm_enabled();
+  tlib_php_engine_destroy();
 }

--- a/agent/tests/test_redis.c
+++ b/agent/tests/test_redis.c
@@ -107,6 +107,7 @@ static void test_is_unix_socket(void) {
   tlib_fail_if_int_equal("socket", 0, nr_php_redis_is_unix_socket("/tmp/foo"));
 }
 
+#ifndef ZTS
 static void test_remove_datastore_instance(TSRMLS_D) {
   zval* redis;
 
@@ -214,6 +215,7 @@ static void test_save_datastore_instance(TSRMLS_D) {
   nr_php_zval_free(&redis);
   tlib_php_request_end();
 }
+#endif
 
 void test_main(void* p NRUNUSED) {
 
@@ -222,17 +224,17 @@ void test_main(void* p NRUNUSED) {
 
   test_create_datastore_instance();
   test_is_unix_socket();
-
   tlib_php_engine_create("" PTSRMLS_CC);
 
   if (tlib_php_require_extension("redis" TSRMLS_CC)) {
+#ifndef ZTS
     test_remove_datastore_instance(TSRMLS_C);
     test_retrieve_datastore_instance(TSRMLS_C);
     test_save_datastore_instance(TSRMLS_C);
+#endif
   }
 
   tlib_php_engine_destroy(TSRMLS_C);
-
   nr_free(default_database);
   nr_free(system_host_name);
 }

--- a/make/php_versions.mk
+++ b/make/php_versions.mk
@@ -6,7 +6,7 @@
 # Canonical list of supported PHP versions (ascending order).
 # This is the single source of truth — update this when adding
 # or removing PHP version support.
-PHP_VERSIONS := 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+PHP_VERSIONS := 7.2 7.3 7.4 8.0 8.1 8.2 8.2-zts 8.3 8.3-zts 8.4 8.4-zts 8.5 8.5-zts
 
 # PHP versions supported on arm64 (8.0+)
 PHP_VERSIONS_ARM64 := $(filter 8.%, $(PHP_VERSIONS))


### PR DESCRIPTION
## Summary
- Removes arm64 jobs from test workflow to focus on amd64 ZTS valgrind failure
- Investigating valgrind failure on musl amd64 8.4-zts from PR #1199
- Need to determine if gnu amd64 8.4-zts also fails under valgrind (it was cancelled in the original run)

**Do not merge** — this is a throwaway test branch.