### PR TITLE
fix(agent): make transient wraprecs and func hashmaps thread safe for ZTS

### DIFF
--- a/agent/config.m4
+++ b/agent/config.m4
@@ -43,6 +43,13 @@ PHP_ARG_WITH(pcre-static,,
 if test "$PHP_NEWRELIC" = "yes"; then
   AC_DEFINE(HAVE_NEWRELIC, 1, [Whether you have New Relic])
 
+  dnl ZTS is only supported on PHP 8.2+.
+  if test "$PHP_THREAD_SAFETY" = "yes"; then
+    php_version=`$PHP_CONFIG --version 2>/dev/null`
+    AS_VERSION_COMPARE([$php_version], [8.2],
+      [AC_MSG_ERROR([ZTS (thread-safe) PHP requires PHP 8.2 or newer (found $php_version)])])
+  fi
+
   LT_AC_PROG_SED
 
   NEWRELIC_CFLAGS="${NEWRELIC_CFLAGS} -std=gnu99"

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -501,7 +501,11 @@ PHP_MINIT_FUNCTION(newrelic) {
    * deep copied into per-request hashmaps at RINIT.
    */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+#ifdef ZTS
   nr_php_user_instrument_wraprec_hashmap_ini_init();
+#else
+  nr_php_user_instrument_wraprec_hashmap_init();
+#endif
 #endif
   nr_php_register_ini_entries(module_number TSRMLS_CC);
 

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -492,6 +492,18 @@ PHP_MINIT_FUNCTION(newrelic) {
    */
   nr_php_generate_internal_wrap_records();
 
+  /*
+   * Non-ZTS: create the wraprec hashmaps now so they exist when INI OnModify
+   * handlers fire during nr_php_register_ini_entries(). These are file-scoped
+   * statics that persist until MSHUTDOWN.
+   *
+   * ZTS: per-request hashmaps are created at RINIT. INI wraprecs created
+   * here at MINIT are captured in a template list and replayed into each
+   * request's hashmaps at RINIT.
+   */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO && !defined(ZTS)
+  nr_php_user_instrument_wraprec_hashmap_init();
+#endif
   nr_php_register_ini_entries(module_number TSRMLS_CC);
 
   if (0 == NR_PHP_PROCESS_GLOBALS(enabled)) {

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -493,16 +493,15 @@ PHP_MINIT_FUNCTION(newrelic) {
   nr_php_generate_internal_wrap_records();
 
   /*
-   * Non-ZTS: create the wraprec hashmaps now so they exist when INI OnModify
-   * handlers fire during nr_php_register_ini_entries(). These are file-scoped
-   * statics that persist until MSHUTDOWN.
+   * Initialize wraprec hashmaps before INI registration so that INI OnModify
+   * handlers (nr_wtfuncs_mh, nr_ttcustom_mh) can create wraprecs.
    *
-   * ZTS: per-request hashmaps are created at RINIT. INI wraprecs created
-   * here at MINIT are captured in a template list and replayed into each
-   * request's hashmaps at RINIT.
+   * NTS: creates file-scoped statics that persist until MSHUTDOWN.
+   * ZTS: creates process-global ini_scope_ht / ini_global_funcs_ht that are
+   * deep copied into per-request hashmaps at RINIT.
    */
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO && !defined(ZTS)
-  nr_php_user_instrument_wraprec_hashmap_init();
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+  nr_php_user_instrument_wraprec_hashmap_ini_init();
 #endif
   nr_php_register_ini_entries(module_number TSRMLS_CC);
 

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -492,16 +492,6 @@ PHP_MINIT_FUNCTION(newrelic) {
    */
   nr_php_generate_internal_wrap_records();
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
-  /* 
-   * The user function wraprec hashmap must be initialized before INI processing
-   * because INI processing adds wraprecs:
-   *  - newrelic.webtransaction.name.functions
-   *  - newrelic.transaction_tracer.custom
-  */
-  nr_php_user_instrument_wraprec_hashmap_init();
-#endif
-
   nr_php_register_ini_entries(module_number TSRMLS_CC);
 
   if (0 == NR_PHP_PROCESS_GLOBALS(enabled)) {

--- a/agent/php_mshutdown.c
+++ b/agent/php_mshutdown.c
@@ -12,6 +12,7 @@
 #include "php_globals.h"
 #include "php_internal_instrument.h"
 #include "php_user_instrument.h"
+#include "php_user_instrument_wraprec_hashmap.h"
 #include "php_vm.h"
 #include "nr_agent.h"
 #include "util_logging.h"

--- a/agent/php_mshutdown.c
+++ b/agent/php_mshutdown.c
@@ -57,6 +57,9 @@ PHP_MSHUTDOWN_FUNCTION(newrelic) {
 
   nr_php_remove_opcode_handlers();
   nr_php_destroy_internal_wrap_records();
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO && defined(ZTS)
+  nr_php_user_instrument_wraprec_hashmap_ini_destroy();
+#endif
   nr_php_destroy_user_wrap_records();
   nr_php_global_destroy();
   nr_applist_destroy(&nr_agent_applist);

--- a/agent/php_mshutdown.c
+++ b/agent/php_mshutdown.c
@@ -57,10 +57,20 @@ PHP_MSHUTDOWN_FUNCTION(newrelic) {
 
   nr_php_remove_opcode_handlers();
   nr_php_destroy_internal_wrap_records();
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO && defined(ZTS)
+  /*
+   * Mirrors MINIT hashmap creation for teardown.
+   *
+   * ZTS frees the process-global INI staging hashmaps (ini_scope_ht /
+   * ini_global_funcs_ht); per-request copies were already freed at RSHUTDOWN.
+   *
+   * NTS frees persistent wraprecs via nr_php_destroy_user_wrap_records which
+   * handles the PHP < 8.0 linked list and PHP 8+ file-scoped hashmaps.
+   */
+#ifdef ZTS
   nr_php_user_instrument_wraprec_hashmap_ini_destroy();
-#endif
+#else
   nr_php_destroy_user_wrap_records();
+#endif
   nr_php_global_destroy();
   nr_applist_destroy(&nr_agent_applist);
 

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -34,6 +34,14 @@ extern zend_module_entry newrelic_module_entry;
 #define phpext_newrelic_ptr &newrelic_module_entry
 
 /*
+ * Compile guard for ZTS support for only PHPs that FrankenPHP supports */
+#ifdef ZTS
+#if ZEND_MODULE_API_NO < ZEND_8_2_X_API_NO
+#error "ZTS is only supported with PHP 8.2+"
+#endif
+#endif
+
+/*
  * PHP 5.5 and 7.0 both introduced a number of changes to the internal
  * representation of execute data state. These macros abstract away the vast
  * majority of those changes so the rest of the code can simply use the macros

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -16,7 +16,6 @@
 #include "php_extension.h"
 #include "util_hashmap.h"
 #include "util_matcher.h"
-#include "php_user_instrument_wraprec_hashmap.h"
 #include "util_vector.h"
 
 #define PHP_NEWRELIC_EXT_NAME "newrelic"
@@ -104,7 +103,9 @@ extern zend_module_entry newrelic_module_entry;
  */
 #define NR_UNUSED_TSRMLS
 
+/* move include here to avoid circular dependencies */
 #include "php_user_instrument.h"
+#include "php_user_instrument_wraprec_hashmap.h"
 
 typedef enum {
   NR_FW_UNSET = 0,

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -103,6 +103,8 @@ extern zend_module_entry newrelic_module_entry;
  */
 #define NR_UNUSED_TSRMLS
 
+#include "php_user_instrument.h"
+
 typedef enum {
   NR_FW_UNSET = 0,
 
@@ -569,6 +571,13 @@ nrinibool_t message_tracer_segment_parameters_enabled; /* newrelic.segment_trace
  */
 uint64_t pid;
 nr_vector_t* user_function_wrappers;
+#endif
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+/*
+ * transient wrappers are stored at request level for thread safety
+ */
+nruserfn_t* transient_wraprecs; /* a singly linked list */
 #endif
 
 nrapp_t* app; /* The application used in the last attempt to initialize a

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -111,10 +111,6 @@ extern zend_module_entry newrelic_module_entry;
  */
 #define NR_UNUSED_TSRMLS
 
-/* move include here to avoid circular dependencies */
-#include "php_user_instrument.h"
-#include "php_user_instrument_wraprec_hashmap.h"
-
 typedef enum {
   NR_FW_UNSET = 0,
 
@@ -587,7 +583,7 @@ nr_vector_t* user_function_wrappers;
 /*
  * transient wrappers are stored at request level for thread safety
  */
-nruserfn_t* transient_wraprecs; /* a singly linked list */
+struct _nruserfn_t* transient_wraprecs; /* a singly linked list */
 
 #ifdef ZTS
 /*
@@ -595,8 +591,8 @@ nruserfn_t* transient_wraprecs; /* a singly linked list */
  * thread safety. For non-ZTS, these are file-scoped statics in
  * php_user_instrument_wraprec_hashmap.c (persisting from MINIT to MSHUTDOWN).
  */
-nr_func_hashmap_t* global_funcs_ht; /* hashmap for global functions */
-nr_scope_hashmap_t* scope_ht;       /* hashmap for scoped methods */
+struct _nr_func_hashmap* global_funcs_ht; /* hashmap for global functions */
+struct _nr_scope_hashmap* scope_ht;       /* hashmap for scoped methods */
 #endif /* ZTS */
 #endif
 

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -16,6 +16,7 @@
 #include "php_extension.h"
 #include "util_hashmap.h"
 #include "util_matcher.h"
+#include "php_user_instrument_wraprec_hashmap.h"
 #include "util_vector.h"
 
 #define PHP_NEWRELIC_EXT_NAME "newrelic"
@@ -578,6 +579,13 @@ nr_vector_t* user_function_wrappers;
  * transient wrappers are stored at request level for thread safety
  */
 nruserfn_t* transient_wraprecs; /* a singly linked list */
+
+/*
+ * User instrumentation wraprec hashmaps stored at request level for thread
+ * safety
+ */
+nr_func_hashmap_t* global_funcs_ht; /* hashmap for global functions */
+nr_scope_hashmap_t* scope_ht;       /* hashmap for scoped methods */
 #endif
 
 nrapp_t* app; /* The application used in the last attempt to initialize a

--- a/agent/php_newrelic.h
+++ b/agent/php_newrelic.h
@@ -581,12 +581,15 @@ nr_vector_t* user_function_wrappers;
  */
 nruserfn_t* transient_wraprecs; /* a singly linked list */
 
+#ifdef ZTS
 /*
- * User instrumentation wraprec hashmaps stored at request level for thread
- * safety
+ * User instrumentation wraprec hashmaps stored at request level for ZTS
+ * thread safety. For non-ZTS, these are file-scoped statics in
+ * php_user_instrument_wraprec_hashmap.c (persisting from MINIT to MSHUTDOWN).
  */
 nr_func_hashmap_t* global_funcs_ht; /* hashmap for global functions */
 nr_scope_hashmap_t* scope_ht;       /* hashmap for scoped methods */
+#endif /* ZTS */
 #endif
 
 nrapp_t* app; /* The application used in the last attempt to initialize a

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1674,9 +1674,6 @@ static PHP_INI_MH(nr_framework_mh) {
 }
 
 #ifdef ZTS
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
-#error "ZTS is only supported with PHP 8.0+"
-#endif
 /*
  * ZTS MINIT callbacks for INI wraprec creation. These match the foreach_fn_t
  * signature and route to the INI hashmap instead of the per-request hashmap.
@@ -1711,9 +1708,6 @@ static PHP_INI_MH(nr_wtfuncs_mh) {
 
   if (NEW_VALUE_LEN > 0) {
 #ifdef ZTS
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
-#error "ZTS is only supported with PHP 8.0+"
-#endif
     /* ZTS: INI modifications outside of startup are currently ignored. */
     if (ZEND_INI_STAGE_STARTUP == stage) {
       foreach_list(NEW_VALUE, nr_ini_wraprec_add_naming_fn TSRMLS_CC);
@@ -1735,9 +1729,6 @@ static PHP_INI_MH(nr_ttcustom_mh) {
 
   if (0 != NEW_VALUE_LEN) {
 #ifdef ZTS
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
-#error "ZTS is only supported with PHP 8.0+"
-#endif
     /* ZTS: INI modifications outside of startup are currently ignored. */
     if (ZEND_INI_STAGE_STARTUP == stage) {
       foreach_list(NEW_VALUE, nr_ini_wraprec_add_custom_tracer TSRMLS_CC);

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -8,6 +8,7 @@
 #include "php_hash.h"
 #include "php_internal_instrument.h"
 #include "php_user_instrument.h"
+#include "php_user_instrument_wraprec_hashmap.h"
 
 #include "nr_commands.h"
 #include "nr_configstrings.h"

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1673,6 +1673,36 @@ static PHP_INI_MH(nr_framework_mh) {
   return FAILURE;
 }
 
+#ifdef ZTS
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
+#error "ZTS is only supported with PHP 8.0+"
+#endif
+/*
+ * ZTS MINIT callbacks for INI wraprec creation. These match the foreach_fn_t
+ * signature and route to the INI hashmap instead of the per-request hashmap.
+ */
+static void nr_ini_wraprec_add_naming_fn(const char* namestr,
+                                         int namestrlen TSRMLS_DC) {
+  nruserfn_t* wraprec
+      = nr_php_user_instrument_wraprec_hashmap_ini_add(namestr, namestrlen);
+
+  if (NULL != wraprec) {
+    wraprec->is_names_wt_simple = 1;
+  }
+}
+
+static void nr_ini_wraprec_add_custom_tracer(const char* namestr,
+                                             int namestrlen TSRMLS_DC) {
+  nruserfn_t* wraprec
+      = nr_php_user_instrument_wraprec_hashmap_ini_add(namestr, namestrlen);
+
+  if (NULL != wraprec) {
+    wraprec->create_metric = 1;
+    wraprec->is_user_added = 1;
+  }
+}
+#endif /* ZTS */
+
 static PHP_INI_MH(nr_wtfuncs_mh) {
   (void)entry;
   (void)mh_arg1;
@@ -1680,7 +1710,17 @@ static PHP_INI_MH(nr_wtfuncs_mh) {
   (void)mh_arg3;
 
   if (NEW_VALUE_LEN > 0) {
-    foreach_list(NEW_VALUE, nr_php_add_transaction_naming_function TSRMLS_CC);
+#ifdef ZTS
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
+#error "ZTS is only supported with PHP 8.0+"
+#endif
+    if (ZEND_INI_STAGE_STARTUP == stage) {
+      foreach_list(NEW_VALUE, nr_ini_wraprec_add_naming_fn TSRMLS_CC);
+    } else
+#endif /* ZTS */
+    {
+      foreach_list(NEW_VALUE, nr_php_add_transaction_naming_function TSRMLS_CC);
+    }
   }
 
   NRPRG(wtfuncs_where) = stage;
@@ -1694,7 +1734,17 @@ static PHP_INI_MH(nr_ttcustom_mh) {
   (void)mh_arg3;
 
   if (0 != NEW_VALUE_LEN) {
-    foreach_list(NEW_VALUE, nr_php_add_custom_tracer TSRMLS_CC);
+#ifdef ZTS
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
+#error "ZTS is only supported with PHP 8.0+"
+#endif
+    if (ZEND_INI_STAGE_STARTUP == stage) {
+      foreach_list(NEW_VALUE, nr_ini_wraprec_add_custom_tracer TSRMLS_CC);
+    } else
+#endif /* ZTS */
+    {
+      foreach_list(NEW_VALUE, nr_php_add_custom_tracer TSRMLS_CC);
+    }
   }
 
   NRPRG(ttcustom_where) = stage;

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1714,13 +1714,13 @@ static PHP_INI_MH(nr_wtfuncs_mh) {
 #if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
 #error "ZTS is only supported with PHP 8.0+"
 #endif
+    /* ZTS: INI modifications outside of startup are currently ignored. */
     if (ZEND_INI_STAGE_STARTUP == stage) {
       foreach_list(NEW_VALUE, nr_ini_wraprec_add_naming_fn TSRMLS_CC);
-    } else
-#endif /* ZTS */
-    {
-      foreach_list(NEW_VALUE, nr_php_add_transaction_naming_function TSRMLS_CC);
     }
+#else
+    foreach_list(NEW_VALUE, nr_php_add_transaction_naming_function TSRMLS_CC);
+#endif /* ZTS */
   }
 
   NRPRG(wtfuncs_where) = stage;
@@ -1738,13 +1738,13 @@ static PHP_INI_MH(nr_ttcustom_mh) {
 #if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
 #error "ZTS is only supported with PHP 8.0+"
 #endif
+    /* ZTS: INI modifications outside of startup are currently ignored. */
     if (ZEND_INI_STAGE_STARTUP == stage) {
       foreach_list(NEW_VALUE, nr_ini_wraprec_add_custom_tracer TSRMLS_CC);
-    } else
-#endif /* ZTS */
-    {
-      foreach_list(NEW_VALUE, nr_php_add_custom_tracer TSRMLS_CC);
     }
+#else
+    foreach_list(NEW_VALUE, nr_php_add_custom_tracer TSRMLS_CC);
+#endif /* ZTS */
   }
 
   NRPRG(ttcustom_where) = stage;

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -73,19 +73,12 @@ PHP_RINIT_FUNCTION(newrelic) {
   nrl_verbosedebug(NRL_INSTRUMENT, "%s: initialized transient_wraprecs to NULL",
                    __func__);
 
-  /* initialization of user instrumentation wraprec hashmaps which are per
-   * request globals */
-  if (NRPRG(scope_ht) != NULL) {
-    nrl_verbosedebug(NRL_INSTRUMENT, "%s: scope_ht was not NULL at RINIT",
-                     __func__);
-  }
-  if (NRPRG(global_funcs_ht) != NULL) {
-    nrl_verbosedebug(NRL_INSTRUMENT,
-                     "%s: global_funcs_ht was not NULL at RINIT", __func__);
-  }
+#ifdef ZTS
+  /* ZTS: create per-request hashmaps. Non-ZTS hashmaps persist from MINIT. */
   nr_php_user_instrument_wraprec_hashmap_init();
   nrl_verbosedebug(NRL_INSTRUMENT, "%s: initialized wraprec hashmaps",
                    __func__);
+#endif
 #endif
 
   if ((0 == NR_PHP_PROCESS_GLOBALS(enabled)) || (0 == NRINI(enabled))) {

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -12,6 +12,7 @@
 #include "php_globals.h"
 #include "php_header.h"
 #include "php_user_instrument.h"
+#include "php_user_instrument_wraprec_hashmap.h"
 #include "nr_datastore_instance.h"
 #include "nr_txn.h"
 #include "nr_rum.h"
@@ -69,6 +70,22 @@ PHP_RINIT_FUNCTION(newrelic) {
   /* initialization of transient wraprecs which are per request globals */
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
   NRPRG(transient_wraprecs) = NULL;
+  nrl_verbosedebug(NRL_INSTRUMENT, "%s: initialized transient_wraprecs to NULL",
+                   __func__);
+
+  /* initialization of user instrumentation wraprec hashmaps which are per
+   * request globals */
+  if (NRPRG(scope_ht) != NULL) {
+    nrl_verbosedebug(NRL_INSTRUMENT, "%s: scope_ht was not NULL at RINIT",
+                     __func__);
+  }
+  if (NRPRG(global_funcs_ht) != NULL) {
+    nrl_verbosedebug(NRL_INSTRUMENT,
+                     "%s: global_funcs_ht was not NULL at RINIT", __func__);
+  }
+  nr_php_user_instrument_wraprec_hashmap_init();
+  nrl_verbosedebug(NRL_INSTRUMENT, "%s: initialized wraprec hashmaps",
+                   __func__);
 #endif
 
   if ((0 == NR_PHP_PROCESS_GLOBALS(enabled)) || (0 == NRINI(enabled))) {

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -74,9 +74,9 @@ PHP_RINIT_FUNCTION(newrelic) {
                    __func__);
 
 #ifdef ZTS
-  /* ZTS: create per-request hashmaps. Non-ZTS hashmaps persist from MINIT. */
-  nr_php_user_instrument_wraprec_hashmap_init();
-  nrl_verbosedebug(NRL_INSTRUMENT, "%s: initialized wraprec hashmaps",
+  /* ZTS: deep copy INI hashmaps into per-request hashmaps. */
+  nr_php_user_instrument_wraprec_hashmap_replay_ini();
+  nrl_verbosedebug(NRL_INSTRUMENT, "%s: replayed INI wraprec hashmaps",
                    __func__);
 #endif
 #endif

--- a/agent/php_rinit.c
+++ b/agent/php_rinit.c
@@ -66,6 +66,11 @@ PHP_RINIT_FUNCTION(newrelic) {
   NRPRG(user_function_wrappers) = nr_vector_create(64, NULL, NULL);
 #endif
 
+  /* initialization of transient wraprecs which are per request globals */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+  NRPRG(transient_wraprecs) = NULL;
+#endif
+
   if ((0 == NR_PHP_PROCESS_GLOBALS(enabled)) || (0 == NRINI(enabled))) {
     return SUCCESS;
   }

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -11,6 +11,7 @@
 #include "php_error.h"
 #include "php_globals.h"
 #include "php_user_instrument.h"
+#include "php_user_instrument_wraprec_hashmap.h"
 #include "php_wrapper.h"
 #include "php_mysqli.h"
 #include "php_pdo.h"
@@ -103,6 +104,12 @@ int nr_php_post_deactivate(void) {
   }
 
   nr_php_remove_transient_user_instrumentation();
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+  /* Destroy per-request wraprec hashmaps */
+  nr_php_user_instrument_wraprec_hashmap_destroy();
+  nrl_verbosedebug(NRL_INSTRUMENT, "%s: destroyed wraprec hashmaps", __func__);
+#endif
 
   nr_php_exception_filters_destroy(&NRPRG(exception_filters));
 

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -105,8 +105,8 @@ int nr_php_post_deactivate(void) {
 
   nr_php_remove_transient_user_instrumentation();
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
-  /* Destroy per-request wraprec hashmaps */
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO && defined(ZTS)
+  /* ZTS: destroy per-request hashmaps. Non-ZTS hashmaps persist to MSHUTDOWN. */
   nr_php_user_instrument_wraprec_hashmap_destroy();
   nrl_verbosedebug(NRL_INSTRUMENT, "%s: destroyed wraprec hashmaps", __func__);
 #endif

--- a/agent/php_rshutdown.c
+++ b/agent/php_rshutdown.c
@@ -105,7 +105,7 @@ int nr_php_post_deactivate(void) {
 
   nr_php_remove_transient_user_instrumentation();
 
-#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO && defined(ZTS)
+#ifdef ZTS
   /* ZTS: destroy per-request hashmaps. Non-ZTS hashmaps persist to MSHUTDOWN. */
   nr_php_user_instrument_wraprec_hashmap_destroy();
   nrl_verbosedebug(NRL_INSTRUMENT, "%s: destroyed wraprec hashmaps", __func__);

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -449,7 +449,7 @@ static int nr_php_user_wraprec_is_match(const nruserfn_t* w1,
 #endif
 
 #if ZEND_MODULE_API_NO > ZEND_7_4_X_API_NO
-static nruserfn_t* nr_transient_wraprecs = NULL; /* a singly linked list */
+/* global nr_transient_wraprecs was removed for ZTS support */
 #else
 static nruserfn_t* nr_wrapped_user_functions = NULL; /* a singly linked list */
 #endif
@@ -461,8 +461,8 @@ static void nr_php_add_custom_tracer_common(nruserfn_t* wraprec) {
     /* Transient (unnamed) wraprecs are not added to wraprec hashmap which only stores named
      * wraprecs. Keep track of all transient wraprecs so that they can be destroyed at the
      * end of the request. */
-    wraprec->next = nr_transient_wraprecs;
-    nr_transient_wraprecs = wraprec;
+    wraprec->next = NRPRG(transient_wraprecs);
+    NRPRG(transient_wraprecs) = wraprec;
     return;
   }
 #endif
@@ -627,13 +627,13 @@ void nr_php_reset_user_instrumentation(void) {
  */
 void nr_php_remove_transient_user_instrumentation(void) {
 #if ZEND_MODULE_API_NO > ZEND_7_4_X_API_NO
-  nruserfn_t* p = nr_transient_wraprecs;
+  nruserfn_t* p = NRPRG(transient_wraprecs);
   while (p) {
     nruserfn_t* wraprec = p;
     p = wraprec->next;
     nr_php_user_wraprec_destroy(&wraprec);
   }
-  nr_transient_wraprecs = NULL;
+  NRPRG(transient_wraprecs) = NULL;
 #endif
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
   nruserfn_t* p = nr_wrapped_user_functions;

--- a/agent/php_user_instrument.c
+++ b/agent/php_user_instrument.c
@@ -596,9 +596,10 @@ nruserfn_t* nr_php_add_custom_tracer_named(const char* namestr,
  */
 void nr_php_reset_user_instrumentation(void) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
-  /* No need to do anything at rshutdown:
-   *  - Observer API takes care of resetting user instrumentation for each request
-   *  - All named wraprecs ever created persist in wraprec hashmap until mshutdown
+  /* No wraprec reset needed in this function for PHP 8+:
+   *  - Observer API re-registers instrumentation each request automatically
+   *  - Non-ZTS: named wraprecs persist in hashmap until MSHUTDOWN
+   *  - ZTS: per-request hashmaps are destroyed in nr_php_post_deactivate()
    */
   return;
 #elif ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -20,6 +20,14 @@
 #ifdef ZTS
 #define NR_SCOPE_HT NRPRG(scope_ht)
 #define NR_GLOBAL_FUNCS_HT NRPRG(global_funcs_ht)
+
+/*
+ * ZTS: process-global INI wraprec storage. Populated at MINIT when INI
+ * OnModify handlers fire, read-only after MINIT. Cloned into per-request
+ * hashmaps at RINIT via _replay_ini(). Freed at MSHUTDOWN.
+ */
+static nr_scope_hashmap_t* ini_scope_ht = NULL;
+static nr_func_hashmap_t* ini_global_funcs_ht = NULL;
 #else
 static nr_scope_hashmap_t* scope_ht = NULL;
 static nr_func_hashmap_t* global_funcs_ht = NULL;
@@ -518,6 +526,170 @@ void nr_php_user_instrument_wraprec_hashmap_destroy(void) {
     nr_func_hashmap_destroy_internal(&NR_GLOBAL_FUNCS_HT);
   }
   return;
+}
+
+/*
+ * Deep copy a nruserfn_t's fields into a freshly created wraprec.
+ * String fields are duplicated so the copy can be freed independently.
+ * Only copies fields relevant to INI-originated wraprecs (naming flags,
+ * metric flags, function/class names, supportability metric).
+ */
+static void nr_func_wraprec_copy_fields(nruserfn_t* dst,
+                                        const nruserfn_t* src) {
+  if (NULL == dst || NULL == src) {
+    return;
+  }
+
+  dst->funcname = nr_strdup(src->funcname);
+  dst->funcnamelen = src->funcnamelen;
+  dst->funcnameLC = nr_strdup(src->funcnameLC);
+  if (src->is_method) {
+    dst->classname = nr_strdup(src->classname);
+    dst->classnamelen = src->classnamelen;
+    dst->classnameLC = nr_strdup(src->classnameLC);
+    dst->is_method = src->is_method;
+  }
+  dst->supportability_metric = nr_strdup(src->supportability_metric);
+  dst->is_names_wt_simple = src->is_names_wt_simple;
+  dst->create_metric = src->create_metric;
+  dst->is_user_added = src->is_user_added;
+}
+
+static nr_func_hashmap_t* nr_func_hashmap_deep_copy(
+    const nr_func_hashmap_t* src) {
+  nr_func_hashmap_t* dst = NULL;
+  size_t count;
+  size_t i;
+
+  if (NULL == src) {
+    return NULL;
+  }
+
+  dst = nr_func_hashmap_create_internal(src->log2_num_buckets);
+
+  count = (size_t)(1 << src->log2_num_buckets);
+  for (i = 0; i < count; i++) {
+    nr_func_bucket_t* bucket = src->buckets[i];
+
+    while (bucket) {
+      nruserfn_t* wraprec
+          = nr_func_hashmap_add_internal(dst, i, bucket->key);
+
+      nr_func_wraprec_copy_fields(wraprec, bucket->wraprec);
+      bucket = bucket->next;
+    }
+  }
+
+  return dst;
+}
+
+static nr_scope_hashmap_t* nr_scope_hashmap_deep_copy(
+    const nr_scope_hashmap_t* src) {
+  nr_scope_hashmap_t* dst = NULL;
+  size_t count;
+  size_t i;
+
+  if (NULL == src) {
+    return NULL;
+  }
+
+  dst = nr_scope_hashmap_create_internal(src->log2_num_buckets);
+
+  count = (size_t)(1 << src->log2_num_buckets);
+  for (i = 0; i < count; i++) {
+    nr_scope_bucket_t* bucket = src->buckets[i];
+
+    while (bucket) {
+      nr_scope_bucket_t* new_bucket
+          = (nr_scope_bucket_t*)nr_malloc(sizeof(nr_scope_bucket_t));
+
+      new_bucket->prev = NULL;
+      new_bucket->next = dst->buckets[i];
+      new_bucket->key
+          = (nr_scope_hashmap_key_t*)nr_malloc(sizeof(nr_scope_hashmap_key_t));
+      new_bucket->key->name
+          = nr_strndup(bucket->key->name, bucket->key->name_len);
+      new_bucket->key->name_len = bucket->key->name_len;
+      new_bucket->key->name_hash = bucket->key->name_hash;
+      new_bucket->scoped_funcs_ht
+          = nr_func_hashmap_deep_copy(bucket->scoped_funcs_ht);
+
+      if (dst->buckets[i]) {
+        dst->buckets[i]->prev = new_bucket;
+      }
+      dst->buckets[i] = new_bucket;
+      ++dst->elements;
+
+      bucket = bucket->next;
+    }
+  }
+
+  return dst;
+}
+
+/*
+ * INI wraprec hashmap functions.
+ *
+ * NTS: INI handlers write directly into the runtime hashmaps (scope_ht /
+ * global_funcs_ht). The _ini_* functions delegate to the regular hashmap
+ * functions since the storage is the same.
+ *
+ * ZTS: INI handlers write into process-global ini_scope_ht / ini_global_funcs_ht
+ * at MINIT. These are deep copied into per-request hashmaps at RINIT.
+ */
+
+void nr_php_user_instrument_wraprec_hashmap_ini_init(void) {
+#ifdef ZTS
+  if (NULL == ini_scope_ht) {
+    ini_scope_ht = nr_scope_hashmap_create_internal(0);
+  }
+  if (NULL == ini_global_funcs_ht) {
+    ini_global_funcs_ht = nr_func_hashmap_create_internal(0);
+  }
+#else
+  nr_php_user_instrument_wraprec_hashmap_init();
+#endif
+}
+
+nruserfn_t* nr_php_user_instrument_wraprec_hashmap_ini_add(
+    const char* namestr,
+    size_t namestrlen) {
+#ifdef ZTS
+  return nr_php_user_instrument_wraprec_hashmap_add_into(
+      ini_scope_ht, ini_global_funcs_ht, namestr, namestrlen);
+#else
+  return nr_php_user_instrument_wraprec_hashmap_add_into(
+      NR_SCOPE_HT, NR_GLOBAL_FUNCS_HT, namestr, namestrlen);
+#endif
+}
+
+void nr_php_user_instrument_wraprec_hashmap_ini_destroy(void) {
+#ifdef ZTS
+  if (NULL != ini_scope_ht) {
+    nr_scope_hashmap_destroy_internal(&ini_scope_ht);
+  }
+  if (NULL != ini_global_funcs_ht) {
+    nr_func_hashmap_destroy_internal(&ini_global_funcs_ht);
+  }
+#endif
+}
+
+void nr_php_user_instrument_wraprec_hashmap_replay_ini(void) {
+#ifdef ZTS
+  if (NULL == NR_SCOPE_HT) {
+    NR_SCOPE_HT = nr_scope_hashmap_deep_copy(ini_scope_ht);
+  } else {
+    nrl_verbosedebug(NRL_INSTRUMENT, "%s: scope_ht was not NULL before replay",
+                     __func__);
+  }
+  if (NULL == NR_GLOBAL_FUNCS_HT) {
+    NR_GLOBAL_FUNCS_HT = nr_func_hashmap_deep_copy(ini_global_funcs_ht);
+  } else {
+    nrl_verbosedebug(NRL_INSTRUMENT,
+                     "%s: global_funcs_ht was not NULL before replay",
+                     __func__);
+  }
+#endif
 }
 
 #endif /* ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO */

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -275,9 +275,22 @@ static bool nr_scope_hashmap_fetch_internal(nr_scope_hashmap_t* hashmap, size_t 
   return false;
 }
 
+/*
+ * Purpose : Insert a new scope bucket into the scope hashmap.
+ *
+ * Params  : 1. The scope hashmap to insert into.
+ *           2. The pre-computed bucket index for the key.
+ *           3. The scope key (name, length, hash). Copied into the bucket.
+ *           4. The func hashmap to attach to the scope bucket. Caller
+ *              provides an empty hashmap for normal usage, or a
+ *              deep-copied hashmap during RINIT replay.
+ *
+ * Returns : The scoped_funcs_ht attached to the new bucket.
+ */
 static nr_func_hashmap_t* nr_scope_hashmap_add_internal(nr_scope_hashmap_t* hashmap,
                              size_t hash_key,
-                             nr_scope_hashmap_key_t* key) {
+                             nr_scope_hashmap_key_t* key,
+                             nr_func_hashmap_t* scoped_funcs_ht) {
   nr_scope_bucket_t* bucket = (nr_scope_bucket_t*)nr_malloc(sizeof(nr_scope_bucket_t));
   bucket->prev = NULL;
   bucket->next = hashmap->buckets[hash_key];
@@ -285,7 +298,7 @@ static nr_func_hashmap_t* nr_scope_hashmap_add_internal(nr_scope_hashmap_t* hash
   bucket->key->name = nr_strndup(key->name, key->name_len);
   bucket->key->name_len = key->name_len;
   bucket->key->name_hash = key->name_hash;
-  bucket->scoped_funcs_ht = nr_func_hashmap_create_internal(0);
+  bucket->scoped_funcs_ht = scoped_funcs_ht;
 
   if (hashmap->buckets[hash_key]) {
     hashmap->buckets[hash_key]->prev = bucket;
@@ -326,7 +339,8 @@ static nr_func_hashmap_t* nr_scope_hashmap_update_internal(nr_scope_hashmap_t* h
     return bucket->scoped_funcs_ht;
   }
 
-  return nr_scope_hashmap_add_internal(hashmap, hash, key);
+  return nr_scope_hashmap_add_internal(hashmap, hash, key,
+                                       nr_func_hashmap_create_internal(0));
 }
 
 static void nr_scope_hashmap_destroy_bucket_internal(nr_scope_bucket_t** bucket_ptr) {
@@ -572,8 +586,9 @@ static nr_func_hashmap_t* nr_func_hashmap_deep_copy(
     nr_func_bucket_t* bucket = src->buckets[i];
 
     while (bucket) {
-      nruserfn_t* wraprec
-          = nr_func_hashmap_add_internal(dst, i, bucket->key);
+      nruserfn_t* wraprec = nr_func_hashmap_add_internal(
+          dst, nr_func_hashmap_hash_key(dst->log2_num_buckets, bucket->key),
+          bucket->key);
 
       nr_func_wraprec_copy_fields(wraprec, bucket->wraprec);
       bucket = bucket->next;
@@ -600,25 +615,11 @@ static nr_scope_hashmap_t* nr_scope_hashmap_deep_copy(
     nr_scope_bucket_t* bucket = src->buckets[i];
 
     while (bucket) {
-      nr_scope_bucket_t* new_bucket
-          = (nr_scope_bucket_t*)nr_malloc(sizeof(nr_scope_bucket_t));
-
-      new_bucket->prev = NULL;
-      new_bucket->next = dst->buckets[i];
-      new_bucket->key
-          = (nr_scope_hashmap_key_t*)nr_malloc(sizeof(nr_scope_hashmap_key_t));
-      new_bucket->key->name
-          = nr_strndup(bucket->key->name, bucket->key->name_len);
-      new_bucket->key->name_len = bucket->key->name_len;
-      new_bucket->key->name_hash = bucket->key->name_hash;
-      new_bucket->scoped_funcs_ht
-          = nr_func_hashmap_deep_copy(bucket->scoped_funcs_ht);
-
-      if (dst->buckets[i]) {
-        dst->buckets[i]->prev = new_bucket;
-      }
-      dst->buckets[i] = new_bucket;
-      ++dst->elements;
+      nr_scope_hashmap_add_internal(
+          dst,
+          nr_scope_hashmap_hash_key(dst->log2_num_buckets, bucket->key),
+          bucket->key,
+          nr_func_hashmap_deep_copy(bucket->scoped_funcs_ht));
 
       bucket = bucket->next;
     }

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -9,6 +9,8 @@
 #include "util_memory.h"
 #include "util_strings.h"
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+
 // -----------------------------------------------------------------------------
 // func hash map
 
@@ -483,3 +485,5 @@ void nr_php_user_instrument_wraprec_hashmap_destroy(void) {
   }
   return;
 }
+
+#endif /* ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO */

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -11,6 +11,22 @@
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
 
+/*
+ * Storage abstraction for scope_ht and global_funcs_ht:
+ * - ZTS: per-request globals via NRPRG() (created at RINIT, destroyed at
+ *   RSHUTDOWN)
+ * - Non-ZTS: file-scoped statics (created at MINIT, destroyed at MSHUTDOWN)
+ */
+#ifdef ZTS
+#define NR_SCOPE_HT NRPRG(scope_ht)
+#define NR_GLOBAL_FUNCS_HT NRPRG(global_funcs_ht)
+#else
+static nr_scope_hashmap_t* scope_ht = NULL;
+static nr_func_hashmap_t* global_funcs_ht = NULL;
+#define NR_SCOPE_HT scope_ht
+#define NR_GLOBAL_FUNCS_HT global_funcs_ht
+#endif
+
 // -----------------------------------------------------------------------------
 // func hash map
 
@@ -379,11 +395,16 @@ static void nr_php_user_instrument_wraprec_hashmap_name2keys(
 }
 
 void nr_php_user_instrument_wraprec_hashmap_init(void) {
-  if (NULL == NRPRG(scope_ht)) {
-    NRPRG(scope_ht) = nr_scope_hashmap_create_internal(0);
+  if (NULL == NR_SCOPE_HT) {
+    NR_SCOPE_HT = nr_scope_hashmap_create_internal(0);
+  } else {
+    nrl_verbosedebug(NRL_INSTRUMENT, "%s: scope_ht was not NULL", __func__);
   }
-  if (NULL == NRPRG(global_funcs_ht)) {
-    NRPRG(global_funcs_ht) = nr_func_hashmap_create_internal(0);
+  if (NULL == NR_GLOBAL_FUNCS_HT) {
+    NR_GLOBAL_FUNCS_HT = nr_func_hashmap_create_internal(0);
+  } else {
+    nrl_verbosedebug(NRL_INSTRUMENT, "%s: global_funcs_ht was not NULL",
+                     __func__);
   }
 }
 
@@ -400,16 +421,16 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add(const char* namestr, size
   bool is_new_wraprec = false;
   nruserfn_t* wraprec = NULL;
 
-  if (NULL == NRPRG(scope_ht) || NULL == NRPRG(global_funcs_ht)) {
+  if (NULL == NR_SCOPE_HT || NULL == NR_GLOBAL_FUNCS_HT) {
     return NULL;
   }
 
   nr_php_user_instrument_wraprec_hashmap_name2keys(&func_key, &scope_key, namestr, namestrlen);
 
   if (func_key.is_method) {
-    funcs_ht = nr_scope_hashmap_update_internal(NRPRG(scope_ht), &scope_key);
+    funcs_ht = nr_scope_hashmap_update_internal(NR_SCOPE_HT, &scope_key);
   } else {
-    funcs_ht = NRPRG(global_funcs_ht);
+    funcs_ht = NR_GLOBAL_FUNCS_HT;
   }
 
   if (NULL == funcs_ht) {
@@ -448,7 +469,7 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, z
   nr_func_hashmap_key_t func_key = {0};
   nr_func_hashmap_t* funcs_ht = NULL;
 
-  if (NULL == NRPRG(scope_ht) || NULL == NRPRG(global_funcs_ht)) {
+  if (NULL == NR_SCOPE_HT || NULL == NR_GLOBAL_FUNCS_HT) {
     return NULL;
   }
   if (NULL == func_name) {
@@ -460,9 +481,9 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, z
     scope_key.name = ZSTR_VAL(scope_name);
     scope_key.name_len = ZSTR_LEN(scope_name);
     scope_key.name_hash = ZSTR_HASH(scope_name);
-    funcs_ht = nr_scope_hashmap_lookup_internal(NRPRG(scope_ht), &scope_key);
+    funcs_ht = nr_scope_hashmap_lookup_internal(NR_SCOPE_HT, &scope_key);
   } else {
-    funcs_ht = NRPRG(global_funcs_ht);
+    funcs_ht = NR_GLOBAL_FUNCS_HT;
   }
 
   if (NULL == funcs_ht) {
@@ -477,11 +498,11 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, z
 }
 
 void nr_php_user_instrument_wraprec_hashmap_destroy(void) {
-  if (NULL != NRPRG(scope_ht)) {
-    nr_scope_hashmap_destroy_internal(&NRPRG(scope_ht));
+  if (NULL != NR_SCOPE_HT) {
+    nr_scope_hashmap_destroy_internal(&NR_SCOPE_HT);
   }
-  if (NULL != NRPRG(global_funcs_ht)) {
-    nr_func_hashmap_destroy_internal(&NRPRG(global_funcs_ht));
+  if (NULL != NR_GLOBAL_FUNCS_HT) {
+    nr_func_hashmap_destroy_internal(&NR_GLOBAL_FUNCS_HT);
   }
   return;
 }

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -20,19 +20,25 @@
 #ifdef ZTS
 #define NR_SCOPE_HT NRPRG(scope_ht)
 #define NR_GLOBAL_FUNCS_HT NRPRG(global_funcs_ht)
-
-/*
- * ZTS: process-global INI wraprec storage. Populated at MINIT when INI
- * OnModify handlers fire, read-only after MINIT. Cloned into per-request
- * hashmaps at RINIT via _replay_ini(). Freed at MSHUTDOWN.
- */
-static nr_scope_hashmap_t* ini_scope_ht = NULL;
-static nr_func_hashmap_t* ini_global_funcs_ht = NULL;
 #else
 static nr_scope_hashmap_t* scope_ht = NULL;
 static nr_func_hashmap_t* global_funcs_ht = NULL;
 #define NR_SCOPE_HT scope_ht
 #define NR_GLOBAL_FUNCS_HT global_funcs_ht
+#endif
+
+/*
+ * ZTS only: process-global staging storage for INI-originated wraprecs.
+ * INI OnModify handlers populate these at MINIT (before any request exists).
+ * At RINIT they are deep-copied into the per-request hashmaps via _replay_ini().
+ * Freed at MSHUTDOWN.
+ *
+ * NTS: no staging needed — INI handlers write directly into the runtime
+ * hashmaps (scope_ht / global_funcs_ht) via the regular _add() path.
+ */
+#ifdef ZTS
+static nr_scope_hashmap_t* ini_scope_ht = NULL;
+static nr_func_hashmap_t* ini_global_funcs_ht = NULL;
 #endif
 
 // -----------------------------------------------------------------------------
@@ -543,6 +549,18 @@ void nr_php_user_instrument_wraprec_hashmap_destroy(void) {
 }
 
 /*
+ * ZTS-only INI wraprec hashmap functions.
+ *
+ * ZTS: INI handlers write into process-global ini_scope_ht / ini_global_funcs_ht
+ * at MINIT. These are deep copied into per-request hashmaps at RINIT.
+ *
+ * NTS: INI handlers write directly into the runtime hashmaps (scope_ht /
+ * global_funcs_ht) via the regular _init() / _add() functions. No separate
+ * INI storage is needed.
+ */
+
+#ifdef ZTS
+/*
  * Deep copy a nruserfn_t's fields into a freshly created wraprec.
  * String fields are duplicated so the copy can be freed independently.
  * Only copies fields relevant to INI-originated wraprecs (naming flags,
@@ -627,19 +645,6 @@ static nr_scope_hashmap_t* nr_scope_hashmap_deep_copy(
 
   return dst;
 }
-
-/*
- * ZTS-only INI wraprec hashmap functions.
- *
- * ZTS: INI handlers write into process-global ini_scope_ht / ini_global_funcs_ht
- * at MINIT. These are deep copied into per-request hashmaps at RINIT.
- *
- * NTS: INI handlers write directly into the runtime hashmaps (scope_ht /
- * global_funcs_ht) via the regular _init() / _add() functions. No separate
- * INI storage is needed.
- */
-
-#ifdef ZTS
 void nr_php_user_instrument_wraprec_hashmap_ini_init(void) {
   if (NULL == ini_scope_ht) {
     ini_scope_ht = nr_scope_hashmap_create_internal(0);

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -340,9 +340,6 @@ static void nr_scope_hashmap_destroy_internal(nr_scope_hashmap_t** hashmap_ptr) 
   nr_realfree((void**)hashmap_ptr);
 }
 
-nr_func_hashmap_t* global_funcs_ht = NULL;
-nr_scope_hashmap_t* scope_ht = NULL;
-
 /* This function expects full_name and full_name_len to be validated with
  * nr_php_user_instrument_is_name_valid() before being passed in.
  * Specifically, it requires that:
@@ -380,11 +377,11 @@ static void nr_php_user_instrument_wraprec_hashmap_name2keys(
 }
 
 void nr_php_user_instrument_wraprec_hashmap_init(void) {
-  if (NULL == scope_ht) {
-    scope_ht = nr_scope_hashmap_create_internal(0);
+  if (NULL == NRPRG(scope_ht)) {
+    NRPRG(scope_ht) = nr_scope_hashmap_create_internal(0);
   }
-  if (NULL == global_funcs_ht) {
-    global_funcs_ht = nr_func_hashmap_create_internal(0);
+  if (NULL == NRPRG(global_funcs_ht)) {
+    NRPRG(global_funcs_ht) = nr_func_hashmap_create_internal(0);
   }
 }
 
@@ -401,17 +398,16 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add(const char* namestr, size
   bool is_new_wraprec = false;
   nruserfn_t* wraprec = NULL;
 
-
-  if (NULL == scope_ht || NULL == global_funcs_ht) {
+  if (NULL == NRPRG(scope_ht) || NULL == NRPRG(global_funcs_ht)) {
     return NULL;
   }
 
   nr_php_user_instrument_wraprec_hashmap_name2keys(&func_key, &scope_key, namestr, namestrlen);
 
   if (func_key.is_method) {
-    funcs_ht = nr_scope_hashmap_update_internal(scope_ht, &scope_key);
+    funcs_ht = nr_scope_hashmap_update_internal(NRPRG(scope_ht), &scope_key);
   } else {
-    funcs_ht = global_funcs_ht;
+    funcs_ht = NRPRG(global_funcs_ht);
   }
 
   if (NULL == funcs_ht) {
@@ -450,7 +446,7 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, z
   nr_func_hashmap_key_t func_key = {0};
   nr_func_hashmap_t* funcs_ht = NULL;
 
-  if (NULL == scope_ht || NULL == global_funcs_ht) {
+  if (NULL == NRPRG(scope_ht) || NULL == NRPRG(global_funcs_ht)) {
     return NULL;
   }
   if (NULL == func_name) {
@@ -462,9 +458,9 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, z
     scope_key.name = ZSTR_VAL(scope_name);
     scope_key.name_len = ZSTR_LEN(scope_name);
     scope_key.name_hash = ZSTR_HASH(scope_name);
-    funcs_ht = nr_scope_hashmap_lookup_internal(scope_ht, &scope_key);
+    funcs_ht = nr_scope_hashmap_lookup_internal(NRPRG(scope_ht), &scope_key);
   } else {
-    funcs_ht = global_funcs_ht;
+    funcs_ht = NRPRG(global_funcs_ht);
   }
 
   if (NULL == funcs_ht) {
@@ -479,11 +475,11 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, z
 }
 
 void nr_php_user_instrument_wraprec_hashmap_destroy(void) {
-  if (NULL != scope_ht) {
-    nr_scope_hashmap_destroy_internal(&scope_ht);
+  if (NULL != NRPRG(scope_ht)) {
+    nr_scope_hashmap_destroy_internal(&NRPRG(scope_ht));
   }
-  if (NULL != global_funcs_ht) {
-    nr_func_hashmap_destroy_internal(&global_funcs_ht);
+  if (NULL != NRPRG(global_funcs_ht)) {
+    nr_func_hashmap_destroy_internal(&NRPRG(global_funcs_ht));
   }
   return;
 }

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -629,54 +629,43 @@ static nr_scope_hashmap_t* nr_scope_hashmap_deep_copy(
 }
 
 /*
- * INI wraprec hashmap functions.
- *
- * NTS: INI handlers write directly into the runtime hashmaps (scope_ht /
- * global_funcs_ht). The _ini_* functions delegate to the regular hashmap
- * functions since the storage is the same.
+ * ZTS-only INI wraprec hashmap functions.
  *
  * ZTS: INI handlers write into process-global ini_scope_ht / ini_global_funcs_ht
  * at MINIT. These are deep copied into per-request hashmaps at RINIT.
+ *
+ * NTS: INI handlers write directly into the runtime hashmaps (scope_ht /
+ * global_funcs_ht) via the regular _init() / _add() functions. No separate
+ * INI storage is needed.
  */
 
-void nr_php_user_instrument_wraprec_hashmap_ini_init(void) {
 #ifdef ZTS
+void nr_php_user_instrument_wraprec_hashmap_ini_init(void) {
   if (NULL == ini_scope_ht) {
     ini_scope_ht = nr_scope_hashmap_create_internal(0);
   }
   if (NULL == ini_global_funcs_ht) {
     ini_global_funcs_ht = nr_func_hashmap_create_internal(0);
   }
-#else
-  nr_php_user_instrument_wraprec_hashmap_init();
-#endif
 }
 
 nruserfn_t* nr_php_user_instrument_wraprec_hashmap_ini_add(
     const char* namestr,
     size_t namestrlen) {
-#ifdef ZTS
   return nr_php_user_instrument_wraprec_hashmap_add_into(
       ini_scope_ht, ini_global_funcs_ht, namestr, namestrlen);
-#else
-  return nr_php_user_instrument_wraprec_hashmap_add_into(
-      NR_SCOPE_HT, NR_GLOBAL_FUNCS_HT, namestr, namestrlen);
-#endif
 }
 
 void nr_php_user_instrument_wraprec_hashmap_ini_destroy(void) {
-#ifdef ZTS
   if (NULL != ini_scope_ht) {
     nr_scope_hashmap_destroy_internal(&ini_scope_ht);
   }
   if (NULL != ini_global_funcs_ht) {
     nr_func_hashmap_destroy_internal(&ini_global_funcs_ht);
   }
-#endif
 }
 
 void nr_php_user_instrument_wraprec_hashmap_replay_ini(void) {
-#ifdef ZTS
   if (NULL == NR_SCOPE_HT) {
     NR_SCOPE_HT = nr_scope_hashmap_deep_copy(ini_scope_ht);
   } else {
@@ -690,7 +679,7 @@ void nr_php_user_instrument_wraprec_hashmap_replay_ini(void) {
                      "%s: global_funcs_ht was not NULL before replay",
                      __func__);
   }
-#endif
 }
+#endif /* ZTS */
 
 #endif /* ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO */

--- a/agent/php_user_instrument_wraprec_hashmap.c
+++ b/agent/php_user_instrument_wraprec_hashmap.c
@@ -412,25 +412,33 @@ void nr_php_user_instrument_wraprec_hashmap_init(void) {
  * nr_php_user_instrument_is_name_valid() before being passed in.
  * Specifically, it requires that:
  * - namestrlen be greater than 0
- * - namestr must not be NULL and must not end with `:` (colon) . */
+ * - namestr must not be NULL and must not end with `:` (colon) .
+ *
+ * _add_into() takes explicit hashmap pointers so callers can target
+ * different hashmaps (runtime vs INI). _add() is a convenience wrapper
+ * that targets the runtime hashmaps via NR_SCOPE_HT / NR_GLOBAL_FUNCS_HT. */
 
-nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add(const char* namestr, size_t namestrlen) {
+static nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add_into(
+    nr_scope_hashmap_t* sht,
+    nr_func_hashmap_t* ght,
+    const char* namestr,
+    size_t namestrlen) {
   nr_scope_hashmap_key_t scope_key = {0};
   nr_func_hashmap_key_t func_key = {0};
   nr_func_hashmap_t* funcs_ht = NULL;
   bool is_new_wraprec = false;
   nruserfn_t* wraprec = NULL;
 
-  if (NULL == NR_SCOPE_HT || NULL == NR_GLOBAL_FUNCS_HT) {
+  if (NULL == sht || NULL == ght) {
     return NULL;
   }
 
   nr_php_user_instrument_wraprec_hashmap_name2keys(&func_key, &scope_key, namestr, namestrlen);
 
   if (func_key.is_method) {
-    funcs_ht = nr_scope_hashmap_update_internal(NR_SCOPE_HT, &scope_key);
+    funcs_ht = nr_scope_hashmap_update_internal(sht, &scope_key);
   } else {
-    funcs_ht = NR_GLOBAL_FUNCS_HT;
+    funcs_ht = ght;
   }
 
   if (NULL == funcs_ht) {
@@ -462,6 +470,11 @@ nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add(const char* namestr, size
   }
 
   return wraprec;
+}
+
+nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add(const char* namestr, size_t namestrlen) {
+  return nr_php_user_instrument_wraprec_hashmap_add_into(
+      NR_SCOPE_HT, NR_GLOBAL_FUNCS_HT, namestr, namestrlen);
 }
 
 nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, zend_string *scope_name) {

--- a/agent/php_user_instrument_wraprec_hashmap.h
+++ b/agent/php_user_instrument_wraprec_hashmap.h
@@ -8,6 +8,10 @@
 
 #include "php_user_instrument.h"
 
+// Forward declarations for hashmap types
+typedef struct _nr_func_hashmap nr_func_hashmap_t;
+typedef struct _nr_scope_hashmap nr_scope_hashmap_t;
+
 // clang-format off
 
 extern void nr_php_user_instrument_wraprec_hashmap_init(void);

--- a/agent/php_user_instrument_wraprec_hashmap.h
+++ b/agent/php_user_instrument_wraprec_hashmap.h
@@ -21,10 +21,12 @@ extern nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add(const char* namest
 extern nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, zend_string *scope_name);
 extern void nr_php_user_instrument_wraprec_hashmap_destroy(void);
 
+#ifdef ZTS
 extern void nr_php_user_instrument_wraprec_hashmap_ini_init(void);
 extern nruserfn_t* nr_php_user_instrument_wraprec_hashmap_ini_add(const char* namestr, size_t namestrlen);
 extern void nr_php_user_instrument_wraprec_hashmap_ini_destroy(void);
 extern void nr_php_user_instrument_wraprec_hashmap_replay_ini(void);
+#endif
 
 // clang-format on
 

--- a/agent/php_user_instrument_wraprec_hashmap.h
+++ b/agent/php_user_instrument_wraprec_hashmap.h
@@ -21,6 +21,11 @@ extern nruserfn_t* nr_php_user_instrument_wraprec_hashmap_add(const char* namest
 extern nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_name, zend_string *scope_name);
 extern void nr_php_user_instrument_wraprec_hashmap_destroy(void);
 
+extern void nr_php_user_instrument_wraprec_hashmap_ini_init(void);
+extern nruserfn_t* nr_php_user_instrument_wraprec_hashmap_ini_add(const char* namestr, size_t namestrlen);
+extern void nr_php_user_instrument_wraprec_hashmap_ini_destroy(void);
+extern void nr_php_user_instrument_wraprec_hashmap_replay_ini(void);
+
 // clang-format on
 
 #endif /* ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO */

--- a/agent/php_user_instrument_wraprec_hashmap.h
+++ b/agent/php_user_instrument_wraprec_hashmap.h
@@ -8,6 +8,8 @@
 
 #include "php_user_instrument.h"
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+
 // Forward declarations for hashmap types
 typedef struct _nr_func_hashmap nr_func_hashmap_t;
 typedef struct _nr_scope_hashmap nr_scope_hashmap_t;
@@ -20,5 +22,7 @@ extern nruserfn_t* nr_php_user_instrument_wraprec_hashmap_get(zend_string *func_
 extern void nr_php_user_instrument_wraprec_hashmap_destroy(void);
 
 // clang-format on
+
+#endif /* ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO */
 
 #endif

--- a/agent/tests/test_user_instrument_wraprec_hashmap.c
+++ b/agent/tests/test_user_instrument_wraprec_hashmap.c
@@ -72,6 +72,199 @@ static void test_wraprecs_hashmap() {
   zend_string_free(method_name);
 }
 
+static void test_ini_add_global_function() {
+  nruserfn_t* wraprec;
+
+  nr_php_user_instrument_wraprec_hashmap_ini_init();
+
+  /* Add a global function via INI add */
+  wraprec = nr_php_user_instrument_wraprec_hashmap_ini_add(
+      NR_PSTR(FUNCTION_NAME));
+  tlib_pass_if_not_null("ini_add global function", wraprec);
+  tlib_pass_if_str_equal("ini_add funcname", FUNCTION_NAME, wraprec->funcname);
+  tlib_pass_if_int_equal("ini_add is_method", 0, wraprec->is_method);
+
+  /* Set flags as the INI handler callbacks would */
+  wraprec->is_names_wt_simple = 1;
+  tlib_pass_if_int_equal("ini_add flag set", 1, wraprec->is_names_wt_simple);
+
+  /* Dedup: adding the same name returns the existing wraprec */
+  nruserfn_t* wraprec2 = nr_php_user_instrument_wraprec_hashmap_ini_add(
+      NR_PSTR(FUNCTION_NAME));
+  tlib_pass_if_ptr_equal("ini_add dedup", wraprec, wraprec2);
+
+  nr_php_user_instrument_wraprec_hashmap_ini_destroy();
+  nr_php_user_instrument_wraprec_hashmap_destroy();
+}
+
+static void test_ini_add_scoped_method() {
+  nruserfn_t* wraprec;
+
+  nr_php_user_instrument_wraprec_hashmap_ini_init();
+
+  wraprec = nr_php_user_instrument_wraprec_hashmap_ini_add(
+      NR_PSTR(SCOPED_METHOD_NAME));
+  tlib_pass_if_not_null("ini_add scoped method", wraprec);
+  tlib_pass_if_str_equal("ini_add method funcname", METHOD_NAME,
+                         wraprec->funcname);
+  tlib_pass_if_str_equal("ini_add method classname", SCOPE_NAME,
+                         wraprec->classname);
+  tlib_pass_if_int_equal("ini_add is_method", 1, wraprec->is_method);
+
+  /* Set flags as the custom tracer INI handler would */
+  wraprec->create_metric = 1;
+  wraprec->is_user_added = 1;
+
+  nr_php_user_instrument_wraprec_hashmap_ini_destroy();
+  nr_php_user_instrument_wraprec_hashmap_destroy();
+}
+
+static void test_ini_add_before_init() {
+  nruserfn_t* wraprec;
+
+  /* Ensure INI hashmaps are not initialized */
+  nr_php_user_instrument_wraprec_hashmap_ini_destroy();
+
+  wraprec = nr_php_user_instrument_wraprec_hashmap_ini_add(
+      NR_PSTR(FUNCTION_NAME));
+  tlib_pass_if_null("ini_add before init returns NULL", wraprec);
+}
+
+static void test_replay_ini_global_function() {
+  nruserfn_t* wraprec;
+  nruserfn_t* found;
+  zend_string* func_name;
+
+  func_name = zend_string_init(NR_PSTR(FUNCTION_NAME), 0);
+
+  nr_php_user_instrument_wraprec_hashmap_ini_init();
+
+  /* Add a naming function to INI hashmap */
+  wraprec = nr_php_user_instrument_wraprec_hashmap_ini_add(
+      NR_PSTR(FUNCTION_NAME));
+  tlib_pass_if_not_null("replay: ini_add", wraprec);
+  wraprec->is_names_wt_simple = 1;
+
+  /* Replay into per-request hashmaps */
+  nr_php_user_instrument_wraprec_hashmap_replay_ini();
+
+  /* Verify the per-request hashmap has the entry with correct flags */
+  found = nr_php_user_instrument_wraprec_hashmap_get(func_name, NULL);
+  tlib_pass_if_not_null("replay: get after replay", found);
+  tlib_pass_if_str_equal("replay: funcname", FUNCTION_NAME, found->funcname);
+  tlib_pass_if_int_equal("replay: is_names_wt_simple", 1,
+                         found->is_names_wt_simple);
+
+  /* The per-request wraprec should be a copy, not the same pointer */
+#ifdef ZTS
+  tlib_pass_if_true("replay: different pointer (deep copy)",
+                    found != wraprec, "%p != %p", found, wraprec);
+#endif
+
+  nr_php_user_instrument_wraprec_hashmap_destroy();
+  nr_php_user_instrument_wraprec_hashmap_ini_destroy();
+
+  zend_string_free(func_name);
+}
+
+static void test_replay_ini_scoped_method() {
+  nruserfn_t* wraprec;
+  nruserfn_t* found;
+  zend_string* method_name;
+  zend_string* scope_name;
+
+  method_name = zend_string_init(NR_PSTR(METHOD_NAME), 0);
+  scope_name = zend_string_init(NR_PSTR(SCOPE_NAME), 0);
+
+  nr_php_user_instrument_wraprec_hashmap_ini_init();
+
+  /* Add a scoped method to INI hashmap */
+  wraprec = nr_php_user_instrument_wraprec_hashmap_ini_add(
+      NR_PSTR(SCOPED_METHOD_NAME));
+  tlib_pass_if_not_null("replay scoped: ini_add", wraprec);
+  wraprec->create_metric = 1;
+  wraprec->is_user_added = 1;
+
+  /* Replay into per-request hashmaps */
+  nr_php_user_instrument_wraprec_hashmap_replay_ini();
+
+  /* Verify the per-request hashmap has the entry with correct flags */
+  found = nr_php_user_instrument_wraprec_hashmap_get(method_name, scope_name);
+  tlib_pass_if_not_null("replay scoped: get after replay", found);
+  tlib_pass_if_str_equal("replay scoped: funcname", METHOD_NAME,
+                         found->funcname);
+  tlib_pass_if_str_equal("replay scoped: classname", SCOPE_NAME,
+                         found->classname);
+  tlib_pass_if_int_equal("replay scoped: create_metric", 1,
+                         found->create_metric);
+  tlib_pass_if_int_equal("replay scoped: is_user_added", 1,
+                         found->is_user_added);
+
+  nr_php_user_instrument_wraprec_hashmap_destroy();
+  nr_php_user_instrument_wraprec_hashmap_ini_destroy();
+
+  zend_string_free(method_name);
+  zend_string_free(scope_name);
+}
+
+static void test_replay_ini_before_init() {
+  /* Replay with no INI hashmaps should be safe (no-op / NULL deep copy) */
+  nr_php_user_instrument_wraprec_hashmap_ini_destroy();
+  nr_php_user_instrument_wraprec_hashmap_destroy();
+
+  nr_php_user_instrument_wraprec_hashmap_replay_ini();
+
+  /* Per-request hashmaps should still be NULL — get should return NULL */
+  zend_string* func_name = zend_string_init(NR_PSTR(FUNCTION_NAME), 0);
+  nruserfn_t* found
+      = nr_php_user_instrument_wraprec_hashmap_get(func_name, NULL);
+  tlib_pass_if_null("replay before init: get returns NULL", found);
+
+  zend_string_free(func_name);
+}
+
+/*
+ * The multi-request cycle (destroy per-request + replay from INI) only applies
+ * to ZTS. On NTS, _replay_ini() is a no-op and the hashmaps persist from MINIT
+ * to MSHUTDOWN — there is no per-request destroy/recreate cycle.
+ */
+#ifdef ZTS
+static void test_replay_ini_multiple_requests() {
+  nruserfn_t* wraprec;
+  nruserfn_t* found;
+  zend_string* func_name;
+
+  func_name = zend_string_init(NR_PSTR(FUNCTION_NAME), 0);
+
+  nr_php_user_instrument_wraprec_hashmap_ini_init();
+  wraprec = nr_php_user_instrument_wraprec_hashmap_ini_add(
+      NR_PSTR(FUNCTION_NAME));
+  wraprec->is_names_wt_simple = 1;
+
+  /* First request */
+  nr_php_user_instrument_wraprec_hashmap_replay_ini();
+  found = nr_php_user_instrument_wraprec_hashmap_get(func_name, NULL);
+  tlib_pass_if_not_null("multi-request: first replay", found);
+  tlib_pass_if_int_equal("multi-request: first is_names_wt_simple", 1,
+                         found->is_names_wt_simple);
+
+  /* Simulate RSHUTDOWN — destroy per-request hashmaps */
+  nr_php_user_instrument_wraprec_hashmap_destroy();
+
+  /* Second request — replay again */
+  nr_php_user_instrument_wraprec_hashmap_replay_ini();
+  found = nr_php_user_instrument_wraprec_hashmap_get(func_name, NULL);
+  tlib_pass_if_not_null("multi-request: second replay", found);
+  tlib_pass_if_int_equal("multi-request: second is_names_wt_simple", 1,
+                         found->is_names_wt_simple);
+
+  nr_php_user_instrument_wraprec_hashmap_destroy();
+  nr_php_user_instrument_wraprec_hashmap_ini_destroy();
+
+  zend_string_free(func_name);
+}
+#endif /* ZTS */
+
 #endif /* ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO */
 
 // clang-format on
@@ -82,6 +275,15 @@ void test_main(void* p NRUNUSED) {
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
   test_wraprecs_hashmap();
+  test_ini_add_global_function();
+  test_ini_add_scoped_method();
+  test_ini_add_before_init();
+  test_replay_ini_global_function();
+  test_replay_ini_scoped_method();
+  test_replay_ini_before_init();
+#ifdef ZTS
+  test_replay_ini_multiple_requests();
+#endif
 #endif
 
   tlib_php_engine_destroy(TSRMLS_C);

--- a/agent/tests/test_user_instrument_wraprec_hashmap.c
+++ b/agent/tests/test_user_instrument_wraprec_hashmap.c
@@ -29,8 +29,9 @@ static void test_wraprecs_hashmap() {
   scope_name = zend_string_init(NR_PSTR(SCOPE_NAME), 0);
   method_name = zend_string_init(NR_PSTR(METHOD_NAME), 0);
 
-  // user_instrument_wraprec_hashmap is initialized at minit
-  // destroy it to test agent's behavior when it is not initialized
+  // Non-ZTS: wraprec hashmap is initialized at MINIT.
+  // ZTS: wraprec hashmap is initialized per-request at RINIT.
+  // Destroy it here to test agent's behavior when it is not initialized.
   nr_php_user_instrument_wraprec_hashmap_destroy();
 
   // Test valid operations before initializing the hashmap

--- a/agent/tests/test_user_instrument_wraprec_hashmap.c
+++ b/agent/tests/test_user_instrument_wraprec_hashmap.c
@@ -72,6 +72,7 @@ static void test_wraprecs_hashmap() {
   zend_string_free(method_name);
 }
 
+#ifdef ZTS
 static void test_ini_add_global_function() {
   nruserfn_t* wraprec;
 
@@ -156,10 +157,8 @@ static void test_replay_ini_global_function() {
                          found->is_names_wt_simple);
 
   /* The per-request wraprec should be a copy, not the same pointer */
-#ifdef ZTS
   tlib_pass_if_true("replay: different pointer (deep copy)",
                     found != wraprec, "%p != %p", found, wraprec);
-#endif
 
   nr_php_user_instrument_wraprec_hashmap_destroy();
   nr_php_user_instrument_wraprec_hashmap_ini_destroy();
@@ -223,12 +222,6 @@ static void test_replay_ini_before_init() {
   zend_string_free(func_name);
 }
 
-/*
- * The multi-request cycle (destroy per-request + replay from INI) only applies
- * to ZTS. On NTS, _replay_ini() is a no-op and the hashmaps persist from MINIT
- * to MSHUTDOWN — there is no per-request destroy/recreate cycle.
- */
-#ifdef ZTS
 static void test_replay_ini_multiple_requests() {
   nruserfn_t* wraprec;
   nruserfn_t* found;
@@ -275,13 +268,13 @@ void test_main(void* p NRUNUSED) {
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
   test_wraprecs_hashmap();
+#ifdef ZTS
   test_ini_add_global_function();
   test_ini_add_scoped_method();
   test_ini_add_before_init();
   test_replay_ini_global_function();
   test_replay_ini_scoped_method();
   test_replay_ini_before_init();
-#ifdef ZTS
   test_replay_ini_multiple_requests();
 #endif
 #endif

--- a/agent/tests/test_user_instrument_wraprec_hashmap.c
+++ b/agent/tests/test_user_instrument_wraprec_hashmap.c
@@ -14,6 +14,8 @@ tlib_parallel_info_t parallel_info
 
 // clang-format off
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
+
 #define SCOPE_NAME "Vendor\\Namespace\\ClassName"
 #define METHOD_NAME "getSomething"
 #define SCOPED_METHOD_NAME SCOPE_NAME "::" METHOD_NAME
@@ -69,13 +71,17 @@ static void test_wraprecs_hashmap() {
   zend_string_free(method_name);
 }
 
+#endif /* ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO */
+
 // clang-format on
 
 void test_main(void* p NRUNUSED) {
 
   tlib_php_engine_create("" PTSRMLS_CC);
 
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO
   test_wraprecs_hashmap();
+#endif
 
   tlib_php_engine_destroy(TSRMLS_C);
 }


### PR DESCRIPTION
Fix ZTS thread safety for wraprec hashmaps and transient wraprecs,
including INI-configured function wrappers under ZTS.

- Move `nr_transient_wraprecs` to per-request global (`NRPRG()`) for
  ZTS thread safety
- Move `scope_ht` / `global_funcs_ht` to per-request globals for ZTS;
  use file-scoped statics for NTS via `NR_SCOPE_HT` /
  `NR_GLOBAL_FUNCS_HT` accessor macros
- NTS: init hashmaps at MINIT before INI registration so OnModify
  handlers (`nr_wtfuncs_mh`, `nr_ttcustom_mh`) can create wraprecs
- ZTS: separate process-global `ini_scope_ht` / `ini_global_funcs_ht`
  capture INI wraprecs at MINIT, deep copied into per-request hashmaps
  at each RINIT
- ZTS INI handlers route via `ZEND_INI_STAGE_STARTUP` check to target
  INI-specific hashmaps
- Guard RINIT init and RSHUTDOWN destroy with `#ifdef ZTS` so NTS
  hashmaps persist from MINIT to MSHUTDOWN
- Guard transient wraprec code to PHP 8+ only