### PR TITLE
feat: add \RedisCluster instrumentation

### DIFF
--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -3290,6 +3290,146 @@ NR_OUTER_WRAPPER(redis_zrevrank)
 NR_OUTER_WRAPPER(redis_zscore)
 NR_OUTER_WRAPPER(redis_zunionstore)
 
+NR_OUTER_WRAPPER(rediscluster_append)
+NR_OUTER_WRAPPER(rediscluster_bitcount)
+NR_OUTER_WRAPPER(rediscluster_bitop)
+NR_OUTER_WRAPPER(rediscluster_bitpos)
+NR_OUTER_WRAPPER(rediscluster_close)
+NR_OUTER_WRAPPER(rediscluster_dbsize)
+NR_OUTER_WRAPPER(rediscluster_decr)
+NR_OUTER_WRAPPER(rediscluster_decrby)
+NR_OUTER_WRAPPER(rediscluster_del)
+NR_OUTER_WRAPPER(rediscluster_eval)
+NR_OUTER_WRAPPER(rediscluster_evalsha)
+NR_OUTER_WRAPPER(rediscluster_exec)
+NR_OUTER_WRAPPER(rediscluster_exists)
+NR_OUTER_WRAPPER(rediscluster_expire)
+NR_OUTER_WRAPPER(rediscluster_expireat)
+NR_OUTER_WRAPPER(rediscluster_flushall)
+NR_OUTER_WRAPPER(rediscluster_flushdb)
+NR_OUTER_WRAPPER(rediscluster_geoadd)
+NR_OUTER_WRAPPER(rediscluster_geodist)
+NR_OUTER_WRAPPER(rediscluster_geohash)
+NR_OUTER_WRAPPER(rediscluster_geopos)
+NR_OUTER_WRAPPER(rediscluster_georadius)
+NR_OUTER_WRAPPER(rediscluster_georadius_ro)
+NR_OUTER_WRAPPER(rediscluster_georadiusbymember)
+NR_OUTER_WRAPPER(rediscluster_georadiusbymember_ro)
+NR_OUTER_WRAPPER(rediscluster_get)
+NR_OUTER_WRAPPER(rediscluster_getbit)
+NR_OUTER_WRAPPER(rediscluster_getrange)
+NR_OUTER_WRAPPER(rediscluster_getset)
+NR_OUTER_WRAPPER(rediscluster_hdel)
+NR_OUTER_WRAPPER(rediscluster_hexists)
+NR_OUTER_WRAPPER(rediscluster_hget)
+NR_OUTER_WRAPPER(rediscluster_hgetall)
+NR_OUTER_WRAPPER(rediscluster_hincrby)
+NR_OUTER_WRAPPER(rediscluster_hincrbyfloat)
+NR_OUTER_WRAPPER(rediscluster_hkeys)
+NR_OUTER_WRAPPER(rediscluster_hlen)
+NR_OUTER_WRAPPER(rediscluster_hmget)
+NR_OUTER_WRAPPER(rediscluster_hmset)
+NR_OUTER_WRAPPER(rediscluster_hset)
+NR_OUTER_WRAPPER(rediscluster_hsetnx)
+NR_OUTER_WRAPPER(rediscluster_hstrlen)
+NR_OUTER_WRAPPER(rediscluster_hvals)
+NR_OUTER_WRAPPER(rediscluster_incr)
+NR_OUTER_WRAPPER(rediscluster_incrby)
+NR_OUTER_WRAPPER(rediscluster_incrbyfloat)
+NR_OUTER_WRAPPER(rediscluster_keys)
+NR_OUTER_WRAPPER(rediscluster_lget)
+NR_OUTER_WRAPPER(rediscluster_lindex)
+NR_OUTER_WRAPPER(rediscluster_linsert)
+NR_OUTER_WRAPPER(rediscluster_llen)
+NR_OUTER_WRAPPER(rediscluster_lpop)
+NR_OUTER_WRAPPER(rediscluster_lpush)
+NR_OUTER_WRAPPER(rediscluster_lpushx)
+NR_OUTER_WRAPPER(rediscluster_lrange)
+NR_OUTER_WRAPPER(rediscluster_lrem)
+NR_OUTER_WRAPPER(rediscluster_lset)
+NR_OUTER_WRAPPER(rediscluster_ltrim)
+NR_OUTER_WRAPPER(rediscluster_mget)
+NR_OUTER_WRAPPER(rediscluster_mset)
+NR_OUTER_WRAPPER(rediscluster_msetnx)
+NR_OUTER_WRAPPER(rediscluster_persist)
+NR_OUTER_WRAPPER(rediscluster_pexpire)
+NR_OUTER_WRAPPER(rediscluster_pexpireat)
+NR_OUTER_WRAPPER(rediscluster_pfadd)
+NR_OUTER_WRAPPER(rediscluster_pfcount)
+NR_OUTER_WRAPPER(rediscluster_pfmerge)
+NR_OUTER_WRAPPER(rediscluster_ping)
+NR_OUTER_WRAPPER(rediscluster_psetex)
+NR_OUTER_WRAPPER(rediscluster_pttl)
+NR_OUTER_WRAPPER(rediscluster_publish)
+NR_OUTER_WRAPPER(rediscluster_randomkey)
+NR_OUTER_WRAPPER(rediscluster_rawcommand)
+NR_OUTER_WRAPPER(rediscluster_rename)
+NR_OUTER_WRAPPER(rediscluster_renamenx)
+NR_OUTER_WRAPPER(rediscluster_rpop)
+NR_OUTER_WRAPPER(rediscluster_rpoplpush)
+NR_OUTER_WRAPPER(rediscluster_rpush)
+NR_OUTER_WRAPPER(rediscluster_rpushx)
+NR_OUTER_WRAPPER(rediscluster_sadd)
+NR_OUTER_WRAPPER(rediscluster_scard)
+NR_OUTER_WRAPPER(rediscluster_sdiff)
+NR_OUTER_WRAPPER(rediscluster_sdiffstore)
+NR_OUTER_WRAPPER(rediscluster_set)
+NR_OUTER_WRAPPER(rediscluster_setbit)
+NR_OUTER_WRAPPER(rediscluster_setex)
+NR_OUTER_WRAPPER(rediscluster_setnx)
+NR_OUTER_WRAPPER(rediscluster_setrange)
+NR_OUTER_WRAPPER(rediscluster_sinter)
+NR_OUTER_WRAPPER(rediscluster_sinterstore)
+NR_OUTER_WRAPPER(rediscluster_sismember)
+NR_OUTER_WRAPPER(rediscluster_smembers)
+NR_OUTER_WRAPPER(rediscluster_smismember)
+NR_OUTER_WRAPPER(rediscluster_smove)
+NR_OUTER_WRAPPER(rediscluster_spop)
+NR_OUTER_WRAPPER(rediscluster_srandmember)
+NR_OUTER_WRAPPER(rediscluster_srem)
+NR_OUTER_WRAPPER(rediscluster_strlen)
+NR_OUTER_WRAPPER(rediscluster_sunion)
+NR_OUTER_WRAPPER(rediscluster_sunionstore)
+NR_OUTER_WRAPPER(rediscluster_time)
+NR_OUTER_WRAPPER(rediscluster_ttl)
+NR_OUTER_WRAPPER(rediscluster_type)
+NR_OUTER_WRAPPER(rediscluster_unlink)
+NR_OUTER_WRAPPER(rediscluster_xack)
+NR_OUTER_WRAPPER(rediscluster_xadd)
+NR_OUTER_WRAPPER(rediscluster_xclaim)
+NR_OUTER_WRAPPER(rediscluster_xdel)
+NR_OUTER_WRAPPER(rediscluster_xgroup)
+NR_OUTER_WRAPPER(rediscluster_xinfo)
+NR_OUTER_WRAPPER(rediscluster_xlen)
+NR_OUTER_WRAPPER(rediscluster_xpending)
+NR_OUTER_WRAPPER(rediscluster_xrange)
+NR_OUTER_WRAPPER(rediscluster_xread)
+NR_OUTER_WRAPPER(rediscluster_xreadgroup)
+NR_OUTER_WRAPPER(rediscluster_xrevrange)
+NR_OUTER_WRAPPER(rediscluster_xtrim)
+NR_OUTER_WRAPPER(rediscluster_zadd)
+NR_OUTER_WRAPPER(rediscluster_zcard)
+NR_OUTER_WRAPPER(rediscluster_zcount)
+NR_OUTER_WRAPPER(rediscluster_zincrby)
+NR_OUTER_WRAPPER(rediscluster_zinterstore)
+NR_OUTER_WRAPPER(rediscluster_zlexcount)
+NR_OUTER_WRAPPER(rediscluster_zpopmax)
+NR_OUTER_WRAPPER(rediscluster_zpopmin)
+NR_OUTER_WRAPPER(rediscluster_zrange)
+NR_OUTER_WRAPPER(rediscluster_zrangebylex)
+NR_OUTER_WRAPPER(rediscluster_zrangebyscore)
+NR_OUTER_WRAPPER(rediscluster_zrank)
+NR_OUTER_WRAPPER(rediscluster_zrem)
+NR_OUTER_WRAPPER(rediscluster_zremrangebylex)
+NR_OUTER_WRAPPER(rediscluster_zremrangebyrank)
+NR_OUTER_WRAPPER(rediscluster_zremrangebyscore)
+NR_OUTER_WRAPPER(rediscluster_zrevrange)
+NR_OUTER_WRAPPER(rediscluster_zrevrangebylex)
+NR_OUTER_WRAPPER(rediscluster_zrevrangebyscore)
+NR_OUTER_WRAPPER(rediscluster_zrevrank)
+NR_OUTER_WRAPPER(rediscluster_zscore)
+NR_OUTER_WRAPPER(rediscluster_zunionstore)
+
 NR_OUTER_WRAPPER(pg_close)
 NR_OUTER_WRAPPER(pg_connect)
 NR_OUTER_WRAPPER(pg_pconnect)
@@ -3792,6 +3932,231 @@ void nr_php_generate_internal_wrap_records(void) {
   NR_INTERNAL_WRAPREC("redis::zscore", redis_zscore, redis_function, 0, 
                       "zscore")
   NR_INTERNAL_WRAPREC("redis::zunionstore", redis_zunionstore, redis_function,
+                      0, "zunionstore")
+
+  NR_INTERNAL_WRAPREC("rediscluster::close", rediscluster_close, redis_close, 0, "close")
+  NR_INTERNAL_WRAPREC("rediscluster::append", rediscluster_append, redis_function, 0,
+                      "append")
+  NR_INTERNAL_WRAPREC("rediscluster::bitcount", rediscluster_bitcount, redis_function, 0,
+                      "bitcount")
+  NR_INTERNAL_WRAPREC("rediscluster::bitop", rediscluster_bitop, redis_function, 0, "bitop")
+  NR_INTERNAL_WRAPREC("rediscluster::bitpos", rediscluster_bitpos, redis_function, 0,
+                      "bitpos")
+  NR_INTERNAL_WRAPREC("rediscluster::decr", rediscluster_decr, redis_function, 0, "decr")
+  NR_INTERNAL_WRAPREC("rediscluster::decrby", rediscluster_decrby, redis_function, 0,
+                      "decrby")
+  NR_INTERNAL_WRAPREC("rediscluster::del", rediscluster_del, redis_function, 0, "del")
+  NR_INTERNAL_WRAPREC("rediscluster::dbsize", rediscluster_dbsize, redis_function, 0,
+                      "dbsize")
+  NR_INTERNAL_WRAPREC("rediscluster::eval", rediscluster_eval, redis_function, 0, "eval")
+  NR_INTERNAL_WRAPREC("rediscluster::evalsha", rediscluster_evalsha, redis_function, 0,
+                      "evalsha")
+  NR_INTERNAL_WRAPREC("rediscluster::exec", rediscluster_exec, redis_function, 0, "exec")
+  NR_INTERNAL_WRAPREC("rediscluster::exists", rediscluster_exists, redis_function, 0,
+                      "exists")
+  NR_INTERNAL_WRAPREC("rediscluster::expire", rediscluster_expire, redis_function, 0,
+                      "expire")
+  NR_INTERNAL_WRAPREC("rediscluster::expireat", rediscluster_expireat, redis_function, 0,
+                      "expireat")
+  NR_INTERNAL_WRAPREC("rediscluster::flushall", rediscluster_flushall, redis_function, 0,
+                      "flushall")
+  NR_INTERNAL_WRAPREC("rediscluster::flushdb", rediscluster_flushdb, redis_function, 0,
+                      "flushdb")
+  NR_INTERNAL_WRAPREC("rediscluster::geoadd", rediscluster_geoadd, redis_function, 0,
+                      "geoadd")
+  NR_INTERNAL_WRAPREC("rediscluster::geodist", rediscluster_geodist, redis_function, 0,
+                      "geodist")
+  NR_INTERNAL_WRAPREC("rediscluster::geohash", rediscluster_geohash, redis_function, 0,
+                      "geohash")
+  NR_INTERNAL_WRAPREC("rediscluster::geopos", rediscluster_geopos, redis_function, 0,
+                      "geopos")
+  NR_INTERNAL_WRAPREC("rediscluster::georadius", rediscluster_georadius, redis_function, 0,
+                      "georadius")
+  NR_INTERNAL_WRAPREC("rediscluster::georadius_ro", rediscluster_georadius_ro, redis_function,
+                      0, "georadius_ro")
+  NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember", rediscluster_georadiusbymember,
+                      redis_function, 0, "georadiusbymember")
+  NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember_ro", rediscluster_georadiusbymember_ro,
+                      redis_function, 0, "georadiusbymember_ro")
+  NR_INTERNAL_WRAPREC("rediscluster::get", rediscluster_get, redis_function, 0, "get")
+  NR_INTERNAL_WRAPREC("rediscluster::getbit", rediscluster_getbit, redis_function, 0,
+                      "getbit")
+  NR_INTERNAL_WRAPREC("rediscluster::getrange", rediscluster_getrange, redis_function, 0,
+                      "getrange")
+  NR_INTERNAL_WRAPREC("rediscluster::getset", rediscluster_getset, redis_function, 0,
+                      "getset")
+  NR_INTERNAL_WRAPREC("rediscluster::hdel", rediscluster_hdel, redis_function, 0, "hdel")
+  NR_INTERNAL_WRAPREC("rediscluster::hexists", rediscluster_hexists, redis_function, 0,
+                      "hexists")
+  NR_INTERNAL_WRAPREC("rediscluster::hget", rediscluster_hget, redis_function, 0, "hget")
+  NR_INTERNAL_WRAPREC("rediscluster::hgetall", rediscluster_hgetall, redis_function, 0,
+                      "hgetall")
+  NR_INTERNAL_WRAPREC("rediscluster::hincrby", rediscluster_hincrby, redis_function, 0,
+                      "hincrby")
+  NR_INTERNAL_WRAPREC("rediscluster::hincrbyfloat", rediscluster_hincrbyfloat, redis_function,
+                      0, "hincrbyfloat")
+  NR_INTERNAL_WRAPREC("rediscluster::hkeys", rediscluster_hkeys, redis_function, 0, "hkeys")
+  NR_INTERNAL_WRAPREC("rediscluster::hlen", rediscluster_hlen, redis_function, 0, "hlen")
+  NR_INTERNAL_WRAPREC("rediscluster::hmget", rediscluster_hmget, redis_function, 0, "hmget")
+  NR_INTERNAL_WRAPREC("rediscluster::hmset", rediscluster_hmset, redis_function, 0, "hmset")
+  NR_INTERNAL_WRAPREC("rediscluster::hset", rediscluster_hset, redis_function, 0, "hset")
+  NR_INTERNAL_WRAPREC("rediscluster::hsetnx", rediscluster_hsetnx, redis_function, 0,
+                      "hsetnx")
+  NR_INTERNAL_WRAPREC("rediscluster::hstrlen", rediscluster_hstrlen, redis_function, 0,
+                      "hstrlen")
+  NR_INTERNAL_WRAPREC("rediscluster::hvals", rediscluster_hvals, redis_function, 0, "hvals")
+  NR_INTERNAL_WRAPREC("rediscluster::incr", rediscluster_incr, redis_function, 0, "incr")
+  NR_INTERNAL_WRAPREC("rediscluster::incrby", rediscluster_incrby, redis_function, 0,
+                      "incrby")
+  NR_INTERNAL_WRAPREC("rediscluster::incrbyfloat", rediscluster_incrbyfloat, redis_function,
+                      0, "incrbyfloat")
+  NR_INTERNAL_WRAPREC("rediscluster::keys", rediscluster_keys, redis_function, 0, "keys")
+  NR_INTERNAL_WRAPREC("rediscluster::lget", rediscluster_lget, redis_function, 0, "lget")
+  NR_INTERNAL_WRAPREC("rediscluster::lindex", rediscluster_lindex, redis_function, 0,
+                      "lindex")
+  NR_INTERNAL_WRAPREC("rediscluster::linsert", rediscluster_linsert, redis_function, 0,
+                      "linsert")
+  NR_INTERNAL_WRAPREC("rediscluster::llen", rediscluster_llen, redis_function, 0, "llen")
+  NR_INTERNAL_WRAPREC("rediscluster::lpop", rediscluster_lpop, redis_function, 0, "lpop")
+  NR_INTERNAL_WRAPREC("rediscluster::lpush", rediscluster_lpush, redis_function, 0, "lpush")
+  NR_INTERNAL_WRAPREC("rediscluster::lpushx", rediscluster_lpushx, redis_function, 0,
+                      "lpushx")
+  NR_INTERNAL_WRAPREC("rediscluster::lrange", rediscluster_lrange, redis_function, 0,
+                      "lrange")
+  NR_INTERNAL_WRAPREC("rediscluster::lrem", rediscluster_lrem, redis_function, 0, "lrem")
+  NR_INTERNAL_WRAPREC("rediscluster::lset", rediscluster_lset, redis_function, 0, "lset")
+  NR_INTERNAL_WRAPREC("rediscluster::ltrim", rediscluster_ltrim, redis_function, 0, "ltrim")
+  NR_INTERNAL_WRAPREC("rediscluster::mget", rediscluster_mget, redis_function, 0, "mget")
+  NR_INTERNAL_WRAPREC("rediscluster::mset", rediscluster_mset, redis_function, 0, "mset")
+  NR_INTERNAL_WRAPREC("rediscluster::msetnx", rediscluster_msetnx, redis_function, 0,
+                      "msetnx")
+  NR_INTERNAL_WRAPREC("rediscluster::persist", rediscluster_persist, redis_function, 0,
+                      "persist")
+  NR_INTERNAL_WRAPREC("rediscluster::pexpire", rediscluster_pexpire, redis_function, 0,
+                      "pexpire")
+  NR_INTERNAL_WRAPREC("rediscluster::pexpireat", rediscluster_pexpireat, redis_function, 0,
+                      "pexpireat")
+  NR_INTERNAL_WRAPREC("rediscluster::pfadd", rediscluster_pfadd, redis_function, 0, "pfadd")
+  NR_INTERNAL_WRAPREC("rediscluster::pfcount", rediscluster_pfcount, redis_function, 0,
+                      "pfcount")
+  NR_INTERNAL_WRAPREC("rediscluster::pfmerge", rediscluster_pfmerge, redis_function, 0,
+                      "pfmerge")
+  NR_INTERNAL_WRAPREC("rediscluster::ping", rediscluster_ping, redis_function, 0, "ping")
+  NR_INTERNAL_WRAPREC("rediscluster::psetex", rediscluster_psetex, redis_function, 0,
+                      "psetex")
+  NR_INTERNAL_WRAPREC("rediscluster::pttl", rediscluster_pttl, redis_function, 0, "pttl")
+  NR_INTERNAL_WRAPREC("rediscluster::publish", rediscluster_publish, redis_function, 0,
+                      "publish")
+  NR_INTERNAL_WRAPREC("rediscluster::randomkey", rediscluster_randomkey, redis_function, 0,
+                      "randomkey")
+  NR_INTERNAL_WRAPREC("rediscluster::rawcommand", rediscluster_rawcommand, redis_function, 0,
+                      "rawcommand")
+  NR_INTERNAL_WRAPREC("rediscluster::rename", rediscluster_rename, redis_function, 0,
+                      "rename")
+  NR_INTERNAL_WRAPREC("rediscluster::renamenx", rediscluster_renamenx, redis_function, 0,
+                      "renamenx")
+  NR_INTERNAL_WRAPREC("rediscluster::rpop", rediscluster_rpop, redis_function, 0, "rpop")
+  NR_INTERNAL_WRAPREC("rediscluster::rpoplpush", rediscluster_rpoplpush, redis_function, 0,
+                      "rpoplpush")
+  NR_INTERNAL_WRAPREC("rediscluster::rpush", rediscluster_rpush, redis_function, 0, "rpush")
+  NR_INTERNAL_WRAPREC("rediscluster::rpushx", rediscluster_rpushx, redis_function, 0,
+                      "rpushx")
+  NR_INTERNAL_WRAPREC("rediscluster::sadd", rediscluster_sadd, redis_function, 0, "sadd")
+  NR_INTERNAL_WRAPREC("rediscluster::scard", rediscluster_scard, redis_function, 0, "scard")
+  NR_INTERNAL_WRAPREC("rediscluster::sdiff", rediscluster_sdiff, redis_function, 0, "sdiff")
+  NR_INTERNAL_WRAPREC("rediscluster::sdiffstore", rediscluster_sdiffstore, redis_function, 0,
+                      "sdiffstore")
+  NR_INTERNAL_WRAPREC("rediscluster::set", rediscluster_set, redis_function, 0, "set")
+  NR_INTERNAL_WRAPREC("rediscluster::setbit", rediscluster_setbit, redis_function, 0,
+                      "setbit")
+  NR_INTERNAL_WRAPREC("rediscluster::setex", rediscluster_setex, redis_function, 0, "setex")
+  NR_INTERNAL_WRAPREC("rediscluster::setnx", rediscluster_setnx, redis_function, 0, "setnx")
+  NR_INTERNAL_WRAPREC("rediscluster::setrange", rediscluster_setrange, redis_function, 0,
+                      "setrange")
+  NR_INTERNAL_WRAPREC("rediscluster::sinter", rediscluster_sinter, redis_function, 0,
+                      "sinter")
+  NR_INTERNAL_WRAPREC("rediscluster::sinterstore", rediscluster_sinterstore, redis_function,
+                      0, "sinterstore")
+  NR_INTERNAL_WRAPREC("rediscluster::sismember", rediscluster_sismember, redis_function, 0,
+                      "sismember")
+  NR_INTERNAL_WRAPREC("rediscluster::smembers", rediscluster_smembers, redis_function, 0,
+                      "smembers")
+  NR_INTERNAL_WRAPREC("rediscluster::smismember", rediscluster_smismember, redis_function, 0,
+                      "smismember")
+  NR_INTERNAL_WRAPREC("rediscluster::smove", rediscluster_smove, redis_function, 0, "smove")
+  NR_INTERNAL_WRAPREC("rediscluster::spop", rediscluster_spop, redis_function, 0, "spop")
+  NR_INTERNAL_WRAPREC("rediscluster::srandmember", rediscluster_srandmember, redis_function,
+                      0, "srandmember")
+  NR_INTERNAL_WRAPREC("rediscluster::srem", rediscluster_srem, redis_function, 0, "srem")
+  NR_INTERNAL_WRAPREC("rediscluster::strlen", rediscluster_strlen, redis_function, 0,
+                      "strlen")
+  NR_INTERNAL_WRAPREC("rediscluster::sunion", rediscluster_sunion, redis_function, 0,
+                      "sunion")
+  NR_INTERNAL_WRAPREC("rediscluster::sunionstore", rediscluster_sunionstore, redis_function,
+                      0, "sunionstore")
+  NR_INTERNAL_WRAPREC("rediscluster::time", rediscluster_time, redis_function, 0, "time")
+  NR_INTERNAL_WRAPREC("rediscluster::ttl", rediscluster_ttl, redis_function, 0, "ttl")
+  NR_INTERNAL_WRAPREC("rediscluster::type", rediscluster_type, redis_function, 0, "type")
+  NR_INTERNAL_WRAPREC("rediscluster::unlink", rediscluster_unlink, redis_function, 0,
+                      "unlink")
+  NR_INTERNAL_WRAPREC("rediscluster::xack", rediscluster_xack, redis_function, 0, "xack")
+  NR_INTERNAL_WRAPREC("rediscluster::xadd", rediscluster_xadd, redis_function, 0, "xadd")
+  NR_INTERNAL_WRAPREC("rediscluster::xclaim", rediscluster_xclaim, redis_function, 0,
+                      "xclaim")
+  NR_INTERNAL_WRAPREC("rediscluster::xdel", rediscluster_xdel, redis_function, 0, "xdel")
+  NR_INTERNAL_WRAPREC("rediscluster::xgroup", rediscluster_xgroup, redis_function, 0, 
+                      "xgroup")
+  NR_INTERNAL_WRAPREC("rediscluster::xinfo", rediscluster_xinfo, redis_function, 0, "xinfo")
+  NR_INTERNAL_WRAPREC("rediscluster::xlen", rediscluster_xlen, redis_function, 0, "xlen")
+  NR_INTERNAL_WRAPREC("rediscluster::xpending", rediscluster_xpending, redis_function, 0,
+                      "xpending")
+  NR_INTERNAL_WRAPREC("rediscluster::xrange", rediscluster_xrange, redis_function, 0,
+                      "xrange")
+  NR_INTERNAL_WRAPREC("rediscluster::xread", rediscluster_xread, redis_function, 0, "xread")
+  NR_INTERNAL_WRAPREC("rediscluster::xreadgroup", rediscluster_xreadgroup, redis_function, 0,
+                      "xreadgroup")
+  NR_INTERNAL_WRAPREC("rediscluster::xrevrange", rediscluster_xrevrange, redis_function, 0,
+                      "xrevrange")
+  NR_INTERNAL_WRAPREC("rediscluster::xtrim", rediscluster_xtrim, redis_function, 0, "xtrim")
+  NR_INTERNAL_WRAPREC("rediscluster::zadd", rediscluster_zadd, redis_function, 0, "zadd")
+  NR_INTERNAL_WRAPREC("rediscluster::zcard", rediscluster_zcard, redis_function, 0, "zcard")
+  NR_INTERNAL_WRAPREC("rediscluster::zcount", rediscluster_zcount, redis_function, 0,
+                      "zcount")
+  NR_INTERNAL_WRAPREC("rediscluster::zincrby", rediscluster_zincrby, redis_function, 0,
+                      "zincrby")
+  NR_INTERNAL_WRAPREC("rediscluster::zinterstore", rediscluster_zinterstore, redis_function,
+                      0, "zinterstore")
+  NR_INTERNAL_WRAPREC("rediscluster::zlexcount", rediscluster_zlexcount, redis_function, 0,
+                      "zlexcount")
+  NR_INTERNAL_WRAPREC("rediscluster::zpopmax", rediscluster_zpopmax, redis_function, 0,
+                      "zpopmax")
+  NR_INTERNAL_WRAPREC("rediscluster::zpopmin", rediscluster_zpopmin, redis_function, 0,
+                      "zpopmin")
+  NR_INTERNAL_WRAPREC("rediscluster::zrange", rediscluster_zrange, redis_function, 0,
+                      "zrange")
+  NR_INTERNAL_WRAPREC("rediscluster::zrangebylex", rediscluster_zrangebylex, redis_function,
+                      0, "zrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::zrangebyscore", rediscluster_zrangebyscore,
+                      redis_function, 0, "zrangebyscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrank", rediscluster_zrank, redis_function, 0, "zrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zrem", rediscluster_zrem, redis_function, 0, "zrem")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebylex", rediscluster_zremrangebylex,
+                      redis_function, 0, "zremrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebyrank", rediscluster_zremrangebyrank,
+                      redis_function, 0, "zremrangebyrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebyscore", rediscluster_zremrangebyscore,
+                      redis_function, 0, "zremrangebyscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrange", rediscluster_zrevrange, redis_function, 0,
+                      "zrevrange")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrangebylex", rediscluster_zrevrangebylex,
+                      redis_function, 0, "zrevrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrangebyscore", rediscluster_zrevrangebyscore,
+                      redis_function, 0, "zrevrangebyscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrank", rediscluster_zrevrank, redis_function, 0,
+                      "zrevrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zscore", rediscluster_zscore, redis_function, 0, 
+                      "zscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zunionstore", rediscluster_zunionstore, redis_function,
                       0, "zunionstore")
 
   NR_INTERNAL_WRAPREC("pg_close", pg_close, pg_close, 0, 0)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,17 @@ services:
   redisdb:
     image: redis
     restart: always
+  redisclusterdb:
+    image: redis
+    restart: always
+    command: >
+      sh -c '
+        redis-server --port 7000 --cluster-enabled yes --cluster-config-file /tmp/nodes.conf &
+        PID=$$!
+        until redis-cli -p 7000 ping >/dev/null 2>&1; do sleep 0.2; done
+        redis-cli -p 7000 cluster addslotsrange 0 16383
+        wait $$PID
+      '
   memcached:
     image: memcached:latest
     restart: always
@@ -54,6 +65,8 @@ services:
 
       PREDIS_HOME: /usr/src/vendor/predis/predis/
       REDIS_HOST: redisdb
+      REDIS_CLUSTER_HOST: redisclusterdb
+      REDIS_CLUSTER_PORT: 7000
 
     volumes:
        - ${AGENT_CODE:-$PWD}:/usr/local/src/newrelic-php-agent
@@ -84,6 +97,8 @@ services:
 
       PREDIS_HOME: /usr/src/vendor/predis/predis/
       REDIS_HOST: redisdb
+      REDIS_CLUSTER_HOST: redisclusterdb
+      REDIS_CLUSTER_PORT: 7000
 
       PS1: "New Relic > "
       NEWRELIC_COLLECTOR_HOST : ${NEW_RELIC_COLLECTOR_HOST:-collector.newrelic.com}

--- a/tests/include/config.php
+++ b/tests/include/config.php
@@ -30,6 +30,9 @@ $MEMCACHE_PORT = isset_or('MEMCACHE_PORT', '11211');
 $REDIS_HOST = isset_or("REDIS_HOST", "127.0.0.1");
 $REDIS_PORT = isset_or("REDIS_PORT", 6379);
 
+$REDIS_CLUSTER_HOST = isset_or("REDIS_CLUSTER_HOST", "127.0.0.1");
+$REDIS_CLUSTER_PORT = isset_or("REDIS_CLUSTER_PORT", 7000);
+
 $PDO_MYSQL_DSN = 'mysql:';
 $PDO_MYSQL_DSN .= 'host=' . $MYSQL_HOST . ';';
 $PDO_MYSQL_DSN .= 'dbname=' . $MYSQL_DB . ';';

--- a/tests/integration/rediscluster/skipif.inc
+++ b/tests/integration/rediscluster/skipif.inc
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+if (!extension_loaded('redis')) {
+  die("skip: redis extension required\n");
+}
+
+if (!class_exists('RedisCluster')) {
+  die("skip: \\RedisCluster class required (build phpredis with cluster support)\n");
+}
+
+if (!isset($minimum_extension_version)) {
+  $minimum_extension_version = '4.3.0';
+}
+$extension_version = phpversion('redis');
+if (version_compare($extension_version, $minimum_extension_version) < 0) {
+  die("skip: redis extension version >= " . $minimum_extension_version
+    . " required, detected version: " . $extension_version . "\n");
+}
+
+if (!isset($minimum_redis_datastore_version)) {
+  /*
+   * `CLUSTER ADDSLOTSRANGE` (used by the docker-compose redisclusterdb service
+   * to bootstrap a single-node cluster) was introduced in Redis 7.0.
+   */
+  $minimum_redis_datastore_version = '7.0.0';
+}
+
+try {
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    5.0, 5.0);
+  /*
+   * \RedisCluster::info() returns a per-master map keyed by "host:port".
+   * Pull the version from the first master.
+   */
+  $info = $cluster->info($REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT);
+  $datastore_version = $info['redis_version'] ?? null;
+  if (null === $datastore_version) {
+    die("skip: could not determine Redis Cluster server version\n");
+  }
+  if (version_compare($datastore_version, $minimum_redis_datastore_version) < 0) {
+    die("skip: Redis Cluster server version >= " . $minimum_redis_datastore_version
+      . " required, detected version: " . $datastore_version . "\n");
+  }
+} catch (RedisClusterException $e) {
+  die("skip: " . $e->getMessage() . "\n");
+}

--- a/tests/integration/rediscluster/test_basic.php
+++ b/tests/integration/rediscluster/test_basic.php
@@ -1,0 +1,209 @@
+<?php
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster basic operations,
+mirroring the coverage of tests/integration/redis/test_basic.php.
+
+The key correctness assertion is that no Datastore/operation/Redis/connect (or
+pconnect / select) metric is produced: \RedisCluster instances are constructed via
+__construct(seeds[]), which the agent must NOT route through the connect-style
+inner handlers. Each individual data operation is asserted to exist as
+Datastore/operation/Redis/<op>, matching how lib_predis.c already reports Predis
+cluster traffic (NR_DATASTORE_REDIS).
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - set key
+ok - get key
+ok - get first character of key
+ok - GET via rawcommand returns key
+ok - set first character of key
+ok - append to key
+ok - get key
+ok - ask redis for key length
+ok - ask redis for key type
+ok - execute getset command
+ok - verify getset updated key
+ok - delete key
+ok - delete missing key
+ok - mset key
+ok - mget key
+ok - msetnx existing key
+ok - delete key
+ok - msetnx non existing key
+ok - unlink key
+ok - reuse deleted key
+ok - set duplicate key
+ok - rename a key
+ok - verify key was properly renamed
+ok - renamenx to a nonexistent key
+ok - create a second key
+ok - renamenx to an existing key
+ok - verify time command works
+ok - we can EVAL a lua script
+ok - we can EVAL a lua script with an SHA hash
+ok - pfadd reports new elements
+ok - pfadd reports no new elements
+ok - pfcount reports correct cardinality
+ok - we can pfmerge into a destination key
+ok - our merged key has the correct count
+ok - there are no listners to a random channel
+ok - delete keys
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/set
+Datastore/operation/Redis/get
+Datastore/operation/Redis/getrange
+Datastore/operation/Redis/rawcommand
+Datastore/operation/Redis/setrange
+Datastore/operation/Redis/append
+Datastore/operation/Redis/strlen
+Datastore/operation/Redis/type
+Datastore/operation/Redis/getset
+Datastore/operation/Redis/del
+Datastore/operation/Redis/mset
+Datastore/operation/Redis/mget
+Datastore/operation/Redis/msetnx
+Datastore/operation/Redis/setnx
+Datastore/operation/Redis/unlink
+Datastore/operation/Redis/rename
+Datastore/operation/Redis/renamenx
+Datastore/operation/Redis/time
+Datastore/operation/Redis/eval
+Datastore/operation/Redis/evalsha
+Datastore/operation/Redis/publish
+Datastore/operation/Redis/pfadd
+Datastore/operation/Redis/pfcount
+Datastore/operation/Redis/pfmerge
+Datastore/operation/Redis/close
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+
+
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_basic_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  /*
+   * \RedisCluster::__construct(?string $name, ?array $seeds, ...). No connect()
+   * call: every connection is established via the constructor, which the agent
+   * must NOT treat as a connect event (asserted by EXPECT_METRICS_DONT_EXIST).
+   */
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /*
+   * Every key shares the {rc_basic} hashtag so multi-key operations
+   * (mset/mget/msetnx/del/rename/renamenx/pfmerge) all route to the same slot
+   * — required for cluster mode to accept them.
+   */
+  $tag = '{rc_basic}';
+  $suffix = randstr(16);
+  $key1 = $tag . '_a_' . $suffix;
+  $key2 = $tag . '_b_' . $suffix;
+
+  tap_assert($cluster->set($key1, 'car'), 'set key');
+  tap_equal('car', $cluster->get($key1), 'get key');
+  tap_equal('c', $cluster->getrange($key1, 0, 0), 'get first character of key');
+
+  tap_equal('car', $cluster->rawcommand($key1, 'get', $key1), 'GET via rawcommand returns key');
+
+  tap_equal(3, $cluster->setrange($key1, 0, 'b'), 'set first character of key');
+  tap_equal(strlen('barometric'), $cluster->append($key1, 'ometric'), 'append to key');
+  tap_equal('barometric', $cluster->get($key1), 'get key');
+  tap_equal(strlen('barometric'), $cluster->strlen($key1), 'ask redis for key length');
+
+  /* \RedisCluster doesn't expose the REDIS_STRING type constants the way \Redis
+     does; type() returns an int (1 == string per phpredis). */
+  tap_equal(Redis::REDIS_STRING, $cluster->type($key1), 'ask redis for key type');
+
+  tap_equal('barometric', $cluster->getset($key1, 'geometric'), 'execute getset command');
+  tap_equal('geometric', $cluster->get($key1), 'verify getset updated key');
+
+  tap_equal(1, $cluster->del($key1), 'delete key');
+  tap_equal(0, $cluster->del($key1), 'delete missing key');
+
+  tap_assert($cluster->mset([$key1 => 'bar']), 'mset key');
+  tap_equal(['bar'], $cluster->mget([$key1]), 'mget key');
+
+  /* \RedisCluster::msetnx returns an array of per-master results, not a bool.
+     With single-slot {tag} keys all values go to one master → 1-element array. */
+  tap_equal([0], $cluster->msetnx([$key1 => 'newbar']), 'msetnx existing key');
+  tap_equal(1, $cluster->del($key1), 'delete key');
+  tap_equal([1], $cluster->msetnx([$key1 => 'newbar']), 'msetnx non existing key');
+  tap_equal(1, $cluster->unlink($key1), 'unlink key');
+
+  tap_assert($cluster->setnx($key1, 'bar'), 'reuse deleted key');
+  tap_refute($cluster->setnx($key1, 'bar'), 'set duplicate key');
+
+  tap_assert($cluster->rename($key1, $key2), 'rename a key');
+  tap_equal('bar', $cluster->get($key2), 'verify key was properly renamed');
+  tap_assert($cluster->renamenx($key2, $key1), 'renamenx to a nonexistent key');
+  tap_assert($cluster->set($key2, 'baz'), 'create a second key');
+  tap_refute($cluster->renamenx($key1, $key2), 'renamenx to an existing key');
+
+  /* time() is per-shard in cluster mode; route via the tag key. */
+  $res = $cluster->time($key1);
+  tap_assert(is_array($res) && count($res) == 2 && is_numeric($res[0]) && is_numeric($res[1]),
+             'verify time command works');
+
+  $lua = 'return 42';
+  tap_equal(42, $cluster->eval($lua, [$key1], 1), 'we can EVAL a lua script');
+  tap_equal(42, $cluster->evalsha(sha1($lua), [$key1], 1),
+            'we can EVAL a lua script with an SHA hash');
+
+  /* HyperLogLog operations — pfmerge requires same-slot keys; tag covers it.
+     \RedisCluster::pfadd returns bool (not int) — the underlying RESP integer
+     is converted by phpredis at the cluster client layer. */
+  tap_equal(2, $cluster->del([$key1, $key2]), 'delete keys');
+  tap_assert($cluster->pfadd($key1, ['one', 'two', 'three']), 'pfadd reports new elements');
+  tap_refute($cluster->pfadd($key1, ['three']), 'pfadd reports no new elements');
+  tap_equal(3, $cluster->pfcount($key1), 'pfcount reports correct cardinality');
+  tap_assert($cluster->pfmerge($key2, [$key1]), 'we can pfmerge into a destination key');
+  tap_equal(3, $cluster->pfcount($key2), 'our merged key has the correct count');
+
+  /* Same publish-with-no-subscriber pattern as the \Redis baseline. The channel
+     name routes the command in cluster mode, so use a tag-bound name. */
+  tap_equal(0, $cluster->publish($tag . '_chan_' . $suffix, 'message'),
+            'there are no listners to a random channel');
+
+  /* cleanup */
+  tap_equal(2, $cluster->del([$key1, $key2]), 'delete keys');
+
+  /* close connection — exercised so its metric appears in EXPECT_METRICS_EXIST. */
+  $cluster->close();
+}
+
+test_basic_cluster();


### PR DESCRIPTION
The agent already auto-instruments 149 `\Redis::*` methods (`php_internal_instrument.c`). The phpredis `\RedisCluster` class exposes the same operation surface with the same semantics but does not extend `\Redis`, so the existing hooks don't fire on cluster-mode instances. Applications using ElastiCache/Valkey/Redis cluster get effectively zero datastore visibility from this agent — only `redis::connect/select/eval` are auto-recorded (because they're called via the `\Redis` fallback path), all other methods (`get`/`set`/`mget`/`hgetall`/...) are missed.

This change adds 139 parallel `\RedisCluster::*` hooks routing to the existing class-agnostic INNER handlers (`redis_function`, `redis_close`). The handlers use `NR_PHP_INTERNAL_FN_THIS()` and don't depend on the concrete class. `NR_DATASTORE_REDIS` is reused so cluster traffic shows up under the standard `Datastore/Redis/*` metric namespace — matching how `lib_predis.c` already reports cluster-mode Predis traffic.

Excluded methods (10 total, none of which exist on `\RedisCluster`):

- **Connection management** — `connect`/`pconnect`/`open`/`popen`/`select`. `RedisCluster` is constructed via `__construct(seeds[])`, not `connect`, and cluster mode supports only db 0.
- **`\Redis`-only or single-node-only methods** — `move`/`swapdb` (cluster has only db 0), `migrate` (single-node only), `lremove`/`delete` (`\Redis`-only aliases for `lrem`/`del`).

No `__construct` hook is added in this PR, so per-instance datastore metadata (host, port) is never populated — segments record with `peer.address = unknown:unknown`. Timing/throughput aggregates still work; only the per-instance breakdown is missing.

## Validation

End-to-end smoke-tested on a Symfony 7.1 / PHP 8.3 sandbox:

- **Backend**: official `redis:7-alpine`, single-node, cluster-mode enabled with all 16384 slots assigned to itself via `CLUSTER ADDSLOTSRANGE 0 16383` — the minimum topology `\RedisCluster::__construct` accepts.
- **Workload**: a controller that calls `\RedisCluster::set` / `get` / `mget` / `del` on a fresh per-request key, hit repeatedly with `curl`.
- **Comparison**: same image, same sandbox, only `/usr/lib/php/20230831/newrelic.so` swapped between the stock NR agent (12.6.0.34) and a build of this branch. Two distinct `appName`s used to keep the data sets separable in NR.

After the swap, NR receives metrics that didn't exist before — `Datastore/Redis/all`, `Datastore/Redis/allWeb`, and per-operation `Datastore/operation/Redis/<op>` (e.g. `get`, `set`, `mget`, `del`) — and `category=datastore` Span events with `component=Redis`:

| `name` | `category` | `component` |
|---|---|---|
| `Datastore/operation/Redis/get` | `datastore` | `Redis` |
| `Datastore/operation/Redis/set` | `datastore` | `Redis` |
| `Datastore/operation/Redis/mget` | `datastore` | `Redis` |
| `Datastore/operation/Redis/del` | `datastore` | `Redis` |

Refs: #130