### PR TITLE
test: Add pgsql cross-transaction integration test suite

### DIFF
--- a/tests/integration/pgsql/test_cross_transaction.php
+++ b/tests/integration/pgsql/test_cross_transaction.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+pgsql_last_conn and datastore_connections are per-request state, created in
+rinit and torn down in rshutdown; they are NOT reset at the transaction
+boundary. The agent SHALL retain pgsql_last_conn across a transaction restart,
+so a connection-less pg_query($sql) issued in a later transaction is still
+attributed to the connection opened in an earlier one.
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.transaction_tracer.record_sql = obfuscated
+*/
+
+/*EXPECT
+ok - connect successful
+ok - pg_query successful
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/instance/Postgres/ENV[PG_HOST]/ENV[PG_PORT], 1
+Datastore/statement/Postgres/pg_user/select, 1
+Datastore/operation/Postgres/select, 1
+Supportability/api/start_transaction, 1
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Supportability/api/end_transaction
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/statement\/Postgres\/pg_user\/select",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Postgres"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[PG_HOST]",
+      "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
+      "db.statement": "SELECT ? FROM pg_user"
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+
+function test_cross_transaction() {
+  global $PG_CONNECTION;
+
+  /*
+   * T1: open the connection. pg_connect() saves the instance keyed by the
+   * connection and points pgsql_last_conn at it (php_pgsql.c).
+   */
+  $conn = pg_connect($PG_CONNECTION);
+  tap_assert(false !== $conn, "connect successful");
+
+  /*
+   * Restart the transaction the same way the FrankenPHP worker request
+   * boundary does: fcall_end/fcall_begin call nr_php_txn_end/nr_php_txn_begin,
+   * exactly like this explicit end+start pair. pgsql_last_conn is per-request
+   * state torn down only in rshutdown, so it survives this restart.
+   */
+  newrelic_end_transaction(true);
+  newrelic_start_transaction(ini_get("newrelic.appname"));
+
+  /*
+   * T2: a connection-less pg_query($sql) has no handle to key off of, so it
+   * falls back to pgsql_last_conn. If that survived, the datastore node is
+   * attributed to the real instance (postgres/5432); if it didn't, the agent
+   * would synthesize the default (localhost//tmp) instance instead.
+   *
+   * The single-arg form's *userland* output (resource vs PgSql\Connection,
+   * a possible deprecation notice) differs across the PHP 8.1 boundary, so
+   * suppress it and let the instance metric name be the assertion.
+   */
+  $result = @pg_query("SELECT 1 FROM pg_user");
+  $row = pg_fetch_row($result);
+  tap_assert($row[0] == 1, "pg_query successful");
+}
+
+test_cross_transaction();

--- a/tests/integration/pgsql/test_cross_transaction.php
+++ b/tests/integration/pgsql/test_cross_transaction.php
@@ -36,6 +36,7 @@ Supportability/api/start_transaction, 1
 
 /*EXPECT_METRICS_DONT_EXIST
 Supportability/api/end_transaction
+Datastore/instance/Postgres/__HOST__//tmp
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE

--- a/tests/integration/pgsql/test_cross_transaction_close.php
+++ b/tests/integration/pgsql/test_cross_transaction_close.php
@@ -1,0 +1,124 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+pg_close() frees pgsql_last_conn when the closed connection's key matches it
+(php_pgsql.c). So, unlike test_cross_transaction.php, once the only connection
+is closed there is nothing for a later connection-less pg_query($sql) to fall
+back on: the agent SHALL synthesize the default instance
+(nr_php_pgsql_retrieve_datastore_instance(NULL) with no pgsql_last_conn) rather
+than carry stale attribution to the real postgres/5432 instance. At the PHP
+level the query itself fails (no connection is open), but the agent still
+records a datastore node for the attempt.
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.transaction_tracer.record_sql = obfuscated
+*/
+
+/*EXPECT
+ok - connect successful
+ok - close successful
+ok - pg_query failed without an open connection
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/statement/Postgres/pg_user/select, 1
+Datastore/operation/Postgres/select, 1
+Supportability/api/start_transaction, 1
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Datastore/instance/Postgres/ENV[PG_HOST]/ENV[PG_PORT]
+Supportability/api/end_transaction
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/statement\/Postgres\/pg_user\/select",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Postgres"
+    },
+    {},
+    {
+      "peer.hostname": "??",
+      "peer.address": "??",
+      "db.statement": "SELECT ? FROM pg_user"
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+
+function test_cross_transaction_close() {
+  global $PG_CONNECTION;
+
+  /*
+   * T1: open the connection, then close it. Closing frees pgsql_last_conn
+   * because its key matches the connection being closed (php_pgsql.c), so no
+   * connection remains for a later connection-less lookup to fall back on.
+   */
+  $conn = pg_connect($PG_CONNECTION);
+  tap_assert(false !== $conn, "connect successful");
+
+  tap_assert(pg_close($conn), "close successful");
+
+  /*
+   * Restart the transaction the same way the FrankenPHP worker request
+   * boundary does: fcall_end/fcall_begin call nr_php_txn_end/nr_php_txn_begin,
+   * exactly like this explicit end+start pair. Ignore T1 (nothing but the
+   * connect/close happened in it) so only T2's query is harvested.
+   */
+  newrelic_end_transaction(true);
+  newrelic_start_transaction(ini_get("newrelic.appname"));
+
+  /*
+   * T2: with no connection open and pgsql_last_conn cleared, the
+   * connection-less pg_query($sql) fails at the PHP level (warns + returns
+   * false) -- suppress the warning. The agent still records a datastore node
+   * for the attempt, synthesizing a default instance rather than carrying
+   * stale postgres/5432 attribution. The default instance's exact host/port
+   * depend on the container's libpq env (PGHOST/PGPORT, which the php
+   * container does not set), so the lock here is the *absence* of the real
+   * instance metric, not a specific default string.
+   */
+  try {
+    $result = @pg_query("SELECT 1 FROM pg_user");
+    // PHP 7.x return false on failure, so assert that the query failed.
+    tap_assert(false === $result, "pg_query failed without an open connection");
+  }
+  catch (\Throwable $e) {
+    // PHP 8.0+ throws a fatal error instead returning false, so
+    // catch it and assert that the query failed.
+    tap_ok("pg_query failed without an open connection");
+  }
+}
+
+test_cross_transaction_close();

--- a/tests/integration/pgsql/test_cross_transaction_close.php
+++ b/tests/integration/pgsql/test_cross_transaction_close.php
@@ -32,6 +32,7 @@ ok - pg_query failed without an open connection
 */
 
 /*EXPECT_METRICS_EXIST
+Datastore/instance/Postgres/__HOST__//tmp, 1
 Datastore/statement/Postgres/pg_user/select, 1
 Datastore/operation/Postgres/select, 1
 Supportability/api/start_transaction, 1

--- a/tests/integration/pgsql/test_cross_transaction_close.php
+++ b/tests/integration/pgsql/test_cross_transaction_close.php
@@ -115,7 +115,7 @@ function test_cross_transaction_close() {
     // PHP 7.x return false on failure, so assert that the query failed.
     tap_assert(false === $result, "pg_query failed without an open connection");
   }
-  catch (\Throwable $e) {
+  catch (\Throwable $e) { // $e unused, required for PHP 7.4 catch syntax
     // PHP 8.0+ throws a fatal error instead returning false, so
     // catch it and assert that the query failed.
     tap_ok("pg_query failed without an open connection");

--- a/tests/integration/pgsql/test_cross_transaction_explicit_handle.php
+++ b/tests/integration/pgsql/test_cross_transaction_explicit_handle.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The datastore_connections hashmap is per-request state, created in rinit and
+torn down in rshutdown; it is NOT reset at the transaction boundary. The agent
+SHALL retain the hashmap entry for a connection across a transaction restart,
+so pg_query($conn, $sql) issued with an explicit handle in a later transaction
+is still attributed to the instance recorded when that connection was opened.
+Unlike test_cross_transaction.php, this does not depend on pgsql_last_conn at
+all: the hashmap is keyed by the connection itself.
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.transaction_tracer.record_sql = obfuscated
+*/
+
+/*EXPECT
+ok - connect successful
+ok - pg_query successful
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/instance/Postgres/ENV[PG_HOST]/ENV[PG_PORT], 1
+Datastore/statement/Postgres/pg_user/select, 1
+Datastore/operation/Postgres/select, 1
+Supportability/api/start_transaction, 1
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Supportability/api/end_transaction
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/statement\/Postgres\/pg_user\/select",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Postgres"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[PG_HOST]",
+      "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
+      "db.statement": "SELECT ? FROM pg_user"
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+
+function test_cross_transaction_explicit_handle() {
+  global $PG_CONNECTION;
+
+  /*
+   * T1: open the connection. pg_connect() saves the instance keyed by the
+   * connection itself (php_pgsql.c), independent of pgsql_last_conn.
+   */
+  $conn = pg_connect($PG_CONNECTION);
+  tap_assert(false !== $conn, "connect successful");
+
+  /*
+   * Restart the transaction the same way the FrankenPHP worker request
+   * boundary does: fcall_end/fcall_begin call nr_php_txn_end/nr_php_txn_begin,
+   * exactly like this explicit end+start pair. Ignore T1 (nothing but the
+   * connect happened in it) so only T2's query is harvested.
+   */
+  newrelic_end_transaction(true);
+  newrelic_start_transaction(ini_get("newrelic.appname"));
+
+  /*
+   * T2: pass the connection handle explicitly, so the datastore lookup keys
+   * off $conn directly (nr_php_pgsql_retrieve_datastore_instance) rather than
+   * pgsql_last_conn. The connection's PHP-level handle/object is unaffected
+   * by the transaction restart, so the lookup must still hit and attribute
+   * the node to the real instance (postgres/5432).
+   */
+  $result = pg_query($conn, "SELECT 1 FROM pg_user");
+  $row = pg_fetch_row($result);
+  tap_assert($row[0] == 1, "pg_query successful");
+}
+
+test_cross_transaction_explicit_handle();

--- a/tests/integration/pgsql/test_cross_transaction_explicit_handle.php
+++ b/tests/integration/pgsql/test_cross_transaction_explicit_handle.php
@@ -38,6 +38,7 @@ Supportability/api/start_transaction, 1
 
 /*EXPECT_METRICS_DONT_EXIST
 Supportability/api/end_transaction
+Datastore/instance/Postgres/__HOST__//tmp
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE

--- a/tests/integration/pgsql/test_cross_transaction_pconnect.php
+++ b/tests/integration/pgsql/test_cross_transaction_pconnect.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+pgsql_last_conn and datastore_connections are per-request state, created in
+rinit and torn down in rshutdown; they are NOT reset at the transaction
+boundary. This is also true for persistent (pg_pconnect) links: the agent
+SHALL retain pgsql_last_conn across a transaction restart, so a
+connection-less pg_query($sql) issued in a later transaction is still
+attributed to the persistent connection opened in an earlier one.
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.transaction_tracer.record_sql = obfuscated
+*/
+
+/*EXPECT
+ok - connect successful
+ok - pg_query successful
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/instance/Postgres/ENV[PG_HOST]/ENV[PG_PORT], 1
+Datastore/statement/Postgres/pg_user/select, 1
+Datastore/operation/Postgres/select, 1
+Supportability/api/start_transaction, 1
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Supportability/api/end_transaction
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/statement\/Postgres\/pg_user\/select",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Postgres"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[PG_HOST]",
+      "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
+      "db.statement": "SELECT ? FROM pg_user"
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+
+function test_cross_transaction_pconnect() {
+  global $PG_CONNECTION;
+
+  /*
+   * T1: open a persistent connection. pg_pconnect() goes through the same
+   * inner handler as pg_connect() (php_internal_instrument.c), so it saves
+   * the instance keyed by the connection and points pgsql_last_conn at it
+   * (php_pgsql.c) exactly the same way.
+   */
+  $conn = pg_pconnect($PG_CONNECTION);
+  tap_assert(false !== $conn, "connect successful");
+
+  /*
+   * Restart the transaction the same way the FrankenPHP worker request
+   * boundary does: fcall_end/fcall_begin call nr_php_txn_end/nr_php_txn_begin,
+   * exactly like this explicit end+start pair. Ignore T1 (nothing but the
+   * connect happened in it) so only T2's query is harvested. pgsql_last_conn
+   * is per-request state torn down only in rshutdown, so it survives this
+   * restart regardless.
+   */
+  newrelic_end_transaction(true);
+  newrelic_start_transaction(ini_get("newrelic.appname"));
+
+  /*
+   * T2: a connection-less pg_query($sql) has no handle to key off of, so it
+   * falls back to pgsql_last_conn. The persistent link is still open (pg_close
+   * is a no-op on persistent connections, and we never call it here), and
+   * pgsql_last_conn still points at it, so the datastore node is attributed
+   * to the real instance (postgres/5432) rather than the synthesized default.
+   *
+   * The single-arg form's *userland* output (resource vs PgSql\Connection,
+   * a possible deprecation notice) differs across the PHP 8.1 boundary, so
+   * suppress it and let the instance metric name be the assertion.
+   */
+  $result = @pg_query("SELECT 1 FROM pg_user");
+  $row = pg_fetch_row($result);
+  tap_assert($row[0] == 1, "pg_query successful");
+}
+
+test_cross_transaction_pconnect();

--- a/tests/integration/pgsql/test_cross_transaction_pconnect.php
+++ b/tests/integration/pgsql/test_cross_transaction_pconnect.php
@@ -37,6 +37,7 @@ Supportability/api/start_transaction, 1
 
 /*EXPECT_METRICS_DONT_EXIST
 Supportability/api/end_transaction
+Datastore/instance/Postgres/__HOST__//tmp
 */
 
 /*EXPECT_SPAN_EVENTS_LIKE

--- a/tests/integration/pgsql/test_cross_transaction_set_appname.php
+++ b/tests/integration/pgsql/test_cross_transaction_set_appname.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+pgsql_last_conn and datastore_connections are per-request state, created in
+rinit and torn down in rshutdown; they are NOT reset at the transaction
+boundary. The agent SHALL retain pgsql_last_conn across a transaction restart,
+so a connection-less pg_query($sql) issued in a later transaction is still
+attributed to the connection opened in an earlier one. This is the same
+survival as test_cross_transaction.php, but restarted via
+newrelic_set_appname() (which itself ends + begins a transaction), mirroring
+the predis suite's tests/integration/predis/test_cross_transaction.php.
+*/
+
+/*SKIPIF
+<?php require("skipif.inc");
+*/
+
+/*INI
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.transaction_tracer.record_sql = obfuscated
+*/
+
+/*EXPECT
+ok - connect successful
+ok - pg_query successful
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/instance/Postgres/ENV[PG_HOST]/ENV[PG_PORT], 1
+Datastore/statement/Postgres/pg_user/select, 1
+Datastore/operation/Postgres/select, 1
+Supportability/api/set_appname/after, 1
+*/
+
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/statement\/Postgres\/pg_user\/select",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Postgres"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[PG_HOST]",
+      "peer.address": "ENV[PG_HOST]:ENV[PG_PORT]",
+      "db.statement": "SELECT ? FROM pg_user"
+    }
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+require_once(realpath(dirname(__FILE__)) . '/../../include/config.php');
+require_once(realpath(dirname(__FILE__)) . '/../../include/tap.php');
+
+function test_cross_transaction_set_appname() {
+  global $PG_CONNECTION;
+
+  /*
+   * T1: open the connection. pg_connect() saves the instance keyed by the
+   * connection and points pgsql_last_conn at it (php_pgsql.c).
+   */
+  $conn = pg_connect($PG_CONNECTION);
+  tap_assert(false !== $conn, "connect successful");
+
+  /*
+   * Restart the transaction via newrelic_set_appname(), the same public API
+   * the predis suite uses to pin this behavior. Internally it does the same
+   * end + begin as test_cross_transaction.php (php_api.c), and with no
+   * $xmit argument it discards (ignores) T1 rather than harvesting it.
+   * pgsql_last_conn is per-request state torn down only in rshutdown, so it
+   * survives this transactionrestart regardless.
+   */
+  newrelic_set_appname(ini_get("newrelic.appname"));
+
+  /*
+   * T2: a connection-less pg_query($sql) has no handle to key off of, so it
+   * falls back to pgsql_last_conn. If that survived, the datastore node is
+   * attributed to the real instance (postgres/5432); if it didn't, the agent
+   * would synthesize the default (localhost//tmp) instance instead.
+   *
+   * The single-arg form's *userland* output (resource vs PgSql\Connection,
+   * a possible deprecation notice) differs across the PHP 8.1 boundary, so
+   * suppress it and let the instance metric name be the assertion.
+   */
+  $result = @pg_query("SELECT 1 FROM pg_user");
+  $row = pg_fetch_row($result);
+  tap_assert($row[0] == 1, "pg_query successful");
+}
+
+test_cross_transaction_set_appname();

--- a/tests/integration/pgsql/test_cross_transaction_set_appname.php
+++ b/tests/integration/pgsql/test_cross_transaction_set_appname.php
@@ -37,6 +37,11 @@ Datastore/operation/Postgres/select, 1
 Supportability/api/set_appname/after, 1
 */
 
+/*EXPECT_METRICS_DONT_EXIST
+Supportability/api/set_appname/before
+Datastore/instance/Postgres/__HOST__//tmp
+*/
+
 /*EXPECT_SPAN_EVENTS_LIKE
 [
   [


### PR DESCRIPTION
`pgsql_last_conn` and `datastore_connections` are per-request state, created
in rinit and torn down in rshutdown, so they are not expected to reset at
the transaction boundary — the same lifecycle class predis's
test_cross_transaction.php already pins for `predis_commands`. These tests
are meant to catch the regression before it ships.

Each file restarts the transaction via the explicit end+start API (the
CLI surrogate for the FrankenPHP worker boundary) or, for the appname
variant, via newrelic_set_appname(), then exercises a distinct survival
path:
- test_cross_transaction: pgsql_last_conn survives for a connection-less
  pg_query()
- test_cross_transaction_set_appname: same lock, 1:1 mirror of the predis
  suite's restart mechanism
- test_cross_transaction_explicit_handle: the datastore_connections
  hashmap survives independent of pgsql_last_conn
- test_cross_transaction_pconnect: persistent links survive the same way
- test_cross_transaction_close: pg_close() clears pgsql_last_conn, so a
  later connection-less query gets the synthesized default instance
  instead of stale postgres/5432 attribution