### PR TITLE
fix(daemon): report correct Instance/Reporting count

### DIFF
--- a/daemon/internal/newrelic/harvest.go
+++ b/daemon/internal/newrelic/harvest.go
@@ -102,17 +102,7 @@ func (h *Harvest) createEndpointAttemptsMetric(endpoint string, val float64) {
 
 }
 
-func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, mc *MetricsController, oldPidSet map[int]struct{}) {
-	pidSetSize := len(oldPidSet)
-
-	if 0 == pidSetSize {
-		// For UI purposes, Instance/Reporting has to be nonzero.
-		pidSetSize = 1
-	}
-
-	// NOTE: It is important that this metric be created once per harvest period.
-	h.Metrics.AddCount("Instance/Reporting", "", float64(pidSetSize), Forced)
-
+func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, mc *MetricsController) {
 	if len(mc.duc) == 0 && len(mc.mc) == 0 {
 		// No agent data received, do not create derived metrics. This allows
 		// upstream to detect inactivity sooner.

--- a/daemon/internal/newrelic/harvest.go
+++ b/daemon/internal/newrelic/harvest.go
@@ -102,6 +102,16 @@ func (h *Harvest) createEndpointAttemptsMetric(endpoint string, val float64) {
 
 }
 
+// NOTE: It is important that this metric be created once per harvest period.
+func (h *Harvest) addInstanceReportingMetric() {
+	pidSetSize := len(h.pidSet)
+	if pidSetSize == 0 {
+		// For UI purposes, Instance/Reporting has to be nonzero.
+		pidSetSize = 1
+	}
+	h.Metrics.AddCount("Instance/Reporting", "", float64(pidSetSize), Forced)
+}
+
 func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, mc *MetricsController) {
 	if len(mc.duc) == 0 && len(mc.mc) == 0 {
 		// No agent data received, do not create derived metrics. This allows

--- a/daemon/internal/newrelic/harvest.go
+++ b/daemon/internal/newrelic/harvest.go
@@ -102,8 +102,8 @@ func (h *Harvest) createEndpointAttemptsMetric(endpoint string, val float64) {
 
 }
 
-func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, mc *MetricsController) {
-	pidSetSize := len(h.pidSet)
+func (h *Harvest) createFinalMetrics(harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, mc *MetricsController, oldPidSet map[int]struct{}) {
+	pidSetSize := len(oldPidSet)
 
 	if 0 == pidSetSize {
 		// For UI purposes, Instance/Reporting has to be nonzero.

--- a/daemon/internal/newrelic/harvest_test.go
+++ b/daemon/internal/newrelic/harvest_test.go
@@ -117,7 +117,7 @@ func TestCreateFinalMetricsWithLotsOfMetrics(t *testing.T) {
 	harvest.LogEvents.FailedHarvest(harvest)
 	mc.AddMetricData(collector.CommandLogEvents, 0, 0, harvest.LogEvents.NumFailedAttempts())
 
-	harvest.createFinalMetrics(limits, nil, mc)
+	harvest.createFinalMetrics(limits, nil, mc, harvest.pidSet)
 
 	var expectedJSON = `["12345",1447203720,1417136520,` +
 		`[[{"name":"Instance/Reporting"},[1,0,0,0,0,0]],` +
@@ -176,7 +176,7 @@ func TestCreateFinalMetricsWithNoMetrics(t *testing.T) {
 			},
 		},
 	}
-	harvest.createFinalMetrics(limits, nil, mc)
+	harvest.createFinalMetrics(limits, nil, mc, harvest.pidSet)
 
 	var expectedJSON = `["12345",1447203720,1417136520,` +
 		`[[{"name":"Instance/Reporting"},[1,0,0,0,0,0]]]]`
@@ -185,6 +185,36 @@ func TestCreateFinalMetricsWithNoMetrics(t *testing.T) {
 	if nil != err {
 		t.Fatal(err)
 	}
+	if got := string(json); got != expectedJSON {
+		t.Errorf("got=%q want=%q", got, expectedJSON)
+	}
+}
+
+// TestInstanceReportingUsesOldPidSet guards against a regression where
+// createFinalMetrics read the current pidSet after HarvestDefaultData had
+// already reset it, causing Instance/Reporting to always report 1. The fix
+// passes the pre-reset pidSet explicitly, so reporting must reflect the old set
+// even when the current pidSet is empty.
+func TestInstanceReportingUsesOldPidSet(t *testing.T) {
+	harvest := NewHarvest(time.Date(2015, time.November, 11, 1, 2, 0, 0, time.UTC), collector.NewHarvestLimits(nil))
+	mc := mockMetricsController()
+
+	harvest.pidSet[1] = struct{}{}
+	harvest.pidSet[2] = struct{}{}
+	harvest.pidSet[3] = struct{}{}
+
+	// Simulate what HarvestDefaultData does: save the old pidSet then reset.
+	oldPidSet := harvest.pidSet
+	harvest.pidSet = make(map[int]struct{})
+
+	harvest.createFinalMetrics(collector.EventHarvestConfig{}, nil, mc, oldPidSet)
+
+	json, err := harvest.Metrics.CollectorJSONSorted(AgentRunID(`12345`), end)
+	if nil != err {
+		t.Fatal(err)
+	}
+	var expectedJSON = `["12345",1447203720,1417136520,` +
+		`[[{"name":"Instance/Reporting"},[3,0,0,0,0,0]]]]`
 	if got := string(json); got != expectedJSON {
 		t.Errorf("got=%q want=%q", got, expectedJSON)
 	}

--- a/daemon/internal/newrelic/harvest_test.go
+++ b/daemon/internal/newrelic/harvest_test.go
@@ -117,11 +117,10 @@ func TestCreateFinalMetricsWithLotsOfMetrics(t *testing.T) {
 	harvest.LogEvents.FailedHarvest(harvest)
 	mc.AddMetricData(collector.CommandLogEvents, 0, 0, harvest.LogEvents.NumFailedAttempts())
 
-	harvest.createFinalMetrics(limits, nil, mc, harvest.pidSet)
+	harvest.createFinalMetrics(limits, nil, mc)
 
 	var expectedJSON = `["12345",1447203720,1417136520,` +
-		`[[{"name":"Instance/Reporting"},[1,0,0,0,0,0]],` +
-		`[{"name":"Supportability/Agent/Collector/custom_event_data/Attempts"},[1,0,0,0,0,0]],` +
+		`[[{"name":"Supportability/Agent/Collector/custom_event_data/Attempts"},[1,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Agent/Collector/error_event_data/Attempts"},[2,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Agent/Collector/log_event_data/Attempts"},[4,0,0,0,0,0]],` +
 		`[{"name":"Supportability/Agent/Collector/span_event_data/Attempts"},[3,0,0,0,0,0]],` +
@@ -176,45 +175,14 @@ func TestCreateFinalMetricsWithNoMetrics(t *testing.T) {
 			},
 		},
 	}
-	harvest.createFinalMetrics(limits, nil, mc, harvest.pidSet)
+	harvest.createFinalMetrics(limits, nil, mc)
 
-	var expectedJSON = `["12345",1447203720,1417136520,` +
-		`[[{"name":"Instance/Reporting"},[1,0,0,0,0,0]]]]`
-
-	json, err := harvest.Metrics.CollectorJSONSorted(AgentRunID(`12345`), end)
-	if nil != err {
-		t.Fatal(err)
-	}
-	if got := string(json); got != expectedJSON {
-		t.Errorf("got=%q want=%q", got, expectedJSON)
-	}
-}
-
-// TestInstanceReportingUsesOldPidSet guards against a regression where
-// createFinalMetrics read the current pidSet after HarvestDefaultData had
-// already reset it, causing Instance/Reporting to always report 1. The fix
-// passes the pre-reset pidSet explicitly, so reporting must reflect the old set
-// even when the current pidSet is empty.
-func TestInstanceReportingUsesOldPidSet(t *testing.T) {
-	harvest := NewHarvest(time.Date(2015, time.November, 11, 1, 2, 0, 0, time.UTC), collector.NewHarvestLimits(nil))
-	mc := mockMetricsController()
-
-	harvest.pidSet[1] = struct{}{}
-	harvest.pidSet[2] = struct{}{}
-	harvest.pidSet[3] = struct{}{}
-
-	// Simulate what HarvestDefaultData does: save the old pidSet then reset.
-	oldPidSet := harvest.pidSet
-	harvest.pidSet = make(map[int]struct{})
-
-	harvest.createFinalMetrics(collector.EventHarvestConfig{}, nil, mc, oldPidSet)
+	var expectedJSON = `["12345",1447203720,1417136520,[]]`
 
 	json, err := harvest.Metrics.CollectorJSONSorted(AgentRunID(`12345`), end)
 	if nil != err {
 		t.Fatal(err)
 	}
-	var expectedJSON = `["12345",1447203720,1417136520,` +
-		`[[{"name":"Instance/Reporting"},[3,0,0,0,0,0]]]]`
 	if got := string(json); got != expectedJSON {
 		t.Errorf("got=%q want=%q", got, expectedJSON)
 	}

--- a/daemon/internal/newrelic/processor.go
+++ b/daemon/internal/newrelic/processor.go
@@ -675,9 +675,9 @@ func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.Eve
 	considerHarvestPayload(harvest.PhpPackages, args, mc)
 
 	if args.blocking {
-		harvestMetrics(harvest, args, mc, harvestLimits, to)
+		harvestMetrics(harvest, args, mc, harvestLimits, to, harvest.pidSet)
 	} else {
-		go harvestMetrics(harvest, args, mc, harvestLimits, to)
+		go harvestMetrics(harvest, args, mc, harvestLimits, to, harvest.pidSet)
 	}
 }
 
@@ -723,6 +723,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		harvest.TxnTraces = NewTxnTraces()
 		harvest.PhpPackages = NewPhpPackages()
 		harvest.commandsProcessed = 0
+		oldPidSet := harvest.pidSet
 		harvest.pidSet = make(map[int]struct{})
 
 		considerHarvestPayload(errors, args, mc)
@@ -731,9 +732,9 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		considerHarvestPayload(phpPackages, args, mc)
 
 		if args.blocking {
-			harvestMetrics(harvest, args, mc, ah.connectReply.EventHarvestConfig, ah.TraceObserver)
+			harvestMetrics(harvest, args, mc, ah.connectReply.EventHarvestConfig, ah.TraceObserver, oldPidSet)
 		} else {
-			go harvestMetrics(harvest, args, mc, ah.connectReply.EventHarvestConfig, ah.TraceObserver)
+			go harvestMetrics(harvest, args, mc, ah.connectReply.EventHarvestConfig, ah.TraceObserver, oldPidSet)
 		}
 	}
 
@@ -783,7 +784,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 }
 
-func harvestMetrics(h *Harvest, args *harvestArgs, mc *MetricsController, harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver) {
+func harvestMetrics(h *Harvest, args *harvestArgs, mc *MetricsController, harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, oldPidSet map[int]struct{}) {
 	if !mc.mu.TryLock() {
 		log.Warnf("harvestMetrics skipped: previous cycle still running")
 		return
@@ -799,7 +800,7 @@ func harvestMetrics(h *Harvest, args *harvestArgs, mc *MetricsController, harves
 	mc.wg.Wait()
 	log.Debugf("harvesting metrics")
 
-	h.createFinalMetrics(harvestLimits, to, mc)
+	h.createFinalMetrics(harvestLimits, to, mc, oldPidSet)
 	harvestDataUsage(h, args, mc)
 
 	h.Metrics = h.Metrics.ApplyRules(args.rules)

--- a/daemon/internal/newrelic/processor.go
+++ b/daemon/internal/newrelic/processor.go
@@ -664,11 +664,7 @@ func considerHarvestPayloadTxnEvents(txnEvents *TxnEvents, args *harvestArgs, mc
 func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, mc *MetricsController) {
 	log.Debugf("harvesting %d commands processed", harvest.commandsProcessed)
 
-	pidSetSize := len(harvest.pidSet)
-	if pidSetSize == 0 {
-		pidSetSize = 1
-	}
-	harvest.Metrics.AddCount("Instance/Reporting", "", float64(pidSetSize), Forced)
+	harvest.addInstanceReportingMetric()
 
 	considerHarvestPayload(harvest.CustomEvents, args, mc)
 	considerHarvestPayload(harvest.ErrorEvents, args, mc)
@@ -729,11 +725,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		harvest.TxnTraces = NewTxnTraces()
 		harvest.PhpPackages = NewPhpPackages()
 		harvest.commandsProcessed = 0
-		pidSetSize := len(harvest.pidSet)
-		if pidSetSize == 0 {
-			pidSetSize = 1
-		}
-		harvest.Metrics.AddCount("Instance/Reporting", "", float64(pidSetSize), Forced)
+		harvest.addInstanceReportingMetric()
 		harvest.pidSet = make(map[int]struct{})
 
 		considerHarvestPayload(errors, args, mc)

--- a/daemon/internal/newrelic/processor.go
+++ b/daemon/internal/newrelic/processor.go
@@ -664,6 +664,12 @@ func considerHarvestPayloadTxnEvents(txnEvents *TxnEvents, args *harvestArgs, mc
 func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, mc *MetricsController) {
 	log.Debugf("harvesting %d commands processed", harvest.commandsProcessed)
 
+	pidSetSize := len(harvest.pidSet)
+	if pidSetSize == 0 {
+		pidSetSize = 1
+	}
+	harvest.Metrics.AddCount("Instance/Reporting", "", float64(pidSetSize), Forced)
+
 	considerHarvestPayload(harvest.CustomEvents, args, mc)
 	considerHarvestPayload(harvest.ErrorEvents, args, mc)
 	considerHarvestPayload(harvest.Errors, args, mc)
@@ -675,9 +681,9 @@ func harvestAll(harvest *Harvest, args *harvestArgs, harvestLimits collector.Eve
 	considerHarvestPayload(harvest.PhpPackages, args, mc)
 
 	if args.blocking {
-		harvestMetrics(harvest, args, mc, harvestLimits, to, harvest.pidSet)
+		harvestMetrics(harvest, args, mc, harvestLimits, to)
 	} else {
-		go harvestMetrics(harvest, args, mc, harvestLimits, to, harvest.pidSet)
+		go harvestMetrics(harvest, args, mc, harvestLimits, to)
 	}
 }
 
@@ -723,7 +729,11 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		harvest.TxnTraces = NewTxnTraces()
 		harvest.PhpPackages = NewPhpPackages()
 		harvest.commandsProcessed = 0
-		oldPidSet := harvest.pidSet
+		pidSetSize := len(harvest.pidSet)
+		if pidSetSize == 0 {
+			pidSetSize = 1
+		}
+		harvest.Metrics.AddCount("Instance/Reporting", "", float64(pidSetSize), Forced)
 		harvest.pidSet = make(map[int]struct{})
 
 		considerHarvestPayload(errors, args, mc)
@@ -732,9 +742,9 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 		considerHarvestPayload(phpPackages, args, mc)
 
 		if args.blocking {
-			harvestMetrics(harvest, args, mc, ah.connectReply.EventHarvestConfig, ah.TraceObserver, oldPidSet)
+			harvestMetrics(harvest, args, mc, ah.connectReply.EventHarvestConfig, ah.TraceObserver)
 		} else {
-			go harvestMetrics(harvest, args, mc, ah.connectReply.EventHarvestConfig, ah.TraceObserver, oldPidSet)
+			go harvestMetrics(harvest, args, mc, ah.connectReply.EventHarvestConfig, ah.TraceObserver)
 		}
 	}
 
@@ -784,7 +794,7 @@ func harvestByType(ah *AppHarvest, args *harvestArgs, ht HarvestType) {
 
 }
 
-func harvestMetrics(h *Harvest, args *harvestArgs, mc *MetricsController, harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver, oldPidSet map[int]struct{}) {
+func harvestMetrics(h *Harvest, args *harvestArgs, mc *MetricsController, harvestLimits collector.EventHarvestConfig, to *infinite_tracing.TraceObserver) {
 	if !mc.mu.TryLock() {
 		log.Warnf("harvestMetrics skipped: previous cycle still running")
 		return
@@ -800,7 +810,7 @@ func harvestMetrics(h *Harvest, args *harvestArgs, mc *MetricsController, harves
 	mc.wg.Wait()
 	log.Debugf("harvesting metrics")
 
-	h.createFinalMetrics(harvestLimits, to, mc, oldPidSet)
+	h.createFinalMetrics(harvestLimits, to, mc)
 	harvestDataUsage(h, args, mc)
 
 	h.Metrics = h.Metrics.ApplyRules(args.rules)

--- a/daemon/internal/newrelic/processor_test.go
+++ b/daemon/internal/newrelic/processor_test.go
@@ -305,12 +305,14 @@ func TestProcessorHarvestDefaultData(t *testing.T) {
 // pidSet count across distinct pids, duplicate inserts, and empty pidSet.
 func TestProcessorHarvestDefaultDataInstanceReporting(t *testing.T) {
 	tests := []struct {
-		name  string
-		seed  func(map[int]struct{})
-		wantN int
+		name        string
+		harvestType HarvestType
+		seed        func(map[int]struct{})
+		wantN       int
 	}{
 		{
-			name: "distinct pids",
+			name:        "HarvestDefaultData distinct pids",
+			harvestType: HarvestDefaultData,
 			seed: func(ps map[int]struct{}) {
 				ps[100] = struct{}{}
 				ps[101] = struct{}{}
@@ -319,7 +321,8 @@ func TestProcessorHarvestDefaultDataInstanceReporting(t *testing.T) {
 			wantN: 3,
 		},
 		{
-			name: "duplicate inserts count once each",
+			name:        "HarvestDefaultData duplicate inserts count once each",
+			harvestType: HarvestDefaultData,
 			seed: func(ps map[int]struct{}) {
 				ps[100] = struct{}{}
 				ps[100] = struct{}{} // duplicate
@@ -330,9 +333,20 @@ func TestProcessorHarvestDefaultDataInstanceReporting(t *testing.T) {
 			wantN: 3,
 		},
 		{
-			name:  "empty pidSet floors to 1",
-			seed:  func(ps map[int]struct{}) {},
-			wantN: 1,
+			name:        "HarvestDefaultData empty pidSet floors to 1",
+			harvestType: HarvestDefaultData,
+			seed:        func(ps map[int]struct{}) {},
+			wantN:       1,
+		},
+		{
+			name:        "HarvestAll distinct pids",
+			harvestType: HarvestAll,
+			seed: func(ps map[int]struct{}) {
+				ps[100] = struct{}{}
+				ps[101] = struct{}{}
+				ps[102] = struct{}{}
+			},
+			wantN: 3,
 		},
 	}
 
@@ -348,7 +362,7 @@ func TestProcessorHarvestDefaultDataInstanceReporting(t *testing.T) {
 			m.processorHarvestChan <- ProcessorHarvest{
 				AppHarvest: m.p.harvests[idOne],
 				ID:         idOne,
-				Type:       HarvestDefaultData,
+				Type:       tc.harvestType,
 			}
 
 			m.clientReturn <- ClientReturn{nil, nil, 202}

--- a/daemon/internal/newrelic/processor_test.go
+++ b/daemon/internal/newrelic/processor_test.go
@@ -299,6 +299,75 @@ func TestProcessorHarvestDefaultData(t *testing.T) {
 	m.QuitTestProcessor()
 }
 
+// TestProcessorHarvestDefaultDataInstanceReporting guards against the
+// regression where Instance/Reporting was read after pidSet was reset,
+// causing it to always report 1. Verifies the metric reflects the pre-reset
+// pidSet count across distinct pids, duplicate inserts, and empty pidSet.
+func TestProcessorHarvestDefaultDataInstanceReporting(t *testing.T) {
+	tests := []struct {
+		name  string
+		seed  func(map[int]struct{})
+		wantN int
+	}{
+		{
+			name: "distinct pids",
+			seed: func(ps map[int]struct{}) {
+				ps[100] = struct{}{}
+				ps[101] = struct{}{}
+				ps[102] = struct{}{}
+			},
+			wantN: 3,
+		},
+		{
+			name: "duplicate inserts count once each",
+			seed: func(ps map[int]struct{}) {
+				ps[100] = struct{}{}
+				ps[100] = struct{}{} // duplicate
+				ps[101] = struct{}{}
+				ps[101] = struct{}{} // duplicate
+				ps[102] = struct{}{}
+			},
+			wantN: 3,
+		},
+		{
+			name:  "empty pidSet floors to 1",
+			seed:  func(ps map[int]struct{}) {},
+			wantN: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMockedProcessor(1)
+			m.DoAppInfo(t, nil, AppStateUnknown)
+			m.DoConnect(t, &idOne)
+			m.DoAppInfo(t, nil, AppStateConnected)
+
+			tc.seed(m.p.harvests[idOne].Harvest.pidSet)
+
+			m.processorHarvestChan <- ProcessorHarvest{
+				AppHarvest: m.p.harvests[idOne],
+				ID:         idOne,
+				Type:       HarvestDefaultData,
+			}
+
+			m.clientReturn <- ClientReturn{nil, nil, 202}
+			cp := <-m.clientParams
+			<-m.p.trackProgress
+
+			time1 := strings.Split(string(cp.data), ",")[1]
+			time2 := strings.Split(string(cp.data), ",")[2]
+			expected := fmt.Sprintf(`["one",%s,%s,[[{"name":"Instance/Reporting"},[%d,0,0,0,0,0]]]]`,
+				time1, time2, tc.wantN)
+			if got, _ := OrderScrubMetrics(cp.data, nil); string(got) != expected {
+				t.Errorf("got=%s", got)
+			}
+
+			m.QuitTestProcessor()
+		})
+	}
+}
+
 // split Php Packages out from DefaultData test - trying to
 // combine the txn trace and php packages data did not work
 // as these goto different endpoints - combining them here


### PR DESCRIPTION
## Problem

\`createFinalMetrics\` runs inside the \`harvestMetrics\` goroutine and read the live \`h.pidSet\`. In the \`HarvestDefaultData\` path of \`harvestByType\`, \`pidSet\` is reset in place just before that goroutine is spawned, so \`createFinalMetrics\` almost always observed an empty set and reported \`Instance/Reporting = 1\` regardless of how many instances were actually active.

## Fix

Record \`Instance/Reporting\` inline at the point where \`pidSet\` is still intact — immediately before the reset in the \`HarvestDefaultData\` path, and at the top of \`harvestAll\` — following the same capture-before-handoff pattern already used by the surrounding harvest payloads. \`createFinalMetrics\` no longer reads \`pidSet\` or produces this metric.

## Changes

- \`daemon/internal/newrelic/harvest.go\` — remove \`Instance/Reporting\` logic and the \`pidSet\` parameter from \`createFinalMetrics\`.
- \`daemon/internal/newrelic/processor.go\` — record \`Instance/Reporting\` inline with a floor of 1 in both the \`HarvestDefaultData\` path (before the pidSet reset) and in \`harvestAll\` (before handoff to the goroutine).
- \`daemon/internal/newrelic/harvest_test.go\` — update expected JSON in \`TestCreateFinalMetrics*\`; remove now-hollow \`Instance/Reporting\`-specific test.
- \`daemon/internal/newrelic/processor_test.go\` — add \`TestProcessorHarvestDefaultDataInstanceReporting\` with three subtests: distinct pids, duplicate inserts (map set semantics), and empty pidSet (floor of 1).

## Testing

- \`go build ./...\` and \`go test ./internal/newrelic/...\` pass.
- The new regression test covers the pre-reset count, duplicate-insert deduplication, and the empty floor. \`TestSupportabilityHarvest\` confirms the existing aggregation-on-retry behavior (\`Instance/Reporting = 2\` after a 408 failure) is preserved.
- Verified with a 300s nginx/php-fpm soak (worker pool fixed at static, 5 workers): \`Instance/Reporting = 5\` every harvest cycle.
