### PR TITLE
security(daemon): upgrade golang to 1.26.4

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/newrelic-php-agent/daemon
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/google/flatbuffers v25.12.19+incompatible


### PR DESCRIPTION
security(daemon): upgrade golang to 1.26.4