### PR TITLE
fix(agent): per-thread RNG to eliminate ZTS race

### DIFF
--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -128,6 +128,7 @@ PHP_GSHUTDOWN_FUNCTION(newrelic) {
   /*
    * Remove this thread's per-thread harvest stats entry from every app's
    * harvest_map so it is not left dangling after the thread exits.
+   * Also removes the per-thread RNG state entry from rnd_map.
    */
   if (nr_agent_applist) {
     uint64_t key = (uint64_t)nr_gettid();
@@ -135,9 +136,10 @@ PHP_GSHUTDOWN_FUNCTION(newrelic) {
     nrt_mutex_lock(&nr_agent_applist->applist_lock);
     for (int i = 0; i < nr_agent_applist->num_apps; i++) {
       nrapp_t* app = nr_agent_applist->apps[i];
-      if (app && app->harvest_map) {
+      if (app && (app->harvest_map || app->rnd_map)) {
         nrt_mutex_lock(&app->app_lock);
         nr_hashmap_index_delete(app->harvest_map, key);
+        nr_hashmap_index_delete(app->rnd_map, key);
         nrt_mutex_unlock(&app->app_lock);
       }
     }

--- a/axiom/Makefile
+++ b/axiom/Makefile
@@ -89,6 +89,7 @@ OBJS := \
 	nr_app.o \
 	nr_app_harvest.o \
 	nr_app_harvest_map.o \
+	nr_app_rnd_map.o \
 	nr_attributes.o \
 	nr_banner.o \
 	nr_configstrings.o \

--- a/axiom/nr_app.c
+++ b/axiom/nr_app.c
@@ -126,8 +126,8 @@ void nr_app_destroy(nrapp_t** app_ptr) {
   nr_segment_terms_destroy(&app->segment_terms);
   nro_delete(app->connect_reply);
   nro_delete(app->security_policies);
-  nr_random_destroy(&app->rnd);
   nr_hashmap_destroy(&app->harvest_map);
+  nr_hashmap_destroy(&app->rnd_map);
 
   nrt_mutex_unlock(&app->app_lock);
   nrt_mutex_destroy(&app->app_lock);
@@ -284,8 +284,8 @@ static nrapp_t* create_new_app(const nr_app_info_t* info) {
   app->info.docker_id = nr_strdup(info->docker_id);
   app->harvest_map
       = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_harvest_stats_dtor);
-  app->rnd = nr_random_create();
-  nr_random_seed_from_time(app->rnd);
+  app->rnd_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
 
   nrt_mutex_init(&app->app_lock, 0);
   nrt_mutex_lock(&app->app_lock);

--- a/axiom/nr_app.h
+++ b/axiom/nr_app.h
@@ -98,7 +98,6 @@ typedef struct _nr_app_limits_t {
 
 typedef struct _nrapp_t {
   nr_app_info_t info;
-  nr_random_t* rnd;         /* Random number generator */
   int state;                /* Connection state */
   char* plicense;           /* Printable license (abbreviated for security) */
   char* agent_run_id;       /* The collector's agent run ID; assigned from the
@@ -126,6 +125,9 @@ typedef struct _nrapp_t {
                                                        from daemon; updated on
                                                        every appinfo reply */
   nr_hashmap_t* harvest_map;                        /* Per-thread harvest stats,
+                                                       keyed by
+                                                       (uint64_t)nr_gettid() */
+  nr_hashmap_t* rnd_map;                            /* Per-thread RNG state,
                                                        keyed by
                                                        (uint64_t)nr_gettid() */
 
@@ -331,5 +333,26 @@ extern void nr_app_update_harvest_config(nrapp_t* app,
 extern nr_app_harvest_stats_t* nr_app_get_or_create_thread_harvest(
     nrapp_t* app,
     uint64_t key);
+
+/*
+ * Purpose : Destructor for nr_random_t values stored in rnd_map.
+ *           For use as nr_hashmap_create dtor argument.
+ *
+ * Params  : 1. The rnd pointer to free.
+ */
+extern void nr_app_rnd_dtor(nr_random_t* rnd);
+
+/*
+ * Purpose : Return the RNG for the calling thread, creating and seeding one
+ *           if this thread has not been seen before.  Must be called with
+ *           app->app_lock held.
+ *
+ * Params  : 1. The application.
+ *           2. The thread key: (uint64_t)nr_gettid().
+ *
+ * Returns : Pointer to the per-thread RNG, or NULL on allocation failure.
+ */
+extern nr_random_t* nr_app_get_or_create_thread_rnd(nrapp_t* app,
+                                                     uint64_t key);
 
 #endif /* NR_APP_HDR */

--- a/axiom/nr_app_rnd_map.c
+++ b/axiom/nr_app_rnd_map.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nr_axiom.h"
+
+#include "nr_app.h"
+#include "util_hashmap.h"
+#include "util_random.h"
+
+void nr_app_rnd_dtor(nr_random_t* rnd) {
+  nr_random_destroy(&rnd);
+}
+
+nr_random_t* nr_app_get_or_create_thread_rnd(nrapp_t* app, uint64_t key) {
+  nr_random_t* rnd;
+
+  if (NULL == app || NULL == app->rnd_map) {
+    return NULL;
+  }
+
+  rnd = (nr_random_t*)nr_hashmap_index_get(app->rnd_map, key);
+  if (rnd) {
+    return rnd;
+  }
+
+  rnd = nr_random_create();
+  nr_random_seed_from_time(rnd);
+
+  if (NR_SUCCESS != nr_hashmap_index_set(app->rnd_map, key, rnd)) {
+    nr_random_destroy(&rnd);
+    return NULL;
+  }
+
+  return rnd;
+}

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -456,6 +456,7 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nr_sampling_priority_t priority;
   nr_slab_t* segment_slab;
   nr_app_harvest_stats_t* thread_harvest;
+  nr_random_t* thread_rnd;
   int tid;
 
   if (NULL == app) {
@@ -484,7 +485,9 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nt->status.path_is_frozen = 0;
   nt->status.path_type = NR_PATH_TYPE_UNKNOWN;
   nt->agent_run_id = nr_strdup(app->agent_run_id);
-  nt->rnd = app->rnd;
+  tid = nr_gettid();
+  thread_rnd = nr_app_get_or_create_thread_rnd(app, (uint64_t)tid);
+  nt->rnd = thread_rnd;
   nt->segment_slab = segment_slab;
 
   /*
@@ -640,7 +643,7 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
    * The trace id will be overwritten by accepting an inbound DT
    * payload.
    */
-  guid = nr_guid_create(app->rnd);
+  guid = nr_guid_create(thread_rnd);
   nr_distributed_trace_set_txn_id(nt->distributed_trace, guid);
   nr_distributed_trace_set_trace_id(nt->distributed_trace, guid,
                                     opts->distributed_tracing_pad_trace_id);
@@ -656,11 +659,10 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
       nro_get_hash_string(nt->app_connect_reply, "primary_application_id",
                           &err));
 
-  priority = nr_generate_initial_priority(app->rnd);
-  tid = nr_gettid();
+  priority = nr_generate_initial_priority(thread_rnd);
   thread_harvest = nr_app_get_or_create_thread_harvest(app, (uint64_t)tid);
   if (nr_app_harvest_should_sample(&app->adaptive_sampling_config,
-                                    thread_harvest, app->rnd)) {
+                                    thread_harvest, thread_rnd)) {
     nr_distributed_trace_set_sampled(nt->distributed_trace, true);
     priority += 1.0;
   }

--- a/axiom/tests/test_app.c
+++ b/axiom/tests/test_app.c
@@ -1238,6 +1238,43 @@ static void test_sync_harvest_config(void) {
   nrt_mutex_destroy(&app.app_lock);
 }
 
+static void test_get_or_create_thread_rnd(void) {
+  nrapp_t app = {0};
+  nr_random_t* r1;
+  nr_random_t* r2;
+
+  /* NULL app returns NULL. */
+  tlib_pass_if_null("NULL app", nr_app_get_or_create_thread_rnd(NULL, 1));
+
+  /* NULL rnd_map returns NULL. */
+  tlib_pass_if_null("NULL rnd_map",
+                    nr_app_get_or_create_thread_rnd(&app, 1));
+
+  app.rnd_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
+
+  /* First call for key 1 creates a seeded entry. */
+  r1 = nr_app_get_or_create_thread_rnd(&app, 1);
+  tlib_pass_if_not_null("first call returns non-NULL", r1);
+
+  /* Verify rnd is seeded and functional (not all-zero xsubi). */
+  tlib_pass_if_true("rnd produces in-range value",
+                    nr_random_range(r1, 1000) < 1000,
+                    "rnd=%p", (void*)r1);
+
+  /* Second call for key 1 returns the same pointer (no re-seed). */
+  r2 = nr_app_get_or_create_thread_rnd(&app, 1);
+  tlib_pass_if_true("same pointer on second call", r1 == r2,
+                    "r1=%p r2=%p", (void*)r1, (void*)r2);
+
+  /* Different key returns a different pointer. */
+  r2 = nr_app_get_or_create_thread_rnd(&app, 2);
+  tlib_pass_if_not_null("key 2 non-NULL", r2);
+  tlib_pass_if_true("different pointer for different key", r1 != r2,
+                    "r1=%p r2=%p", (void*)r1, (void*)r2);
+
+  nr_hashmap_destroy(&app.rnd_map);
+}
+
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = 4, .state_size = sizeof(test_app_state_t)};
 
@@ -1262,4 +1299,5 @@ void test_main(void* p NRUNUSED) {
   test_app_consider_appinfo_refresh();
   test_get_or_create_thread_harvest();
   test_sync_harvest_config();
+  test_get_or_create_thread_rnd();
 }

--- a/axiom/tests/test_app.c
+++ b/axiom/tests/test_app.c
@@ -1256,8 +1256,13 @@ static void test_get_or_create_thread_rnd(void) {
   r1 = nr_app_get_or_create_thread_rnd(&app, 1);
   tlib_pass_if_not_null("first call returns non-NULL", r1);
 
-  /* Verify rnd is seeded and functional (not all-zero xsubi). */
-  tlib_pass_if_true("rnd produces in-range value",
+  /*
+   * The "< 1000" pulls little weight -- nr_random_range() is range-bounded for
+   * any seed, so it's near-tautological (would only trip if the range contract
+   * regressed). The real check here is that calling the RNG on the returned
+   * generator does not crash. Seeding is verified in test_random.c:test_range.
+   */
+  tlib_pass_if_true("rnd is usable (RNG call does not crash)",
                     nr_random_range(r1, 1000) < 1000,
                     "rnd=%p", (void*)r1);
 

--- a/axiom/tests/test_segment_helpers.h
+++ b/axiom/tests/test_segment_helpers.h
@@ -238,7 +238,7 @@ static NRUNUSED nrtxn_t* new_txn(int background) {
   app.connect_reply = nro_create_from_json(
       "{\"collect_traces\":true,\"collect_errors\":true}");
   app.info.license = nr_strdup("0123456789012345678901234567890123456789");
-  app.rnd = NULL;
+  app.rnd_map = NULL;
   app.limits = (nr_app_limits_t){
       .analytics_events = NR_MAX_ANALYTIC_EVENTS,
       .custom_events = NR_DEFAULT_CUSTOM_EVENTS_MAX_SAMPLES_STORED,

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -32,6 +32,7 @@
 #include "util_metrics.h"
 #include "util_metrics_private.h"
 #include "util_random.h"
+#include "util_syscalls.h"
 #include "util_strings.h"
 #include "util_text.h"
 #include "util_url.h"
@@ -1707,8 +1708,13 @@ static void test_begin(void) {
   opts->span_queue_batch_timeout = 1 * NR_TIME_DIVISOR;
   opts->distributed_tracing_pad_trace_id = false;
 
-  app->rnd = nr_random_create();
-  nr_random_seed(app->rnd, 345345);
+  app->rnd_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
+  {
+    int self = nr_gettid();
+    nr_random_t* rnd = nr_random_create();
+    nr_random_seed(rnd, 345345);
+    nr_hashmap_index_set(app->rnd_map, (uint64_t)self, rnd);
+  }
   app->info.high_security = 0;
   app->connect_reply = nro_new_hash();
   app->security_policies = nro_new_hash();
@@ -1927,8 +1933,8 @@ static void test_begin(void) {
   nro_delete(app->connect_reply);
   nro_delete(app->security_policies);
   nr_hashmap_destroy(&app->harvest_map);
+  nr_hashmap_destroy(&app->rnd_map);
   nr_attribute_config_destroy(&attribute_config);
-  nr_random_destroy(&app->rnd);
 }
 
 static int metric_exists(nrmtable_t* metrics, const char* name) {
@@ -2135,8 +2141,13 @@ static void test_end(void) {
   nrtime_t duration;
   test_txn_state_t* p = (test_txn_state_t*)tlib_getspecific();
 
-  app->rnd = nr_random_create();
-  nr_random_seed(app->rnd, 345345);
+  app->rnd_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
+  {
+    int self = nr_gettid();
+    nr_random_t* rnd = nr_random_create();
+    nr_random_seed(rnd, 345345);
+    nr_hashmap_index_set(app->rnd_map, (uint64_t)self, rnd);
+  }
   app->info.high_security = 0;
   app->state = NR_APP_OK;
   nrt_mutex_init(&app->app_lock, 0);
@@ -2307,10 +2318,10 @@ static void test_end(void) {
   tlib_pass_if_time_equal("duration is manually retimed", duration, 1000000);
   nr_txn_destroy(&txn);
 
-  nr_random_destroy(&app->rnd);
   nr_rules_destroy(&app->url_rules);
   nr_rules_destroy(&app->txn_rules);
   nr_hashmap_destroy(&app->harvest_map);
+  nr_hashmap_destroy(&app->rnd_map);
   nrt_mutex_destroy(&app->app_lock);
   nro_delete(app->connect_reply);
   nro_delete(app->security_policies);
@@ -5144,12 +5155,17 @@ static void test_txn_trace_context_cross_agent_tests(void) {
   nrobj_t* array = 0;
   nrotype_t otype;
   int i;
+  int size;
   nrapp_t app = {
       .state = NR_APP_OK,
       .limits = default_app_limits(),
-      .rnd = nr_random_create(),
   };
-  int size;
+  app.rnd_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
+  {
+    int self = nr_gettid();
+    nr_random_t* rnd = nr_random_create();
+    nr_hashmap_index_set(app.rnd_map, (uint64_t)self, rnd);
+  }
 
   json = nr_read_file_contents(CROSS_AGENT_TESTS_DIR
                                "/distributed_tracing/trace_context.json",
@@ -5168,7 +5184,7 @@ static void test_txn_trace_context_cross_agent_tests(void) {
   nr_free(app.info.appname);
   nro_delete(app.connect_reply);
   nro_delete(array);
-  nr_random_destroy(&app.rnd);
+  nr_hashmap_destroy(&app.rnd_map);
   nr_free(json);
 }
 


### PR DESCRIPTION
## Summary

- Replaces shared `app->rnd` with per-thread `rnd_map` on `nrapp_t`, keyed by `nr_gettid()`, mirroring the `harvest_map` pattern from #1229
- Under ZTS, all threads aliased `app->rnd` via `nt->rnd = app->rnd`, causing concurrent `nrand48()` calls to race on the same `xsubi[3]` state — corrupting the LCG sequence and producing non-unique random values across threads, which degrades the uniqueness guarantees of span and trace identifiers
- Each thread now gets its own `nr_random_t`, lazily created under `app_lock` on first transaction; GSHUTDOWN removes the entry on thread exit
- NTS behaviour unchanged aside from using one map entry per process