### PR TITLE
fix(axiom): mitigate possible snprintf overflow

### DIFF
--- a/axiom/nr_rules.c
+++ b/axiom/nr_rules.c
@@ -168,7 +168,7 @@ nr_status_t nr_rule_replace_string(const char* repl,
         if (num > count) {
           *dest = 0;
           len = snprintf(dest, dest_len, "\\%d", num);
-          if (len < 0 || len >= (int)dest_len) {
+          if (len < 0 || (size_t)len >= dest_len) {
             return NR_FAILURE;
           }
           dest += len;
@@ -178,7 +178,7 @@ nr_status_t nr_rule_replace_string(const char* repl,
 
           if (sub) {
             len = snprintf(dest, dest_len, "%s", sub);
-            if (len < 0 || len >= (int)dest_len) {
+            if (len < 0 || (size_t)len >= dest_len) {
               nr_free(sub);
               return NR_FAILURE;
             }

--- a/axiom/nr_rules.c
+++ b/axiom/nr_rules.c
@@ -126,10 +126,10 @@ void nr_rules_sort(nrrules_t* rules) {
         qsort_comparator_for_rules);
 }
 
-void nr_rule_replace_string(const char* repl,
-                            char* dest,
-                            size_t dest_len,
-                            const nr_regex_substrings_t* ss) {
+nr_status_t nr_rule_replace_string(const char* repl,
+                                   char* dest,
+                                   size_t dest_len,
+                                   const nr_regex_substrings_t* ss) {
   int state = 0;
   int ch;
   int num = 0;
@@ -137,11 +137,11 @@ void nr_rule_replace_string(const char* repl,
   int count = nr_regex_substrings_count(ss);
 
   if (0 == dest) {
-    return;
+    return NR_SUCCESS;
   }
 
   if (0 == dest_len) {
-    return;
+    return NR_SUCCESS;
   }
 
   while (0 != (ch = *repl)) {
@@ -168,6 +168,9 @@ void nr_rule_replace_string(const char* repl,
         if (num > count) {
           *dest = 0;
           len = snprintf(dest, dest_len, "\\%d", num);
+          if (len < 0 || len >= (int)dest_len) {
+            return NR_FAILURE;
+          }
           dest += len;
           dest_len -= len;
         } else {
@@ -175,6 +178,10 @@ void nr_rule_replace_string(const char* repl,
 
           if (sub) {
             len = snprintf(dest, dest_len, "%s", sub);
+            if (len < 0 || len >= (int)dest_len) {
+              nr_free(sub);
+              return NR_FAILURE;
+            }
             dest += len;
             dest_len -= len;
           }
@@ -186,6 +193,7 @@ void nr_rule_replace_string(const char* repl,
     repl++;
   }
   *dest = 0;
+  return NR_SUCCESS;
 }
 
 /*
@@ -261,7 +269,10 @@ static nr_rules_result_t nr_rule_apply(char* str,
 
       /* Copy the match replacement. */
       if (rule->rflags & NR_RULE_HAS_CAPTURES) {
-        nr_rule_replace_string(rule->replacement, repl, repl_len, ss);
+        if (NR_FAILURE
+            == nr_rule_replace_string(rule->replacement, repl, repl_len, ss)) {
+          return NR_RULES_RESULT_UNCHANGED;
+        }
         wp = nr_strlcpy(wp, repl, NRULE_BUF_SIZE);
       } else {
         wp = nr_strlcpy(wp, rule->replacement, NRULE_BUF_SIZE);
@@ -294,7 +305,11 @@ static nr_rules_result_t nr_rule_apply(char* str,
       if (ss) {
         changed++;
         if (rule->rflags & NR_RULE_HAS_CAPTURES) {
-          nr_rule_replace_string(rule->replacement, repl, repl_len, ss);
+          if (NR_FAILURE
+              == nr_rule_replace_string(rule->replacement, repl, repl_len,
+                                        ss)) {
+            return NR_RULES_RESULT_UNCHANGED;
+          }
           wp = nr_strcpy(wp, repl);
         } else {
           wp = nr_strcpy(wp, rule->replacement);
@@ -357,7 +372,11 @@ static nr_rules_result_t nr_rule_apply(char* str,
       /* Calculate replacement. */
       if (need_replacement) {
         if (rule->rflags & NR_RULE_HAS_CAPTURES) {
-          nr_rule_replace_string(rule->replacement, repl, repl_len, ss);
+          if (NR_FAILURE
+              == nr_rule_replace_string(rule->replacement, repl, repl_len,
+                                        ss)) {
+            return NR_RULES_RESULT_UNCHANGED;
+          }
         } else {
           nr_strcpy(repl, rule->replacement);
         }

--- a/axiom/nr_rules.c
+++ b/axiom/nr_rules.c
@@ -271,6 +271,7 @@ static nr_rules_result_t nr_rule_apply(char* str,
       if (rule->rflags & NR_RULE_HAS_CAPTURES) {
         if (NR_FAILURE
             == nr_rule_replace_string(rule->replacement, repl, repl_len, ss)) {
+          nr_regex_substrings_destroy(&ss);
           return NR_RULES_RESULT_UNCHANGED;
         }
         wp = nr_strlcpy(wp, repl, NRULE_BUF_SIZE);
@@ -308,6 +309,7 @@ static nr_rules_result_t nr_rule_apply(char* str,
           if (NR_FAILURE
               == nr_rule_replace_string(rule->replacement, repl, repl_len,
                                         ss)) {
+            nr_regex_substrings_destroy(&ss);
             return NR_RULES_RESULT_UNCHANGED;
           }
           wp = nr_strcpy(wp, repl);
@@ -375,6 +377,7 @@ static nr_rules_result_t nr_rule_apply(char* str,
           if (NR_FAILURE
               == nr_rule_replace_string(rule->replacement, repl, repl_len,
                                         ss)) {
+            nr_regex_substrings_destroy(&ss);
             return NR_RULES_RESULT_UNCHANGED;
           }
         } else {

--- a/axiom/nr_rules_private.h
+++ b/axiom/nr_rules_private.h
@@ -31,9 +31,9 @@ struct _nrrules_t {
 
 extern void nr_rules_process_rule(nrrules_t* rules, const nrobj_t* rule);
 
-extern void nr_rule_replace_string(const char* repl,
-                                   char* dest,
-                                   size_t dest_len,
-                                   const nr_regex_substrings_t* ss);
+extern nr_status_t nr_rule_replace_string(const char* repl,
+                                          char* dest,
+                                          size_t dest_len,
+                                          const nr_regex_substrings_t* ss);
 
 #endif /* NR_RULES_PRIVATE_HDR */

--- a/axiom/tests/test_rules.c
+++ b/axiom/tests/test_rules.c
@@ -540,6 +540,7 @@ static void test_create_from_obj_bad_params(void) {
 static void test_replace_string(void) {
   int study = 1;
   char dest[64];
+  nr_status_t st;
 
   const char* pattern = "^.*(abc).*(stu)";
   nr_regex_t* regex = nr_regex_create(
@@ -555,52 +556,99 @@ static void test_replace_string(void) {
   ss = nr_regex_match_capture(regex, subject, slen);
   nr_regex_destroy(&regex);
 
-  nr_rule_replace_string("QQ\\2RRR\\1STUV", dest, sizeof(dest), ss);
+  st = nr_rule_replace_string("QQ\\2RRR\\1STUV", dest, sizeof(dest), ss);
+  tlib_pass_if_status_success("basic", st);
   tlib_pass_if_str_equal("basic", "QQstuRRRabcSTUV", dest);
 
-  nr_rule_replace_string("\\2\\1", dest, sizeof(dest), ss);
+  st = nr_rule_replace_string("\\2\\1", dest, sizeof(dest), ss);
+  tlib_pass_if_status_success("basic", st);
   tlib_pass_if_str_equal("basic", "stuabc", dest);
 
-  nr_rule_replace_string("\\1\\1\\1", dest, sizeof(dest), ss);
+  st = nr_rule_replace_string("\\1\\1\\1", dest, sizeof(dest), ss);
+  tlib_pass_if_status_success("basic", st);
   tlib_pass_if_str_equal("basic", "abcabcabc", dest);
 
-  nr_rule_replace_string("", dest, sizeof(dest), ss);
+  st = nr_rule_replace_string("", dest, sizeof(dest), ss);
+  tlib_pass_if_status_success("basic", st);
   tlib_pass_if_str_equal("basic", "", dest);
 
   /*
    * Back substitute everything that matched
    */
-  nr_rule_replace_string("\\0", dest, sizeof(dest), ss);
+  st = nr_rule_replace_string("\\0", dest, sizeof(dest), ss);
+  tlib_pass_if_status_success("basic", st);
   tlib_pass_if_str_equal("basic", "rrabcbqrstu", dest);
 
   /*
    * Dest is too small to receive the value
    */
-  nr_rule_replace_string("\\1\\1\\1", dest, 2, ss);
-  tlib_pass_if_str_equal("basic", "a", dest);
+  st = nr_rule_replace_string("\\1\\1\\1", dest, 2, ss);
+  tlib_pass_if_status_failure("substring overflow returns failure", st);
 
   /*
    * dest is null
    */
   dest[0] = 0;
-  nr_rule_replace_string("\\1\\1\\1", 0, sizeof(dest), ss);
+  st = nr_rule_replace_string("\\1\\1\\1", 0, sizeof(dest), ss);
+  tlib_pass_if_status_success("null dest is success", st);
   tlib_pass_if_str_equal("basic", "", dest);
 
   dest[0] = 0;
-  nr_rule_replace_string("\\1\\1\\1", dest, 0, ss);
+  st = nr_rule_replace_string("\\1\\1\\1", dest, 0, ss);
+  tlib_pass_if_status_success("zero dest_len is success", st);
   tlib_pass_if_str_equal("basic", "", dest);
 
   /*
    * Out of range selector number
    */
-  nr_rule_replace_string("\\3", dest, sizeof(dest), ss);
+  st = nr_rule_replace_string("\\3", dest, sizeof(dest), ss);
+  tlib_pass_if_status_success("out-of-range selector", st);
   tlib_pass_if_str_equal("basic", "\\3", dest);
 
   /*
    * Out of range selector number
    */
-  nr_rule_replace_string("\\13", dest, sizeof(dest), ss);
+  st = nr_rule_replace_string("\\13", dest, sizeof(dest), ss);
+  tlib_pass_if_status_success("out-of-range selector", st);
   tlib_pass_if_str_equal("basic", "\\13", dest);
+
+  /*
+   * Out-of-range selector overflows the destination buffer
+   */
+  st = nr_rule_replace_string("\\13", dest, 2, ss);
+  tlib_pass_if_status_failure("out-of-range selector overflow", st);
+
+  /*
+   * Substring replacement fits exactly with room for the trailing NUL
+   */
+  st = nr_rule_replace_string("\\1", dest, 4, ss);
+  tlib_pass_if_status_success("exact fit substring", st);
+  tlib_pass_if_str_equal("exact fit substring", "abc", dest);
+
+  /*
+   * Substring replacement is one byte short of the trailing NUL
+   */
+  st = nr_rule_replace_string("\\1", dest, 3, ss);
+  tlib_pass_if_status_failure("off-by-one substring overflow", st);
+
+  /*
+   * Out-of-range "\\NUM" replacement fits exactly with room for NUL
+   */
+  st = nr_rule_replace_string("\\3", dest, 3, ss);
+  tlib_pass_if_status_success("exact fit out-of-range selector", st);
+  tlib_pass_if_str_equal("exact fit out-of-range selector", "\\3", dest);
+
+  /*
+   * Out-of-range "\\NUM" replacement is one byte short of the trailing NUL
+   */
+  st = nr_rule_replace_string("\\3", dest, 2, ss);
+  tlib_pass_if_status_failure("off-by-one out-of-range selector overflow", st);
+
+  /*
+   * Earlier writes consume the buffer so a later snprintf overflows
+   */
+  st = nr_rule_replace_string("X\\1", dest, 2, ss);
+  tlib_pass_if_status_failure("late substring overflow", st);
 
   nr_regex_substrings_destroy(&ss);
 
@@ -610,7 +658,8 @@ static void test_replace_string(void) {
   subject = "";
   slen = nr_strlen(subject);
   ss = nr_regex_match_capture(regex, subject, slen);
-  nr_rule_replace_string("\\0", dest, sizeof(dest), ss);
+  st = nr_rule_replace_string("\\0", dest, sizeof(dest), ss);
+  tlib_pass_if_status_success("0-length subject", st);
   tlib_pass_if_str_equal("0-length subject", "\\0", dest);
   nr_regex_substrings_destroy(&ss);
 }


### PR DESCRIPTION
Mitigates a possible `snprintf` overflow by checking the return value of the call to `snprintf` and exit with an `NR_FAILURE` status if that value is negative or greater than the length of the buffer provided. The function signature of `nr_rule_replace_string` has been changed to return `nr_status_t` from `void` to signal to callers failures from the `snprintf` calls.