### PR TITLE
fix(axiom): all force_current_segment references should only apply to PHPs < 8.0

### DIFF
--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3218,12 +3218,11 @@ nr_segment_t* nr_txn_get_current_segment(nrtxn_t* txn,
         nr_hashmap_index_get(txn->parent_stacks, (uint64_t)async_context_idx));
   }
 
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
-  /* This is ONLY ever set with non-OAPI and PHPs less than 8. */
+  /* This is ONLY ever set with non-OAPI and PHPs less than 8. Do not assume or
+   * use force_current_segment with PHPs >= 8.0 */
   if (txn->force_current_segment) {
     return txn->force_current_segment;
   }
-#endif
 
   return nr_stack_get_top(&txn->default_parent_stack);
 }

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -1599,8 +1599,7 @@ void nr_txn_record_error(nrtxn_t* txn,
   /* Only try to get a span_id in cases where we know spans should be created.
    */
   if (nr_txn_should_create_span_events(txn)) {
-    span_id = nr_txn_get_current_span_id(
-        txn, nr_string_get(txn->trace_strings, txn->current_async_context));
+    span_id = nr_txn_get_current_span_id(txn, nr_txn_get_current_context(txn));
 
     /*
      * The specification says span_id MUST be included so if span events are
@@ -1614,7 +1613,8 @@ void nr_txn_record_error(nrtxn_t* txn,
     }
 
     if (add_to_current_segment) {
-      current_segment = nr_txn_get_current_segment(txn, NULL);
+      current_segment
+          = nr_txn_get_current_segment(txn, nr_txn_get_current_context(txn));
 
       if (current_segment) {
         nr_segment_set_error(current_segment, errmsg, errclass);
@@ -1756,7 +1756,7 @@ nr_status_t nr_txn_add_user_custom_parameter(nrtxn_t* txn,
   }
 
   if (nr_txn_should_create_span_events(txn)) {
-    current = nr_txn_get_current_segment(txn, NULL);
+    current = nr_txn_get_current_segment(txn, nr_txn_get_current_context(txn));
 
     nr_segment_attributes_user_txn_event_add(
         current, NR_ATTRIBUTE_DESTINATION_SPAN, key, value);
@@ -3218,9 +3218,12 @@ nr_segment_t* nr_txn_get_current_segment(nrtxn_t* txn,
         nr_hashmap_index_get(txn->parent_stacks, (uint64_t)async_context_idx));
   }
 
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
+  /* This is ONLY ever set with non-OAPI and PHPs less than 8. */
   if (txn->force_current_segment) {
     return txn->force_current_segment;
   }
+#endif
 
   return nr_stack_get_top(&txn->default_parent_stack);
 }

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -273,9 +273,12 @@ typedef struct _nrtxn_t {
   nr_hashmap_t* parent_stacks;     /* A hashmap of stacks to track the current
                                       parent in a tree of segments, keyed by async
                                       context */
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
   nr_segment_t* force_current_segment; /* Enforce a current segment for the
                                           default context, overriding the
-                                          default parent stack. */
+                                          default parent stack. Only used with
+                                          PHP < 8.0 */
+#endif
   size_t segment_count; /* A count of segments for this transaction, maintained
                            throughout the life of this transaction */
   nr_minmax_heap_t*
@@ -1088,6 +1091,7 @@ extern const char* nr_txn_get_current_context(nrtxn_t* txn);
 extern nr_segment_t* nr_txn_get_current_segment(nrtxn_t* txn,
                                                 const char* async_context);
 
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
 /*
  * Purpose : Force the given segment to be the current segment.
  *
@@ -1101,6 +1105,7 @@ extern nr_segment_t* nr_txn_get_current_segment(nrtxn_t* txn,
  *
  *           This function is useful to temporarily inject segments that don't
  *           use the default allocator.
+ * Note    : This is ONLY ever set with non-OAPI and PHPs less than 8.0.
  */
 inline static void nr_txn_force_current_segment(nrtxn_t* txn,
                                                 nr_segment_t* segment) {
@@ -1108,7 +1113,7 @@ inline static void nr_txn_force_current_segment(nrtxn_t* txn,
     txn->force_current_segment = segment;
   }
 }
-
+#endif
 /*
  * Purpose : Set the current segment for the transaction.
  *

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -273,12 +273,11 @@ typedef struct _nrtxn_t {
   nr_hashmap_t* parent_stacks;     /* A hashmap of stacks to track the current
                                       parent in a tree of segments, keyed by async
                                       context */
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
   nr_segment_t* force_current_segment; /* Enforce a current segment for the
                                           default context, overriding the
                                           default parent stack. Only used with
-                                          PHP < 8.0 */
-#endif
+                                          PHP < 8.0. Do no tuse with OAPI; it is
+                                          not setup to utilize this.*/
   size_t segment_count; /* A count of segments for this transaction, maintained
                            throughout the life of this transaction */
   nr_minmax_heap_t*

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -1090,7 +1090,6 @@ extern const char* nr_txn_get_current_context(nrtxn_t* txn);
 extern nr_segment_t* nr_txn_get_current_segment(nrtxn_t* txn,
                                                 const char* async_context);
 
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
 /*
  * Purpose : Force the given segment to be the current segment.
  *
@@ -1104,7 +1103,8 @@ extern nr_segment_t* nr_txn_get_current_segment(nrtxn_t* txn,
  *
  *           This function is useful to temporarily inject segments that don't
  *           use the default allocator.
- * Note    : This is ONLY ever set with non-OAPI and PHPs less than 8.0.
+ * Note    : This is ONLY ever set with non-OAPI and PHPs less than 8.0. Do not
+ * use with OAPI; it is not setup to utilize this.
  */
 inline static void nr_txn_force_current_segment(nrtxn_t* txn,
                                                 nr_segment_t* segment) {
@@ -1112,7 +1112,7 @@ inline static void nr_txn_force_current_segment(nrtxn_t* txn,
     txn->force_current_segment = segment;
   }
 }
-#endif
+
 /*
  * Purpose : Set the current segment for the transaction.
  *

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -7637,6 +7637,7 @@ static void test_parent_stacks(void) {
    * nr_txn_retire_current_segment(). */
 }
 
+#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
 static void test_force_current_segment(void) {
   nrapp_t app = {.state = NR_APP_OK};
   nrtxnopt_t opts = {0};
@@ -7709,6 +7710,7 @@ static void test_force_current_segment(void) {
   nr_segment_children_deinit(&segment_stacked.children);
   nr_txn_destroy(&txn);
 }
+#endif
 
 static void test_txn_is_sampled(void) {
   nrtxn_t txn;
@@ -9140,7 +9142,9 @@ void test_main(void* p NRUNUSED) {
   test_root_segment_priority();
   test_should_create_span_events();
   test_parent_stacks();
+  #if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO 
   test_force_current_segment();
+  #endif
   test_txn_is_sampled();
   test_get_current_trace_id();
   test_get_current_span_id();

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -7637,7 +7637,6 @@ static void test_parent_stacks(void) {
    * nr_txn_retire_current_segment(). */
 }
 
-#if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO
 static void test_force_current_segment(void) {
   nrapp_t app = {.state = NR_APP_OK};
   nrtxnopt_t opts = {0};
@@ -7710,7 +7709,6 @@ static void test_force_current_segment(void) {
   nr_segment_children_deinit(&segment_stacked.children);
   nr_txn_destroy(&txn);
 }
-#endif
 
 static void test_txn_is_sampled(void) {
   nrtxn_t txn;
@@ -9142,9 +9140,7 @@ void test_main(void* p NRUNUSED) {
   test_root_segment_priority();
   test_should_create_span_events();
   test_parent_stacks();
-  #if ZEND_MODULE_API_NO < ZEND_8_0_X_API_NO 
   test_force_current_segment();
-  #endif
   test_txn_is_sampled();
   test_get_current_trace_id();
   test_get_current_span_id();


### PR DESCRIPTION
Most of references to force_current_segment or nr_txn_force_current segment were placed in if/endif blocks with the OAPI effort.  The change was never explicitly mentioned and there's a chance it could be used in a breaking manner. All remaining references in axiom specify explicitly it is not to be used with oapi.  Axiom doesn't understand ZEND_API numbers so it can't be placed in if/endif blocks.