### PR TITLE
ci: add labels for FR triage

### DIFF
--- a/.github/workflows/issue-close.yml
+++ b/.github/workflows/issue-close.yml
@@ -1,0 +1,25 @@
+# Copyright 2026 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: issue-close
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      issue-number:
+        type: number
+        required: true
+    secrets:
+      token:
+        required: true
+
+jobs:
+  close-issue:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.token }}
+    steps:
+      - name: close issue
+        run: gh issue -R ${{ github.repository }} close ${{ inputs.issue-number }}

--- a/.github/workflows/issue-decline-label.yml
+++ b/.github/workflows/issue-decline-label.yml
@@ -1,0 +1,33 @@
+# Copyright 2026 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: issue-decline-label
+permissions: {}
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  decline-response:
+    if: "github.event.label.name == 'status: declined' && github.event.issue.state == 'open'"
+    uses: ./.github/workflows/issue-comment.yml
+    secrets:
+      token: ${{ secrets.ISSUE_BOT_TOKEN }}
+    with:
+      issue-number: ${{ github.event.issue.number }}
+      message: >
+        Thank you for your feedback and for taking the time to share this suggestion. After
+        reviewing this with the team, we've determined that this is not something we will be
+        working on at this time as it doesn't align with our current product focus. We'll be
+        closing this issue to keep our backlog manageable, but we appreciate your contribution to the community.
+
+  close-issue:
+    needs: decline-response
+    uses: ./.github/workflows/issue-close.yml
+    secrets:
+      token: ${{ secrets.ISSUE_BOT_TOKEN }}
+    with:
+      issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/issue-roadmap-label.yml
+++ b/.github/workflows/issue-roadmap-label.yml
@@ -1,0 +1,33 @@
+# Copyright 2026 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: issue-roadmap-label
+permissions: {}
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  roadmap-response:
+    if: "github.event.label.name == 'status: on-roadmap' && github.event.issue.state == 'open'"
+    uses: ./.github/workflows/issue-comment.yml
+    secrets:
+      token: ${{ secrets.ISSUE_BOT_TOKEN }}
+    with:
+      issue-number: ${{ github.event.issue.number }}
+      message: >
+        Thank you for the feedback! We've reviewed this request and added it to our long-term
+        roadmap. While we don't have a specific time commitment for implementation yet, we have
+        created an internal ticket to track this and have linked it to this issue for context.
+        We will close this GitHub issue for now and provide updates here if it moves into active development.
+
+  close-issue:
+    needs: roadmap-response
+    uses: ./.github/workflows/issue-close.yml
+    secrets:
+      token: ${{ secrets.ISSUE_BOT_TOKEN }}
+    with:
+      issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/issue-scheduled-label.yml
+++ b/.github/workflows/issue-scheduled-label.yml
@@ -1,0 +1,25 @@
+# Copyright 2026 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: issue-scheduled-label
+permissions: {}
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  scheduled-response:
+    if: "github.event.label.name == 'status: scheduled' && github.event.issue.state == 'open'"
+    uses: ./.github/workflows/issue-comment.yml
+    secrets:
+      token: ${{ secrets.ISSUE_BOT_TOKEN }}
+    with:
+      issue-number: ${{ github.event.issue.number }}
+      message: >
+        Thank you for your feedback! We are happy to share that this has been added to our roadmap.
+        We are currently aiming to address this in the next 1-2 quarters. We will update this GitHub
+        issue as we make progress. Please note that these windows are subject to change based on development
+        priorities. We will keep this issue open as we move toward implementation.


### PR DESCRIPTION
This PR adds the following labels for FR triage:

- `status: declined`
- `status: on-roadmap`
- `status: scheduled`