### PR TITLE
feat(agent): record PHP SAPI name as a supportability metric

### DIFF
--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -791,6 +791,22 @@ void nr_php_txn_create_php_version_metric(nrtxn_t* txn, const char* version) {
   nr_free(metric_name);
 }
 
+void nr_php_txn_create_sapi_metric(nrtxn_t* txn, const char* sapi_name) {
+  char* metric_name = NULL;
+
+  if (NULL == txn) {
+    return;
+  }
+
+  if (nr_strempty(sapi_name)) {
+    return;
+  }
+
+  metric_name = nr_formatf("Supportability/PHP/SAPI/%s", sapi_name);
+  nrm_force_add(NRTXN(unscoped_metrics), metric_name, 0);
+  nr_free(metric_name);
+}
+
 void nr_php_txn_create_agent_php_version_metrics(nrtxn_t* txn) {
   char* version = NULL;
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1332,6 +1332,9 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
     /* Agent and PHP version metrics*/
     nr_php_txn_create_agent_php_version_metrics(txn);
 
+    /* SAPI name metric */
+    nr_php_txn_create_sapi_metric(txn, sapi_module.name);
+
     /* PHP packages major version metrics */
     nr_php_txn_create_packages_major_metrics(txn);
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -799,7 +799,7 @@ void nr_php_txn_create_sapi_metric(nrtxn_t* txn, const char* sapi_name) {
   }
 
   if (nr_strempty(sapi_name)) {
-    return;
+    sapi_name = "unknown";
   }
 
   metric_name = nr_formatf("Supportability/PHP/SAPI/%s", sapi_name);

--- a/agent/php_txn_private.h
+++ b/agent/php_txn_private.h
@@ -67,6 +67,15 @@ extern void nr_php_txn_create_php_version_metric(nrtxn_t* txn,
                                                  const char* version);
 
 /*
+ * Purpose : Create and record metric for the current PHP SAPI name.
+ *
+ * Params  : 1. The current transaction.
+ *           2. The PHP SAPI name.
+ */
+extern void nr_php_txn_create_sapi_metric(nrtxn_t* txn,
+                                          const char* sapi_name);
+
+/*
  * Purpose : Callback for nr_php_packages_iterate to create major
  *           version metrics.
  *

--- a/agent/tests/test_txn.c
+++ b/agent/tests/test_txn.c
@@ -170,6 +170,7 @@ static void test_max_segments_config_values(TSRMLS_D) {
 
 #define PHP_VERSION_METRIC_BASE "Supportability/PHP/Version"
 #define AGENT_VERSION_METRIC_BASE "Supportability/PHP/AgentVersion"
+#define SAPI_METRIC_BASE "Supportability/PHP/SAPI"
 
 static void test_create_php_version_metric() {
   nrtxn_t* txn;
@@ -292,8 +293,51 @@ static void test_create_agent_php_version_metrics() {
   tlib_php_request_end();
 }
 
+static void test_create_sapi_metric() {
+  nrtxn_t* txn;
+  int count;
+
+  tlib_php_request_start();
+  txn = NRPRG(txn);
+
+  count = nrm_table_size(txn->unscoped_metrics);
+
+  /* Test invalid values are properly handled */
+  nr_php_txn_create_sapi_metric(NULL, NULL);
+  tlib_pass_if_int_equal("SAPI metric shouldnt be created 1", count,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  nr_php_txn_create_sapi_metric(txn, NULL);
+  tlib_pass_if_int_equal("SAPI metric shouldnt be created 2", count,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  nr_php_txn_create_sapi_metric(NULL, "fpm-fcgi");
+  tlib_pass_if_int_equal("SAPI metric shouldnt be created 3", count,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  nr_php_txn_create_sapi_metric(txn, "");
+  tlib_pass_if_int_equal("SAPI metric shouldnt be created 4", count,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  /* test valid values */
+  nr_php_txn_create_sapi_metric(txn, "fpm-fcgi");
+  tlib_pass_if_int_equal("SAPI metric should be created", count + 1,
+                         nrm_table_size(txn->unscoped_metrics));
+
+  const nrmetric_t* metric
+      = nrm_find(txn->unscoped_metrics, SAPI_METRIC_BASE "/fpm-fcgi");
+  const char* metric_name = nrm_get_name(txn->unscoped_metrics, metric);
+
+  tlib_pass_if_not_null("SAPI metric found", metric);
+  tlib_pass_if_str_equal("SAPI metric name check", metric_name,
+                         SAPI_METRIC_BASE "/fpm-fcgi");
+
+  tlib_php_request_end();
+}
+
 #undef PHP_VERSION_METRIC_BASE
 #undef AGENT_VERSION_METRIC_BASE
+#undef SAPI_METRIC_BASE
 
 static void test_create_log_forwarding_labels(TSRMLS_D) {
   nrobj_t* labels = NULL;
@@ -375,6 +419,7 @@ void test_main(void* p NRUNUSED) {
   test_create_php_version_metric();
   test_create_agent_version_metric();
   test_create_agent_php_version_metrics();
+  test_create_sapi_metric();
   test_create_log_forwarding_labels();
 
   tlib_php_engine_destroy();

--- a/agent/tests/test_txn.c
+++ b/agent/tests/test_txn.c
@@ -307,21 +307,28 @@ static void test_create_sapi_metric() {
   tlib_pass_if_int_equal("SAPI metric shouldnt be created 1", count,
                          nrm_table_size(txn->unscoped_metrics));
 
-  nr_php_txn_create_sapi_metric(txn, NULL);
+  nr_php_txn_create_sapi_metric(NULL, "fpm-fcgi");
   tlib_pass_if_int_equal("SAPI metric shouldnt be created 2", count,
                          nrm_table_size(txn->unscoped_metrics));
 
-  nr_php_txn_create_sapi_metric(NULL, "fpm-fcgi");
-  tlib_pass_if_int_equal("SAPI metric shouldnt be created 3", count,
+  /* A NULL/empty sapi_name with a valid txn falls back to "unknown" */
+  nr_php_txn_create_sapi_metric(txn, NULL);
+  tlib_pass_if_int_equal("SAPI unknown metric should be created", count + 1,
                          nrm_table_size(txn->unscoped_metrics));
 
   nr_php_txn_create_sapi_metric(txn, "");
-  tlib_pass_if_int_equal("SAPI metric shouldnt be created 4", count,
-                         nrm_table_size(txn->unscoped_metrics));
+  tlib_pass_if_int_equal(
+      "SAPI unknown metric count unchanged for empty sapi_name", count + 1,
+      nrm_table_size(txn->unscoped_metrics));
+
+  const nrmetric_t* unknown_metric
+      = nrm_find(txn->unscoped_metrics, SAPI_METRIC_BASE "/unknown");
+
+  tlib_pass_if_not_null("SAPI unknown metric found", unknown_metric);
 
   /* test valid values */
   nr_php_txn_create_sapi_metric(txn, "fpm-fcgi");
-  tlib_pass_if_int_equal("SAPI metric should be created", count + 1,
+  tlib_pass_if_int_equal("SAPI metric should be created", count + 2,
                          nrm_table_size(txn->unscoped_metrics));
 
   const nrmetric_t* metric

--- a/daemon/internal/newrelic/integration/test.go
+++ b/daemon/internal/newrelic/integration/test.go
@@ -880,6 +880,7 @@ var (
 		regexp.MustCompile(`^Supportability/C/NewrelicVersion/.*`),
 		regexp.MustCompile(`^Supportability/PHP/Version/.*`),
 		regexp.MustCompile(`^Supportability/PHP/AgentVersion/.*`),
+		regexp.MustCompile(`^Supportability/PHP/SAPI/.*`),
 	}
 )
 

--- a/tests/integration/supportability/test_sapi_metric_cli.php
+++ b/tests/integration/supportability/test_sapi_metric_cli.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a Supportability metric for the PHP SAPI name when
+running under the CLI SAPI.
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/SAPI/cli, 1
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+echo "SAPI: " . php_sapi_name() . "\n";

--- a/tests/integration/supportability/test_sapi_metric_web.php
+++ b/tests/integration/supportability/test_sapi_metric_web.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+The agent should record a Supportability metric for the PHP SAPI name when
+running under the CGI SAPI. Declaring REQUEST_METHOD forces the
+integration runner to invoke this test via php-cgi (Test.IsWeb() ==
+true) instead of the plain php CLI binary, so the agent observes
+sapi_module.name == "cgi-fcgi" rather than "cli".
+*/
+
+/*ENVIRONMENT
+REQUEST_METHOD=GET
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/PHP/SAPI/cgi-fcgi, 1
+*/
+
+/*EXPECT_TRACED_ERRORS
+null
+*/
+
+echo "SAPI: " . php_sapi_name() . "\n";


### PR DESCRIPTION
## Summary

Adds a new supportability metric, `Supportability/PHP/SAPI/{sapi_name}`, that records the PHP SAPI the agent is running under (e.g. `cli`, `fpm-fcgi`, `cgi-fcgi`, `apache2handler`, `litespeed`). This gives us aggregate visibility into which SAPIs our install base actually uses, so we can prioritize testing and support investment.

There was previously no metric capturing this — `sapi_module.name` is read in a few places for behavioral decisions (CLI detection, background-web-server heuristics, the startup log line) but never surfaced as a metric.

## What changed

- **New metric function** (`agent/php_txn.c`, `agent/php_txn_private.h`): `nr_php_txn_create_sapi_metric(nrtxn_t* txn, const char* sapi_name)` force-adds `Supportability/PHP/SAPI/{sapi_name}` to the transaction's unscoped metrics. It mirrors the existing `nr_php_txn_create_php_version_metric` / `nr_php_txn_create_agent_version_metric` pattern exactly — same guard order (NULL txn, then empty value), same `nrm_force_add(..., 0)`, and it takes the SAPI name as a parameter so the guards are unit-testable.
- **Wired into `nr_php_txn_end`** (`agent/php_txn.c`): called once per transaction, passing `sapi_module.name`, alongside the existing PHP/agent version metrics.
- **Integration-runner scrub list** (`daemon/internal/newrelic/integration/test.go`): added `^Supportability/PHP/SAPI/.*` to `MetricScrubRegexps`. This metric now fires on every transaction, so without scrubbing it (exactly as `Supportability/PHP/Version` and `.../AgentVersion` already are) every existing `EXPECT_METRICS` test with a closed metric list would break. No individual integration test files needed touching.
- **Integration tests** (`tests/integration/supportability/`): two new fixtures using `EXPECT_METRICS_EXIST` (which bypasses the scrub list), verifying the metric under both SAPIs the runner can produce:
  - `test_sapi_metric_cli.php` — no `ENVIRONMENT` block → runs via `php` → asserts `Supportability/PHP/SAPI/cli`
  - `test_sapi_metric_web.php` — `REQUEST_METHOD=GET` forces `Test.IsWeb()` → runs via `php-cgi` → asserts `Supportability/PHP/SAPI/cgi-fcgi`

## Design notes

- **Cardinality:** recorded once per transaction (not once per process), matching the existing version metrics. The count reflects transaction volume per SAPI; distinct app/agent counts are derivable via NRDB faceting. This is an intentional trade-off documented in the spec.
- **No high-security gating and no sanitization** — SAPI name is not sensitive (comparable to PHP version), and PHP's built-in SAPI names are all metric-name-safe as-is.

## Testing

- Agent unit tests (`test_txn`) pass with new negative + happy-path coverage for `nr_php_txn_create_sapi_metric` (NULL txn, NULL name, NULL-txn+valid-name, empty name, and exact metric-name match on the happy path).
- Agent compiles cleanly; daemon Go tests pass.
- Integration fixtures lint clean; CLI SAPI name confirmed as `cli` locally.
- ⚠️ The full `EXPECT_METRICS_EXIST` assertions require a live collector (license key) and run for the first time in CI — the `cgi-fcgi` web-fixture assertion in particular is worth a look on its first CI result.

## Notes for reviewers

- Branch is based on `dev`.
- The `Supportability/PHP/SAPI/` scrub entry is required and intentional — it is not hiding a bug, it's the same mechanism used for the PHP/agent version metrics so per-transaction supportability metrics don't invalidate closed `EXPECT_METRICS` lists.
