### PR TITLE
feat(agent): Add Redis Cluster instrumentation

### DIFF
--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -3307,6 +3307,146 @@ NR_OUTER_WRAPPER(redis_zrevrank)
 NR_OUTER_WRAPPER(redis_zscore)
 NR_OUTER_WRAPPER(redis_zunionstore)
 
+NR_OUTER_WRAPPER(rediscluster_append)
+NR_OUTER_WRAPPER(rediscluster_bitcount)
+NR_OUTER_WRAPPER(rediscluster_bitop)
+NR_OUTER_WRAPPER(rediscluster_bitpos)
+NR_OUTER_WRAPPER(rediscluster_close)
+NR_OUTER_WRAPPER(rediscluster_dbsize)
+NR_OUTER_WRAPPER(rediscluster_decr)
+NR_OUTER_WRAPPER(rediscluster_decrby)
+NR_OUTER_WRAPPER(rediscluster_del)
+NR_OUTER_WRAPPER(rediscluster_eval)
+NR_OUTER_WRAPPER(rediscluster_evalsha)
+NR_OUTER_WRAPPER(rediscluster_exec)
+NR_OUTER_WRAPPER(rediscluster_exists)
+NR_OUTER_WRAPPER(rediscluster_expire)
+NR_OUTER_WRAPPER(rediscluster_expireat)
+NR_OUTER_WRAPPER(rediscluster_flushall)
+NR_OUTER_WRAPPER(rediscluster_flushdb)
+NR_OUTER_WRAPPER(rediscluster_geoadd)
+NR_OUTER_WRAPPER(rediscluster_geodist)
+NR_OUTER_WRAPPER(rediscluster_geohash)
+NR_OUTER_WRAPPER(rediscluster_geopos)
+NR_OUTER_WRAPPER(rediscluster_georadius)
+NR_OUTER_WRAPPER(rediscluster_georadius_ro)
+NR_OUTER_WRAPPER(rediscluster_georadiusbymember)
+NR_OUTER_WRAPPER(rediscluster_georadiusbymember_ro)
+NR_OUTER_WRAPPER(rediscluster_get)
+NR_OUTER_WRAPPER(rediscluster_getbit)
+NR_OUTER_WRAPPER(rediscluster_getrange)
+NR_OUTER_WRAPPER(rediscluster_getset)
+NR_OUTER_WRAPPER(rediscluster_hdel)
+NR_OUTER_WRAPPER(rediscluster_hexists)
+NR_OUTER_WRAPPER(rediscluster_hget)
+NR_OUTER_WRAPPER(rediscluster_hgetall)
+NR_OUTER_WRAPPER(rediscluster_hincrby)
+NR_OUTER_WRAPPER(rediscluster_hincrbyfloat)
+NR_OUTER_WRAPPER(rediscluster_hkeys)
+NR_OUTER_WRAPPER(rediscluster_hlen)
+NR_OUTER_WRAPPER(rediscluster_hmget)
+NR_OUTER_WRAPPER(rediscluster_hmset)
+NR_OUTER_WRAPPER(rediscluster_hset)
+NR_OUTER_WRAPPER(rediscluster_hsetnx)
+NR_OUTER_WRAPPER(rediscluster_hstrlen)
+NR_OUTER_WRAPPER(rediscluster_hvals)
+NR_OUTER_WRAPPER(rediscluster_incr)
+NR_OUTER_WRAPPER(rediscluster_incrby)
+NR_OUTER_WRAPPER(rediscluster_incrbyfloat)
+NR_OUTER_WRAPPER(rediscluster_keys)
+NR_OUTER_WRAPPER(rediscluster_lget)
+NR_OUTER_WRAPPER(rediscluster_lindex)
+NR_OUTER_WRAPPER(rediscluster_linsert)
+NR_OUTER_WRAPPER(rediscluster_llen)
+NR_OUTER_WRAPPER(rediscluster_lpop)
+NR_OUTER_WRAPPER(rediscluster_lpush)
+NR_OUTER_WRAPPER(rediscluster_lpushx)
+NR_OUTER_WRAPPER(rediscluster_lrange)
+NR_OUTER_WRAPPER(rediscluster_lrem)
+NR_OUTER_WRAPPER(rediscluster_lset)
+NR_OUTER_WRAPPER(rediscluster_ltrim)
+NR_OUTER_WRAPPER(rediscluster_mget)
+NR_OUTER_WRAPPER(rediscluster_mset)
+NR_OUTER_WRAPPER(rediscluster_msetnx)
+NR_OUTER_WRAPPER(rediscluster_persist)
+NR_OUTER_WRAPPER(rediscluster_pexpire)
+NR_OUTER_WRAPPER(rediscluster_pexpireat)
+NR_OUTER_WRAPPER(rediscluster_pfadd)
+NR_OUTER_WRAPPER(rediscluster_pfcount)
+NR_OUTER_WRAPPER(rediscluster_pfmerge)
+NR_OUTER_WRAPPER(rediscluster_ping)
+NR_OUTER_WRAPPER(rediscluster_psetex)
+NR_OUTER_WRAPPER(rediscluster_pttl)
+NR_OUTER_WRAPPER(rediscluster_publish)
+NR_OUTER_WRAPPER(rediscluster_randomkey)
+NR_OUTER_WRAPPER(rediscluster_rawcommand)
+NR_OUTER_WRAPPER(rediscluster_rename)
+NR_OUTER_WRAPPER(rediscluster_renamenx)
+NR_OUTER_WRAPPER(rediscluster_rpop)
+NR_OUTER_WRAPPER(rediscluster_rpoplpush)
+NR_OUTER_WRAPPER(rediscluster_rpush)
+NR_OUTER_WRAPPER(rediscluster_rpushx)
+NR_OUTER_WRAPPER(rediscluster_sadd)
+NR_OUTER_WRAPPER(rediscluster_scard)
+NR_OUTER_WRAPPER(rediscluster_sdiff)
+NR_OUTER_WRAPPER(rediscluster_sdiffstore)
+NR_OUTER_WRAPPER(rediscluster_set)
+NR_OUTER_WRAPPER(rediscluster_setbit)
+NR_OUTER_WRAPPER(rediscluster_setex)
+NR_OUTER_WRAPPER(rediscluster_setnx)
+NR_OUTER_WRAPPER(rediscluster_setrange)
+NR_OUTER_WRAPPER(rediscluster_sinter)
+NR_OUTER_WRAPPER(rediscluster_sinterstore)
+NR_OUTER_WRAPPER(rediscluster_sismember)
+NR_OUTER_WRAPPER(rediscluster_smembers)
+NR_OUTER_WRAPPER(rediscluster_smismember)
+NR_OUTER_WRAPPER(rediscluster_smove)
+NR_OUTER_WRAPPER(rediscluster_spop)
+NR_OUTER_WRAPPER(rediscluster_srandmember)
+NR_OUTER_WRAPPER(rediscluster_srem)
+NR_OUTER_WRAPPER(rediscluster_strlen)
+NR_OUTER_WRAPPER(rediscluster_sunion)
+NR_OUTER_WRAPPER(rediscluster_sunionstore)
+NR_OUTER_WRAPPER(rediscluster_time)
+NR_OUTER_WRAPPER(rediscluster_ttl)
+NR_OUTER_WRAPPER(rediscluster_type)
+NR_OUTER_WRAPPER(rediscluster_unlink)
+NR_OUTER_WRAPPER(rediscluster_xack)
+NR_OUTER_WRAPPER(rediscluster_xadd)
+NR_OUTER_WRAPPER(rediscluster_xclaim)
+NR_OUTER_WRAPPER(rediscluster_xdel)
+NR_OUTER_WRAPPER(rediscluster_xgroup)
+NR_OUTER_WRAPPER(rediscluster_xinfo)
+NR_OUTER_WRAPPER(rediscluster_xlen)
+NR_OUTER_WRAPPER(rediscluster_xpending)
+NR_OUTER_WRAPPER(rediscluster_xrange)
+NR_OUTER_WRAPPER(rediscluster_xread)
+NR_OUTER_WRAPPER(rediscluster_xreadgroup)
+NR_OUTER_WRAPPER(rediscluster_xrevrange)
+NR_OUTER_WRAPPER(rediscluster_xtrim)
+NR_OUTER_WRAPPER(rediscluster_zadd)
+NR_OUTER_WRAPPER(rediscluster_zcard)
+NR_OUTER_WRAPPER(rediscluster_zcount)
+NR_OUTER_WRAPPER(rediscluster_zincrby)
+NR_OUTER_WRAPPER(rediscluster_zinterstore)
+NR_OUTER_WRAPPER(rediscluster_zlexcount)
+NR_OUTER_WRAPPER(rediscluster_zpopmax)
+NR_OUTER_WRAPPER(rediscluster_zpopmin)
+NR_OUTER_WRAPPER(rediscluster_zrange)
+NR_OUTER_WRAPPER(rediscluster_zrangebylex)
+NR_OUTER_WRAPPER(rediscluster_zrangebyscore)
+NR_OUTER_WRAPPER(rediscluster_zrank)
+NR_OUTER_WRAPPER(rediscluster_zrem)
+NR_OUTER_WRAPPER(rediscluster_zremrangebylex)
+NR_OUTER_WRAPPER(rediscluster_zremrangebyrank)
+NR_OUTER_WRAPPER(rediscluster_zremrangebyscore)
+NR_OUTER_WRAPPER(rediscluster_zrevrange)
+NR_OUTER_WRAPPER(rediscluster_zrevrangebylex)
+NR_OUTER_WRAPPER(rediscluster_zrevrangebyscore)
+NR_OUTER_WRAPPER(rediscluster_zrevrank)
+NR_OUTER_WRAPPER(rediscluster_zscore)
+NR_OUTER_WRAPPER(rediscluster_zunionstore)
+
 NR_OUTER_WRAPPER(pg_close)
 NR_OUTER_WRAPPER(pg_connect)
 NR_OUTER_WRAPPER(pg_pconnect)
@@ -3809,6 +3949,231 @@ void nr_php_generate_internal_wrap_records(void) {
   NR_INTERNAL_WRAPREC("redis::zscore", redis_zscore, redis_function, 0,
                       "zscore")
   NR_INTERNAL_WRAPREC("redis::zunionstore", redis_zunionstore, redis_function,
+                      0, "zunionstore")
+
+  NR_INTERNAL_WRAPREC("rediscluster::close", rediscluster_close, redis_close, 0, "close")
+  NR_INTERNAL_WRAPREC("rediscluster::append", rediscluster_append, redis_function, 0,
+                      "append")
+  NR_INTERNAL_WRAPREC("rediscluster::bitcount", rediscluster_bitcount, redis_function, 0,
+                      "bitcount")
+  NR_INTERNAL_WRAPREC("rediscluster::bitop", rediscluster_bitop, redis_function, 0, "bitop")
+  NR_INTERNAL_WRAPREC("rediscluster::bitpos", rediscluster_bitpos, redis_function, 0,
+                      "bitpos")
+  NR_INTERNAL_WRAPREC("rediscluster::decr", rediscluster_decr, redis_function, 0, "decr")
+  NR_INTERNAL_WRAPREC("rediscluster::decrby", rediscluster_decrby, redis_function, 0,
+                      "decrby")
+  NR_INTERNAL_WRAPREC("rediscluster::del", rediscluster_del, redis_function, 0, "del")
+  NR_INTERNAL_WRAPREC("rediscluster::dbsize", rediscluster_dbsize, redis_function, 0,
+                      "dbsize")
+  NR_INTERNAL_WRAPREC("rediscluster::eval", rediscluster_eval, redis_function, 0, "eval")
+  NR_INTERNAL_WRAPREC("rediscluster::evalsha", rediscluster_evalsha, redis_function, 0,
+                      "evalsha")
+  NR_INTERNAL_WRAPREC("rediscluster::exec", rediscluster_exec, redis_function, 0, "exec")
+  NR_INTERNAL_WRAPREC("rediscluster::exists", rediscluster_exists, redis_function, 0,
+                      "exists")
+  NR_INTERNAL_WRAPREC("rediscluster::expire", rediscluster_expire, redis_function, 0,
+                      "expire")
+  NR_INTERNAL_WRAPREC("rediscluster::expireat", rediscluster_expireat, redis_function, 0,
+                      "expireat")
+  NR_INTERNAL_WRAPREC("rediscluster::flushall", rediscluster_flushall, redis_function, 0,
+                      "flushall")
+  NR_INTERNAL_WRAPREC("rediscluster::flushdb", rediscluster_flushdb, redis_function, 0,
+                      "flushdb")
+  NR_INTERNAL_WRAPREC("rediscluster::geoadd", rediscluster_geoadd, redis_function, 0,
+                      "geoadd")
+  NR_INTERNAL_WRAPREC("rediscluster::geodist", rediscluster_geodist, redis_function, 0,
+                      "geodist")
+  NR_INTERNAL_WRAPREC("rediscluster::geohash", rediscluster_geohash, redis_function, 0,
+                      "geohash")
+  NR_INTERNAL_WRAPREC("rediscluster::geopos", rediscluster_geopos, redis_function, 0,
+                      "geopos")
+  NR_INTERNAL_WRAPREC("rediscluster::georadius", rediscluster_georadius, redis_function, 0,
+                      "georadius")
+  NR_INTERNAL_WRAPREC("rediscluster::georadius_ro", rediscluster_georadius_ro, redis_function,
+                      0, "georadius_ro")
+  NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember", rediscluster_georadiusbymember,
+                      redis_function, 0, "georadiusbymember")
+  NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember_ro", rediscluster_georadiusbymember_ro,
+                      redis_function, 0, "georadiusbymember_ro")
+  NR_INTERNAL_WRAPREC("rediscluster::get", rediscluster_get, redis_function, 0, "get")
+  NR_INTERNAL_WRAPREC("rediscluster::getbit", rediscluster_getbit, redis_function, 0,
+                      "getbit")
+  NR_INTERNAL_WRAPREC("rediscluster::getrange", rediscluster_getrange, redis_function, 0,
+                      "getrange")
+  NR_INTERNAL_WRAPREC("rediscluster::getset", rediscluster_getset, redis_function, 0,
+                      "getset")
+  NR_INTERNAL_WRAPREC("rediscluster::hdel", rediscluster_hdel, redis_function, 0, "hdel")
+  NR_INTERNAL_WRAPREC("rediscluster::hexists", rediscluster_hexists, redis_function, 0,
+                      "hexists")
+  NR_INTERNAL_WRAPREC("rediscluster::hget", rediscluster_hget, redis_function, 0, "hget")
+  NR_INTERNAL_WRAPREC("rediscluster::hgetall", rediscluster_hgetall, redis_function, 0,
+                      "hgetall")
+  NR_INTERNAL_WRAPREC("rediscluster::hincrby", rediscluster_hincrby, redis_function, 0,
+                      "hincrby")
+  NR_INTERNAL_WRAPREC("rediscluster::hincrbyfloat", rediscluster_hincrbyfloat, redis_function,
+                      0, "hincrbyfloat")
+  NR_INTERNAL_WRAPREC("rediscluster::hkeys", rediscluster_hkeys, redis_function, 0, "hkeys")
+  NR_INTERNAL_WRAPREC("rediscluster::hlen", rediscluster_hlen, redis_function, 0, "hlen")
+  NR_INTERNAL_WRAPREC("rediscluster::hmget", rediscluster_hmget, redis_function, 0, "hmget")
+  NR_INTERNAL_WRAPREC("rediscluster::hmset", rediscluster_hmset, redis_function, 0, "hmset")
+  NR_INTERNAL_WRAPREC("rediscluster::hset", rediscluster_hset, redis_function, 0, "hset")
+  NR_INTERNAL_WRAPREC("rediscluster::hsetnx", rediscluster_hsetnx, redis_function, 0,
+                      "hsetnx")
+  NR_INTERNAL_WRAPREC("rediscluster::hstrlen", rediscluster_hstrlen, redis_function, 0,
+                      "hstrlen")
+  NR_INTERNAL_WRAPREC("rediscluster::hvals", rediscluster_hvals, redis_function, 0, "hvals")
+  NR_INTERNAL_WRAPREC("rediscluster::incr", rediscluster_incr, redis_function, 0, "incr")
+  NR_INTERNAL_WRAPREC("rediscluster::incrby", rediscluster_incrby, redis_function, 0,
+                      "incrby")
+  NR_INTERNAL_WRAPREC("rediscluster::incrbyfloat", rediscluster_incrbyfloat, redis_function,
+                      0, "incrbyfloat")
+  NR_INTERNAL_WRAPREC("rediscluster::keys", rediscluster_keys, redis_function, 0, "keys")
+  NR_INTERNAL_WRAPREC("rediscluster::lget", rediscluster_lget, redis_function, 0, "lget")
+  NR_INTERNAL_WRAPREC("rediscluster::lindex", rediscluster_lindex, redis_function, 0,
+                      "lindex")
+  NR_INTERNAL_WRAPREC("rediscluster::linsert", rediscluster_linsert, redis_function, 0,
+                      "linsert")
+  NR_INTERNAL_WRAPREC("rediscluster::llen", rediscluster_llen, redis_function, 0, "llen")
+  NR_INTERNAL_WRAPREC("rediscluster::lpop", rediscluster_lpop, redis_function, 0, "lpop")
+  NR_INTERNAL_WRAPREC("rediscluster::lpush", rediscluster_lpush, redis_function, 0, "lpush")
+  NR_INTERNAL_WRAPREC("rediscluster::lpushx", rediscluster_lpushx, redis_function, 0,
+                      "lpushx")
+  NR_INTERNAL_WRAPREC("rediscluster::lrange", rediscluster_lrange, redis_function, 0,
+                      "lrange")
+  NR_INTERNAL_WRAPREC("rediscluster::lrem", rediscluster_lrem, redis_function, 0, "lrem")
+  NR_INTERNAL_WRAPREC("rediscluster::lset", rediscluster_lset, redis_function, 0, "lset")
+  NR_INTERNAL_WRAPREC("rediscluster::ltrim", rediscluster_ltrim, redis_function, 0, "ltrim")
+  NR_INTERNAL_WRAPREC("rediscluster::mget", rediscluster_mget, redis_function, 0, "mget")
+  NR_INTERNAL_WRAPREC("rediscluster::mset", rediscluster_mset, redis_function, 0, "mset")
+  NR_INTERNAL_WRAPREC("rediscluster::msetnx", rediscluster_msetnx, redis_function, 0,
+                      "msetnx")
+  NR_INTERNAL_WRAPREC("rediscluster::persist", rediscluster_persist, redis_function, 0,
+                      "persist")
+  NR_INTERNAL_WRAPREC("rediscluster::pexpire", rediscluster_pexpire, redis_function, 0,
+                      "pexpire")
+  NR_INTERNAL_WRAPREC("rediscluster::pexpireat", rediscluster_pexpireat, redis_function, 0,
+                      "pexpireat")
+  NR_INTERNAL_WRAPREC("rediscluster::pfadd", rediscluster_pfadd, redis_function, 0, "pfadd")
+  NR_INTERNAL_WRAPREC("rediscluster::pfcount", rediscluster_pfcount, redis_function, 0,
+                      "pfcount")
+  NR_INTERNAL_WRAPREC("rediscluster::pfmerge", rediscluster_pfmerge, redis_function, 0,
+                      "pfmerge")
+  NR_INTERNAL_WRAPREC("rediscluster::ping", rediscluster_ping, redis_function, 0, "ping")
+  NR_INTERNAL_WRAPREC("rediscluster::psetex", rediscluster_psetex, redis_function, 0,
+                      "psetex")
+  NR_INTERNAL_WRAPREC("rediscluster::pttl", rediscluster_pttl, redis_function, 0, "pttl")
+  NR_INTERNAL_WRAPREC("rediscluster::publish", rediscluster_publish, redis_function, 0,
+                      "publish")
+  NR_INTERNAL_WRAPREC("rediscluster::randomkey", rediscluster_randomkey, redis_function, 0,
+                      "randomkey")
+  NR_INTERNAL_WRAPREC("rediscluster::rawcommand", rediscluster_rawcommand, redis_function, 0,
+                      "rawcommand")
+  NR_INTERNAL_WRAPREC("rediscluster::rename", rediscluster_rename, redis_function, 0,
+                      "rename")
+  NR_INTERNAL_WRAPREC("rediscluster::renamenx", rediscluster_renamenx, redis_function, 0,
+                      "renamenx")
+  NR_INTERNAL_WRAPREC("rediscluster::rpop", rediscluster_rpop, redis_function, 0, "rpop")
+  NR_INTERNAL_WRAPREC("rediscluster::rpoplpush", rediscluster_rpoplpush, redis_function, 0,
+                      "rpoplpush")
+  NR_INTERNAL_WRAPREC("rediscluster::rpush", rediscluster_rpush, redis_function, 0, "rpush")
+  NR_INTERNAL_WRAPREC("rediscluster::rpushx", rediscluster_rpushx, redis_function, 0,
+                      "rpushx")
+  NR_INTERNAL_WRAPREC("rediscluster::sadd", rediscluster_sadd, redis_function, 0, "sadd")
+  NR_INTERNAL_WRAPREC("rediscluster::scard", rediscluster_scard, redis_function, 0, "scard")
+  NR_INTERNAL_WRAPREC("rediscluster::sdiff", rediscluster_sdiff, redis_function, 0, "sdiff")
+  NR_INTERNAL_WRAPREC("rediscluster::sdiffstore", rediscluster_sdiffstore, redis_function, 0,
+                      "sdiffstore")
+  NR_INTERNAL_WRAPREC("rediscluster::set", rediscluster_set, redis_function, 0, "set")
+  NR_INTERNAL_WRAPREC("rediscluster::setbit", rediscluster_setbit, redis_function, 0,
+                      "setbit")
+  NR_INTERNAL_WRAPREC("rediscluster::setex", rediscluster_setex, redis_function, 0, "setex")
+  NR_INTERNAL_WRAPREC("rediscluster::setnx", rediscluster_setnx, redis_function, 0, "setnx")
+  NR_INTERNAL_WRAPREC("rediscluster::setrange", rediscluster_setrange, redis_function, 0,
+                      "setrange")
+  NR_INTERNAL_WRAPREC("rediscluster::sinter", rediscluster_sinter, redis_function, 0,
+                      "sinter")
+  NR_INTERNAL_WRAPREC("rediscluster::sinterstore", rediscluster_sinterstore, redis_function,
+                      0, "sinterstore")
+  NR_INTERNAL_WRAPREC("rediscluster::sismember", rediscluster_sismember, redis_function, 0,
+                      "sismember")
+  NR_INTERNAL_WRAPREC("rediscluster::smembers", rediscluster_smembers, redis_function, 0,
+                      "smembers")
+  NR_INTERNAL_WRAPREC("rediscluster::smismember", rediscluster_smismember, redis_function, 0,
+                      "smismember")
+  NR_INTERNAL_WRAPREC("rediscluster::smove", rediscluster_smove, redis_function, 0, "smove")
+  NR_INTERNAL_WRAPREC("rediscluster::spop", rediscluster_spop, redis_function, 0, "spop")
+  NR_INTERNAL_WRAPREC("rediscluster::srandmember", rediscluster_srandmember, redis_function,
+                      0, "srandmember")
+  NR_INTERNAL_WRAPREC("rediscluster::srem", rediscluster_srem, redis_function, 0, "srem")
+  NR_INTERNAL_WRAPREC("rediscluster::strlen", rediscluster_strlen, redis_function, 0,
+                      "strlen")
+  NR_INTERNAL_WRAPREC("rediscluster::sunion", rediscluster_sunion, redis_function, 0,
+                      "sunion")
+  NR_INTERNAL_WRAPREC("rediscluster::sunionstore", rediscluster_sunionstore, redis_function,
+                      0, "sunionstore")
+  NR_INTERNAL_WRAPREC("rediscluster::time", rediscluster_time, redis_function, 0, "time")
+  NR_INTERNAL_WRAPREC("rediscluster::ttl", rediscluster_ttl, redis_function, 0, "ttl")
+  NR_INTERNAL_WRAPREC("rediscluster::type", rediscluster_type, redis_function, 0, "type")
+  NR_INTERNAL_WRAPREC("rediscluster::unlink", rediscluster_unlink, redis_function, 0,
+                      "unlink")
+  NR_INTERNAL_WRAPREC("rediscluster::xack", rediscluster_xack, redis_function, 0, "xack")
+  NR_INTERNAL_WRAPREC("rediscluster::xadd", rediscluster_xadd, redis_function, 0, "xadd")
+  NR_INTERNAL_WRAPREC("rediscluster::xclaim", rediscluster_xclaim, redis_function, 0,
+                      "xclaim")
+  NR_INTERNAL_WRAPREC("rediscluster::xdel", rediscluster_xdel, redis_function, 0, "xdel")
+  NR_INTERNAL_WRAPREC("rediscluster::xgroup", rediscluster_xgroup, redis_function, 0, 
+                      "xgroup")
+  NR_INTERNAL_WRAPREC("rediscluster::xinfo", rediscluster_xinfo, redis_function, 0, "xinfo")
+  NR_INTERNAL_WRAPREC("rediscluster::xlen", rediscluster_xlen, redis_function, 0, "xlen")
+  NR_INTERNAL_WRAPREC("rediscluster::xpending", rediscluster_xpending, redis_function, 0,
+                      "xpending")
+  NR_INTERNAL_WRAPREC("rediscluster::xrange", rediscluster_xrange, redis_function, 0,
+                      "xrange")
+  NR_INTERNAL_WRAPREC("rediscluster::xread", rediscluster_xread, redis_function, 0, "xread")
+  NR_INTERNAL_WRAPREC("rediscluster::xreadgroup", rediscluster_xreadgroup, redis_function, 0,
+                      "xreadgroup")
+  NR_INTERNAL_WRAPREC("rediscluster::xrevrange", rediscluster_xrevrange, redis_function, 0,
+                      "xrevrange")
+  NR_INTERNAL_WRAPREC("rediscluster::xtrim", rediscluster_xtrim, redis_function, 0, "xtrim")
+  NR_INTERNAL_WRAPREC("rediscluster::zadd", rediscluster_zadd, redis_function, 0, "zadd")
+  NR_INTERNAL_WRAPREC("rediscluster::zcard", rediscluster_zcard, redis_function, 0, "zcard")
+  NR_INTERNAL_WRAPREC("rediscluster::zcount", rediscluster_zcount, redis_function, 0,
+                      "zcount")
+  NR_INTERNAL_WRAPREC("rediscluster::zincrby", rediscluster_zincrby, redis_function, 0,
+                      "zincrby")
+  NR_INTERNAL_WRAPREC("rediscluster::zinterstore", rediscluster_zinterstore, redis_function,
+                      0, "zinterstore")
+  NR_INTERNAL_WRAPREC("rediscluster::zlexcount", rediscluster_zlexcount, redis_function, 0,
+                      "zlexcount")
+  NR_INTERNAL_WRAPREC("rediscluster::zpopmax", rediscluster_zpopmax, redis_function, 0,
+                      "zpopmax")
+  NR_INTERNAL_WRAPREC("rediscluster::zpopmin", rediscluster_zpopmin, redis_function, 0,
+                      "zpopmin")
+  NR_INTERNAL_WRAPREC("rediscluster::zrange", rediscluster_zrange, redis_function, 0,
+                      "zrange")
+  NR_INTERNAL_WRAPREC("rediscluster::zrangebylex", rediscluster_zrangebylex, redis_function,
+                      0, "zrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::zrangebyscore", rediscluster_zrangebyscore,
+                      redis_function, 0, "zrangebyscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrank", rediscluster_zrank, redis_function, 0, "zrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zrem", rediscluster_zrem, redis_function, 0, "zrem")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebylex", rediscluster_zremrangebylex,
+                      redis_function, 0, "zremrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebyrank", rediscluster_zremrangebyrank,
+                      redis_function, 0, "zremrangebyrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebyscore", rediscluster_zremrangebyscore,
+                      redis_function, 0, "zremrangebyscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrange", rediscluster_zrevrange, redis_function, 0,
+                      "zrevrange")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrangebylex", rediscluster_zrevrangebylex,
+                      redis_function, 0, "zrevrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrangebyscore", rediscluster_zrevrangebyscore,
+                      redis_function, 0, "zrevrangebyscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrank", rediscluster_zrevrank, redis_function, 0,
+                      "zrevrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zscore", rediscluster_zscore, redis_function, 0, 
+                      "zscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zunionstore", rediscluster_zunionstore, redis_function,
                       0, "zunionstore")
 
   NR_INTERNAL_WRAPREC("pg_close", pg_close, pg_close, 0, 0)

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -3324,7 +3324,6 @@ NR_OUTER_WRAPPER(rediscluster_append)
 NR_OUTER_WRAPPER(rediscluster_bitcount)
 NR_OUTER_WRAPPER(rediscluster_bitop)
 NR_OUTER_WRAPPER(rediscluster_bitpos)
-NR_OUTER_WRAPPER(rediscluster_close)
 NR_OUTER_WRAPPER(rediscluster_dbsize)
 NR_OUTER_WRAPPER(rediscluster_decr)
 NR_OUTER_WRAPPER(rediscluster_decrby)
@@ -3964,7 +3963,6 @@ void nr_php_generate_internal_wrap_records(void) {
   NR_INTERNAL_WRAPREC("redis::zunionstore", redis_zunionstore, redis_function,
                       0, "zunionstore")
 
-  NR_INTERNAL_WRAPREC("rediscluster::close", rediscluster_close, redis_close, 0, "close")
   NR_INTERNAL_WRAPREC("rediscluster::append", rediscluster_append, rediscluster_function, 0,
                       "append")
   NR_INTERNAL_WRAPREC("rediscluster::bitcount", rediscluster_bitcount, rediscluster_function, 0,

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -1696,13 +1696,15 @@ NR_INNER_WRAPPER(redis_function) {
  * port_path_or_id are set to unknown.
  */
 NR_INNER_WRAPPER(rediscluster_function) {
-  nr_datastore_instance_t* instance
-      = nr_datastore_instance_create("unknown", "unknown", NULL);
+  nr_datastore_instance_t instance = {
+      .host = "unknown",
+      .port_path_or_id = "unknown",
+      .database_name = NULL,
+  };
 
   nr_php_instrument_datastore_operation_call(nr_wrapper, NR_DATASTORE_REDIS,
-                                             nr_wrapper->extra, instance,
+                                             nr_wrapper->extra, &instance,
                                              INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  nr_datastore_instance_destroy(&instance);
 }
 
 static char* nr_php_prepared_statement_make_pgsql_key(

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -1692,12 +1692,17 @@ NR_INNER_WRAPPER(redis_function) {
  *   bool rediscluster::*
  *
  * Instance information is not recorded for Redis Cluster, so the instance
- * lookup that redis_function performs is skipped here.
+ * lookup that redis_function performs is skipped here. Instead, host and
+ * port_path_or_id are set to unknown.
  */
 NR_INNER_WRAPPER(rediscluster_function) {
+  nr_datastore_instance_t* instance
+      = nr_datastore_instance_create("unknown", "unknown", NULL);
+
   nr_php_instrument_datastore_operation_call(nr_wrapper, NR_DATASTORE_REDIS,
-                                             nr_wrapper->extra, NULL,
+                                             nr_wrapper->extra, instance,
                                              INTERNAL_FUNCTION_PARAM_PASSTHRU);
+  nr_datastore_instance_destroy(&instance);
 }
 
 static char* nr_php_prepared_statement_make_pgsql_key(

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -1687,6 +1687,19 @@ NR_INNER_WRAPPER(redis_function) {
                                              INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
+/*
+ * Handle
+ *   bool rediscluster::*
+ *
+ * Instance information is not recorded for Redis Cluster, so the instance
+ * lookup that redis_function performs is skipped here.
+ */
+NR_INNER_WRAPPER(rediscluster_function) {
+  nr_php_instrument_datastore_operation_call(nr_wrapper, NR_DATASTORE_REDIS,
+                                             nr_wrapper->extra, NULL,
+                                             INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
 static char* nr_php_prepared_statement_make_pgsql_key(
     const zval* conn,
     const char* stmtname,
@@ -3952,228 +3965,228 @@ void nr_php_generate_internal_wrap_records(void) {
                       0, "zunionstore")
 
   NR_INTERNAL_WRAPREC("rediscluster::close", rediscluster_close, redis_close, 0, "close")
-  NR_INTERNAL_WRAPREC("rediscluster::append", rediscluster_append, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::append", rediscluster_append, rediscluster_function, 0,
                       "append")
-  NR_INTERNAL_WRAPREC("rediscluster::bitcount", rediscluster_bitcount, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::bitcount", rediscluster_bitcount, rediscluster_function, 0,
                       "bitcount")
-  NR_INTERNAL_WRAPREC("rediscluster::bitop", rediscluster_bitop, redis_function, 0, "bitop")
-  NR_INTERNAL_WRAPREC("rediscluster::bitpos", rediscluster_bitpos, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::bitop", rediscluster_bitop, rediscluster_function, 0, "bitop")
+  NR_INTERNAL_WRAPREC("rediscluster::bitpos", rediscluster_bitpos, rediscluster_function, 0,
                       "bitpos")
-  NR_INTERNAL_WRAPREC("rediscluster::decr", rediscluster_decr, redis_function, 0, "decr")
-  NR_INTERNAL_WRAPREC("rediscluster::decrby", rediscluster_decrby, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::decr", rediscluster_decr, rediscluster_function, 0, "decr")
+  NR_INTERNAL_WRAPREC("rediscluster::decrby", rediscluster_decrby, rediscluster_function, 0,
                       "decrby")
-  NR_INTERNAL_WRAPREC("rediscluster::del", rediscluster_del, redis_function, 0, "del")
-  NR_INTERNAL_WRAPREC("rediscluster::dbsize", rediscluster_dbsize, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::del", rediscluster_del, rediscluster_function, 0, "del")
+  NR_INTERNAL_WRAPREC("rediscluster::dbsize", rediscluster_dbsize, rediscluster_function, 0,
                       "dbsize")
-  NR_INTERNAL_WRAPREC("rediscluster::eval", rediscluster_eval, redis_function, 0, "eval")
-  NR_INTERNAL_WRAPREC("rediscluster::evalsha", rediscluster_evalsha, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::eval", rediscluster_eval, rediscluster_function, 0, "eval")
+  NR_INTERNAL_WRAPREC("rediscluster::evalsha", rediscluster_evalsha, rediscluster_function, 0,
                       "evalsha")
-  NR_INTERNAL_WRAPREC("rediscluster::exec", rediscluster_exec, redis_function, 0, "exec")
-  NR_INTERNAL_WRAPREC("rediscluster::exists", rediscluster_exists, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::exec", rediscluster_exec, rediscluster_function, 0, "exec")
+  NR_INTERNAL_WRAPREC("rediscluster::exists", rediscluster_exists, rediscluster_function, 0,
                       "exists")
-  NR_INTERNAL_WRAPREC("rediscluster::expire", rediscluster_expire, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::expire", rediscluster_expire, rediscluster_function, 0,
                       "expire")
-  NR_INTERNAL_WRAPREC("rediscluster::expireat", rediscluster_expireat, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::expireat", rediscluster_expireat, rediscluster_function, 0,
                       "expireat")
-  NR_INTERNAL_WRAPREC("rediscluster::flushall", rediscluster_flushall, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::flushall", rediscluster_flushall, rediscluster_function, 0,
                       "flushall")
-  NR_INTERNAL_WRAPREC("rediscluster::flushdb", rediscluster_flushdb, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::flushdb", rediscluster_flushdb, rediscluster_function, 0,
                       "flushdb")
-  NR_INTERNAL_WRAPREC("rediscluster::geoadd", rediscluster_geoadd, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::geoadd", rediscluster_geoadd, rediscluster_function, 0,
                       "geoadd")
-  NR_INTERNAL_WRAPREC("rediscluster::geodist", rediscluster_geodist, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::geodist", rediscluster_geodist, rediscluster_function, 0,
                       "geodist")
-  NR_INTERNAL_WRAPREC("rediscluster::geohash", rediscluster_geohash, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::geohash", rediscluster_geohash, rediscluster_function, 0,
                       "geohash")
-  NR_INTERNAL_WRAPREC("rediscluster::geopos", rediscluster_geopos, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::geopos", rediscluster_geopos, rediscluster_function, 0,
                       "geopos")
-  NR_INTERNAL_WRAPREC("rediscluster::georadius", rediscluster_georadius, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::georadius", rediscluster_georadius, rediscluster_function, 0,
                       "georadius")
-  NR_INTERNAL_WRAPREC("rediscluster::georadius_ro", rediscluster_georadius_ro, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::georadius_ro", rediscluster_georadius_ro, rediscluster_function,
                       0, "georadius_ro")
   NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember", rediscluster_georadiusbymember,
                       redis_function, 0, "georadiusbymember")
   NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember_ro", rediscluster_georadiusbymember_ro,
                       redis_function, 0, "georadiusbymember_ro")
-  NR_INTERNAL_WRAPREC("rediscluster::get", rediscluster_get, redis_function, 0, "get")
-  NR_INTERNAL_WRAPREC("rediscluster::getbit", rediscluster_getbit, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::get", rediscluster_get, rediscluster_function, 0, "get")
+  NR_INTERNAL_WRAPREC("rediscluster::getbit", rediscluster_getbit, rediscluster_function, 0,
                       "getbit")
-  NR_INTERNAL_WRAPREC("rediscluster::getrange", rediscluster_getrange, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::getrange", rediscluster_getrange, rediscluster_function, 0,
                       "getrange")
-  NR_INTERNAL_WRAPREC("rediscluster::getset", rediscluster_getset, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::getset", rediscluster_getset, rediscluster_function, 0,
                       "getset")
-  NR_INTERNAL_WRAPREC("rediscluster::hdel", rediscluster_hdel, redis_function, 0, "hdel")
-  NR_INTERNAL_WRAPREC("rediscluster::hexists", rediscluster_hexists, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::hdel", rediscluster_hdel, rediscluster_function, 0, "hdel")
+  NR_INTERNAL_WRAPREC("rediscluster::hexists", rediscluster_hexists, rediscluster_function, 0,
                       "hexists")
-  NR_INTERNAL_WRAPREC("rediscluster::hget", rediscluster_hget, redis_function, 0, "hget")
-  NR_INTERNAL_WRAPREC("rediscluster::hgetall", rediscluster_hgetall, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::hget", rediscluster_hget, rediscluster_function, 0, "hget")
+  NR_INTERNAL_WRAPREC("rediscluster::hgetall", rediscluster_hgetall, rediscluster_function, 0,
                       "hgetall")
-  NR_INTERNAL_WRAPREC("rediscluster::hincrby", rediscluster_hincrby, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::hincrby", rediscluster_hincrby, rediscluster_function, 0,
                       "hincrby")
-  NR_INTERNAL_WRAPREC("rediscluster::hincrbyfloat", rediscluster_hincrbyfloat, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::hincrbyfloat", rediscluster_hincrbyfloat, rediscluster_function,
                       0, "hincrbyfloat")
-  NR_INTERNAL_WRAPREC("rediscluster::hkeys", rediscluster_hkeys, redis_function, 0, "hkeys")
-  NR_INTERNAL_WRAPREC("rediscluster::hlen", rediscluster_hlen, redis_function, 0, "hlen")
-  NR_INTERNAL_WRAPREC("rediscluster::hmget", rediscluster_hmget, redis_function, 0, "hmget")
-  NR_INTERNAL_WRAPREC("rediscluster::hmset", rediscluster_hmset, redis_function, 0, "hmset")
-  NR_INTERNAL_WRAPREC("rediscluster::hset", rediscluster_hset, redis_function, 0, "hset")
-  NR_INTERNAL_WRAPREC("rediscluster::hsetnx", rediscluster_hsetnx, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::hkeys", rediscluster_hkeys, rediscluster_function, 0, "hkeys")
+  NR_INTERNAL_WRAPREC("rediscluster::hlen", rediscluster_hlen, rediscluster_function, 0, "hlen")
+  NR_INTERNAL_WRAPREC("rediscluster::hmget", rediscluster_hmget, rediscluster_function, 0, "hmget")
+  NR_INTERNAL_WRAPREC("rediscluster::hmset", rediscluster_hmset, rediscluster_function, 0, "hmset")
+  NR_INTERNAL_WRAPREC("rediscluster::hset", rediscluster_hset, rediscluster_function, 0, "hset")
+  NR_INTERNAL_WRAPREC("rediscluster::hsetnx", rediscluster_hsetnx, rediscluster_function, 0,
                       "hsetnx")
-  NR_INTERNAL_WRAPREC("rediscluster::hstrlen", rediscluster_hstrlen, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::hstrlen", rediscluster_hstrlen, rediscluster_function, 0,
                       "hstrlen")
-  NR_INTERNAL_WRAPREC("rediscluster::hvals", rediscluster_hvals, redis_function, 0, "hvals")
-  NR_INTERNAL_WRAPREC("rediscluster::incr", rediscluster_incr, redis_function, 0, "incr")
-  NR_INTERNAL_WRAPREC("rediscluster::incrby", rediscluster_incrby, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::hvals", rediscluster_hvals, rediscluster_function, 0, "hvals")
+  NR_INTERNAL_WRAPREC("rediscluster::incr", rediscluster_incr, rediscluster_function, 0, "incr")
+  NR_INTERNAL_WRAPREC("rediscluster::incrby", rediscluster_incrby, rediscluster_function, 0,
                       "incrby")
-  NR_INTERNAL_WRAPREC("rediscluster::incrbyfloat", rediscluster_incrbyfloat, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::incrbyfloat", rediscluster_incrbyfloat, rediscluster_function,
                       0, "incrbyfloat")
-  NR_INTERNAL_WRAPREC("rediscluster::keys", rediscluster_keys, redis_function, 0, "keys")
-  NR_INTERNAL_WRAPREC("rediscluster::lget", rediscluster_lget, redis_function, 0, "lget")
-  NR_INTERNAL_WRAPREC("rediscluster::lindex", rediscluster_lindex, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::keys", rediscluster_keys, rediscluster_function, 0, "keys")
+  NR_INTERNAL_WRAPREC("rediscluster::lget", rediscluster_lget, rediscluster_function, 0, "lget")
+  NR_INTERNAL_WRAPREC("rediscluster::lindex", rediscluster_lindex, rediscluster_function, 0,
                       "lindex")
-  NR_INTERNAL_WRAPREC("rediscluster::linsert", rediscluster_linsert, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::linsert", rediscluster_linsert, rediscluster_function, 0,
                       "linsert")
-  NR_INTERNAL_WRAPREC("rediscluster::llen", rediscluster_llen, redis_function, 0, "llen")
-  NR_INTERNAL_WRAPREC("rediscluster::lpop", rediscluster_lpop, redis_function, 0, "lpop")
-  NR_INTERNAL_WRAPREC("rediscluster::lpush", rediscluster_lpush, redis_function, 0, "lpush")
-  NR_INTERNAL_WRAPREC("rediscluster::lpushx", rediscluster_lpushx, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::llen", rediscluster_llen, rediscluster_function, 0, "llen")
+  NR_INTERNAL_WRAPREC("rediscluster::lpop", rediscluster_lpop, rediscluster_function, 0, "lpop")
+  NR_INTERNAL_WRAPREC("rediscluster::lpush", rediscluster_lpush, rediscluster_function, 0, "lpush")
+  NR_INTERNAL_WRAPREC("rediscluster::lpushx", rediscluster_lpushx, rediscluster_function, 0,
                       "lpushx")
-  NR_INTERNAL_WRAPREC("rediscluster::lrange", rediscluster_lrange, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::lrange", rediscluster_lrange, rediscluster_function, 0,
                       "lrange")
-  NR_INTERNAL_WRAPREC("rediscluster::lrem", rediscluster_lrem, redis_function, 0, "lrem")
-  NR_INTERNAL_WRAPREC("rediscluster::lset", rediscluster_lset, redis_function, 0, "lset")
-  NR_INTERNAL_WRAPREC("rediscluster::ltrim", rediscluster_ltrim, redis_function, 0, "ltrim")
-  NR_INTERNAL_WRAPREC("rediscluster::mget", rediscluster_mget, redis_function, 0, "mget")
-  NR_INTERNAL_WRAPREC("rediscluster::mset", rediscluster_mset, redis_function, 0, "mset")
-  NR_INTERNAL_WRAPREC("rediscluster::msetnx", rediscluster_msetnx, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::lrem", rediscluster_lrem, rediscluster_function, 0, "lrem")
+  NR_INTERNAL_WRAPREC("rediscluster::lset", rediscluster_lset, rediscluster_function, 0, "lset")
+  NR_INTERNAL_WRAPREC("rediscluster::ltrim", rediscluster_ltrim, rediscluster_function, 0, "ltrim")
+  NR_INTERNAL_WRAPREC("rediscluster::mget", rediscluster_mget, rediscluster_function, 0, "mget")
+  NR_INTERNAL_WRAPREC("rediscluster::mset", rediscluster_mset, rediscluster_function, 0, "mset")
+  NR_INTERNAL_WRAPREC("rediscluster::msetnx", rediscluster_msetnx, rediscluster_function, 0,
                       "msetnx")
-  NR_INTERNAL_WRAPREC("rediscluster::persist", rediscluster_persist, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::persist", rediscluster_persist, rediscluster_function, 0,
                       "persist")
-  NR_INTERNAL_WRAPREC("rediscluster::pexpire", rediscluster_pexpire, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::pexpire", rediscluster_pexpire, rediscluster_function, 0,
                       "pexpire")
-  NR_INTERNAL_WRAPREC("rediscluster::pexpireat", rediscluster_pexpireat, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::pexpireat", rediscluster_pexpireat, rediscluster_function, 0,
                       "pexpireat")
-  NR_INTERNAL_WRAPREC("rediscluster::pfadd", rediscluster_pfadd, redis_function, 0, "pfadd")
-  NR_INTERNAL_WRAPREC("rediscluster::pfcount", rediscluster_pfcount, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::pfadd", rediscluster_pfadd, rediscluster_function, 0, "pfadd")
+  NR_INTERNAL_WRAPREC("rediscluster::pfcount", rediscluster_pfcount, rediscluster_function, 0,
                       "pfcount")
-  NR_INTERNAL_WRAPREC("rediscluster::pfmerge", rediscluster_pfmerge, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::pfmerge", rediscluster_pfmerge, rediscluster_function, 0,
                       "pfmerge")
-  NR_INTERNAL_WRAPREC("rediscluster::ping", rediscluster_ping, redis_function, 0, "ping")
-  NR_INTERNAL_WRAPREC("rediscluster::psetex", rediscluster_psetex, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::ping", rediscluster_ping, rediscluster_function, 0, "ping")
+  NR_INTERNAL_WRAPREC("rediscluster::psetex", rediscluster_psetex, rediscluster_function, 0,
                       "psetex")
-  NR_INTERNAL_WRAPREC("rediscluster::pttl", rediscluster_pttl, redis_function, 0, "pttl")
-  NR_INTERNAL_WRAPREC("rediscluster::publish", rediscluster_publish, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::pttl", rediscluster_pttl, rediscluster_function, 0, "pttl")
+  NR_INTERNAL_WRAPREC("rediscluster::publish", rediscluster_publish, rediscluster_function, 0,
                       "publish")
-  NR_INTERNAL_WRAPREC("rediscluster::randomkey", rediscluster_randomkey, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::randomkey", rediscluster_randomkey, rediscluster_function, 0,
                       "randomkey")
-  NR_INTERNAL_WRAPREC("rediscluster::rawcommand", rediscluster_rawcommand, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::rawcommand", rediscluster_rawcommand, rediscluster_function, 0,
                       "rawcommand")
-  NR_INTERNAL_WRAPREC("rediscluster::rename", rediscluster_rename, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::rename", rediscluster_rename, rediscluster_function, 0,
                       "rename")
-  NR_INTERNAL_WRAPREC("rediscluster::renamenx", rediscluster_renamenx, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::renamenx", rediscluster_renamenx, rediscluster_function, 0,
                       "renamenx")
-  NR_INTERNAL_WRAPREC("rediscluster::rpop", rediscluster_rpop, redis_function, 0, "rpop")
-  NR_INTERNAL_WRAPREC("rediscluster::rpoplpush", rediscluster_rpoplpush, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::rpop", rediscluster_rpop, rediscluster_function, 0, "rpop")
+  NR_INTERNAL_WRAPREC("rediscluster::rpoplpush", rediscluster_rpoplpush, rediscluster_function, 0,
                       "rpoplpush")
-  NR_INTERNAL_WRAPREC("rediscluster::rpush", rediscluster_rpush, redis_function, 0, "rpush")
-  NR_INTERNAL_WRAPREC("rediscluster::rpushx", rediscluster_rpushx, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::rpush", rediscluster_rpush, rediscluster_function, 0, "rpush")
+  NR_INTERNAL_WRAPREC("rediscluster::rpushx", rediscluster_rpushx, rediscluster_function, 0,
                       "rpushx")
-  NR_INTERNAL_WRAPREC("rediscluster::sadd", rediscluster_sadd, redis_function, 0, "sadd")
-  NR_INTERNAL_WRAPREC("rediscluster::scard", rediscluster_scard, redis_function, 0, "scard")
-  NR_INTERNAL_WRAPREC("rediscluster::sdiff", rediscluster_sdiff, redis_function, 0, "sdiff")
-  NR_INTERNAL_WRAPREC("rediscluster::sdiffstore", rediscluster_sdiffstore, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::sadd", rediscluster_sadd, rediscluster_function, 0, "sadd")
+  NR_INTERNAL_WRAPREC("rediscluster::scard", rediscluster_scard, rediscluster_function, 0, "scard")
+  NR_INTERNAL_WRAPREC("rediscluster::sdiff", rediscluster_sdiff, rediscluster_function, 0, "sdiff")
+  NR_INTERNAL_WRAPREC("rediscluster::sdiffstore", rediscluster_sdiffstore, rediscluster_function, 0,
                       "sdiffstore")
-  NR_INTERNAL_WRAPREC("rediscluster::set", rediscluster_set, redis_function, 0, "set")
-  NR_INTERNAL_WRAPREC("rediscluster::setbit", rediscluster_setbit, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::set", rediscluster_set, rediscluster_function, 0, "set")
+  NR_INTERNAL_WRAPREC("rediscluster::setbit", rediscluster_setbit, rediscluster_function, 0,
                       "setbit")
-  NR_INTERNAL_WRAPREC("rediscluster::setex", rediscluster_setex, redis_function, 0, "setex")
-  NR_INTERNAL_WRAPREC("rediscluster::setnx", rediscluster_setnx, redis_function, 0, "setnx")
-  NR_INTERNAL_WRAPREC("rediscluster::setrange", rediscluster_setrange, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::setex", rediscluster_setex, rediscluster_function, 0, "setex")
+  NR_INTERNAL_WRAPREC("rediscluster::setnx", rediscluster_setnx, rediscluster_function, 0, "setnx")
+  NR_INTERNAL_WRAPREC("rediscluster::setrange", rediscluster_setrange, rediscluster_function, 0,
                       "setrange")
-  NR_INTERNAL_WRAPREC("rediscluster::sinter", rediscluster_sinter, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::sinter", rediscluster_sinter, rediscluster_function, 0,
                       "sinter")
-  NR_INTERNAL_WRAPREC("rediscluster::sinterstore", rediscluster_sinterstore, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::sinterstore", rediscluster_sinterstore, rediscluster_function,
                       0, "sinterstore")
-  NR_INTERNAL_WRAPREC("rediscluster::sismember", rediscluster_sismember, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::sismember", rediscluster_sismember, rediscluster_function, 0,
                       "sismember")
-  NR_INTERNAL_WRAPREC("rediscluster::smembers", rediscluster_smembers, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::smembers", rediscluster_smembers, rediscluster_function, 0,
                       "smembers")
-  NR_INTERNAL_WRAPREC("rediscluster::smismember", rediscluster_smismember, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::smismember", rediscluster_smismember, rediscluster_function, 0,
                       "smismember")
-  NR_INTERNAL_WRAPREC("rediscluster::smove", rediscluster_smove, redis_function, 0, "smove")
-  NR_INTERNAL_WRAPREC("rediscluster::spop", rediscluster_spop, redis_function, 0, "spop")
-  NR_INTERNAL_WRAPREC("rediscluster::srandmember", rediscluster_srandmember, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::smove", rediscluster_smove, rediscluster_function, 0, "smove")
+  NR_INTERNAL_WRAPREC("rediscluster::spop", rediscluster_spop, rediscluster_function, 0, "spop")
+  NR_INTERNAL_WRAPREC("rediscluster::srandmember", rediscluster_srandmember, rediscluster_function,
                       0, "srandmember")
-  NR_INTERNAL_WRAPREC("rediscluster::srem", rediscluster_srem, redis_function, 0, "srem")
-  NR_INTERNAL_WRAPREC("rediscluster::strlen", rediscluster_strlen, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::srem", rediscluster_srem, rediscluster_function, 0, "srem")
+  NR_INTERNAL_WRAPREC("rediscluster::strlen", rediscluster_strlen, rediscluster_function, 0,
                       "strlen")
-  NR_INTERNAL_WRAPREC("rediscluster::sunion", rediscluster_sunion, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::sunion", rediscluster_sunion, rediscluster_function, 0,
                       "sunion")
-  NR_INTERNAL_WRAPREC("rediscluster::sunionstore", rediscluster_sunionstore, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::sunionstore", rediscluster_sunionstore, rediscluster_function,
                       0, "sunionstore")
-  NR_INTERNAL_WRAPREC("rediscluster::time", rediscluster_time, redis_function, 0, "time")
-  NR_INTERNAL_WRAPREC("rediscluster::ttl", rediscluster_ttl, redis_function, 0, "ttl")
-  NR_INTERNAL_WRAPREC("rediscluster::type", rediscluster_type, redis_function, 0, "type")
-  NR_INTERNAL_WRAPREC("rediscluster::unlink", rediscluster_unlink, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::time", rediscluster_time, rediscluster_function, 0, "time")
+  NR_INTERNAL_WRAPREC("rediscluster::ttl", rediscluster_ttl, rediscluster_function, 0, "ttl")
+  NR_INTERNAL_WRAPREC("rediscluster::type", rediscluster_type, rediscluster_function, 0, "type")
+  NR_INTERNAL_WRAPREC("rediscluster::unlink", rediscluster_unlink, rediscluster_function, 0,
                       "unlink")
-  NR_INTERNAL_WRAPREC("rediscluster::xack", rediscluster_xack, redis_function, 0, "xack")
-  NR_INTERNAL_WRAPREC("rediscluster::xadd", rediscluster_xadd, redis_function, 0, "xadd")
-  NR_INTERNAL_WRAPREC("rediscluster::xclaim", rediscluster_xclaim, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::xack", rediscluster_xack, rediscluster_function, 0, "xack")
+  NR_INTERNAL_WRAPREC("rediscluster::xadd", rediscluster_xadd, rediscluster_function, 0, "xadd")
+  NR_INTERNAL_WRAPREC("rediscluster::xclaim", rediscluster_xclaim, rediscluster_function, 0,
                       "xclaim")
-  NR_INTERNAL_WRAPREC("rediscluster::xdel", rediscluster_xdel, redis_function, 0, "xdel")
-  NR_INTERNAL_WRAPREC("rediscluster::xgroup", rediscluster_xgroup, redis_function, 0, 
+  NR_INTERNAL_WRAPREC("rediscluster::xdel", rediscluster_xdel, rediscluster_function, 0, "xdel")
+  NR_INTERNAL_WRAPREC("rediscluster::xgroup", rediscluster_xgroup, rediscluster_function, 0, 
                       "xgroup")
-  NR_INTERNAL_WRAPREC("rediscluster::xinfo", rediscluster_xinfo, redis_function, 0, "xinfo")
-  NR_INTERNAL_WRAPREC("rediscluster::xlen", rediscluster_xlen, redis_function, 0, "xlen")
-  NR_INTERNAL_WRAPREC("rediscluster::xpending", rediscluster_xpending, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::xinfo", rediscluster_xinfo, rediscluster_function, 0, "xinfo")
+  NR_INTERNAL_WRAPREC("rediscluster::xlen", rediscluster_xlen, rediscluster_function, 0, "xlen")
+  NR_INTERNAL_WRAPREC("rediscluster::xpending", rediscluster_xpending, rediscluster_function, 0,
                       "xpending")
-  NR_INTERNAL_WRAPREC("rediscluster::xrange", rediscluster_xrange, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::xrange", rediscluster_xrange, rediscluster_function, 0,
                       "xrange")
-  NR_INTERNAL_WRAPREC("rediscluster::xread", rediscluster_xread, redis_function, 0, "xread")
-  NR_INTERNAL_WRAPREC("rediscluster::xreadgroup", rediscluster_xreadgroup, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::xread", rediscluster_xread, rediscluster_function, 0, "xread")
+  NR_INTERNAL_WRAPREC("rediscluster::xreadgroup", rediscluster_xreadgroup, rediscluster_function, 0,
                       "xreadgroup")
-  NR_INTERNAL_WRAPREC("rediscluster::xrevrange", rediscluster_xrevrange, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::xrevrange", rediscluster_xrevrange, rediscluster_function, 0,
                       "xrevrange")
-  NR_INTERNAL_WRAPREC("rediscluster::xtrim", rediscluster_xtrim, redis_function, 0, "xtrim")
-  NR_INTERNAL_WRAPREC("rediscluster::zadd", rediscluster_zadd, redis_function, 0, "zadd")
-  NR_INTERNAL_WRAPREC("rediscluster::zcard", rediscluster_zcard, redis_function, 0, "zcard")
-  NR_INTERNAL_WRAPREC("rediscluster::zcount", rediscluster_zcount, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::xtrim", rediscluster_xtrim, rediscluster_function, 0, "xtrim")
+  NR_INTERNAL_WRAPREC("rediscluster::zadd", rediscluster_zadd, rediscluster_function, 0, "zadd")
+  NR_INTERNAL_WRAPREC("rediscluster::zcard", rediscluster_zcard, rediscluster_function, 0, "zcard")
+  NR_INTERNAL_WRAPREC("rediscluster::zcount", rediscluster_zcount, rediscluster_function, 0,
                       "zcount")
-  NR_INTERNAL_WRAPREC("rediscluster::zincrby", rediscluster_zincrby, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::zincrby", rediscluster_zincrby, rediscluster_function, 0,
                       "zincrby")
-  NR_INTERNAL_WRAPREC("rediscluster::zinterstore", rediscluster_zinterstore, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::zinterstore", rediscluster_zinterstore, rediscluster_function,
                       0, "zinterstore")
-  NR_INTERNAL_WRAPREC("rediscluster::zlexcount", rediscluster_zlexcount, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::zlexcount", rediscluster_zlexcount, rediscluster_function, 0,
                       "zlexcount")
-  NR_INTERNAL_WRAPREC("rediscluster::zpopmax", rediscluster_zpopmax, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::zpopmax", rediscluster_zpopmax, rediscluster_function, 0,
                       "zpopmax")
-  NR_INTERNAL_WRAPREC("rediscluster::zpopmin", rediscluster_zpopmin, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::zpopmin", rediscluster_zpopmin, rediscluster_function, 0,
                       "zpopmin")
-  NR_INTERNAL_WRAPREC("rediscluster::zrange", rediscluster_zrange, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::zrange", rediscluster_zrange, rediscluster_function, 0,
                       "zrange")
-  NR_INTERNAL_WRAPREC("rediscluster::zrangebylex", rediscluster_zrangebylex, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::zrangebylex", rediscluster_zrangebylex, rediscluster_function,
                       0, "zrangebylex")
   NR_INTERNAL_WRAPREC("rediscluster::zrangebyscore", rediscluster_zrangebyscore,
                       redis_function, 0, "zrangebyscore")
-  NR_INTERNAL_WRAPREC("rediscluster::zrank", rediscluster_zrank, redis_function, 0, "zrank")
-  NR_INTERNAL_WRAPREC("rediscluster::zrem", rediscluster_zrem, redis_function, 0, "zrem")
+  NR_INTERNAL_WRAPREC("rediscluster::zrank", rediscluster_zrank, rediscluster_function, 0, "zrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zrem", rediscluster_zrem, rediscluster_function, 0, "zrem")
   NR_INTERNAL_WRAPREC("rediscluster::zremrangebylex", rediscluster_zremrangebylex,
                       redis_function, 0, "zremrangebylex")
   NR_INTERNAL_WRAPREC("rediscluster::zremrangebyrank", rediscluster_zremrangebyrank,
                       redis_function, 0, "zremrangebyrank")
   NR_INTERNAL_WRAPREC("rediscluster::zremrangebyscore", rediscluster_zremrangebyscore,
                       redis_function, 0, "zremrangebyscore")
-  NR_INTERNAL_WRAPREC("rediscluster::zrevrange", rediscluster_zrevrange, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrange", rediscluster_zrevrange, rediscluster_function, 0,
                       "zrevrange")
   NR_INTERNAL_WRAPREC("rediscluster::zrevrangebylex", rediscluster_zrevrangebylex,
                       redis_function, 0, "zrevrangebylex")
   NR_INTERNAL_WRAPREC("rediscluster::zrevrangebyscore", rediscluster_zrevrangebyscore,
                       redis_function, 0, "zrevrangebyscore")
-  NR_INTERNAL_WRAPREC("rediscluster::zrevrank", rediscluster_zrevrank, redis_function, 0,
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrank", rediscluster_zrevrank, rediscluster_function, 0,
                       "zrevrank")
-  NR_INTERNAL_WRAPREC("rediscluster::zscore", rediscluster_zscore, redis_function, 0, 
+  NR_INTERNAL_WRAPREC("rediscluster::zscore", rediscluster_zscore, rediscluster_function, 0, 
                       "zscore")
-  NR_INTERNAL_WRAPREC("rediscluster::zunionstore", rediscluster_zunionstore, redis_function,
+  NR_INTERNAL_WRAPREC("rediscluster::zunionstore", rediscluster_zunionstore, rediscluster_function,
                       0, "zunionstore")
 
   NR_INTERNAL_WRAPREC("pg_close", pg_close, pg_close, 0, 0)

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -4003,9 +4003,9 @@ void nr_php_generate_internal_wrap_records(void) {
   NR_INTERNAL_WRAPREC("rediscluster::georadius_ro", rediscluster_georadius_ro, rediscluster_function,
                       0, "georadius_ro")
   NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember", rediscluster_georadiusbymember,
-                      redis_function, 0, "georadiusbymember")
+                      rediscluster_function, 0, "georadiusbymember")
   NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember_ro", rediscluster_georadiusbymember_ro,
-                      redis_function, 0, "georadiusbymember_ro")
+                      rediscluster_function, 0, "georadiusbymember_ro")
   NR_INTERNAL_WRAPREC("rediscluster::get", rediscluster_get, rediscluster_function, 0, "get")
   NR_INTERNAL_WRAPREC("rediscluster::getbit", rediscluster_getbit, rediscluster_function, 0,
                       "getbit")
@@ -4165,21 +4165,21 @@ void nr_php_generate_internal_wrap_records(void) {
   NR_INTERNAL_WRAPREC("rediscluster::zrangebylex", rediscluster_zrangebylex, rediscluster_function,
                       0, "zrangebylex")
   NR_INTERNAL_WRAPREC("rediscluster::zrangebyscore", rediscluster_zrangebyscore,
-                      redis_function, 0, "zrangebyscore")
+                      rediscluster_function, 0, "zrangebyscore")
   NR_INTERNAL_WRAPREC("rediscluster::zrank", rediscluster_zrank, rediscluster_function, 0, "zrank")
   NR_INTERNAL_WRAPREC("rediscluster::zrem", rediscluster_zrem, rediscluster_function, 0, "zrem")
   NR_INTERNAL_WRAPREC("rediscluster::zremrangebylex", rediscluster_zremrangebylex,
-                      redis_function, 0, "zremrangebylex")
+                      rediscluster_function, 0, "zremrangebylex")
   NR_INTERNAL_WRAPREC("rediscluster::zremrangebyrank", rediscluster_zremrangebyrank,
-                      redis_function, 0, "zremrangebyrank")
+                      rediscluster_function, 0, "zremrangebyrank")
   NR_INTERNAL_WRAPREC("rediscluster::zremrangebyscore", rediscluster_zremrangebyscore,
-                      redis_function, 0, "zremrangebyscore")
+                      rediscluster_function, 0, "zremrangebyscore")
   NR_INTERNAL_WRAPREC("rediscluster::zrevrange", rediscluster_zrevrange, rediscluster_function, 0,
                       "zrevrange")
   NR_INTERNAL_WRAPREC("rediscluster::zrevrangebylex", rediscluster_zrevrangebylex,
-                      redis_function, 0, "zrevrangebylex")
+                      rediscluster_function, 0, "zrevrangebylex")
   NR_INTERNAL_WRAPREC("rediscluster::zrevrangebyscore", rediscluster_zrevrangebyscore,
-                      redis_function, 0, "zrevrangebyscore")
+                      rediscluster_function, 0, "zrevrangebyscore")
   NR_INTERNAL_WRAPREC("rediscluster::zrevrank", rediscluster_zrevrank, rediscluster_function, 0,
                       "zrevrank")
   NR_INTERNAL_WRAPREC("rediscluster::zscore", rediscluster_zscore, rediscluster_function, 0, 

--- a/agent/php_internal_instrument.c
+++ b/agent/php_internal_instrument.c
@@ -3968,229 +3968,289 @@ void nr_php_generate_internal_wrap_records(void) {
   NR_INTERNAL_WRAPREC("redis::zunionstore", redis_zunionstore, redis_function,
                       0, "zunionstore")
 
-  NR_INTERNAL_WRAPREC("rediscluster::append", rediscluster_append, rediscluster_function, 0,
-                      "append")
-  NR_INTERNAL_WRAPREC("rediscluster::bitcount", rediscluster_bitcount, rediscluster_function, 0,
-                      "bitcount")
-  NR_INTERNAL_WRAPREC("rediscluster::bitop", rediscluster_bitop, rediscluster_function, 0, "bitop")
-  NR_INTERNAL_WRAPREC("rediscluster::bitpos", rediscluster_bitpos, rediscluster_function, 0,
-                      "bitpos")
-  NR_INTERNAL_WRAPREC("rediscluster::decr", rediscluster_decr, rediscluster_function, 0, "decr")
-  NR_INTERNAL_WRAPREC("rediscluster::decrby", rediscluster_decrby, rediscluster_function, 0,
-                      "decrby")
-  NR_INTERNAL_WRAPREC("rediscluster::del", rediscluster_del, rediscluster_function, 0, "del")
-  NR_INTERNAL_WRAPREC("rediscluster::dbsize", rediscluster_dbsize, rediscluster_function, 0,
-                      "dbsize")
-  NR_INTERNAL_WRAPREC("rediscluster::eval", rediscluster_eval, rediscluster_function, 0, "eval")
-  NR_INTERNAL_WRAPREC("rediscluster::evalsha", rediscluster_evalsha, rediscluster_function, 0,
-                      "evalsha")
-  NR_INTERNAL_WRAPREC("rediscluster::exec", rediscluster_exec, rediscluster_function, 0, "exec")
-  NR_INTERNAL_WRAPREC("rediscluster::exists", rediscluster_exists, rediscluster_function, 0,
-                      "exists")
-  NR_INTERNAL_WRAPREC("rediscluster::expire", rediscluster_expire, rediscluster_function, 0,
-                      "expire")
-  NR_INTERNAL_WRAPREC("rediscluster::expireat", rediscluster_expireat, rediscluster_function, 0,
-                      "expireat")
-  NR_INTERNAL_WRAPREC("rediscluster::flushall", rediscluster_flushall, rediscluster_function, 0,
-                      "flushall")
-  NR_INTERNAL_WRAPREC("rediscluster::flushdb", rediscluster_flushdb, rediscluster_function, 0,
-                      "flushdb")
-  NR_INTERNAL_WRAPREC("rediscluster::geoadd", rediscluster_geoadd, rediscluster_function, 0,
-                      "geoadd")
-  NR_INTERNAL_WRAPREC("rediscluster::geodist", rediscluster_geodist, rediscluster_function, 0,
-                      "geodist")
-  NR_INTERNAL_WRAPREC("rediscluster::geohash", rediscluster_geohash, rediscluster_function, 0,
-                      "geohash")
-  NR_INTERNAL_WRAPREC("rediscluster::geopos", rediscluster_geopos, rediscluster_function, 0,
-                      "geopos")
-  NR_INTERNAL_WRAPREC("rediscluster::georadius", rediscluster_georadius, rediscluster_function, 0,
-                      "georadius")
-  NR_INTERNAL_WRAPREC("rediscluster::georadius_ro", rediscluster_georadius_ro, rediscluster_function,
-                      0, "georadius_ro")
-  NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember", rediscluster_georadiusbymember,
-                      rediscluster_function, 0, "georadiusbymember")
-  NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember_ro", rediscluster_georadiusbymember_ro,
-                      rediscluster_function, 0, "georadiusbymember_ro")
-  NR_INTERNAL_WRAPREC("rediscluster::get", rediscluster_get, rediscluster_function, 0, "get")
-  NR_INTERNAL_WRAPREC("rediscluster::getbit", rediscluster_getbit, rediscluster_function, 0,
-                      "getbit")
-  NR_INTERNAL_WRAPREC("rediscluster::getrange", rediscluster_getrange, rediscluster_function, 0,
-                      "getrange")
-  NR_INTERNAL_WRAPREC("rediscluster::getset", rediscluster_getset, rediscluster_function, 0,
-                      "getset")
-  NR_INTERNAL_WRAPREC("rediscluster::hdel", rediscluster_hdel, rediscluster_function, 0, "hdel")
-  NR_INTERNAL_WRAPREC("rediscluster::hexists", rediscluster_hexists, rediscluster_function, 0,
-                      "hexists")
-  NR_INTERNAL_WRAPREC("rediscluster::hget", rediscluster_hget, rediscluster_function, 0, "hget")
-  NR_INTERNAL_WRAPREC("rediscluster::hgetall", rediscluster_hgetall, rediscluster_function, 0,
-                      "hgetall")
-  NR_INTERNAL_WRAPREC("rediscluster::hincrby", rediscluster_hincrby, rediscluster_function, 0,
-                      "hincrby")
-  NR_INTERNAL_WRAPREC("rediscluster::hincrbyfloat", rediscluster_hincrbyfloat, rediscluster_function,
-                      0, "hincrbyfloat")
-  NR_INTERNAL_WRAPREC("rediscluster::hkeys", rediscluster_hkeys, rediscluster_function, 0, "hkeys")
-  NR_INTERNAL_WRAPREC("rediscluster::hlen", rediscluster_hlen, rediscluster_function, 0, "hlen")
-  NR_INTERNAL_WRAPREC("rediscluster::hmget", rediscluster_hmget, rediscluster_function, 0, "hmget")
-  NR_INTERNAL_WRAPREC("rediscluster::hmset", rediscluster_hmset, rediscluster_function, 0, "hmset")
-  NR_INTERNAL_WRAPREC("rediscluster::hset", rediscluster_hset, rediscluster_function, 0, "hset")
-  NR_INTERNAL_WRAPREC("rediscluster::hsetnx", rediscluster_hsetnx, rediscluster_function, 0,
-                      "hsetnx")
-  NR_INTERNAL_WRAPREC("rediscluster::hstrlen", rediscluster_hstrlen, rediscluster_function, 0,
-                      "hstrlen")
-  NR_INTERNAL_WRAPREC("rediscluster::hvals", rediscluster_hvals, rediscluster_function, 0, "hvals")
-  NR_INTERNAL_WRAPREC("rediscluster::incr", rediscluster_incr, rediscluster_function, 0, "incr")
-  NR_INTERNAL_WRAPREC("rediscluster::incrby", rediscluster_incrby, rediscluster_function, 0,
-                      "incrby")
-  NR_INTERNAL_WRAPREC("rediscluster::incrbyfloat", rediscluster_incrbyfloat, rediscluster_function,
-                      0, "incrbyfloat")
-  NR_INTERNAL_WRAPREC("rediscluster::keys", rediscluster_keys, rediscluster_function, 0, "keys")
-  NR_INTERNAL_WRAPREC("rediscluster::lget", rediscluster_lget, rediscluster_function, 0, "lget")
-  NR_INTERNAL_WRAPREC("rediscluster::lindex", rediscluster_lindex, rediscluster_function, 0,
-                      "lindex")
-  NR_INTERNAL_WRAPREC("rediscluster::linsert", rediscluster_linsert, rediscluster_function, 0,
-                      "linsert")
-  NR_INTERNAL_WRAPREC("rediscluster::llen", rediscluster_llen, rediscluster_function, 0, "llen")
-  NR_INTERNAL_WRAPREC("rediscluster::lpop", rediscluster_lpop, rediscluster_function, 0, "lpop")
-  NR_INTERNAL_WRAPREC("rediscluster::lpush", rediscluster_lpush, rediscluster_function, 0, "lpush")
-  NR_INTERNAL_WRAPREC("rediscluster::lpushx", rediscluster_lpushx, rediscluster_function, 0,
-                      "lpushx")
-  NR_INTERNAL_WRAPREC("rediscluster::lrange", rediscluster_lrange, rediscluster_function, 0,
-                      "lrange")
-  NR_INTERNAL_WRAPREC("rediscluster::lrem", rediscluster_lrem, rediscluster_function, 0, "lrem")
-  NR_INTERNAL_WRAPREC("rediscluster::lset", rediscluster_lset, rediscluster_function, 0, "lset")
-  NR_INTERNAL_WRAPREC("rediscluster::ltrim", rediscluster_ltrim, rediscluster_function, 0, "ltrim")
-  NR_INTERNAL_WRAPREC("rediscluster::mget", rediscluster_mget, rediscluster_function, 0, "mget")
-  NR_INTERNAL_WRAPREC("rediscluster::mset", rediscluster_mset, rediscluster_function, 0, "mset")
-  NR_INTERNAL_WRAPREC("rediscluster::msetnx", rediscluster_msetnx, rediscluster_function, 0,
-                      "msetnx")
-  NR_INTERNAL_WRAPREC("rediscluster::persist", rediscluster_persist, rediscluster_function, 0,
-                      "persist")
-  NR_INTERNAL_WRAPREC("rediscluster::pexpire", rediscluster_pexpire, rediscluster_function, 0,
-                      "pexpire")
-  NR_INTERNAL_WRAPREC("rediscluster::pexpireat", rediscluster_pexpireat, rediscluster_function, 0,
-                      "pexpireat")
-  NR_INTERNAL_WRAPREC("rediscluster::pfadd", rediscluster_pfadd, rediscluster_function, 0, "pfadd")
-  NR_INTERNAL_WRAPREC("rediscluster::pfcount", rediscluster_pfcount, rediscluster_function, 0,
-                      "pfcount")
-  NR_INTERNAL_WRAPREC("rediscluster::pfmerge", rediscluster_pfmerge, rediscluster_function, 0,
-                      "pfmerge")
-  NR_INTERNAL_WRAPREC("rediscluster::ping", rediscluster_ping, rediscluster_function, 0, "ping")
-  NR_INTERNAL_WRAPREC("rediscluster::psetex", rediscluster_psetex, rediscluster_function, 0,
-                      "psetex")
-  NR_INTERNAL_WRAPREC("rediscluster::pttl", rediscluster_pttl, rediscluster_function, 0, "pttl")
-  NR_INTERNAL_WRAPREC("rediscluster::publish", rediscluster_publish, rediscluster_function, 0,
-                      "publish")
-  NR_INTERNAL_WRAPREC("rediscluster::randomkey", rediscluster_randomkey, rediscluster_function, 0,
-                      "randomkey")
-  NR_INTERNAL_WRAPREC("rediscluster::rawcommand", rediscluster_rawcommand, rediscluster_function, 0,
-                      "rawcommand")
-  NR_INTERNAL_WRAPREC("rediscluster::rename", rediscluster_rename, rediscluster_function, 0,
-                      "rename")
-  NR_INTERNAL_WRAPREC("rediscluster::renamenx", rediscluster_renamenx, rediscluster_function, 0,
-                      "renamenx")
-  NR_INTERNAL_WRAPREC("rediscluster::rpop", rediscluster_rpop, rediscluster_function, 0, "rpop")
-  NR_INTERNAL_WRAPREC("rediscluster::rpoplpush", rediscluster_rpoplpush, rediscluster_function, 0,
-                      "rpoplpush")
-  NR_INTERNAL_WRAPREC("rediscluster::rpush", rediscluster_rpush, rediscluster_function, 0, "rpush")
-  NR_INTERNAL_WRAPREC("rediscluster::rpushx", rediscluster_rpushx, rediscluster_function, 0,
-                      "rpushx")
-  NR_INTERNAL_WRAPREC("rediscluster::sadd", rediscluster_sadd, rediscluster_function, 0, "sadd")
-  NR_INTERNAL_WRAPREC("rediscluster::scard", rediscluster_scard, rediscluster_function, 0, "scard")
-  NR_INTERNAL_WRAPREC("rediscluster::sdiff", rediscluster_sdiff, rediscluster_function, 0, "sdiff")
-  NR_INTERNAL_WRAPREC("rediscluster::sdiffstore", rediscluster_sdiffstore, rediscluster_function, 0,
-                      "sdiffstore")
-  NR_INTERNAL_WRAPREC("rediscluster::set", rediscluster_set, rediscluster_function, 0, "set")
-  NR_INTERNAL_WRAPREC("rediscluster::setbit", rediscluster_setbit, rediscluster_function, 0,
-                      "setbit")
-  NR_INTERNAL_WRAPREC("rediscluster::setex", rediscluster_setex, rediscluster_function, 0, "setex")
-  NR_INTERNAL_WRAPREC("rediscluster::setnx", rediscluster_setnx, rediscluster_function, 0, "setnx")
-  NR_INTERNAL_WRAPREC("rediscluster::setrange", rediscluster_setrange, rediscluster_function, 0,
-                      "setrange")
-  NR_INTERNAL_WRAPREC("rediscluster::sinter", rediscluster_sinter, rediscluster_function, 0,
-                      "sinter")
-  NR_INTERNAL_WRAPREC("rediscluster::sinterstore", rediscluster_sinterstore, rediscluster_function,
-                      0, "sinterstore")
-  NR_INTERNAL_WRAPREC("rediscluster::sismember", rediscluster_sismember, rediscluster_function, 0,
-                      "sismember")
-  NR_INTERNAL_WRAPREC("rediscluster::smembers", rediscluster_smembers, rediscluster_function, 0,
-                      "smembers")
-  NR_INTERNAL_WRAPREC("rediscluster::smismember", rediscluster_smismember, rediscluster_function, 0,
-                      "smismember")
-  NR_INTERNAL_WRAPREC("rediscluster::smove", rediscluster_smove, rediscluster_function, 0, "smove")
-  NR_INTERNAL_WRAPREC("rediscluster::spop", rediscluster_spop, rediscluster_function, 0, "spop")
-  NR_INTERNAL_WRAPREC("rediscluster::srandmember", rediscluster_srandmember, rediscluster_function,
-                      0, "srandmember")
-  NR_INTERNAL_WRAPREC("rediscluster::srem", rediscluster_srem, rediscluster_function, 0, "srem")
-  NR_INTERNAL_WRAPREC("rediscluster::strlen", rediscluster_strlen, rediscluster_function, 0,
-                      "strlen")
-  NR_INTERNAL_WRAPREC("rediscluster::sunion", rediscluster_sunion, rediscluster_function, 0,
-                      "sunion")
-  NR_INTERNAL_WRAPREC("rediscluster::sunionstore", rediscluster_sunionstore, rediscluster_function,
-                      0, "sunionstore")
-  NR_INTERNAL_WRAPREC("rediscluster::time", rediscluster_time, rediscluster_function, 0, "time")
-  NR_INTERNAL_WRAPREC("rediscluster::ttl", rediscluster_ttl, rediscluster_function, 0, "ttl")
-  NR_INTERNAL_WRAPREC("rediscluster::type", rediscluster_type, rediscluster_function, 0, "type")
-  NR_INTERNAL_WRAPREC("rediscluster::unlink", rediscluster_unlink, rediscluster_function, 0,
-                      "unlink")
-  NR_INTERNAL_WRAPREC("rediscluster::xack", rediscluster_xack, rediscluster_function, 0, "xack")
-  NR_INTERNAL_WRAPREC("rediscluster::xadd", rediscluster_xadd, rediscluster_function, 0, "xadd")
-  NR_INTERNAL_WRAPREC("rediscluster::xclaim", rediscluster_xclaim, rediscluster_function, 0,
-                      "xclaim")
-  NR_INTERNAL_WRAPREC("rediscluster::xdel", rediscluster_xdel, rediscluster_function, 0, "xdel")
-  NR_INTERNAL_WRAPREC("rediscluster::xgroup", rediscluster_xgroup, rediscluster_function, 0, 
-                      "xgroup")
-  NR_INTERNAL_WRAPREC("rediscluster::xinfo", rediscluster_xinfo, rediscluster_function, 0, "xinfo")
-  NR_INTERNAL_WRAPREC("rediscluster::xlen", rediscluster_xlen, rediscluster_function, 0, "xlen")
-  NR_INTERNAL_WRAPREC("rediscluster::xpending", rediscluster_xpending, rediscluster_function, 0,
-                      "xpending")
-  NR_INTERNAL_WRAPREC("rediscluster::xrange", rediscluster_xrange, rediscluster_function, 0,
-                      "xrange")
-  NR_INTERNAL_WRAPREC("rediscluster::xread", rediscluster_xread, rediscluster_function, 0, "xread")
-  NR_INTERNAL_WRAPREC("rediscluster::xreadgroup", rediscluster_xreadgroup, rediscluster_function, 0,
-                      "xreadgroup")
-  NR_INTERNAL_WRAPREC("rediscluster::xrevrange", rediscluster_xrevrange, rediscluster_function, 0,
-                      "xrevrange")
-  NR_INTERNAL_WRAPREC("rediscluster::xtrim", rediscluster_xtrim, rediscluster_function, 0, "xtrim")
-  NR_INTERNAL_WRAPREC("rediscluster::zadd", rediscluster_zadd, rediscluster_function, 0, "zadd")
-  NR_INTERNAL_WRAPREC("rediscluster::zcard", rediscluster_zcard, rediscluster_function, 0, "zcard")
-  NR_INTERNAL_WRAPREC("rediscluster::zcount", rediscluster_zcount, rediscluster_function, 0,
-                      "zcount")
-  NR_INTERNAL_WRAPREC("rediscluster::zincrby", rediscluster_zincrby, rediscluster_function, 0,
-                      "zincrby")
-  NR_INTERNAL_WRAPREC("rediscluster::zinterstore", rediscluster_zinterstore, rediscluster_function,
-                      0, "zinterstore")
-  NR_INTERNAL_WRAPREC("rediscluster::zlexcount", rediscluster_zlexcount, rediscluster_function, 0,
-                      "zlexcount")
-  NR_INTERNAL_WRAPREC("rediscluster::zpopmax", rediscluster_zpopmax, rediscluster_function, 0,
-                      "zpopmax")
-  NR_INTERNAL_WRAPREC("rediscluster::zpopmin", rediscluster_zpopmin, rediscluster_function, 0,
-                      "zpopmin")
-  NR_INTERNAL_WRAPREC("rediscluster::zrange", rediscluster_zrange, rediscluster_function, 0,
-                      "zrange")
-  NR_INTERNAL_WRAPREC("rediscluster::zrangebylex", rediscluster_zrangebylex, rediscluster_function,
-                      0, "zrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::append", rediscluster_append,
+                      rediscluster_function, 0, "append")
+  NR_INTERNAL_WRAPREC("rediscluster::bitcount", rediscluster_bitcount,
+                      rediscluster_function, 0, "bitcount")
+  NR_INTERNAL_WRAPREC("rediscluster::bitop", rediscluster_bitop,
+                      rediscluster_function, 0, "bitop")
+  NR_INTERNAL_WRAPREC("rediscluster::bitpos", rediscluster_bitpos,
+                      rediscluster_function, 0, "bitpos")
+  NR_INTERNAL_WRAPREC("rediscluster::decr", rediscluster_decr,
+                      rediscluster_function, 0, "decr")
+  NR_INTERNAL_WRAPREC("rediscluster::decrby", rediscluster_decrby,
+                      rediscluster_function, 0, "decrby")
+  NR_INTERNAL_WRAPREC("rediscluster::del", rediscluster_del,
+                      rediscluster_function, 0, "del")
+  NR_INTERNAL_WRAPREC("rediscluster::dbsize", rediscluster_dbsize,
+                      rediscluster_function, 0, "dbsize")
+  NR_INTERNAL_WRAPREC("rediscluster::eval", rediscluster_eval,
+                      rediscluster_function, 0, "eval")
+  NR_INTERNAL_WRAPREC("rediscluster::evalsha", rediscluster_evalsha,
+                      rediscluster_function, 0, "evalsha")
+  NR_INTERNAL_WRAPREC("rediscluster::exec", rediscluster_exec,
+                      rediscluster_function, 0, "exec")
+  NR_INTERNAL_WRAPREC("rediscluster::exists", rediscluster_exists,
+                      rediscluster_function, 0, "exists")
+  NR_INTERNAL_WRAPREC("rediscluster::expire", rediscluster_expire,
+                      rediscluster_function, 0, "expire")
+  NR_INTERNAL_WRAPREC("rediscluster::expireat", rediscluster_expireat,
+                      rediscluster_function, 0, "expireat")
+  NR_INTERNAL_WRAPREC("rediscluster::flushall", rediscluster_flushall,
+                      rediscluster_function, 0, "flushall")
+  NR_INTERNAL_WRAPREC("rediscluster::flushdb", rediscluster_flushdb,
+                      rediscluster_function, 0, "flushdb")
+  NR_INTERNAL_WRAPREC("rediscluster::geoadd", rediscluster_geoadd,
+                      rediscluster_function, 0, "geoadd")
+  NR_INTERNAL_WRAPREC("rediscluster::geodist", rediscluster_geodist,
+                      rediscluster_function, 0, "geodist")
+  NR_INTERNAL_WRAPREC("rediscluster::geohash", rediscluster_geohash,
+                      rediscluster_function, 0, "geohash")
+  NR_INTERNAL_WRAPREC("rediscluster::geopos", rediscluster_geopos,
+                      rediscluster_function, 0, "geopos")
+  NR_INTERNAL_WRAPREC("rediscluster::georadius", rediscluster_georadius,
+                      rediscluster_function, 0, "georadius")
+  NR_INTERNAL_WRAPREC("rediscluster::georadius_ro", rediscluster_georadius_ro,
+                      rediscluster_function, 0, "georadius_ro")
+  NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember",
+                      rediscluster_georadiusbymember, rediscluster_function, 0,
+                      "georadiusbymember")
+  NR_INTERNAL_WRAPREC("rediscluster::georadiusbymember_ro",
+                      rediscluster_georadiusbymember_ro, rediscluster_function,
+                      0, "georadiusbymember_ro")
+  NR_INTERNAL_WRAPREC("rediscluster::get", rediscluster_get,
+                      rediscluster_function, 0, "get")
+  NR_INTERNAL_WRAPREC("rediscluster::getbit", rediscluster_getbit,
+                      rediscluster_function, 0, "getbit")
+  NR_INTERNAL_WRAPREC("rediscluster::getrange", rediscluster_getrange,
+                      rediscluster_function, 0, "getrange")
+  NR_INTERNAL_WRAPREC("rediscluster::getset", rediscluster_getset,
+                      rediscluster_function, 0, "getset")
+  NR_INTERNAL_WRAPREC("rediscluster::hdel", rediscluster_hdel,
+                      rediscluster_function, 0, "hdel")
+  NR_INTERNAL_WRAPREC("rediscluster::hexists", rediscluster_hexists,
+                      rediscluster_function, 0, "hexists")
+  NR_INTERNAL_WRAPREC("rediscluster::hget", rediscluster_hget,
+                      rediscluster_function, 0, "hget")
+  NR_INTERNAL_WRAPREC("rediscluster::hgetall", rediscluster_hgetall,
+                      rediscluster_function, 0, "hgetall")
+  NR_INTERNAL_WRAPREC("rediscluster::hincrby", rediscluster_hincrby,
+                      rediscluster_function, 0, "hincrby")
+  NR_INTERNAL_WRAPREC("rediscluster::hincrbyfloat", rediscluster_hincrbyfloat,
+                      rediscluster_function, 0, "hincrbyfloat")
+  NR_INTERNAL_WRAPREC("rediscluster::hkeys", rediscluster_hkeys,
+                      rediscluster_function, 0, "hkeys")
+  NR_INTERNAL_WRAPREC("rediscluster::hlen", rediscluster_hlen,
+                      rediscluster_function, 0, "hlen")
+  NR_INTERNAL_WRAPREC("rediscluster::hmget", rediscluster_hmget,
+                      rediscluster_function, 0, "hmget")
+  NR_INTERNAL_WRAPREC("rediscluster::hmset", rediscluster_hmset,
+                      rediscluster_function, 0, "hmset")
+  NR_INTERNAL_WRAPREC("rediscluster::hset", rediscluster_hset,
+                      rediscluster_function, 0, "hset")
+  NR_INTERNAL_WRAPREC("rediscluster::hsetnx", rediscluster_hsetnx,
+                      rediscluster_function, 0, "hsetnx")
+  NR_INTERNAL_WRAPREC("rediscluster::hstrlen", rediscluster_hstrlen,
+                      rediscluster_function, 0, "hstrlen")
+  NR_INTERNAL_WRAPREC("rediscluster::hvals", rediscluster_hvals,
+                      rediscluster_function, 0, "hvals")
+  NR_INTERNAL_WRAPREC("rediscluster::incr", rediscluster_incr,
+                      rediscluster_function, 0, "incr")
+  NR_INTERNAL_WRAPREC("rediscluster::incrby", rediscluster_incrby,
+                      rediscluster_function, 0, "incrby")
+  NR_INTERNAL_WRAPREC("rediscluster::incrbyfloat", rediscluster_incrbyfloat,
+                      rediscluster_function, 0, "incrbyfloat")
+  NR_INTERNAL_WRAPREC("rediscluster::keys", rediscluster_keys,
+                      rediscluster_function, 0, "keys")
+  NR_INTERNAL_WRAPREC("rediscluster::lget", rediscluster_lget,
+                      rediscluster_function, 0, "lget")
+  NR_INTERNAL_WRAPREC("rediscluster::lindex", rediscluster_lindex,
+                      rediscluster_function, 0, "lindex")
+  NR_INTERNAL_WRAPREC("rediscluster::linsert", rediscluster_linsert,
+                      rediscluster_function, 0, "linsert")
+  NR_INTERNAL_WRAPREC("rediscluster::llen", rediscluster_llen,
+                      rediscluster_function, 0, "llen")
+  NR_INTERNAL_WRAPREC("rediscluster::lpop", rediscluster_lpop,
+                      rediscluster_function, 0, "lpop")
+  NR_INTERNAL_WRAPREC("rediscluster::lpush", rediscluster_lpush,
+                      rediscluster_function, 0, "lpush")
+  NR_INTERNAL_WRAPREC("rediscluster::lpushx", rediscluster_lpushx,
+                      rediscluster_function, 0, "lpushx")
+  NR_INTERNAL_WRAPREC("rediscluster::lrange", rediscluster_lrange,
+                      rediscluster_function, 0, "lrange")
+  NR_INTERNAL_WRAPREC("rediscluster::lrem", rediscluster_lrem,
+                      rediscluster_function, 0, "lrem")
+  NR_INTERNAL_WRAPREC("rediscluster::lset", rediscluster_lset,
+                      rediscluster_function, 0, "lset")
+  NR_INTERNAL_WRAPREC("rediscluster::ltrim", rediscluster_ltrim,
+                      rediscluster_function, 0, "ltrim")
+  NR_INTERNAL_WRAPREC("rediscluster::mget", rediscluster_mget,
+                      rediscluster_function, 0, "mget")
+  NR_INTERNAL_WRAPREC("rediscluster::mset", rediscluster_mset,
+                      rediscluster_function, 0, "mset")
+  NR_INTERNAL_WRAPREC("rediscluster::msetnx", rediscluster_msetnx,
+                      rediscluster_function, 0, "msetnx")
+  NR_INTERNAL_WRAPREC("rediscluster::persist", rediscluster_persist,
+                      rediscluster_function, 0, "persist")
+  NR_INTERNAL_WRAPREC("rediscluster::pexpire", rediscluster_pexpire,
+                      rediscluster_function, 0, "pexpire")
+  NR_INTERNAL_WRAPREC("rediscluster::pexpireat", rediscluster_pexpireat,
+                      rediscluster_function, 0, "pexpireat")
+  NR_INTERNAL_WRAPREC("rediscluster::pfadd", rediscluster_pfadd,
+                      rediscluster_function, 0, "pfadd")
+  NR_INTERNAL_WRAPREC("rediscluster::pfcount", rediscluster_pfcount,
+                      rediscluster_function, 0, "pfcount")
+  NR_INTERNAL_WRAPREC("rediscluster::pfmerge", rediscluster_pfmerge,
+                      rediscluster_function, 0, "pfmerge")
+  NR_INTERNAL_WRAPREC("rediscluster::ping", rediscluster_ping,
+                      rediscluster_function, 0, "ping")
+  NR_INTERNAL_WRAPREC("rediscluster::psetex", rediscluster_psetex,
+                      rediscluster_function, 0, "psetex")
+  NR_INTERNAL_WRAPREC("rediscluster::pttl", rediscluster_pttl,
+                      rediscluster_function, 0, "pttl")
+  NR_INTERNAL_WRAPREC("rediscluster::publish", rediscluster_publish,
+                      rediscluster_function, 0, "publish")
+  NR_INTERNAL_WRAPREC("rediscluster::randomkey", rediscluster_randomkey,
+                      rediscluster_function, 0, "randomkey")
+  NR_INTERNAL_WRAPREC("rediscluster::rawcommand", rediscluster_rawcommand,
+                      rediscluster_function, 0, "rawcommand")
+  NR_INTERNAL_WRAPREC("rediscluster::rename", rediscluster_rename,
+                      rediscluster_function, 0, "rename")
+  NR_INTERNAL_WRAPREC("rediscluster::renamenx", rediscluster_renamenx,
+                      rediscluster_function, 0, "renamenx")
+  NR_INTERNAL_WRAPREC("rediscluster::rpop", rediscluster_rpop,
+                      rediscluster_function, 0, "rpop")
+  NR_INTERNAL_WRAPREC("rediscluster::rpoplpush", rediscluster_rpoplpush,
+                      rediscluster_function, 0, "rpoplpush")
+  NR_INTERNAL_WRAPREC("rediscluster::rpush", rediscluster_rpush,
+                      rediscluster_function, 0, "rpush")
+  NR_INTERNAL_WRAPREC("rediscluster::rpushx", rediscluster_rpushx,
+                      rediscluster_function, 0, "rpushx")
+  NR_INTERNAL_WRAPREC("rediscluster::sadd", rediscluster_sadd,
+                      rediscluster_function, 0, "sadd")
+  NR_INTERNAL_WRAPREC("rediscluster::scard", rediscluster_scard,
+                      rediscluster_function, 0, "scard")
+  NR_INTERNAL_WRAPREC("rediscluster::sdiff", rediscluster_sdiff,
+                      rediscluster_function, 0, "sdiff")
+  NR_INTERNAL_WRAPREC("rediscluster::sdiffstore", rediscluster_sdiffstore,
+                      rediscluster_function, 0, "sdiffstore")
+  NR_INTERNAL_WRAPREC("rediscluster::set", rediscluster_set,
+                      rediscluster_function, 0, "set")
+  NR_INTERNAL_WRAPREC("rediscluster::setbit", rediscluster_setbit,
+                      rediscluster_function, 0, "setbit")
+  NR_INTERNAL_WRAPREC("rediscluster::setex", rediscluster_setex,
+                      rediscluster_function, 0, "setex")
+  NR_INTERNAL_WRAPREC("rediscluster::setnx", rediscluster_setnx,
+                      rediscluster_function, 0, "setnx")
+  NR_INTERNAL_WRAPREC("rediscluster::setrange", rediscluster_setrange,
+                      rediscluster_function, 0, "setrange")
+  NR_INTERNAL_WRAPREC("rediscluster::sinter", rediscluster_sinter,
+                      rediscluster_function, 0, "sinter")
+  NR_INTERNAL_WRAPREC("rediscluster::sinterstore", rediscluster_sinterstore,
+                      rediscluster_function, 0, "sinterstore")
+  NR_INTERNAL_WRAPREC("rediscluster::sismember", rediscluster_sismember,
+                      rediscluster_function, 0, "sismember")
+  NR_INTERNAL_WRAPREC("rediscluster::smembers", rediscluster_smembers,
+                      rediscluster_function, 0, "smembers")
+  NR_INTERNAL_WRAPREC("rediscluster::smismember", rediscluster_smismember,
+                      rediscluster_function, 0, "smismember")
+  NR_INTERNAL_WRAPREC("rediscluster::smove", rediscluster_smove,
+                      rediscluster_function, 0, "smove")
+  NR_INTERNAL_WRAPREC("rediscluster::spop", rediscluster_spop,
+                      rediscluster_function, 0, "spop")
+  NR_INTERNAL_WRAPREC("rediscluster::srandmember", rediscluster_srandmember,
+                      rediscluster_function, 0, "srandmember")
+  NR_INTERNAL_WRAPREC("rediscluster::srem", rediscluster_srem,
+                      rediscluster_function, 0, "srem")
+  NR_INTERNAL_WRAPREC("rediscluster::strlen", rediscluster_strlen,
+                      rediscluster_function, 0, "strlen")
+  NR_INTERNAL_WRAPREC("rediscluster::sunion", rediscluster_sunion,
+                      rediscluster_function, 0, "sunion")
+  NR_INTERNAL_WRAPREC("rediscluster::sunionstore", rediscluster_sunionstore,
+                      rediscluster_function, 0, "sunionstore")
+  NR_INTERNAL_WRAPREC("rediscluster::time", rediscluster_time,
+                      rediscluster_function, 0, "time")
+  NR_INTERNAL_WRAPREC("rediscluster::ttl", rediscluster_ttl,
+                      rediscluster_function, 0, "ttl")
+  NR_INTERNAL_WRAPREC("rediscluster::type", rediscluster_type,
+                      rediscluster_function, 0, "type")
+  NR_INTERNAL_WRAPREC("rediscluster::unlink", rediscluster_unlink,
+                      rediscluster_function, 0, "unlink")
+  NR_INTERNAL_WRAPREC("rediscluster::xack", rediscluster_xack,
+                      rediscluster_function, 0, "xack")
+  NR_INTERNAL_WRAPREC("rediscluster::xadd", rediscluster_xadd,
+                      rediscluster_function, 0, "xadd")
+  NR_INTERNAL_WRAPREC("rediscluster::xclaim", rediscluster_xclaim,
+                      rediscluster_function, 0, "xclaim")
+  NR_INTERNAL_WRAPREC("rediscluster::xdel", rediscluster_xdel,
+                      rediscluster_function, 0, "xdel")
+  NR_INTERNAL_WRAPREC("rediscluster::xgroup", rediscluster_xgroup,
+                      rediscluster_function, 0, "xgroup")
+  NR_INTERNAL_WRAPREC("rediscluster::xinfo", rediscluster_xinfo,
+                      rediscluster_function, 0, "xinfo")
+  NR_INTERNAL_WRAPREC("rediscluster::xlen", rediscluster_xlen,
+                      rediscluster_function, 0, "xlen")
+  NR_INTERNAL_WRAPREC("rediscluster::xpending", rediscluster_xpending,
+                      rediscluster_function, 0, "xpending")
+  NR_INTERNAL_WRAPREC("rediscluster::xrange", rediscluster_xrange,
+                      rediscluster_function, 0, "xrange")
+  NR_INTERNAL_WRAPREC("rediscluster::xread", rediscluster_xread,
+                      rediscluster_function, 0, "xread")
+  NR_INTERNAL_WRAPREC("rediscluster::xreadgroup", rediscluster_xreadgroup,
+                      rediscluster_function, 0, "xreadgroup")
+  NR_INTERNAL_WRAPREC("rediscluster::xrevrange", rediscluster_xrevrange,
+                      rediscluster_function, 0, "xrevrange")
+  NR_INTERNAL_WRAPREC("rediscluster::xtrim", rediscluster_xtrim,
+                      rediscluster_function, 0, "xtrim")
+  NR_INTERNAL_WRAPREC("rediscluster::zadd", rediscluster_zadd,
+                      rediscluster_function, 0, "zadd")
+  NR_INTERNAL_WRAPREC("rediscluster::zcard", rediscluster_zcard,
+                      rediscluster_function, 0, "zcard")
+  NR_INTERNAL_WRAPREC("rediscluster::zcount", rediscluster_zcount,
+                      rediscluster_function, 0, "zcount")
+  NR_INTERNAL_WRAPREC("rediscluster::zincrby", rediscluster_zincrby,
+                      rediscluster_function, 0, "zincrby")
+  NR_INTERNAL_WRAPREC("rediscluster::zinterstore", rediscluster_zinterstore,
+                      rediscluster_function, 0, "zinterstore")
+  NR_INTERNAL_WRAPREC("rediscluster::zlexcount", rediscluster_zlexcount,
+                      rediscluster_function, 0, "zlexcount")
+  NR_INTERNAL_WRAPREC("rediscluster::zpopmax", rediscluster_zpopmax,
+                      rediscluster_function, 0, "zpopmax")
+  NR_INTERNAL_WRAPREC("rediscluster::zpopmin", rediscluster_zpopmin,
+                      rediscluster_function, 0, "zpopmin")
+  NR_INTERNAL_WRAPREC("rediscluster::zrange", rediscluster_zrange,
+                      rediscluster_function, 0, "zrange")
+  NR_INTERNAL_WRAPREC("rediscluster::zrangebylex", rediscluster_zrangebylex,
+                      rediscluster_function, 0, "zrangebylex")
   NR_INTERNAL_WRAPREC("rediscluster::zrangebyscore", rediscluster_zrangebyscore,
                       rediscluster_function, 0, "zrangebyscore")
-  NR_INTERNAL_WRAPREC("rediscluster::zrank", rediscluster_zrank, rediscluster_function, 0, "zrank")
-  NR_INTERNAL_WRAPREC("rediscluster::zrem", rediscluster_zrem, rediscluster_function, 0, "zrem")
-  NR_INTERNAL_WRAPREC("rediscluster::zremrangebylex", rediscluster_zremrangebylex,
-                      rediscluster_function, 0, "zremrangebylex")
-  NR_INTERNAL_WRAPREC("rediscluster::zremrangebyrank", rediscluster_zremrangebyrank,
-                      rediscluster_function, 0, "zremrangebyrank")
-  NR_INTERNAL_WRAPREC("rediscluster::zremrangebyscore", rediscluster_zremrangebyscore,
-                      rediscluster_function, 0, "zremrangebyscore")
-  NR_INTERNAL_WRAPREC("rediscluster::zrevrange", rediscluster_zrevrange, rediscluster_function, 0,
-                      "zrevrange")
-  NR_INTERNAL_WRAPREC("rediscluster::zrevrangebylex", rediscluster_zrevrangebylex,
-                      rediscluster_function, 0, "zrevrangebylex")
-  NR_INTERNAL_WRAPREC("rediscluster::zrevrangebyscore", rediscluster_zrevrangebyscore,
-                      rediscluster_function, 0, "zrevrangebyscore")
-  NR_INTERNAL_WRAPREC("rediscluster::zrevrank", rediscluster_zrevrank, rediscluster_function, 0,
-                      "zrevrank")
-  NR_INTERNAL_WRAPREC("rediscluster::zscore", rediscluster_zscore, rediscluster_function, 0, 
-                      "zscore")
-  NR_INTERNAL_WRAPREC("rediscluster::zunionstore", rediscluster_zunionstore, rediscluster_function,
-                      0, "zunionstore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrank", rediscluster_zrank,
+                      rediscluster_function, 0, "zrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zrem", rediscluster_zrem,
+                      rediscluster_function, 0, "zrem")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebylex",
+                      rediscluster_zremrangebylex, rediscluster_function, 0,
+                      "zremrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebyrank",
+                      rediscluster_zremrangebyrank, rediscluster_function, 0,
+                      "zremrangebyrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zremrangebyscore",
+                      rediscluster_zremrangebyscore, rediscluster_function, 0,
+                      "zremrangebyscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrange", rediscluster_zrevrange,
+                      rediscluster_function, 0, "zrevrange")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrangebylex",
+                      rediscluster_zrevrangebylex, rediscluster_function, 0,
+                      "zrevrangebylex")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrangebyscore",
+                      rediscluster_zrevrangebyscore, rediscluster_function, 0,
+                      "zrevrangebyscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zrevrank", rediscluster_zrevrank,
+                      rediscluster_function, 0, "zrevrank")
+  NR_INTERNAL_WRAPREC("rediscluster::zscore", rediscluster_zscore,
+                      rediscluster_function, 0, "zscore")
+  NR_INTERNAL_WRAPREC("rediscluster::zunionstore", rediscluster_zunionstore,
+                      rediscluster_function, 0, "zunionstore")
 
   NR_INTERNAL_WRAPREC("pg_close", pg_close, pg_close, 0, 0)
   NR_INTERNAL_WRAPREC("pg_connect", pg_connect, pg_connect, 0, 0)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
     restart: always
     command: >
       sh -c '
-        redis-server --port 7000 --cluster-enabled yes --cluster-config-file /tmp/nodes.conf --cluster-announce-ip redisclusterdb &
+        redis-server --port 7000 --cluster-enabled yes --cluster-config-file /tmp/nodes.conf --cluster-announce-ip $$(hostname -i) &
         PID=$$!
         until redis-cli -p 7000 ping >/dev/null 2>&1; do sleep 0.2; done
         redis-cli -p 7000 cluster addslotsrange 0 16383

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,7 +66,6 @@ services:
       PREDIS_HOME: /usr/src/vendor/predis/predis/
       REDIS_HOST: redisdb
       REDIS_CLUSTER_HOST: redisclusterdb
-      REDIS_CLUSTER_PORT: 7000
 
     volumes:
        - ${AGENT_CODE:-$PWD}:/usr/local/src/newrelic-php-agent
@@ -98,7 +97,6 @@ services:
       PREDIS_HOME: /usr/src/vendor/predis/predis/
       REDIS_HOST: redisdb
       REDIS_CLUSTER_HOST: redisclusterdb
-      REDIS_CLUSTER_PORT: 7000
 
       PS1: "New Relic > "
       NEWRELIC_COLLECTOR_HOST : ${NEW_RELIC_COLLECTOR_HOST:-collector.newrelic.com}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,17 @@ services:
   redisdb:
     image: redis
     restart: always
+  redisclusterdb:
+    image: redis
+    restart: always
+    command: >
+      sh -c '
+        redis-server --port 7000 --cluster-enabled yes --cluster-config-file /tmp/nodes.conf &
+        PID=$$!
+        until redis-cli -p 7000 ping >/dev/null 2>&1; do sleep 0.2; done
+        redis-cli -p 7000 cluster addslotsrange 0 16383
+        wait $$PID
+      '
   memcached:
     image: memcached:latest
     restart: always
@@ -54,6 +65,8 @@ services:
 
       PREDIS_HOME: /usr/src/vendor/predis/predis/
       REDIS_HOST: redisdb
+      REDIS_CLUSTER_HOST: redisclusterdb
+      REDIS_CLUSTER_PORT: 7000
 
     volumes:
        - ${AGENT_CODE:-$PWD}:/usr/local/src/newrelic-php-agent
@@ -84,6 +97,8 @@ services:
 
       PREDIS_HOME: /usr/src/vendor/predis/predis/
       REDIS_HOST: redisdb
+      REDIS_CLUSTER_HOST: redisclusterdb
+      REDIS_CLUSTER_PORT: 7000
 
       PS1: "New Relic > "
       NEWRELIC_COLLECTOR_HOST : ${NEW_RELIC_COLLECTOR_HOST:-collector.newrelic.com}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
     restart: always
     command: >
       sh -c '
-        redis-server --port 7000 --cluster-enabled yes --cluster-config-file /tmp/nodes.conf &
+        redis-server --port 7000 --cluster-enabled yes --cluster-config-file /tmp/nodes.conf --cluster-announce-ip redisclusterdb &
         PID=$$!
         until redis-cli -p 7000 ping >/dev/null 2>&1; do sleep 0.2; done
         redis-cli -p 7000 cluster addslotsrange 0 16383

--- a/tests/include/config.php
+++ b/tests/include/config.php
@@ -30,6 +30,9 @@ $MEMCACHE_PORT = isset_or('MEMCACHE_PORT', '11211');
 $REDIS_HOST = isset_or("REDIS_HOST", "127.0.0.1");
 $REDIS_PORT = isset_or("REDIS_PORT", 6379);
 
+$REDIS_CLUSTER_HOST = isset_or("REDIS_CLUSTER_HOST", "127.0.0.1");
+$REDIS_CLUSTER_PORT = isset_or("REDIS_CLUSTER_PORT", 7000);
+
 $PDO_MYSQL_DSN = 'mysql:';
 $PDO_MYSQL_DSN .= 'host=' . $MYSQL_HOST . ';';
 $PDO_MYSQL_DSN .= 'dbname=' . $MYSQL_DB . ';';

--- a/tests/integration/predis/test_cluster_basic.php
+++ b/tests/integration/predis/test_cluster_basic.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent SHALL report Datastore metrics for Redis basic operations when
+using Predis in cluster mode.
+*/
+
+/*SKIPIF
+<?php
+require('predis.inc');
+*/
+
+/*EXPECT
+ok - set key
+ok - get key
+ok - delete key
+ok - delete missing key
+ok - reuse deleted key
+ok - set duplicate key
+ok - delete key
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/instance/Redis/redisclusterdb/7000
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+Datastore/operation/Redis/get
+Datastore/operation/Redis/set
+Datastore/operation/Redis/setnx
+*/
+
+/*EXPECT_TRACED_ERRORS null */
+
+require_once(__DIR__.'/../../include/config.php');
+require_once(__DIR__.'/../../include/helpers.php');
+require_once(__DIR__.'/../../include/tap.php');
+require_once(__DIR__.'/predis.inc');
+
+function test_cluster_basic() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $client = new Predis\Client(
+    array('host' => $REDIS_CLUSTER_HOST, 'port' => $REDIS_CLUSTER_PORT),
+    array('cluster' => 'redis')
+  );
+
+  try {
+    $client->connect();
+  } catch (Exception $e) {
+    die("skip: " . $e->getMessage() . "\n");
+  }
+
+  /* Generate a unique key to use for this test run */
+  $key = randstr(16);
+  if ($client->exists($key)) {
+    echo "key already exists: $key\n";
+    exit(1);
+  }
+
+  $rval = $client->set($key, 'bar');
+  tap_equal('OK', $rval->getPayload(), 'set key');
+  tap_equal('bar', $client->get($key), 'get key');
+  tap_equal(1, $client->del($key), 'delete key');
+  tap_equal(0, $client->del($key), 'delete missing key');
+
+  tap_assert($client->setnx($key, 'bar') == 1, 'reuse deleted key');
+  tap_refute($client->setnx($key, 'bar') == 1, 'set duplicate key');
+
+  /* Cleanup the key used by this test run */
+  tap_equal(1, $client->del($key), 'delete key');
+
+  /* Close connection */
+  $client->disconnect();
+}
+
+test_cluster_basic();

--- a/tests/integration/predis/test_cluster_basic.php
+++ b/tests/integration/predis/test_cluster_basic.php
@@ -48,7 +48,9 @@ function test_cluster_basic() {
   global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
 
   $client = new Predis\Client(
-    array('host' => $REDIS_CLUSTER_HOST, 'port' => $REDIS_CLUSTER_PORT),
+    array(
+      array('host' => $REDIS_CLUSTER_HOST, 'port' => $REDIS_CLUSTER_PORT),
+    ),
     array('cluster' => 'redis')
   );
 

--- a/tests/integration/rediscluster/skipif.inc
+++ b/tests/integration/rediscluster/skipif.inc
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+if (!extension_loaded('redis')) {
+  die("skip: redis extension required\n");
+}
+
+if (!class_exists('RedisCluster')) {
+  die("skip: \\RedisCluster class required (build phpredis with cluster support)\n");
+}
+
+if (!isset($minimum_extension_version)) {
+  $minimum_extension_version = '4.3.0';
+}
+$extension_version = phpversion('redis');
+if (version_compare($extension_version, $minimum_extension_version) < 0) {
+  die("skip: redis extension version >= " . $minimum_extension_version
+    . " required, detected version: " . $extension_version . "\n");
+}
+
+if (!isset($minimum_redis_datastore_version)) {
+  /*
+   * `CLUSTER ADDSLOTSRANGE` (used by the docker-compose redisclusterdb service
+   * to bootstrap a single-node cluster) was introduced in Redis 7.0.
+   */
+  $minimum_redis_datastore_version = '7.0.0';
+}
+
+try {
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    5.0, 5.0);
+  /*
+   * \RedisCluster::info() returns a per-master map keyed by "host:port".
+   * Pull the version from the first master.
+   */
+  $info = $cluster->info($REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT);
+  $datastore_version = $info['redis_version'] ?? null;
+  if (null === $datastore_version) {
+    die("skip: could not determine Redis Cluster server version\n");
+  }
+  if (version_compare($datastore_version, $minimum_redis_datastore_version) < 0) {
+    die("skip: Redis Cluster server version >= " . $minimum_redis_datastore_version
+      . " required, detected version: " . $datastore_version . "\n");
+  }
+} catch (RedisClusterException $e) {
+  die("skip: " . $e->getMessage() . "\n");
+}

--- a/tests/integration/rediscluster/skipif.inc
+++ b/tests/integration/rediscluster/skipif.inc
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 New Relic Corporation. All rights reserved.
+ * Copyright 2026 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/tests/integration/rediscluster/test_basic.php
+++ b/tests/integration/rediscluster/test_basic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 New Relic Corporation. All rights reserved.
+ * Copyright 2026 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -104,9 +104,6 @@ Datastore/operation/Redis/open
 Datastore/operation/Redis/popen
 Datastore/operation/Redis/select
 */
-
-
-
 
 require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
 require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');

--- a/tests/integration/rediscluster/test_basic.php
+++ b/tests/integration/rediscluster/test_basic.php
@@ -1,0 +1,209 @@
+<?php
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster basic operations,
+mirroring the coverage of tests/integration/redis/test_basic.php.
+
+The key correctness assertion is that no Datastore/operation/Redis/connect (or
+pconnect / select) metric is produced: \RedisCluster instances are constructed via
+__construct(seeds[]), which the agent must NOT route through the connect-style
+inner handlers. Each individual data operation is asserted to exist as
+Datastore/operation/Redis/<op>, matching how lib_predis.c already reports Predis
+cluster traffic (NR_DATASTORE_REDIS).
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - set key
+ok - get key
+ok - get first character of key
+ok - GET via rawcommand returns key
+ok - set first character of key
+ok - append to key
+ok - get key
+ok - ask redis for key length
+ok - ask redis for key type
+ok - execute getset command
+ok - verify getset updated key
+ok - delete key
+ok - delete missing key
+ok - mset key
+ok - mget key
+ok - msetnx existing key
+ok - delete key
+ok - msetnx non existing key
+ok - unlink key
+ok - reuse deleted key
+ok - set duplicate key
+ok - rename a key
+ok - verify key was properly renamed
+ok - renamenx to a nonexistent key
+ok - create a second key
+ok - renamenx to an existing key
+ok - verify time command works
+ok - we can EVAL a lua script
+ok - we can EVAL a lua script with an SHA hash
+ok - pfadd reports new elements
+ok - pfadd reports no new elements
+ok - pfcount reports correct cardinality
+ok - we can pfmerge into a destination key
+ok - our merged key has the correct count
+ok - there are no listners to a random channel
+ok - delete keys
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/set
+Datastore/operation/Redis/get
+Datastore/operation/Redis/getrange
+Datastore/operation/Redis/rawcommand
+Datastore/operation/Redis/setrange
+Datastore/operation/Redis/append
+Datastore/operation/Redis/strlen
+Datastore/operation/Redis/type
+Datastore/operation/Redis/getset
+Datastore/operation/Redis/del
+Datastore/operation/Redis/mset
+Datastore/operation/Redis/mget
+Datastore/operation/Redis/msetnx
+Datastore/operation/Redis/setnx
+Datastore/operation/Redis/unlink
+Datastore/operation/Redis/rename
+Datastore/operation/Redis/renamenx
+Datastore/operation/Redis/time
+Datastore/operation/Redis/eval
+Datastore/operation/Redis/evalsha
+Datastore/operation/Redis/publish
+Datastore/operation/Redis/pfadd
+Datastore/operation/Redis/pfcount
+Datastore/operation/Redis/pfmerge
+Datastore/operation/Redis/close
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+
+
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_basic_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  /*
+   * \RedisCluster::__construct(?string $name, ?array $seeds, ...). No connect()
+   * call: every connection is established via the constructor, which the agent
+   * must NOT treat as a connect event (asserted by EXPECT_METRICS_DONT_EXIST).
+   */
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /*
+   * Every key shares the {rc_basic} hashtag so multi-key operations
+   * (mset/mget/msetnx/del/rename/renamenx/pfmerge) all route to the same slot
+   * — required for cluster mode to accept them.
+   */
+  $tag = '{rc_basic}';
+  $suffix = randstr(16);
+  $key1 = $tag . '_a_' . $suffix;
+  $key2 = $tag . '_b_' . $suffix;
+
+  tap_assert($cluster->set($key1, 'car'), 'set key');
+  tap_equal('car', $cluster->get($key1), 'get key');
+  tap_equal('c', $cluster->getrange($key1, 0, 0), 'get first character of key');
+
+  tap_equal('car', $cluster->rawcommand($key1, 'get', $key1), 'GET via rawcommand returns key');
+
+  tap_equal(3, $cluster->setrange($key1, 0, 'b'), 'set first character of key');
+  tap_equal(strlen('barometric'), $cluster->append($key1, 'ometric'), 'append to key');
+  tap_equal('barometric', $cluster->get($key1), 'get key');
+  tap_equal(strlen('barometric'), $cluster->strlen($key1), 'ask redis for key length');
+
+  /* \RedisCluster doesn't expose the REDIS_STRING type constants the way \Redis
+     does; type() returns an int (1 == string per phpredis). */
+  tap_equal(Redis::REDIS_STRING, $cluster->type($key1), 'ask redis for key type');
+
+  tap_equal('barometric', $cluster->getset($key1, 'geometric'), 'execute getset command');
+  tap_equal('geometric', $cluster->get($key1), 'verify getset updated key');
+
+  tap_equal(1, $cluster->del($key1), 'delete key');
+  tap_equal(0, $cluster->del($key1), 'delete missing key');
+
+  tap_assert($cluster->mset([$key1 => 'bar']), 'mset key');
+  tap_equal(['bar'], $cluster->mget([$key1]), 'mget key');
+
+  /* \RedisCluster::msetnx returns an array of per-master results, not a bool.
+     With single-slot {tag} keys all values go to one master → 1-element array. */
+  tap_equal([0], $cluster->msetnx([$key1 => 'newbar']), 'msetnx existing key');
+  tap_equal(1, $cluster->del($key1), 'delete key');
+  tap_equal([1], $cluster->msetnx([$key1 => 'newbar']), 'msetnx non existing key');
+  tap_equal(1, $cluster->unlink($key1), 'unlink key');
+
+  tap_assert($cluster->setnx($key1, 'bar'), 'reuse deleted key');
+  tap_refute($cluster->setnx($key1, 'bar'), 'set duplicate key');
+
+  tap_assert($cluster->rename($key1, $key2), 'rename a key');
+  tap_equal('bar', $cluster->get($key2), 'verify key was properly renamed');
+  tap_assert($cluster->renamenx($key2, $key1), 'renamenx to a nonexistent key');
+  tap_assert($cluster->set($key2, 'baz'), 'create a second key');
+  tap_refute($cluster->renamenx($key1, $key2), 'renamenx to an existing key');
+
+  /* time() is per-shard in cluster mode; route via the tag key. */
+  $res = $cluster->time($key1);
+  tap_assert(is_array($res) && count($res) == 2 && is_numeric($res[0]) && is_numeric($res[1]),
+             'verify time command works');
+
+  $lua = 'return 42';
+  tap_equal(42, $cluster->eval($lua, [$key1], 1), 'we can EVAL a lua script');
+  tap_equal(42, $cluster->evalsha(sha1($lua), [$key1], 1),
+            'we can EVAL a lua script with an SHA hash');
+
+  /* HyperLogLog operations — pfmerge requires same-slot keys; tag covers it.
+     \RedisCluster::pfadd returns bool (not int) — the underlying RESP integer
+     is converted by phpredis at the cluster client layer. */
+  tap_equal(2, $cluster->del([$key1, $key2]), 'delete keys');
+  tap_assert($cluster->pfadd($key1, ['one', 'two', 'three']), 'pfadd reports new elements');
+  tap_refute($cluster->pfadd($key1, ['three']), 'pfadd reports no new elements');
+  tap_equal(3, $cluster->pfcount($key1), 'pfcount reports correct cardinality');
+  tap_assert($cluster->pfmerge($key2, [$key1]), 'we can pfmerge into a destination key');
+  tap_equal(3, $cluster->pfcount($key2), 'our merged key has the correct count');
+
+  /* Same publish-with-no-subscriber pattern as the \Redis baseline. The channel
+     name routes the command in cluster mode, so use a tag-bound name. */
+  tap_equal(0, $cluster->publish($tag . '_chan_' . $suffix, 'message'),
+            'there are no listners to a random channel');
+
+  /* cleanup */
+  tap_equal(2, $cluster->del([$key1, $key2]), 'delete keys');
+
+  /* close connection — exercised so its metric appears in EXPECT_METRICS_EXIST. */
+  $cluster->close();
+}
+
+test_basic_cluster();

--- a/tests/integration/rediscluster/test_basic.php
+++ b/tests/integration/rediscluster/test_basic.php
@@ -56,6 +56,7 @@ ok - renamenx to an existing key
 ok - verify time command works
 ok - we can EVAL a lua script
 ok - we can EVAL a lua script with an SHA hash
+ok - delete keys
 ok - pfadd reports new elements
 ok - pfadd reports no new elements
 ok - pfcount reports correct cardinality
@@ -94,7 +95,6 @@ Datastore/operation/Redis/publish
 Datastore/operation/Redis/pfadd
 Datastore/operation/Redis/pfcount
 Datastore/operation/Redis/pfmerge
-Datastore/operation/Redis/close
 */
 
 /*EXPECT_METRICS_DONT_EXIST
@@ -202,7 +202,7 @@ function test_basic_cluster() {
   /* cleanup */
   tap_equal(2, $cluster->del([$key1, $key2]), 'delete keys');
 
-  /* close connection — exercised so its metric appears in EXPECT_METRICS_EXIST. */
+  /* close connection */
   $cluster->close();
 }
 

--- a/tests/integration/rediscluster/test_bitops.php
+++ b/tests/integration/rediscluster/test_bitops.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster bit operations,
+mirroring the coverage of tests/integration/redis/test_bitops.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - set initial key
+ok - set second key
+ok - count set bits in key
+ok - find first clear bit in key
+ok - find first set bit in key
+ok - verify first bit clear
+ok - verify second bit set
+ok - clear third bit
+ok - set fourth bit
+ok - verify new key value
+ok - perform bit operations on two keys
+ok - verify value after ANDing
+ok - delete test keys
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/set
+Datastore/operation/Redis/get
+Datastore/operation/Redis/bitcount
+Datastore/operation/Redis/bitpos
+Datastore/operation/Redis/getbit
+Datastore/operation/Redis/setbit
+Datastore/operation/Redis/bitop
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_bitops_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /*
+   * All three keys share a hashtag so multi-key operations
+   * route to the same slot, which is required in cluster mode.
+   */
+  $tag  = '{rc_bitops}';
+  $suffix = randstr(16);
+  $key1 = $tag . '_a_' . $suffix;
+  $key2 = $tag . '_b_' . $suffix;
+  $dkey = $tag . '_d_' . $suffix;
+
+  if ($cluster->exists([$key1, $key2, $dkey])) {
+    die("skip: key(s) already exist: $key1, $key2, $dkey\n");
+  }
+
+  /* T - 01010100; E - 01000101; N - 01001110 */
+  tap_assert($cluster->set($key1, 'TEN'), 'set initial key');
+  tap_assert($cluster->set($key2, 'HAT'), 'set second key');
+
+  tap_equal(10, $cluster->bitcount($key1), 'count set bits in key');
+  tap_equal(0, $cluster->bitpos($key1, 0), 'find first clear bit in key');
+  tap_equal(1, $cluster->bitpos($key1, 1), 'find first set bit in key');
+
+  tap_equal(0, $cluster->getbit($key1, 0), 'verify first bit clear');
+  tap_equal(1, $cluster->getbit($key1, 1), 'verify second bit set');
+
+  /* T - 01010100 -> L - 01001100 */
+  tap_equal(1, $cluster->setbit($key1, 3, 0), 'clear third bit');
+  tap_equal(0, $cluster->setbit($key1, 4, 1), 'set fourth bit');
+  tap_equal('LEN', $cluster->get($key1), 'verify new key value');
+
+  /* |L| 01001100 |E| 01000101 |N| 01000100 &
+     |H| 01001000 |A| 01000001 |T| 01010100
+     |H| 01001000 |A| 01000001 |D| 01000100 */
+  tap_equal(3, $cluster->bitop('AND', $dkey, $key1, $key2), 'perform bit operations on two keys');
+  tap_equal('HAD', $cluster->get($dkey), 'verify value after ANDing');
+
+  tap_equal(3, $cluster->del([$key1, $key2, $dkey]), 'delete test keys');
+
+  $cluster->close();
+}
+
+test_bitops_cluster();

--- a/tests/integration/rediscluster/test_bitops.php
+++ b/tests/integration/rediscluster/test_bitops.php
@@ -11,6 +11,7 @@ mirroring the coverage of tests/integration/redis/test_bitops.php.
 
 /*SKIPIF
 <?php
+$minimum_extension_version = '6.0.0';
 require("skipif.inc");
 */
 

--- a/tests/integration/rediscluster/test_decr.php
+++ b/tests/integration/rediscluster/test_decr.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster decrement
+operations, mirroring the coverage of tests/integration/redis/test_decr.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - set key
+ok - check value
+ok - decrement by 1
+ok - check value
+ok - decrement by 3
+ok - check final value
+ok - delete key
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/set
+Datastore/operation/Redis/get
+Datastore/operation/Redis/decr
+Datastore/operation/Redis/decrby
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+Datastore/operation/Redis/expire
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_decr_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /* generate a unique key to use for this test run */
+  $key = randstr(16);
+  if ($cluster->exists($key)) {
+    die("skip: key already exists: $key\n");
+  }
+
+  /* Ensure the key doesn't persist (too much) longer than the test. */
+  $cluster->expire($key, 30 /* seconds */);
+
+  tap_assert($cluster->set($key, 20), 'set key');
+  tap_equal('20', $cluster->get($key), 'check value');
+  tap_equal(19, $cluster->decr($key), 'decrement by 1');
+  tap_equal('19', $cluster->get($key), 'check value');
+  tap_equal(16, $cluster->decrBy($key, 3), 'decrement by 3');
+  tap_equal('16', $cluster->get($key), 'check final value');
+
+  /* cleanup the key used by this test run */
+  tap_equal(1, $cluster->del($key), 'delete key');
+
+  $cluster->close();
+}
+
+test_decr_cluster();

--- a/tests/integration/rediscluster/test_geo.php
+++ b/tests/integration/rediscluster/test_geo.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster geo operations,
+mirroring the coverage of tests/integration/redis/test_geo.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - add Seattle to a geo sorted set
+ok - add Cupertino to geo sorted set
+ok - add Tokyo to geo sorted set
+ok - query distance between two cities
+ok - query Tokyo geohash string
+ok - verify Seattle geopos in redis
+ok - query cities within 1000mi of Seattle
+ok - query cities within 1000mi of Seattle [readonly cmd]
+ok - query cities within 5000mi of seattle by member
+ok - query cities within 5000mi of seattle by member [readonly cmd]
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/geoadd
+Datastore/operation/Redis/geodist
+Datastore/operation/Redis/geohash
+Datastore/operation/Redis/geopos
+Datastore/operation/Redis/georadius
+Datastore/operation/Redis/georadius_ro
+Datastore/operation/Redis/georadiusbymember
+Datastore/operation/Redis/georadiusbymember_ro
+Datastore/operation/Redis/exists
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_geo_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /* generate a unique key to use for this test run */
+  $key = randstr(16);
+  if ($cluster->exists($key)) {
+    die("skip: key already exists: $key\n");
+  }
+
+  $seattle = [-122.335167, 47.608013];
+  $cupertino = [-122.032182, 37.322998];
+  $tokyo = [139.839478, 35.652832];
+
+  tap_equal(1, $cluster->geoadd($key, $seattle[0], $seattle[1], 'Seattle'), 'add Seattle to a geo sorted set');
+  tap_equal(1, $cluster->geoadd($key, $cupertino[0], $cupertino[1], 'Cupertino'), 'add Cupertino to geo sorted set');
+  tap_equal(1, $cluster->geoadd($key, $tokyo[0], $tokyo[1], 'Tokyo'), 'add Tokyo to geo sorted set');
+
+  tap_equal(711.0, round($cluster->geodist($key, 'Seattle', 'Cupertino', 'mi')), 'query distance between two cities');
+  tap_equal(["xn76y4khb10"], $cluster->geohash($key, "Tokyo"), 'query Tokyo geohash string');
+
+  list($redis_lat, $redis_lng) = $cluster->geopos($key, 'Seattle')[0];
+  tap_equal([round($seattle[0], 2), round($seattle[1], 2)], [round($redis_lat, 2), round($redis_lng, 2)],
+            'verify Seattle geopos in redis');
+
+  list($lat, $long) = $seattle;
+  tap_equal_unordered_values(['Seattle', 'Cupertino'], $cluster->georadius($key, $lat, $long, 1000, 'mi'), 'query cities within 1000mi of Seattle');
+  tap_equal_unordered_values(['Seattle', 'Cupertino'], $cluster->georadius_ro($key, $lat, $long, 1000, 'mi'), 'query cities within 1000mi of Seattle [readonly cmd]');
+
+  tap_equal_unordered_values(['Seattle', 'Cupertino', 'Tokyo'], $cluster->georadiusbymember($key, 'Seattle', 5000, 'mi'), 'query cities within 5000mi of seattle by member');
+  tap_equal_unordered_values(['Seattle', 'Cupertino', 'Tokyo'], $cluster->georadiusbymember_ro($key, 'Seattle', 5000, 'mi'), 'query cities within 5000mi of seattle by member [readonly cmd]');
+
+  $cluster->close();
+}
+
+test_geo_cluster();

--- a/tests/integration/rediscluster/test_hash.php
+++ b/tests/integration/rediscluster/test_hash.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster hash operations,
+mirroring the coverage of tests/integration/redis/test_hash.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - set hash key
+ok - check hash key
+ok - ensure hash key exists
+ok - delete existing hash key
+ok - delete missing hash key
+ok - ensure hash key does not exist
+ok - re-use deleted hash key
+ok - duplicate hash key
+ok - set multiple hash keys
+ok - increment hash key by int
+ok - increment hash key by float
+ok - get multiple hash keys
+ok - get hash length
+ok - get hash key string length
+ok - get all hash keys and values
+ok - get all hash keys
+ok - get all hash values
+ok - delete hash
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/hset
+Datastore/operation/Redis/hget
+Datastore/operation/Redis/hexists
+Datastore/operation/Redis/hdel
+Datastore/operation/Redis/hsetnx
+Datastore/operation/Redis/hmset
+Datastore/operation/Redis/hincrby
+Datastore/operation/Redis/hincrbyfloat
+Datastore/operation/Redis/hmget
+Datastore/operation/Redis/hlen
+Datastore/operation/Redis/hstrlen
+Datastore/operation/Redis/hgetall
+Datastore/operation/Redis/hkeys
+Datastore/operation/Redis/hvals
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+Datastore/operation/Redis/expire
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_hash_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /* Generate a unique key to use for this test run. */
+  $hash = randstr(16);
+  if ($cluster->exists($hash)) {
+    die("skip: key already exists: $hash\n");
+  }
+
+  /* Ensure the hash doesn't persist longer than the test. */
+  $cluster->expire($hash, 30 /* seconds */);
+
+  $key = 'foo';
+  $value = 'aaa';
+
+  tap_equal(1, $cluster->hSet($hash, $key, $value), 'set hash key');
+  tap_equal($value, $cluster->hGet($hash, $key), 'check hash key');
+
+  tap_assert($cluster->hExists($hash, $key), 'ensure hash key exists');
+
+  tap_equal(1, $cluster->hDel($hash, $key), 'delete existing hash key');
+  tap_equal(0, $cluster->hDel($hash, $key), 'delete missing hash key');
+
+  tap_refute($cluster->hExists($hash, $key), 'ensure hash key does not exist');
+
+  tap_assert($cluster->hSetnx($hash, $key, $value), 're-use deleted hash key');
+  tap_refute($cluster->hSetnx($hash, $key, $value), 'duplicate hash key');
+
+  tap_assert($cluster->hMset($hash, array('dval' => 1.5, 'ival' => 30)), 'set multiple hash keys');
+  tap_equal(32, $cluster->hIncrBy($hash, 'ival', 2), 'increment hash key by int');
+  tap_equal(2.5, $cluster->hIncrByFloat($hash, 'dval', 1.0), 'increment hash key by float');
+
+  $want = array('dval' => '2.5', 'ival' => '32');
+  $got = $cluster->hMget($hash, array('dval', 'ival'));
+  tap_equal_unordered_values($want, $got, 'get multiple hash keys');
+
+  $want[$key] = $value;
+  tap_equal(count($want), $cluster->hlen($hash), 'get hash length');
+  tap_equal(strlen($value), $cluster->hstrlen($hash, $key), 'get hash key string length');
+  tap_equal_unordered($want, $cluster->hgetall($hash), 'get all hash keys and values');
+  tap_equal_unordered_values(array_keys($want), $cluster->hkeys($hash), 'get all hash keys');
+  tap_equal_unordered_values(array_values($want), $cluster->hvals($hash), 'get all hash values');
+
+  /* Cleanup the key used by this test run. */
+  tap_equal(1, $cluster->del($hash), 'delete hash');
+
+  $cluster->close();
+}
+
+test_hash_cluster();

--- a/tests/integration/rediscluster/test_incr.php
+++ b/tests/integration/rediscluster/test_incr.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster increment
+operations, mirroring the coverage of tests/integration/redis/test_incr.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - set key
+ok - check value
+ok - increment by 1
+ok - check value
+ok - increment by 3
+ok - check final value
+ok - delete key
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/set
+Datastore/operation/Redis/get
+Datastore/operation/Redis/incr
+Datastore/operation/Redis/incrby
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+Datastore/operation/Redis/expire
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_incr_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /* generate a unique key to use for this test run */
+  $key = randstr(16);
+  if ($cluster->exists($key)) {
+    die("skip: key already exists: $key\n");
+  }
+
+  /* Ensure the key doesn't persist (too much) longer than the test. */
+  $cluster->expire($key, 30 /* seconds */);
+
+  tap_assert($cluster->set($key, 20), 'set key');
+  tap_equal('20', $cluster->get($key), 'check value');
+  tap_equal(21, $cluster->incr($key), 'increment by 1');
+  tap_equal('21', $cluster->get($key), 'check value');
+  tap_equal(24, $cluster->incrBy($key, 3), 'increment by 3');
+  tap_equal('24', $cluster->get($key), 'check final value');
+
+  /* cleanup the key used by this test run */
+  tap_equal(1, $cluster->del($key), 'delete key');
+
+  $cluster->close();
+}
+
+test_incr_cluster();

--- a/tests/integration/rediscluster/test_instance_basic.php
+++ b/tests/integration/rediscluster/test_instance_basic.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/instance/Redis/unknown/unknown for
+\RedisCluster operations.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 1
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+*/
+
+/*EXPECT
+ok - set key
+ok - get key
+ok - delete key
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/instance/Redis/unknown/unknown
+Datastore/operation/Redis/set
+Datastore/operation/Redis/get
+Datastore/operation/Redis/del
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_instance_basic_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  $key = randstr(16);
+
+  tap_assert($cluster->set($key, 'car'), 'set key');
+  tap_equal('car', $cluster->get($key), 'get key');
+  tap_equal(1, $cluster->del($key), 'delete key');
+
+  $cluster->close();
+}
+
+test_instance_basic_cluster();

--- a/tests/integration/rediscluster/test_list.php
+++ b/tests/integration/rediscluster/test_list.php
@@ -1,0 +1,169 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster list operations,
+mirroring the coverage of tests/integration/redis/test_list.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - append B
+ok - append C
+ok - prepend A
+ok - retrieve element 0
+ok - retrieve element 1
+ok - retrieve element 2
+ok - retrieve last element
+ok - retrieve invalid element
+ok - retrieve element 0
+ok - retrieve element 1
+ok - retrieve element 2
+ok - linsert BEFORE A
+ok - check list elements
+ok - linsert AFTER B
+ok - check list elements
+ok - retreive list length
+ok - pop the first element off list
+ok - pop the last element off list
+ok - lpushx to a list that exists
+ok - rpushx to a list that exists
+ok - pop from one list and push to another
+ok - check the list we pushed to
+ok - delete list with ltrim
+ok - verify list is deleted
+ok - add new elements
+ok - remove first occurence of B
+ok - verify list elements
+ok - remove missing element
+ok - replace list head
+ok - list head was replaced
+ok - delete list
+ok - delete second list
+ok - lpushx to a list that does not exist
+ok - rpushx to a list that does not exist
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/rpush
+Datastore/operation/Redis/lpush
+Datastore/operation/Redis/lindex
+Datastore/operation/Redis/linsert
+Datastore/operation/Redis/lrange
+Datastore/operation/Redis/llen
+Datastore/operation/Redis/lpop
+Datastore/operation/Redis/rpop
+Datastore/operation/Redis/lpushx
+Datastore/operation/Redis/rpushx
+Datastore/operation/Redis/rpoplpush
+Datastore/operation/Redis/ltrim
+Datastore/operation/Redis/lrem
+Datastore/operation/Redis/lset
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+Datastore/operation/Redis/expire
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_list_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /*
+   * Both keys share a hashtag so multi-key operations route to
+   * the same slot, which is required in cluster mode.
+   */
+  $tag = '{rc_list}';
+  $suffix = randstr(16);
+  $key  = $tag . '_a_' . $suffix;
+  $key2 = $tag . '_b_' . $suffix;
+
+  if ($cluster->exists([$key, $key2])) {
+    die("skip: key(s) already exist: $key, $key2\n");
+  }
+
+  /* Ensure the keys don't persist longer than the test. */
+  $cluster->expire($key, 30 /* seconds */);
+  $cluster->expire($key2, 30 /* seconds */);
+
+  tap_equal(1, $cluster->rPush($key, 'B'), 'append B');
+  tap_equal(2, $cluster->rPush($key, 'C'), 'append C');
+  tap_equal(3, $cluster->lPush($key, 'A'), 'prepend A');
+
+  tap_equal('A', $cluster->lIndex($key, 0), 'retrieve element 0');
+  tap_equal('B', $cluster->lIndex($key, 1), 'retrieve element 1');
+  tap_equal('C', $cluster->lIndex($key, 2), 'retrieve element 2');
+  tap_equal('C', $cluster->lIndex($key, -1), 'retrieve last element');
+  tap_refute($cluster->lIndex($key, 10), 'retrieve invalid element');
+
+  tap_equal('A', $cluster->lIndex($key, 0), 'retrieve element 0');
+  tap_equal('B', $cluster->lIndex($key, 1), 'retrieve element 1');
+  tap_equal('C', $cluster->lIndex($key, 2), 'retrieve element 2');
+
+  tap_equal(4, $cluster->lInsert($key, Redis::BEFORE, 'A', 'a'), 'linsert BEFORE A');
+  tap_equal(['a', 'A', 'B', 'C'], $cluster->lrange($key, 0, -1), 'check list elements');
+  tap_equal(5, $cluster->lInsert($key, Redis::AFTER, 'B', 'b'), 'linsert AFTER B');
+  tap_equal(['a', 'A', 'B', 'b', 'C'], $cluster->lrange($key, 0, -1), 'check list elements');
+  tap_equal(5, $cluster->llen($key), 'retreive list length');
+  tap_equal('a', $cluster->lpop($key), 'pop the first element off list');
+  tap_equal('C', $cluster->rpop($key), 'pop the last element off list');
+
+  tap_equal(4, $cluster->lpushx($key, 'HEAD'), 'lpushx to a list that exists');
+  tap_equal(5, $cluster->rpushx($key, 'TAIL'), 'rpushx to a list that exists');
+
+  tap_equal('TAIL', $cluster->rpoplpush($key, $key2), 'pop from one list and push to another');
+  tap_equal(['TAIL'], $cluster->lrange($key2, 0, -1), 'check the list we pushed to');
+
+  tap_assert($cluster->ltrim($key, 1, 0), 'delete list with ltrim');
+  tap_equal(0, $cluster->llen($key), 'verify list is deleted');
+
+  tap_equal(4, $cluster->rpush($key, 'A', 'B', 'B', 'C'), 'add new elements');
+
+  tap_equal(1, @$cluster->lRem($key, 'B', 1), 'remove first occurence of B');
+  tap_equal(['A', 'B', 'C'], $cluster->lrange($key, 0, -1), 'verify list elements');
+  tap_equal(0, $cluster->lRem($key, 'NOT_IN_LIST', 1), 'remove missing element');
+
+  tap_assert($cluster->lSet($key, 0, 'AA'), 'replace list head');
+  tap_equal('AA', $cluster->lIndex($key, 0), 'list head was replaced');
+
+  /* cleanup the keys used by this test run */
+  tap_equal(1, $cluster->del($key), 'delete list');
+  tap_equal(1, $cluster->del($key2), 'delete second list');
+
+  tap_equal(0, $cluster->lpushx($key, 'no-op'), 'lpushx to a list that does not exist');
+  tap_equal(0, $cluster->rpushx($key, 'no-op'), 'rpushx to a list that does not exist');
+
+  $cluster->close();
+}
+
+test_list_cluster();

--- a/tests/integration/rediscluster/test_set.php
+++ b/tests/integration/rediscluster/test_set.php
@@ -1,0 +1,138 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster set operations,
+mirroring the coverage of tests/integration/redis/test_set.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - add new element to set
+ok - add existing element to set
+ok - add two elements to second set
+ok - get second set cardinality
+ok - get difference between two sets
+ok - store difference of two sets
+ok - read stored set difference
+ok - get set intersection
+ok - store intersection of two sets
+ok - read stored set intersection
+ok - get set union
+ok - store set union
+ok - read stored set union
+ok - check set membership
+ok - move an element from one set to another
+ok - move a nonexistent element from one set to another
+ok - get a random set element
+ok - pop an element off a set
+ok - remove existing member from a set
+ok - remove nonexistent member from a set
+ok - delete first key
+ok - verify second key already deleted
+ok - remove destination key
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/sadd
+Datastore/operation/Redis/scard
+Datastore/operation/Redis/sdiff
+Datastore/operation/Redis/sdiffstore
+Datastore/operation/Redis/sinter
+Datastore/operation/Redis/sinterstore
+Datastore/operation/Redis/sunion
+Datastore/operation/Redis/sunionstore
+Datastore/operation/Redis/sismember
+Datastore/operation/Redis/smembers
+Datastore/operation/Redis/smove
+Datastore/operation/Redis/srandmember
+Datastore/operation/Redis/spop
+Datastore/operation/Redis/srem
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_set_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /*
+   * All three keys share a hashtag so multi-key operations
+   * route to the same slot, which is required in cluster mode.
+   */
+  $tag  = '{rc_set}';
+  $suffix = randstr(16);
+  $key1 = $tag . '_a_' . $suffix;
+  $key2 = $tag . '_b_' . $suffix;
+  $dkey = $tag . '_d_' . $suffix;
+
+  if ($cluster->exists([$key1, $key2, $dkey])) {
+    die("skip: key(s) already exist: $key1, $key2, $dkey\n");
+  }
+
+  tap_equal(1, $cluster->sadd($key1, 'foo'), 'add new element to set');
+  tap_equal(0, $cluster->sadd($key1, 'foo'), 'add existing element to set');
+  tap_equal(2, $cluster->sadd($key2, 'foo', 'bar'), 'add two elements to second set');
+  tap_equal(2, $cluster->scard($key2), 'get second set cardinality');
+
+  tap_equal(['bar'], $cluster->sdiff([$key2, $key1]), 'get difference between two sets');
+  tap_equal(1, $cluster->sdiffstore($dkey, $key2, $key1), 'store difference of two sets');
+  tap_equal(['bar'], $cluster->smembers($dkey), 'read stored set difference');
+
+  tap_equal(['foo'], $cluster->sinter([$key1, $key2]), 'get set intersection');
+  tap_equal(1, $cluster->sinterstore($dkey, $key1, $key2), 'store intersection of two sets');
+  tap_equal(['foo'], $cluster->smembers($dkey), 'read stored set intersection');
+
+  tap_equal_unordered_values(['foo', 'bar'], $cluster->sunion([$key1, $key2]), 'get set union');
+  tap_equal(2, $cluster->sunionstore($dkey, $key1, $key2), 'store set union');
+  tap_equal_unordered_values(['foo', 'bar'], $cluster->smembers($dkey), 'read stored set union');
+
+  tap_assert($cluster->sismember($key1, 'foo'), 'check set membership');
+
+  tap_assert($cluster->smove($key2, $key1, 'bar'), 'move an element from one set to another');
+  tap_refute($cluster->smove($key2, $key1, 'bar'), 'move a nonexistent element from one set to another');
+  tap_assert(in_array($cluster->srandmember($key1), ['foo', 'bar']), 'get a random set element');
+  tap_assert(in_array($cluster->spop($key1), ['foo', 'bar']), 'pop an element off a set');
+
+  tap_equal(1, $cluster->srem($key2, 'foo'), 'remove existing member from a set');
+  tap_equal(0, $cluster->srem($key2, 'foo'), 'remove nonexistent member from a set');
+
+  tap_equal(1, $cluster->del($key1), 'delete first key');
+  tap_equal(0, $cluster->del($key1), 'verify second key already deleted');
+  tap_equal(1, $cluster->del($dkey), 'remove destination key');
+
+  $cluster->close();
+}
+
+test_set_cluster();

--- a/tests/integration/rediscluster/test_setex.php
+++ b/tests/integration/rediscluster/test_setex.php
@@ -1,0 +1,115 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster setex and
+expiry operations, mirroring the coverage of tests/integration/redis/test_setex.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - set key to expire in 1s
+ok - retrieve key before expiry
+ok - check key ttl
+ok - retrieve expired key
+ok - delete expired key
+ok - set key to expire in 1500ms
+ok - retreive key before expiry
+ok - retreive key ttl in miliseconds
+ok - remove key expiration
+ok - verify expiry removal
+ok - set timestamp expiry
+ok - verify expiry set
+ok - set timestamp expiry in milliseconds
+ok - verify milliscond expiry set
+ok - set an expiry in milliseconds
+ok - verify millisecond expiry
+ok - delete key
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/setex
+Datastore/operation/Redis/get
+Datastore/operation/Redis/ttl
+Datastore/operation/Redis/psetex
+Datastore/operation/Redis/pttl
+Datastore/operation/Redis/persist
+Datastore/operation/Redis/expireat
+Datastore/operation/Redis/pexpireat
+Datastore/operation/Redis/pexpire
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_setex_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /* generate a unique key to use for this test run */
+  $key = randstr(16);
+  if ($cluster->exists($key)) {
+    die("skip: key already exists: $key\n");
+  }
+
+  tap_assert($cluster->setex($key, 1, 'bar'), 'set key to expire in 1s');
+  tap_equal('bar', $cluster->get($key), 'retrieve key before expiry');
+  tap_assert($cluster->ttl($key) == 1, 'check key ttl');
+  sleep(2);
+  tap_refute($cluster->get($key), 'retrieve expired key');
+  tap_equal(0, $cluster->del($key), 'delete expired key');  // it is no longer there: auto expiration
+
+  tap_assert($cluster->psetex($key, 1500, 'pbar'), 'set key to expire in 1500ms');
+  tap_equal('pbar', $cluster->get($key), 'retreive key before expiry');
+
+  $pttl = $cluster->pttl($key);
+  tap_assert($pttl >= 0 && $pttl <= 1500, 'retreive key ttl in miliseconds');
+
+  tap_assert($cluster->persist($key), 'remove key expiration');
+  tap_equal(-1, $cluster->ttl($key), 'verify expiry removal');
+
+  tap_assert($cluster->expireat($key, time() + 1), 'set timestamp expiry');
+  tap_assert($cluster->ttl($key) >= 0, 'verify expiry set');
+
+  tap_assert($cluster->pexpireat($key, (time() + 60) * 1000), 'set timestamp expiry in milliseconds');
+  tap_assert($cluster->ttl($key) > 50, 'verify milliscond expiry set');
+
+  tap_assert($cluster->pexpire($key, 1500), 'set an expiry in milliseconds');
+  tap_assert($cluster->pttl($key) >= 1000, 'verify millisecond expiry');
+
+  tap_equal(1, $cluster->del($key), 'delete key');
+
+  $cluster->close();
+}
+
+test_setex_cluster();

--- a/tests/integration/rediscluster/test_stream.php
+++ b/tests/integration/rediscluster/test_stream.php
@@ -1,0 +1,164 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster stream
+operations, mirroring the coverage of tests/integration/redis/test_stream.redis5.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - result is a valid stream ID
+ok - result is a valid stream ID
+ok - result is a valid stream ID
+ok - result is a valid stream ID
+ok - result is a valid stream ID
+ok - we can delete a stream entry by id
+ok - first stream returns three entries
+ok - second stream returns one entry
+ok - first stream length is three
+ok - trim first stream to two entries
+ok - verify stream was trimmed
+ok - second stream length is one
+ok - get first stream info
+ok - create a consumer group
+ok - xreadgroup returns entries
+ok - first stream is now empty
+ok - proper xread[group] response with 2 elements
+ok - we can acknowledge receipt of an ID
+ok - proper xread[group] response with 1 elements
+ok - our second ID is still pending
+ok - we were able to claim the message
+ok - proper xread[group] response with 2 elements
+ok - delete our test keys
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/xadd
+Datastore/operation/Redis/xdel
+Datastore/operation/Redis/xrange
+Datastore/operation/Redis/xrevrange
+Datastore/operation/Redis/xlen
+Datastore/operation/Redis/xtrim
+Datastore/operation/Redis/xinfo
+Datastore/operation/Redis/xgroup
+Datastore/operation/Redis/xreadgroup
+Datastore/operation/Redis/xack
+Datastore/operation/Redis/xpending
+Datastore/operation/Redis/xclaim
+Datastore/operation/Redis/xread
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+/* Confirm a valid XPENDING response with N elements */
+function tap_xread_response($res, $stream, $n) {
+  tap_assert(is_array($res) && isset($res[$stream]) && count($res[$stream]) == $n,
+             "proper xread[group] response with $n elements");
+}
+
+function tap_valid_stream_id($id) {
+  tap_matches('/[0-9]+\-[0-9]+/', $id, 'result is a valid stream ID');
+}
+
+function test_stream_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /*
+   * Both keys share a hashtag so multi-key operations
+   * route to the same slot, which is required in cluster mode.
+   */
+  $tag  = '{rc_stream}';
+  $suffix = randstr(16);
+  $key1 = $tag . '_a_' . $suffix;
+  $key2 = $tag . '_b_' . $suffix;
+
+  if ($cluster->exists([$key1, $key2])) {
+    die("skip: key(s) already exist: $key1, $key2\n");
+  }
+
+  tap_valid_stream_id($cluster->xadd($key1, '*', ['foo' => 'bar']));
+  tap_valid_stream_id($cluster->xadd($key1, '*', ['baz' => 'bop']));
+  tap_valid_stream_id($cluster->xadd($key1, '*', ['for' => 'fen']));
+  tap_valid_stream_id($cluster->xadd($key2, '*', ['new' => 'one']));
+
+  /* Store this ID specifically so we can delete it with xdel */
+  $id = $cluster->xadd($key2, '*', ['final' => 'value']);
+  tap_valid_stream_id($id);
+  tap_equal(1, $cluster->xdel($key2, [$id]), 'we can delete a stream entry by id');
+
+  tap_equal(3, count($cluster->xrange($key1, 0, '+')), 'first stream returns three entries');
+  tap_equal(1, count($cluster->xrevrange($key2, '+', 0)), 'second stream returns one entry');
+
+  tap_equal(3, $cluster->xlen($key1), 'first stream length is three');
+  tap_equal(1, $cluster->xtrim($key1, 2), 'trim first stream to two entries');
+  tap_equal(2, $cluster->xlen($key1), 'verify stream was trimmed');
+  tap_equal(1, $cluster->xlen($key2), 'second stream length is one');
+
+  $info = $cluster->xinfo('stream', $key1);
+  tap_assert(is_array($info) && (isset($info['length']) || in_array('length', $info)),
+             'get first stream info');
+
+  tap_assert($cluster->xgroup('CREATE', $key1, 'group1', '0'), 'create a consumer group');
+
+  $res = $cluster->xreadgroup('group1', 'consumer1', [$key1 => '>'], 2);
+  tap_assert(is_array($res) && $res, 'xreadgroup returns entries');
+  $res = $cluster->xreadgroup('group1', 'consumer1', [$key1 => '>'], 1);
+  tap_assert(is_array($res) && !$res, 'first stream is now empty');
+
+  /* Execute XREADGROUP and capture results so we can test XACK and XPENDING */
+  $res = $cluster->xreadgroup('group1', 'consumer1', [$key1 => '0']);
+  tap_xread_response($res, $key1, 2);
+  list($id1, $id2) = array_keys($res[$key1]);
+
+  /* XACK a message and verify the other is PENDING */
+  tap_equal(1, $cluster->xack($key1, 'group1', [$id1]), 'we can acknowledge receipt of an ID');
+  tap_xread_response($cluster->xreadgroup('group1', 'consumer1', [$key1 => '0']), $key1, 1);
+  $res = $cluster->xpending($key1, 'group1');
+  tap_assert(is_array($res) && in_array($id2, $res), 'our second ID is still pending');
+
+  /* There is one pending message. Have another consumer claim it */
+  $res = $cluster->xclaim($key1, 'group1', 'newconsumer', 0, [$id2]);
+  tap_assert(is_array($res) && isset($res[$id2]), 'we were able to claim the message');
+
+  /* Finally perform a normal XREAD */
+  tap_xread_response($cluster->xread([$key1 => 0]), $key1, 2);
+
+  tap_equal(2, $cluster->del([$key1, $key2]), 'delete our test keys');
+
+  $cluster->close();
+}
+
+test_stream_cluster();

--- a/tests/integration/rediscluster/test_zset.php
+++ b/tests/integration/rediscluster/test_zset.php
@@ -1,0 +1,147 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should report Datastore/Redis metrics for \RedisCluster sorted set
+operations, mirroring the coverage of tests/integration/redis/test_zset.php.
+*/
+
+/*SKIPIF
+<?php
+require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT
+ok - add elements to first sorted set
+ok - add element to second sorted set
+ok - get cardinality of first sorted set
+ok - count elements in first sorted set by score
+ok - increment element in second sorted set
+ok - compute intersection of two sorted sets
+ok - list intersection keys w/scores
+ok - compute union of two sorted sets
+ok - list union keys w/scores
+ok - count elements in lexographical range
+ok - list elements in lexographical range
+ok - list elements in reverse lexographical range
+ok - list elements by score
+ok - list elements by reverse score
+ok - get rank of an element
+ok - get the score of an element
+ok - get reverse rank of an element
+ok - remove first element from first set
+ok - delete working sets keys
+ok - add elements to new set
+ok - remove elements by rank
+ok - remove elements by lexographical value
+ok - remove final element by score
+ok - ensure all keys are cleaned up
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/all
+Datastore/allOther
+Datastore/Redis/all
+Datastore/Redis/allOther
+Datastore/operation/Redis/zadd
+Datastore/operation/Redis/zcard
+Datastore/operation/Redis/zcount
+Datastore/operation/Redis/zincrby
+Datastore/operation/Redis/zinterstore
+Datastore/operation/Redis/zunionstore
+Datastore/operation/Redis/zlexcount
+Datastore/operation/Redis/zrange
+Datastore/operation/Redis/zrangebylex
+Datastore/operation/Redis/zrangebyscore
+Datastore/operation/Redis/zrank
+Datastore/operation/Redis/zscore
+Datastore/operation/Redis/zrevrange
+Datastore/operation/Redis/zrevrangebylex
+Datastore/operation/Redis/zrevrangebyscore
+Datastore/operation/Redis/zrevrank
+Datastore/operation/Redis/zrem
+Datastore/operation/Redis/zremrangebyrank
+Datastore/operation/Redis/zremrangebylex
+Datastore/operation/Redis/zremrangebyscore
+Datastore/operation/Redis/del
+Datastore/operation/Redis/exists
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/operation/Redis/connect
+Datastore/operation/Redis/pconnect
+Datastore/operation/Redis/open
+Datastore/operation/Redis/popen
+Datastore/operation/Redis/select
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/helpers.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+
+function test_zset_cluster() {
+  global $REDIS_CLUSTER_HOST, $REDIS_CLUSTER_PORT;
+
+  $cluster = new RedisCluster(null,
+    [$REDIS_CLUSTER_HOST . ':' . $REDIS_CLUSTER_PORT],
+    1.5, 1.5, true);
+
+  /*
+   * All three keys share a hashtag so multi-key operations
+   * route to the same slot, which is required in cluster mode.
+   */
+  $tag  = '{rc_zset}';
+  $suffix = randstr(16);
+  $key1 = $tag . '_a_' . $suffix;
+  $key2 = $tag . '_b_' . $suffix;
+  $dkey = $tag . '_d_' . $suffix;
+
+  if ($cluster->exists([$key1, $key2, $dkey])) {
+    die("skip: key(s) already exist: $key1, $key2, $dkey\n");
+  }
+
+  tap_equal(2, $cluster->zadd($key1, 3, 'Fizz', 5, 'Buzz'), 'add elements to first sorted set');
+  tap_equal(2, $cluster->zadd($key2, 3, 'Fizz', 15, 'FizzBuzz'), 'add element to second sorted set');
+  tap_equal(2, $cluster->zcard($key1), 'get cardinality of first sorted set');
+  tap_equal(1, $cluster->zcount($key1, 0, 3), 'count elements in first sorted set by score');
+  tap_equal(30.0, $cluster->zincrby($key2, 15, 'FizzBuzz'), 'increment element in second sorted set');
+
+  tap_equal(1, $cluster->zinterstore($dkey, [$key1, $key2]), 'compute intersection of two sorted sets');
+  tap_equal(['Fizz' => 6.0], $cluster->zrange($dkey, 0, -1, true), 'list intersection keys w/scores');
+
+  tap_equal(3, $cluster->zunionstore($dkey, [$key1, $key2]), 'compute union of two sorted sets');
+  tap_equal(['FizzBuzz' => 30.0, 'Fizz' => 6.0, 'Buzz' => 5.0], $cluster->zrevrange($dkey, 0, -1, true), 'list union keys w/scores');
+
+  tap_equal(2, $cluster->zlexcount($key2, '[Fizz', '[FizzZ'), 'count elements in lexographical range');
+  tap_equal(['Fizz', 'FizzBuzz'], $cluster->zrangebylex($key2, '[Fizz', '[FizzZ'), 'list elements in lexographical range');
+  tap_equal(['FizzBuzz', 'Fizz'], $cluster->zrevrangebylex($key2, '[FizzZ', '[Fizz'), 'list elements in reverse lexographical range');
+  tap_equal(['Fizz', 'FizzBuzz'], $cluster->zrangebyscore($key2, '-inf', '+inf'), 'list elements by score');
+  tap_equal(['FizzBuzz', 'Fizz'], $cluster->zrevrangebyscore($key2, '+inf', '-inf'), 'list elements by reverse score');
+
+  tap_equal(1, $cluster->zrank($key2, 'FizzBuzz'), 'get rank of an element');
+  tap_equal(30.0, $cluster->zscore($key2, 'FizzBuzz'), 'get the score of an element');
+  tap_equal(0, $cluster->zrevrank($key2, 'FizzBuzz'), 'get reverse rank of an element');
+
+  tap_equal(1, $cluster->zrem($key1, 'Fizz'), 'remove first element from first set');
+
+  tap_equal(3, $cluster->del([$key1, $key2, $dkey]), 'delete working sets keys');
+  tap_equal(5, $cluster->zadd($key1, 0, 'Apple', 1, 'Banana', 3, 'Cabbage', 3, 'Carrot', 3, 'Corn'), 'add elements to new set');
+
+  tap_equal(2, $cluster->zremrangebyrank($key1, 0, 1), 'remove elements by rank');
+  tap_equal(2, $cluster->zremrangebylex($key1, '[Ca', '[Cb'), 'remove elements by lexographical value');
+  tap_equal(1, $cluster->zremrangebyscore($key1, 3, 3), 'remove final element by score');
+
+  tap_equal(0, $cluster->exists([$key1, $key2, $dkey]), 'ensure all keys are cleaned up');
+
+  $cluster->close();
+}
+
+test_zset_cluster();


### PR DESCRIPTION
This PR incorporates #1206 by @shavounet contribution with minor adjustments:
---
The agent already auto-instruments 149 `\Redis::*` methods (`php_internal_instrument.c`). The phpredis `\RedisCluster` class exposes the same operation surface with the same semantics but does not extend `\Redis`, so the existing hooks don't fire on cluster-mode instances which results in effectively zero datastore visibility for applications using ElastiCache/Valkey/Redis cluster — only `redis::connect/select/eval` are auto-recorded (because they're called via the `\Redis` fallback path), all other methods (`get`/`set`/`mget`/`hgetall`/...) are missed.

This change adds 139 parallel `\RedisCluster::*` hooks routing to new `rediscluster_function` which differs from existing `redis_function` by skipping instance retrieval (see more detailed explanation below). `NR_DATASTORE_REDIS` is reused so cluster traffic shows up under the standard `Datastore/Redis/*` metric namespace — matching how `lib_predis.c` already reports cluster-mode Predis traffic with the only difference being per-instance metrics.

Excluded `\Redis` methods (10 total, none of which exist on `\RedisCluster`):

- **Connection management** — `connect`/`pconnect`/`open`/`popen`/`select`. `RedisCluster` is constructed via `__construct(seeds[])`, not `connect`, and cluster mode supports only db 0.
- **`\Redis`-only or single-node-only methods** — `move`/`swapdb` (cluster has only db 0), `migrate` (single-node only), `lremove`/`delete` (`\Redis`-only aliases for `lrem`/`del`).

No `__construct` hook is added in this PR, so per-instance datastore metadata (host, port) is never populated — segments record with `peer.address = unknown:unknown` and metrics record `unknown/unknown`. Timing/throughput aggregates still work; only the per-instance breakdown is missing.