### PR TITLE
Fix Composer package detection under FrankenPHP's shared thread pool

### DIFF
--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -94,6 +94,7 @@ TEST_BINARIES = \
 	tests/test_internal_instrument \
 	tests/test_hash \
 	tests/test_lib_aws_sdk_php \
+	tests/test_lib_composer \
         tests/test_lib_php_amqplib \
 	tests/test_memcached \
 	tests/test_mongodb \

--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -152,7 +152,8 @@ static nrapp_t* nr_composer_find_app_no_txn(TSRMLS_D) {
 
 static nr_composer_api_status_t
 nr_execute_handle_autoload_composer_get_packages_information(
-    const char* vendor_path) {
+    const char* vendor_path,
+    nr_php_packages_t* packages_out) {
   zval retval;  // This is used as a return value for zend_eval_string.
                 // It will only be set if the result of the eval is SUCCESS.
   int result = FAILURE;
@@ -233,9 +234,11 @@ nr_execute_handle_autoload_composer_get_packages_information(
         nrl_verbosedebug(NRL_INSTRUMENT, "package %s, version %s",
                          NRSAFESTR(ZSTR_VAL(package_name)),
                          NRSAFESTR(Z_STRVAL_P(package_version)));
-        nr_txn_add_php_package_from_source(NRPRG(txn), ZSTR_VAL(package_name),
-                                           Z_STRVAL_P(package_version),
-                                           NR_PHP_PACKAGE_SOURCE_COMPOSER);
+        nr_php_packages_add_package(
+            packages_out,
+            nr_php_package_create_with_source(ZSTR_VAL(package_name),
+                                              Z_STRVAL_P(package_version),
+                                              NR_PHP_PACKAGE_SOURCE_COMPOSER));
       }
     }
     ZEND_HASH_FOREACH_END();
@@ -315,6 +318,7 @@ void nr_composer_handle_autoload(const char* filename) {
 #define COMPOSER_MAGIC_FILE_3 "composer/installed.php"
 #define COMPOSER_MAGIC_FILE_3_LEN (sizeof(COMPOSER_MAGIC_FILE_3) - 1)
   char* vendor_path = NULL;  // result of dirname(filename)
+  nr_composer_thread_entry_t* entry = NULL;
 
   // nrunlikely because this should alredy be ensured by the caller
   if (nrunlikely(NULL == filename)) {
@@ -351,16 +355,57 @@ void nr_composer_handle_autoload(const char* filename) {
   }
 
   nrl_verbosedebug(NRL_FRAMEWORK, "detected composer");
-  NRPRG(txn)->composer_info.composer_detected = true;
-  nr_fw_support_add_library_supportability_metric(NRPRG(txn), "Composer");
+  if (NULL != NRPRG(txn)) {
+    NRPRG(txn)->composer_info.composer_detected = true;
+    nr_fw_support_add_library_supportability_metric(NRPRG(txn), "Composer");
+  }
 
+  /* Step 1: resolve the per-(app,thread) entry — via the txn's cached
+   * pointer if one exists, or via a fresh find-only lookup if not. */
+  if (NULL != NRPRG(txn)) {
+    entry = NRPRG(txn)->composer_info.entry;
+  } else {
+    nrapp_t* app = nr_composer_find_app_no_txn(TSRMLS_C);
+    if (NULL != app) {
+      entry = nr_app_get_or_create_thread_composer_entry(app,
+                                                         (uint64_t)nr_gettid());
+      /* entry pointer is now safe to use lock-free after this point, same
+       * as the with-txn case (see nr_app.h's per-map locking contract) —
+       * unlock immediately rather than holding through the write below. */
+      nrt_mutex_unlock(&app->app_lock);
+    }
+  }
+
+  if (NULL == entry) {
+    nrl_debug(NRL_FRAMEWORK,
+              "%s - no (app, thread) entry available for composer scan write; "
+              "skipping (expected-unreachable per design assumptions)",
+              __func__);
+    goto leave;
+  }
+
+  /* This write runs lock-free, on purpose: `entry` was resolved above
+   * either from NRPRG(txn)->composer_info.entry (itself fetched lock-free
+   * by this same thread at txn begin) or via a fresh lookup keyed by
+   * (uint64_t)nr_gettid() in the no-txn branch above, and no thread other
+   * than the one that owns an entry ever touches it -- the same
+   * same-owning-thread-only invariant that already justifies
+   * nr_txn_pull_composer_packages()/nr_txn_mark_composer_packages_sent()
+   * being lock-free in axiom/nr_txn.c. See the doc comment on
+   * nr_composer_thread_entry_t in axiom/nr_app.h for the full rationale. */
   {
+    nr_php_packages_t* fresh_packages = nr_php_packages_create();
     nr_composer_api_status_t result
         = nr_execute_handle_autoload_composer_get_packages_information(
-            vendor_path);
-    if (NULL != NRPRG(txn)->composer_info.status) {
-      *NRPRG(txn)->composer_info.status = result;
+            vendor_path, fresh_packages);
+
+    /* Steps 2-4: destroy-if-rescan, install fresh collection, bump epoch */
+    if (NULL != entry->packages) {
+      nr_php_packages_destroy(&entry->packages);
     }
+    entry->packages = fresh_packages;
+    entry->epoch += 1;
+    entry->status = result;
   }
 leave:
   nr_free(vendor_path);

--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -79,13 +79,13 @@ static int nr_execute_handle_autoload_composer_init(const char* vendor_path) {
  * Returns : The matching nrapp_t, with app->app_lock held (caller must
  *           unlock), or NULL if no match exists yet.
  */
-static nrapp_t* nr_composer_find_app_no_txn(TSRMLS_D) {
+static nrapp_t* nr_composer_find_app_no_txn() {
   nr_app_info_t info;
   nrapp_t* app;
 
   nr_memset(&info, 0, sizeof(info));
 
-  nr_php_txn_populate_app_info_identity(&info, NULL, NULL TSRMLS_CC);
+  nr_php_txn_populate_app_info_identity(&info, NULL, NULL);
 
   app = nr_app_find_locked(nr_agent_applist, &info);
 
@@ -308,7 +308,7 @@ void nr_composer_handle_autoload(const char* filename) {
   if (NULL != NRPRG(txn)) {
     entry = NRPRG(txn)->composer_info.entry;
   } else {
-    nrapp_t* app = nr_composer_find_app_no_txn(TSRMLS_C);
+    nrapp_t* app = nr_composer_find_app_no_txn();
     if (NULL != app) {
       entry = nr_app_get_or_create_thread_composer_entry(app,
                                                          (uint64_t)nr_gettid());

--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -7,6 +7,7 @@
 #include "fw_hooks.h"
 #include "fw_support.h"
 #include "nr_txn.h"
+#include "nr_version.h"
 #include "php_globals.h"
 #include "util_logging.h"
 #include "util_memory.h"
@@ -67,6 +68,86 @@ static int nr_execute_handle_autoload_composer_init(const char* vendor_path) {
   }
 
   return NR_SUCCESS;
+}
+
+/*
+ * Purpose : Find (never create) the nrapp_t for the current (app, thread)
+ *           when no txn exists to supply one, by building a throwaway
+ *           nr_app_info_t search key from process-global/SAPI-global state.
+ *           Mirrors agent/php_txn.c:893,971-973's fallback logic for
+ *           appname/license (order between the two independent
+ *           appname/license computations doesn't matter — only that each
+ *           resolves to the same value RINIT would have used), so this
+ *           always resolves to the same nr_app_info_t identity fields
+ *           RINIT already used to create/find the app — otherwise
+ *           nr_app_match cannot match.
+ *
+ *           nr_app_find_locked() rejects the search key outright unless
+ *           nr_app_info_valid() passes, which requires appname, license,
+ *           environment, lang, version, and redirect_collector to all be
+ *           non-NULL (axiom/nr_app.c). Of those, only license, appname,
+ *           trace_observer_host, and trace_observer_port are actually
+ *           compared by nr_app_match(); environment/lang/version/
+ *           redirect_collector are set below purely to satisfy that
+ *           non-NULL gate, mirroring agent/php_txn.c:979,983-984,986's
+ *           equivalent assignments.
+ *
+ * Returns : The matching nrapp_t, with app->app_lock held (caller must
+ *           unlock), or NULL if no match exists yet.
+ */
+static nrapp_t* nr_composer_find_app_no_txn(TSRMLS_D) {
+  nr_app_info_t info;
+  nrapp_t* app;
+  char* appnames = NULL;
+  char* raw_license = NULL;
+  const char* lic_to_use;
+
+  nr_memset(&info, 0, sizeof(info));
+
+#ifdef ZTS
+  if (nr_streq(sapi_module.name, "frankenphp")) {
+    appnames = nr_php_get_server_global("NEW_RELIC_APP_NAME" TSRMLS_CC);
+    raw_license = nr_php_get_server_global("NEW_RELIC_LICENSE_KEY" TSRMLS_CC);
+  }
+#endif
+
+  /* appname fallback, ownership-equivalent to agent/php_txn.c:971-973 (that
+   * code reassigns the pointer and strdup's once, later, unconditionally;
+   * this does the strdup inline in the fallback branch instead — same end
+   * state, different structure, since this function has no later
+   * unconditional strdup point to defer to) */
+  if ((NULL == appnames) || (0 == appnames[0])) {
+    nr_free(appnames);
+    appnames = nr_strdup(NRINI(appnames));
+  }
+  info.appname = appnames; /* ownership transferred; freed by
+                              nr_app_info_destroy_fields below */
+
+  /* license fallback, matching agent/php_txn.c:893 exactly (same helper) */
+  lic_to_use = nr_php_use_license(raw_license TSRMLS_CC);
+  info.license = (NULL != lic_to_use) ? nr_strdup(lic_to_use) : NULL;
+  nr_free(raw_license);
+
+  info.high_security = NR_PHP_PROCESS_GLOBALS(high_security);
+
+  /* Non-NULL-only fields required by nr_app_info_valid(); see the doc
+   * comment above. */
+  info.environment = nro_copy(NR_PHP_PROCESS_GLOBALS(appenv));
+  info.lang = nr_strdup("php");
+  info.version = nr_strdup(nr_version());
+  info.redirect_collector = nr_strdup(NR_PHP_PROCESS_GLOBALS(collector));
+
+  if (NRINI(distributed_tracing_enabled)) {
+    info.trace_observer_host = nr_strdup(NRINI(trace_observer_host));
+  } else {
+    info.trace_observer_host = nr_strdup("");
+  }
+  info.trace_observer_port = NRINI(trace_observer_port);
+
+  app = nr_app_find_locked(nr_agent_applist, &info);
+
+  nr_app_info_destroy_fields(&info);
+  return app; /* still locked if non-NULL */
 }
 
 static nr_composer_api_status_t

--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -7,7 +7,6 @@
 #include "fw_hooks.h"
 #include "fw_support.h"
 #include "nr_txn.h"
-#include "nr_version.h"
 #include "php_globals.h"
 #include "util_logging.h"
 #include "util_memory.h"
@@ -72,25 +71,10 @@ static int nr_execute_handle_autoload_composer_init(const char* vendor_path) {
 
 /*
  * Purpose : Find (never create) the nrapp_t for the current (app, thread)
- *           when no txn exists to supply one, by building a throwaway
- *           nr_app_info_t search key from process-global/SAPI-global state.
- *           Mirrors nr_php_txn_begin()'s (agent/php_txn.c) fallback logic
- *           for appname/license (order between the two independent
- *           appname/license computations doesn't matter — only that each
- *           resolves to the same value RINIT would have used), so this
- *           always resolves to the same nr_app_info_t identity fields
- *           RINIT already used to create/find the app — otherwise
- *           nr_app_match cannot match.
- *
- *           nr_app_find_locked() rejects the search key outright unless
- *           nr_app_info_valid() passes, which requires appname, license,
- *           environment, lang, version, and redirect_collector to all be
- *           non-NULL (axiom/nr_app.c). Of those, only license, appname,
- *           trace_observer_host, and trace_observer_port are actually
- *           compared by nr_app_match(); environment/lang/version/
- *           redirect_collector are set below purely to satisfy that
- *           non-NULL gate, mirroring nr_php_txn_begin()'s equivalent
- *           nr_app_info_t assignments.
+ *           when no txn exists to supply one, by asking
+ *           nr_php_txn_populate_app_info_identity() to build the same
+ *           search-key fields nr_php_txn_begin() would have used with no
+ *           explicit appname/license override.
  *
  * Returns : The matching nrapp_t, with app->app_lock held (caller must
  *           unlock), or NULL if no match exists yet.
@@ -98,51 +82,10 @@ static int nr_execute_handle_autoload_composer_init(const char* vendor_path) {
 static nrapp_t* nr_composer_find_app_no_txn(TSRMLS_D) {
   nr_app_info_t info;
   nrapp_t* app;
-  char* appnames = NULL;
-  char* raw_license = NULL;
-  const char* lic_to_use;
 
   nr_memset(&info, 0, sizeof(info));
 
-#ifdef ZTS
-  if (nr_streq(sapi_module.name, "frankenphp")) {
-    appnames = nr_php_get_server_global("NEW_RELIC_APP_NAME" TSRMLS_CC);
-    raw_license = nr_php_get_server_global("NEW_RELIC_LICENSE_KEY" TSRMLS_CC);
-  }
-#endif
-
-  /* appname fallback, ownership-equivalent to the appname fallback in
-   * nr_php_txn_begin() (that code reassigns the pointer and strdup's once,
-   * later, unconditionally; this does the strdup inline in the fallback
-   * branch instead — same end state, different structure, since this
-   * function has no later unconditional strdup point to defer to) */
-  if ((NULL == appnames) || (0 == appnames[0])) {
-    nr_free(appnames);
-    appnames = nr_strdup(NRINI(appnames));
-  }
-  info.appname = appnames; /* ownership transferred; freed by
-                              nr_app_info_destroy_fields below */
-
-  /* license fallback, matching nr_php_txn_begin() exactly (same helper) */
-  lic_to_use = nr_php_use_license(raw_license TSRMLS_CC);
-  info.license = (NULL != lic_to_use) ? nr_strdup(lic_to_use) : NULL;
-  nr_free(raw_license);
-
-  info.high_security = NR_PHP_PROCESS_GLOBALS(high_security);
-
-  /* Non-NULL-only fields required by nr_app_info_valid(); see the doc
-   * comment above. */
-  info.environment = nro_copy(NR_PHP_PROCESS_GLOBALS(appenv));
-  info.lang = nr_strdup("php");
-  info.version = nr_strdup(nr_version());
-  info.redirect_collector = nr_strdup(NR_PHP_PROCESS_GLOBALS(collector));
-
-  if (NRINI(distributed_tracing_enabled)) {
-    info.trace_observer_host = nr_strdup(NRINI(trace_observer_host));
-  } else {
-    info.trace_observer_host = nr_strdup("");
-  }
-  info.trace_observer_port = NRINI(trace_observer_port);
+  nr_php_txn_populate_app_info_identity(&info, NULL, NULL TSRMLS_CC);
 
   app = nr_app_find_locked(nr_agent_applist, &info);
 

--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -273,9 +273,14 @@ void nr_composer_handle_autoload(const char* filename) {
   NRPRG(txn)->composer_info.composer_detected = true;
   nr_fw_support_add_library_supportability_metric(NRPRG(txn), "Composer");
 
-  NRTXN(composer_info.api_status)
-      = nr_execute_handle_autoload_composer_get_packages_information(
-          vendor_path);
+  {
+    nr_composer_api_status_t result
+        = nr_execute_handle_autoload_composer_get_packages_information(
+            vendor_path);
+    if (NULL != NRPRG(txn)->composer_info.status) {
+      *NRPRG(txn)->composer_info.status = result;
+    }
+  }
 leave:
   nr_free(vendor_path);
 }

--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -74,8 +74,8 @@ static int nr_execute_handle_autoload_composer_init(const char* vendor_path) {
  * Purpose : Find (never create) the nrapp_t for the current (app, thread)
  *           when no txn exists to supply one, by building a throwaway
  *           nr_app_info_t search key from process-global/SAPI-global state.
- *           Mirrors agent/php_txn.c:893,971-973's fallback logic for
- *           appname/license (order between the two independent
+ *           Mirrors nr_php_txn_begin()'s (agent/php_txn.c) fallback logic
+ *           for appname/license (order between the two independent
  *           appname/license computations doesn't matter — only that each
  *           resolves to the same value RINIT would have used), so this
  *           always resolves to the same nr_app_info_t identity fields
@@ -89,8 +89,8 @@ static int nr_execute_handle_autoload_composer_init(const char* vendor_path) {
  *           trace_observer_host, and trace_observer_port are actually
  *           compared by nr_app_match(); environment/lang/version/
  *           redirect_collector are set below purely to satisfy that
- *           non-NULL gate, mirroring agent/php_txn.c:979,983-984,986's
- *           equivalent assignments.
+ *           non-NULL gate, mirroring nr_php_txn_begin()'s equivalent
+ *           nr_app_info_t assignments.
  *
  * Returns : The matching nrapp_t, with app->app_lock held (caller must
  *           unlock), or NULL if no match exists yet.
@@ -111,11 +111,11 @@ static nrapp_t* nr_composer_find_app_no_txn(TSRMLS_D) {
   }
 #endif
 
-  /* appname fallback, ownership-equivalent to agent/php_txn.c:971-973 (that
-   * code reassigns the pointer and strdup's once, later, unconditionally;
-   * this does the strdup inline in the fallback branch instead — same end
-   * state, different structure, since this function has no later
-   * unconditional strdup point to defer to) */
+  /* appname fallback, ownership-equivalent to the appname fallback in
+   * nr_php_txn_begin() (that code reassigns the pointer and strdup's once,
+   * later, unconditionally; this does the strdup inline in the fallback
+   * branch instead — same end state, different structure, since this
+   * function has no later unconditional strdup point to defer to) */
   if ((NULL == appnames) || (0 == appnames[0])) {
     nr_free(appnames);
     appnames = nr_strdup(NRINI(appnames));
@@ -123,7 +123,7 @@ static nrapp_t* nr_composer_find_app_no_txn(TSRMLS_D) {
   info.appname = appnames; /* ownership transferred; freed by
                               nr_app_info_destroy_fields below */
 
-  /* license fallback, matching agent/php_txn.c:893 exactly (same helper) */
+  /* license fallback, matching nr_php_txn_begin() exactly (same helper) */
   lic_to_use = nr_php_use_license(raw_license TSRMLS_CC);
   info.license = (NULL != lic_to_use) ? nr_strdup(lic_to_use) : NULL;
   nr_free(raw_license);

--- a/agent/lib_composer.c
+++ b/agent/lib_composer.c
@@ -342,13 +342,27 @@ void nr_composer_handle_autoload(const char* filename) {
         = nr_execute_handle_autoload_composer_get_packages_information(
             vendor_path, fresh_packages);
 
-    /* Steps 2-4: destroy-if-rescan, install fresh collection, bump epoch */
-    if (NULL != entry->packages) {
-      nr_php_packages_destroy(&entry->packages);
+    if (NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED == result) {
+      /* A successful rescan always replaces whatever was there before. */
+      if (NULL != entry->packages) {
+        nr_php_packages_destroy(&entry->packages);
+      }
+      entry->packages = fresh_packages;
+      entry->epoch += 1;
+      entry->status = result;
+    } else {
+      /* A failed rescan never touches entry->packages/epoch, regardless
+       * of what was there -- there's nothing worth installing. Only
+       * entry->status needs a decision: leave it alone if it's already
+       * PACKAGES_COLLECTED (protects existing good data's status
+       * invariant), otherwise record this attempt's failure code so the
+       * default gate still closes on a never-yet-successful entry,
+       * matching today's/main's give-up-after-failure behavior. */
+      nr_php_packages_destroy(&fresh_packages);
+      if (NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED != entry->status) {
+        entry->status = result;
+      }
     }
-    entry->packages = fresh_packages;
-    entry->epoch += 1;
-    entry->status = result;
   }
 leave:
   nr_free(vendor_path);

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -221,6 +221,29 @@ extern nr_status_t nr_php_txn_begin(const char* appnames,
                                     const char* license TSRMLS_DC);
 
 /*
+ * Purpose : Populate the nr_app_info_t fields that identify an application
+ *           for matching/creation: the fields nr_app_info_valid() requires
+ *           to be non-NULL (appname, license, environment, lang, version,
+ *           redirect_collector), plus high_security and the
+ *           trace_observer_host/port fields nr_app_match() actually
+ *           compares. Any two calls with the same (appnames, license) pair
+ *           must resolve to the same identity fields, or nr_app_match()
+ *           will fail to match a search key against an app that should be
+ *           the same one.
+ *
+ * Params  : 1. Out parameter: the nr_app_info_t to populate. NOT zeroed by
+ *              this function -- caller must nr_memset() it first.
+ *           2. The requested application name(s) (may include rollups),
+ *              or NULL/empty to fall back to a configured default.
+ *           3. The requested license key, or NULL/empty to fall back to
+ *              a configured default (see nr_php_use_license()).
+ */
+extern void nr_php_txn_populate_app_info_identity(nr_app_info_t* info,
+                                                   const char* appnames,
+                                                   const char* license
+                                                       TSRMLS_DC);
+
+/*
  * Purpose : Perform the transaction ending tasks that have to be performed at
  *           RSHUTDOWN: specifically, this includes setting parameters that
  *           depends on variables that will be shutdown before the

--- a/agent/php_agent.h
+++ b/agent/php_agent.h
@@ -240,8 +240,7 @@ extern nr_status_t nr_php_txn_begin(const char* appnames,
  */
 extern void nr_php_txn_populate_app_info_identity(nr_app_info_t* info,
                                                    const char* appnames,
-                                                   const char* license
-                                                       TSRMLS_DC);
+                                                   const char* license);
 
 /*
  * Purpose : Perform the transaction ending tasks that have to be performed at

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -849,11 +849,11 @@ static void nr_execute_handle_autoload(const char* filename,
      * fetch failed (rare allocation failure) — treated as "unknown",
      * same as UNSET, so detection is still attempted.
      */
-    nr_composer_api_status_t* thread_status
+    nr_composer_api_status_t* thread_composer_status
         = NRPRG(txn)->composer_info.status;
 
-    if (NULL != thread_status
-        && NR_COMPOSER_API_STATUS_UNSET != *thread_status) {
+    if (NULL != thread_composer_status
+        && NR_COMPOSER_API_STATUS_UNSET != *thread_composer_status) {
       // do nothing if per-thread detection is enabled and this thread's
       // composer status is already set
       return;

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -828,32 +828,38 @@ static void nr_execute_handle_autoload(const char* filename,
   }
 
   /*
-   *  There is a possibility of the txn being NULL if nr_php_end_txn has been
-   * called. Verify txn is not null before dereferencing and continuing on.
+   *  A NULL txn no longer means "give up" — that used to lose this thread's
+   *  Composer scan whenever autoload ran before a txn existed yet.
+   *  composer_info.autoload_detected and composer_info.entry are both
+   *  per-txn/per-thread caches that don't exist without a txn; skip those
+   *  checks rather than bailing, and let nr_composer_handle_autoload
+   *  (agent/lib_composer.c) resolve the (app, thread) entry itself via the
+   *  no-txn path when needed.
    */
-  if (NULL == NRPRG(txn)) {
-    return;
-  }
-
-  if (NRPRG(txn)->composer_info.autoload_detected) {
-    // autoload already handled
-    return;
+  if (NULL != NRPRG(txn)) {
+    if (NRPRG(txn)->composer_info.autoload_detected) {
+      // autoload already handled for this txn
+      return;
+    }
   }
 
   if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)) {
-    /*
-     * This thread's composer detection status was already fetched once,
-     * under app_lock, in nr_txn_begin — see nr_app.h for the locking
-     * contract and nr_txn.c for where the fetch happens. No lock, no
-     * fetch here; just a read of the cached pointer. NULL means the
-     * fetch failed (rare allocation failure) — treated as "unknown",
-     * same as UNSET, so detection is still attempted.
-     */
-    nr_composer_api_status_t* thread_composer_status
-        = NRPRG(txn)->composer_info.status;
+    nr_composer_thread_entry_t* thread_composer_entry = NULL;
 
-    if (NULL != thread_composer_status
-        && NR_COMPOSER_API_STATUS_UNSET != *thread_composer_status) {
+    if (NULL != NRPRG(txn)) {
+      thread_composer_entry = NRPRG(txn)->composer_info.entry;
+    }
+    /*
+     * No-txn case: there's no cached entry pointer to check here without
+     * doing a fresh lookup, and a fresh lookup on every autoload event would
+     * defeat the point of a cheap short-circuit. Skip the short-circuit and
+     * fall through — nr_composer_handle_autoload's own destroy-if-rescan
+     * write path is safe to run redundantly, so the worst case on this
+     * narrow, rare bootstrap-race path is one extra scan attempt, not a
+     * correctness problem.
+     */
+    if (NULL != thread_composer_entry
+        && NR_COMPOSER_API_STATUS_UNSET != thread_composer_entry->status) {
       // do nothing if per-thread detection is enabled and this thread's
       // composer status is already set
       return;
@@ -868,8 +874,10 @@ static void nr_execute_handle_autoload(const char* filename,
 
   nrl_debug(NRL_FRAMEWORK, "detected autoload with %s, which ends with %s",
             filename, AUTOLOAD_MAGIC_FILE);
-  NRPRG(txn)->composer_info.autoload_detected = true;
-  nr_fw_support_add_library_supportability_metric(NRPRG(txn), "Autoloader");
+  if (NULL != NRPRG(txn)) {
+    NRPRG(txn)->composer_info.autoload_detected = true;
+    nr_fw_support_add_library_supportability_metric(NRPRG(txn), "Autoloader");
+  }
 
   nr_composer_handle_autoload(filename);
 }

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -840,13 +840,25 @@ static void nr_execute_handle_autoload(const char* filename,
     return;
   }
 
-  // clang-format off
-  if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection) &&
-      NR_COMPOSER_API_STATUS_UNSET != NR_PHP_PROCESS_GLOBALS(composer_api_status)) {
-    // do nothing if per-process detection is enabled and composer api status is set
-    return;
+  if (NR_PHP_PROCESS_GLOBALS(composer_api_per_process_detection)) {
+    /*
+     * This thread's composer detection status was already fetched once,
+     * under app_lock, in nr_txn_begin — see nr_app.h for the locking
+     * contract and nr_txn.c for where the fetch happens. No lock, no
+     * fetch here; just a read of the cached pointer. NULL means the
+     * fetch failed (rare allocation failure) — treated as "unknown",
+     * same as UNSET, so detection is still attempted.
+     */
+    nr_composer_api_status_t* thread_status
+        = NRPRG(txn)->composer_info.status;
+
+    if (NULL != thread_status
+        && NR_COMPOSER_API_STATUS_UNSET != *thread_status) {
+      // do nothing if per-thread detection is enabled and this thread's
+      // composer status is already set
+      return;
+    }
   }
-  // clang-format on
 
   if (!nr_striendswith(STR_AND_LEN(filename), AUTOLOAD_MAGIC_FILE,
                        AUTOLOAD_MAGIC_FILE_LEN)) {

--- a/agent/php_globals.h
+++ b/agent/php_globals.h
@@ -78,7 +78,6 @@ typedef struct _nrphpglobals_t {
   int composer_api_per_process_detection;  /* Enables per-process VM package
                                               detection when Composer API is also
                                               enabled */
-  nr_composer_api_status_t composer_api_status; /* Composer API's status */
   char* docker_id; /* 64 byte hex docker ID parsed from /proc/self/mountinfo */
   bool laravel_horizon_worker_used; /* Set to true if Laravel Horizon is used */
 

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -128,7 +128,8 @@ PHP_GSHUTDOWN_FUNCTION(newrelic) {
   /*
    * Remove this thread's per-thread harvest stats entry from every app's
    * harvest_map so it is not left dangling after the thread exits.
-   * Also removes the per-thread RNG state entry from rnd_map.
+   * Also removes the per-thread RNG state entry from rnd_map and the
+   * per-thread Composer detection status entry from composer_map.
    */
   if (nr_agent_applist) {
     uint64_t key = (uint64_t)nr_gettid();
@@ -136,10 +137,9 @@ PHP_GSHUTDOWN_FUNCTION(newrelic) {
     nrt_mutex_lock(&nr_agent_applist->applist_lock);
     for (int i = 0; i < nr_agent_applist->num_apps; i++) {
       nrapp_t* app = nr_agent_applist->apps[i];
-      if (app && (app->harvest_map || app->rnd_map)) {
+      if (app && (app->harvest_map || app->rnd_map || app->composer_map)) {
         nrt_mutex_lock(&app->app_lock);
-        nr_hashmap_index_delete(app->harvest_map, key);
-        nr_hashmap_index_delete(app->rnd_map, key);
+        nr_app_tid_maps_evict(app, key);
         nrt_mutex_unlock(&app->app_lock);
       }
     }

--- a/agent/php_minit.c
+++ b/agent/php_minit.c
@@ -476,7 +476,6 @@ PHP_MINIT_FUNCTION(newrelic) {
       = nr_php_check_for_upgrade_license_key();
   NR_PHP_PROCESS_GLOBALS(high_security) = 0;
   NR_PHP_PROCESS_GLOBALS(preload_framework_library_detection) = 1;
-  NR_PHP_PROCESS_GLOBALS(composer_api_status) = NR_COMPOSER_API_STATUS_UNSET;
   nr_php_populate_apache_process_globals();
   nr_php_api_distributed_trace_register_userland_class(TSRMLS_C);
   /*

--- a/agent/php_nrini.c
+++ b/agent/php_nrini.c
@@ -1680,7 +1680,7 @@ static PHP_INI_MH(nr_framework_mh) {
  * signature and route to the INI hashmap instead of the per-request hashmap.
  */
 static void nr_ini_wraprec_add_naming_fn(const char* namestr,
-                                         int namestrlen TSRMLS_DC) {
+                                         int namestrlen) {
   nruserfn_t* wraprec
       = nr_php_user_instrument_wraprec_hashmap_ini_add(namestr, namestrlen);
 
@@ -1690,7 +1690,7 @@ static void nr_ini_wraprec_add_naming_fn(const char* namestr,
 }
 
 static void nr_ini_wraprec_add_custom_tracer(const char* namestr,
-                                             int namestrlen TSRMLS_DC) {
+                                             int namestrlen) {
   nruserfn_t* wraprec
       = nr_php_user_instrument_wraprec_hashmap_ini_add(namestr, namestrlen);
 
@@ -1711,7 +1711,7 @@ static PHP_INI_MH(nr_wtfuncs_mh) {
 #ifdef ZTS
     /* ZTS: INI modifications outside of startup are currently ignored. */
     if (ZEND_INI_STAGE_STARTUP == stage) {
-      foreach_list(NEW_VALUE, nr_ini_wraprec_add_naming_fn TSRMLS_CC);
+      foreach_list(NEW_VALUE, nr_ini_wraprec_add_naming_fn);
     }
 #else
     foreach_list(NEW_VALUE, nr_php_add_transaction_naming_function TSRMLS_CC);
@@ -1732,7 +1732,7 @@ static PHP_INI_MH(nr_ttcustom_mh) {
 #ifdef ZTS
     /* ZTS: INI modifications outside of startup are currently ignored. */
     if (ZEND_INI_STAGE_STARTUP == stage) {
-      foreach_list(NEW_VALUE, nr_ini_wraprec_add_custom_tracer TSRMLS_CC);
+      foreach_list(NEW_VALUE, nr_ini_wraprec_add_custom_tracer);
     }
 #else
     foreach_list(NEW_VALUE, nr_php_add_custom_tracer TSRMLS_CC);

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1319,6 +1319,8 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
       nr_php_txn_do_shutdown(txn TSRMLS_CC);
     }
 
+    nr_txn_pull_composer_packages(txn);
+
     nrm_force_add(txn->unscoped_metrics,
                   "Supportability/execute/user/call_count",
                   NRTXNGLOBAL(execute_count));
@@ -1356,6 +1358,7 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
        * Check status.ignore again in case it has changed during nr_txn_end.
        */
       ret = nr_cmd_txndata_tx(nr_get_daemon_fd(), txn);
+      nr_txn_mark_composer_packages_sent(txn);
       if (NR_FAILURE == ret) {
         nrl_debug(NRL_TXN, "failed to send txn");
       }

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1378,6 +1378,18 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
      * next request). Accepted tradeoff -- matches how baseline already
      * treats a discarded transaction's data uniformly, with no
      * special-casing for Composer.
+     *
+     * Note this gate reads the ignoretxn local, not txn->status.ignore,
+     * and that is deliberate: an ignore-type url or transaction_name rule
+     * applied inside nr_txn_end sets status.ignore after the local was
+     * computed, so such a transaction has already pulled and falls
+     * through here without discarding. That is the wanted behaviour --
+     * nothing was handed to the daemon, and a thread typically only scans
+     * once in its lifetime, so leaving the unsent scan in the entry lets
+     * the next transaction on this thread re-pull and report it instead
+     * of losing it for the thread's remaining life. Only a transaction
+     * ignored before nr_txn_end runs skipped the pull, and only that one
+     * needs the entry reset.
      */
     nr_txn_discard_composer_packages(NRPRG(txn));
   }

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -870,7 +870,7 @@ void nr_php_txn_create_packages_major_metrics(nrtxn_t* txn) {
 
 void nr_php_txn_populate_app_info_identity(nr_app_info_t* info,
                                            const char* appnames,
-                                           const char* license TSRMLS_DC) {
+                                           const char* license) {
   const char* lic_to_use;
 
   if (NULL == info) {
@@ -880,7 +880,7 @@ void nr_php_txn_populate_app_info_identity(nr_app_info_t* info,
   if ((NULL == appnames) || ('\0' == appnames[0])) {
     appnames = NRINI(appnames);
   }
-  lic_to_use = nr_php_use_license(license TSRMLS_CC);
+  lic_to_use = nr_php_use_license(license);
 
   info->high_security = NR_PHP_PROCESS_GLOBALS(high_security);
   info->license = (NULL != lic_to_use) ? nr_strdup(lic_to_use) : NULL;
@@ -1021,7 +1021,7 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   }
 
   nr_memset(&info, 0, sizeof(info));
-  nr_php_txn_populate_app_info_identity(&info, appnames, license TSRMLS_CC);
+  nr_php_txn_populate_app_info_identity(&info, appnames, license);
   info.settings = NULL; /* Populated through callback. */
   info.metadata = nro_copy(NR_PHP_PROCESS_GLOBALS(metadata));
   info.labels = nr_php_txn_get_labels();

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -849,6 +849,20 @@ void nr_php_txn_php_package_create_major_metric(void* value,
   actual
       = nr_php_packages_get_package(txn->php_packages, suggested->package_name);
 
+  /* txn->php_packages might not have this package yet even though this
+   * thread's own Composer scan cache already does, so fall back to that
+   * cache to get a better "actual version" for the metric below. This is
+   * a read-only lookup: it never writes into txn->php_packages or into
+   * the cache entry, so it can't affect any of the gating, serialization,
+   * or send-once logic elsewhere that relies on those being left alone.
+   * It's also safe without a lock, since composer_info.entry belongs to
+   * and is only ever accessed by the thread that owns this txn.
+   */
+  if ((NULL == actual) && (NULL != txn->composer_info.entry)) {
+    actual = nr_php_packages_get_package(txn->composer_info.entry->packages,
+                                         suggested->package_name);
+  }
+
   nrl_verbosedebug(
       NRL_INSTRUMENT,
       "Creating PHP Package Supportability Metric for package "

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -868,6 +868,38 @@ void nr_php_txn_create_packages_major_metrics(nrtxn_t* txn) {
                           nr_php_txn_php_package_create_major_metric, txn);
 }
 
+void nr_php_txn_populate_app_info_identity(nr_app_info_t* info,
+                                           const char* appnames,
+                                           const char* license TSRMLS_DC) {
+  const char* lic_to_use;
+
+  if (NULL == info) {
+    return;
+  }
+
+  if ((NULL == appnames) || ('\0' == appnames[0])) {
+    appnames = NRINI(appnames);
+  }
+  lic_to_use = nr_php_use_license(license TSRMLS_CC);
+
+  info->high_security = NR_PHP_PROCESS_GLOBALS(high_security);
+  info->license = (NULL != lic_to_use) ? nr_strdup(lic_to_use) : NULL;
+  info->environment = nro_copy(NR_PHP_PROCESS_GLOBALS(appenv));
+  info->lang = nr_strdup("php");
+  info->version = nr_strdup(nr_version());
+  info->appname = nr_strdup(appnames);
+  info->redirect_collector = nr_strdup(NR_PHP_PROCESS_GLOBALS(collector));
+
+  /* If DT is disabled we cannot stream 8T events, so disable the observer
+   * host; the port setting does not depend on DT being enabled. */
+  if (NRINI(distributed_tracing_enabled)) {
+    info->trace_observer_host = nr_strdup(NRINI(trace_observer_host));
+  } else {
+    info->trace_observer_host = nr_strdup("");
+  }
+  info->trace_observer_port = NRINI(trace_observer_port);
+}
+
 nr_status_t nr_php_txn_begin(const char* appnames,
                              const char* license TSRMLS_DC) {
   nrtxnopt_t opts;
@@ -989,27 +1021,14 @@ nr_status_t nr_php_txn_begin(const char* appnames,
   }
 
   nr_memset(&info, 0, sizeof(info));
-  info.high_security = NR_PHP_PROCESS_GLOBALS(high_security);
-  info.license = nr_strdup(lic_to_use);
+  nr_php_txn_populate_app_info_identity(&info, appnames, license TSRMLS_CC);
   info.settings = NULL; /* Populated through callback. */
-  info.environment = nro_copy(NR_PHP_PROCESS_GLOBALS(appenv));
   info.metadata = nro_copy(NR_PHP_PROCESS_GLOBALS(metadata));
   info.labels = nr_php_txn_get_labels();
   info.host_display_name = nr_strdup(NRINI(process_host_display_name));
-  info.lang = nr_strdup("php");
-  info.version = nr_strdup(nr_version());
-  info.appname = nr_strdup(appnames);
-  info.redirect_collector = nr_strdup(NR_PHP_PROCESS_GLOBALS(collector));
   info.security_policies_token = nr_strdup(NRINI(security_policies_token));
   info.supported_security_policies
       = nr_php_txn_get_supported_security_policy_settings(&opts);
-  /* if DT is disabled we cannot stream 8T events so disable observer host */
-  if (NRINI(distributed_tracing_enabled))
-    info.trace_observer_host = nr_strdup(NRINI(trace_observer_host));
-  else
-    info.trace_observer_host = nr_strdup("");
-  /* observer port setting does not really depend on DT being enabled */
-  info.trace_observer_port = NRINI(trace_observer_port);
   info.span_queue_size = NRINI(span_queue_size);
   info.span_events_max_samples_stored = NRINI(span_events_max_samples_stored);
 

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1379,6 +1379,23 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
     }
   }
 
+  if (0 != ignoretxn) {
+    /*
+     * This transaction is being ignored -- the pull/send/mark-sent path
+     * above was skipped entirely, so entry->last_sent_epoch never
+     * advanced. Advance it directly so the next transaction on this
+     * thread doesn't inherit and re-report this discarded scan. Known
+     * limitation: if this transaction's own Composer scan is what's being
+     * discarded, that scan is lost -- permanently in a persistent-worker
+     * context (no future autoload event can re-scan), harmlessly
+     * elsewhere (a traditional per-request context gets another chance
+     * next request). Accepted tradeoff -- matches how baseline already
+     * treats a discarded transaction's data uniformly, with no
+     * special-casing for Composer.
+     */
+    nr_txn_discard_composer_packages(NRPRG(txn));
+  }
+
   nr_txn_destroy(&NRPRG(txn));
 
   nr_hashmap_destroy(&NRTXNGLOBAL(guzzle_objs));

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -849,20 +849,6 @@ void nr_php_txn_php_package_create_major_metric(void* value,
   actual
       = nr_php_packages_get_package(txn->php_packages, suggested->package_name);
 
-  /* txn->php_packages might not have this package yet even though this
-   * thread's own Composer scan cache already does, so fall back to that
-   * cache to get a better "actual version" for the metric below. This is
-   * a read-only lookup: it never writes into txn->php_packages or into
-   * the cache entry, so it can't affect any of the gating, serialization,
-   * or send-once logic elsewhere that relies on those being left alone.
-   * It's also safe without a lock, since composer_info.entry belongs to
-   * and is only ever accessed by the thread that owns this txn.
-   */
-  if ((NULL == actual) && (NULL != txn->composer_info.entry)) {
-    actual = nr_php_packages_get_package(txn->composer_info.entry->packages,
-                                         suggested->package_name);
-  }
-
   nrl_verbosedebug(
       NRL_INSTRUMENT,
       "Creating PHP Package Supportability Metric for package "

--- a/agent/php_txn.c
+++ b/agent/php_txn.c
@@ -1170,8 +1170,6 @@ nr_status_t nr_php_txn_begin(const char* appnames,
     }
   }
 
-  NRTXN(composer_info.api_status) = NR_PHP_PROCESS_GLOBALS(composer_api_status);
-
   return NR_SUCCESS;
 }
 
@@ -1361,8 +1359,6 @@ nr_status_t nr_php_txn_end(int ignoretxn, int in_post_deactivate TSRMLS_DC) {
       if (NR_FAILURE == ret) {
         nrl_debug(NRL_TXN, "failed to send txn");
       }
-      NR_PHP_PROCESS_GLOBALS(composer_api_status)
-          = NRTXN(composer_info.api_status);
     }
   }
 

--- a/agent/tests/test_lib_composer.c
+++ b/agent/tests/test_lib_composer.c
@@ -1,0 +1,603 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "tlib_php.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "php_agent.h"
+#include "php_globals.h"
+#include "fw_hooks.h"
+#include "nr_agent.h"
+#include "nr_app.h"
+#include "nr_php_packages.h"
+#include "util_syscalls.h"
+
+tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};
+
+static char* vendor_path = NULL;
+
+/*
+ * Every scenario in this file uses the same default ("PHP Application")
+ * app, since none of them override newrelic.appname/license -- so the same
+ * (app, tid) composer_map entry persists across scenarios unless reset.
+ * Evicts it so each scenario starts from a genuinely fresh entry, matching
+ * how a real worker thread's entry only ever starts fresh once, at thread
+ * creation.
+ */
+static void reset_entry_between_scenarios(void) {
+  nr_app_info_t info;
+  nrapp_t* app;
+
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, NULL, NULL TSRMLS_CC);
+
+  app = nr_app_find_locked(nr_agent_applist, &info);
+  if (NULL != app) {
+    nr_app_tid_maps_evict(app, (uint64_t)nr_gettid());
+    nrt_mutex_unlock(&app->app_lock);
+  }
+
+  nr_app_info_destroy_fields(&info);
+}
+
+/*
+ * Confirms request start produced a live txn with a real, genuinely
+ * fresh composer entry, asserting whichever precondition failed.
+ * Returns the entry, or NULL if any assertion failed.
+ */
+static nr_composer_thread_entry_t* require_live_entry(TSRMLS_D) {
+  nr_composer_thread_entry_t* entry;
+
+  tlib_pass_if_not_null("request start produced a live txn", NRPRG(txn));
+  if (NULL == NRPRG(txn)) {
+    return NULL;
+  }
+
+  tlib_pass_if_not_null("txn has a real composer entry from RINIT's app",
+                        NRPRG(txn)->composer_info.entry);
+  if (NULL == NRPRG(txn)->composer_info.entry) {
+    return NULL;
+  }
+
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("fresh entry starts UNSET",
+                        (int)NR_COMPOSER_API_STATUS_UNSET, (int)entry->status);
+  tlib_pass_if_null("fresh entry starts with no packages", entry->packages);
+  tlib_pass_if_uint64_t_equal("fresh entry starts at epoch 0", 0, entry->epoch);
+
+  return entry;
+}
+
+/*
+ * Creates a throwaway vendor/composer/ directory with three empty magic
+ * files so nr_composer_handle_autoload()'s file-exists gate passes. This is
+ * created and removed at test time -- not a checked-in fixture.
+ *
+ * mkdtemp() (not a PID-based name) so a crashed prior run's leftover
+ * directory can never collide with this one -- PIDs get reused, a random
+ * suffix doesn't.
+ */
+static void create_vendor_dir(void) {
+  char dir_template[] = "/tmp/nr_test_lib_composer_XXXXXX";
+  char* composer_dir;
+  static const char* const magic_files[]
+      = {"autoload_real.php", "InstalledVersions.php", "installed.php"};
+  size_t i;
+
+  if (NULL == mkdtemp(dir_template)) {
+    return;
+  }
+  vendor_path = nr_strdup(dir_template);
+
+  composer_dir = nr_formatf("%s/composer", vendor_path);
+  mkdir(composer_dir, 0755);
+
+  for (i = 0; i < sizeof(magic_files) / sizeof(magic_files[0]); i++) {
+    char* path = nr_formatf("%s/%s", composer_dir, magic_files[i]);
+    FILE* f = fopen(path, "w");
+    if (NULL != f) {
+      fclose(f);
+    }
+    nr_free(path);
+  }
+
+  nr_free(composer_dir);
+}
+
+static void remove_vendor_dir(void) {
+  static const char* const magic_files[]
+      = {"autoload_real.php", "InstalledVersions.php", "installed.php"};
+  size_t i;
+  char* composer_dir;
+
+  if (NULL == vendor_path) {
+    return;
+  }
+
+  composer_dir = nr_formatf("%s/composer", vendor_path);
+  for (i = 0; i < sizeof(magic_files) / sizeof(magic_files[0]); i++) {
+    char* path = nr_formatf("%s/%s", composer_dir, magic_files[i]);
+    unlink(path);
+    nr_free(path);
+  }
+  rmdir(composer_dir);
+  nr_free(composer_dir);
+
+  rmdir(vendor_path);
+  nr_free(vendor_path);
+  vendor_path = NULL;
+}
+
+static char* autoload_filename(void) {
+  return nr_formatf("%s/autoload.php", vendor_path);
+}
+
+/*
+ * Every scenario below drives nr_composer_handle_autoload() through a real,
+ * live PHP request rather than a hand-built nrtxn_t: tlib_php_request_start()
+ * alone is enough to get a genuine NRPRG(txn)->composer_info.entry, because
+ * the test engine's default INI already has a valid license and
+ * tlib_php_engine_create() installs a synchronous appinfo stub, so RINIT's
+ * normal app lookup/connect finishes instantly with no real daemon needed.
+ */
+
+/*
+ * None of these scenarios call nr_composer_handle_autoload() with no live
+ * txn (the FrankenPHP worker-bootstrap case, where the app hasn't yet been
+ * acknowledged by the daemon) -- every scenario here runs through
+ * tlib_php_request_start()'s live NRPRG(txn). That's adequate today only
+ * because, once the (app, thread) entry is resolved, the function's write
+ * logic never reads NRPRG(txn) again -- the with-txn and no-txn resolution
+ * paths both hand it the same kind of entry pointer, and everything
+ * downstream operates on that pointer alone, not on the txn. If the write
+ * logic ever starts referencing NRPRG(txn) directly, this file's coverage
+ * would no longer stand in for the no-txn case, and a real no-txn scenario
+ * would need to be added.
+ */
+
+/*
+ * The 6 scenarios below cover every combination of the entry's prior
+ * status (never scanned, already collected, or a previous failure) and
+ * this attempt's own result (success or failure). Each scenario number
+ * matches the row number here:
+ *
+ * #  prior status   this result  packages          epoch      status after
+ * 1  UNSET          success      NULL -> install   +1         COLLECTED
+ * 2  UNSET          failure      stays NULL        unchanged  failure code
+ * 3  COLLECTED      success      destroy, install  +1         COLLECTED
+ * 4  COLLECTED      failure      untouched         unchanged  stays COLLECTED
+ * 5  prior failure  success      NULL -> install   +1         COLLECTED
+ * 6  prior failure  failure      stays NULL        unchanged  latest failure code
+ */
+
+/* Scenario 1: a fresh (never-scanned) entry, one successful scan. */
+static void test_scenario_1_fresh_entry_success(TSRMLS_D) {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+
+  tlib_php_request_start();
+
+  entry = require_live_entry(TSRMLS_C);
+  if (NULL == entry) {
+    goto end;
+  }
+
+  /*
+   * A minimal, real Composer\InstalledVersions stub. is_initialized()'s
+   * class/method-existence check short-circuits before ever touching the
+   * filesystem for the include, so the real scan logic (zend_eval_string
+   * running the actual getallrawdata snippet) executes against this stub for
+   * real -- no mocking of the function under test.
+   */
+  tlib_php_request_eval(
+      "namespace Composer;"
+      "class InstalledVersions {"
+      "  public static function getAllRawData() {"
+      "    return array(array('versions' => array("
+      "      'vendor/package' => array('pretty_version' => 'v1.2.3'),"
+      "    )));"
+      "  }"
+      "  public static function getRootPackage() {"
+      "    return array('name' => 'root/package');"
+      "  }"
+      "}" TSRMLS_CC);
+
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("successful scan sets status to COLLECTED",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  tlib_pass_if_not_null("successful scan installs packages", entry->packages);
+  tlib_pass_if_uint64_t_equal("successful scan bumps epoch to 1", 1,
+                             entry->epoch);
+  {
+    nr_php_package_t* package
+        = (NULL == entry->packages)
+              ? NULL
+              : nr_php_packages_get_package(entry->packages, "vendor/package");
+    tlib_pass_if_not_null("the scanned package is present", package);
+    tlib_pass_if_str_equal(
+        "the scanned package's version is captured, 'v' prefix stripped",
+        "1.2.3", NULL == package ? NULL : package->package_version);
+    tlib_pass_if_size_t_equal("successful scan has exactly one package", 1,
+                              nr_php_packages_count(entry->packages));
+  }
+
+end:
+  tlib_php_request_end();
+}
+
+/*
+ * Scenario 2: a fresh entry, one failed scan (INIT_FAILURE) -- no
+ * Composer\InstalledVersions stub is ever defined, and the magic files on
+ * disk are empty, so is_initialized() stays false even after the
+ * include_once attempt. Asserts the entry stays untouched: packages/epoch
+ * never written on a failure with no prior good data, and status records
+ * the failure code (closing the once-per-thread gate for a
+ * never-yet-successful entry).
+ */
+static void test_scenario_2_fresh_entry_init_failure(TSRMLS_D) {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+
+  reset_entry_between_scenarios();
+  tlib_php_request_start();
+
+  entry = require_live_entry(TSRMLS_C);
+  if (NULL == entry) {
+    goto end;
+  }
+
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("failed scan on fresh entry records INIT_FAILURE",
+                        (int)NR_COMPOSER_API_STATUS_INIT_FAILURE,
+                        (int)entry->status);
+  tlib_pass_if_null("failed scan never installs packages", entry->packages);
+  tlib_pass_if_uint64_t_equal("failed scan never bumps epoch", 0,
+                             entry->epoch);
+
+end:
+  tlib_php_request_end();
+}
+
+/*
+ * Scenario 3: an already-COLLECTED entry, then a second successful scan --
+ * both this attempt's success and the resulting entry should simply reflect
+ * the latest scan, same as today's unconditional-overwrite behavior on the
+ * success path.
+ */
+static void test_scenario_3_collected_then_success(TSRMLS_D) {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+
+  reset_entry_between_scenarios();
+  tlib_php_request_start();
+
+  entry = require_live_entry(TSRMLS_C);
+  if (NULL == entry) {
+    goto end;
+  }
+
+  tlib_php_request_eval(
+      "namespace Composer;"
+      "class InstalledVersions {"
+      "  public static $nr_test_calls = 0;"
+      "  public static function getAllRawData() {"
+      "    self::$nr_test_calls++;"
+      "    if (self::$nr_test_calls === 1) {"
+      "      return array(array('versions' => array("
+      "        'vendor/package' => array('pretty_version' => 'v1.2.3'),"
+      "      )));"
+      "    }"
+      "    return array(array('versions' => array("
+      "      'vendor/other-package' => array('pretty_version' => 'v4.5.6'),"
+      "    )));"
+      "  }"
+      "  public static function getRootPackage() {"
+      "    return array('name' => 'root/package');"
+      "  }"
+      "}" TSRMLS_CC);
+
+  filename = autoload_filename();
+
+  /* Call 1: fresh entry -> COLLECTED. */
+  nr_composer_handle_autoload(filename);
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("call 1 collects successfully",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  tlib_pass_if_uint64_t_equal("call 1 bumps epoch to 1", 1, entry->epoch);
+  {
+    nr_php_package_t* package
+        = nr_php_packages_get_package(entry->packages, "vendor/package");
+    tlib_pass_if_not_null("call 1 has vendor/package", package);
+    tlib_pass_if_str_equal("call 1's package version is captured", "1.2.3",
+                          NULL == package ? NULL : package->package_version);
+    tlib_pass_if_size_t_equal("call 1 has exactly one package", 1,
+                              nr_php_packages_count(entry->packages));
+  }
+
+  /* Call 2: already COLLECTED -> a second success still replaces packages
+   * and bumps epoch again. The stub returns a different package on this
+   * call specifically so the assertions below can distinguish "replaced"
+   * from "left alone". */
+  nr_composer_handle_autoload(filename);
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("call 2 stays COLLECTED",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  tlib_pass_if_not_null("call 2 still has packages", entry->packages);
+  tlib_pass_if_uint64_t_equal("call 2 bumps epoch to 2", 2, entry->epoch);
+  tlib_pass_if_null(
+      "call 1's package is gone after call 2's replacement",
+      nr_php_packages_get_package(entry->packages, "vendor/package"));
+  {
+    nr_php_package_t* package = nr_php_packages_get_package(
+        entry->packages, "vendor/other-package");
+    tlib_pass_if_not_null("call 2's own package is present", package);
+    tlib_pass_if_str_equal("call 2's package version is captured", "4.5.6",
+                          NULL == package ? NULL : package->package_version);
+    tlib_pass_if_size_t_equal("call 2 has exactly one package", 1,
+                              nr_php_packages_count(entry->packages));
+  }
+
+  nr_free(filename);
+
+end:
+  tlib_php_request_end();
+}
+
+/*
+ * Scenario 4: an already-COLLECTED entry, then a second scan that fails
+ * with INVALID_RESULT. The failed second attempt must leave the good data
+ * from call 1 completely untouched (packages, epoch, and status all
+ * unchanged).
+ *
+ * Uses a stateful stub (a static call counter) rather than two separately
+ * eval'd classes, since PHP won't allow redeclaring
+ * Composer\InstalledVersions within the same request: call 1 returns real
+ * data; call 2+ throws, which the getallrawdata snippet's own
+ * catch (Throwable) turns into a non-array return (NULL), i.e.
+ * INVALID_RESULT.
+ */
+static void test_scenario_4_collected_then_invalid_result(TSRMLS_D) {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+  nr_php_packages_t* packages_after_call1;
+
+  reset_entry_between_scenarios();
+  tlib_php_request_start();
+
+  entry = require_live_entry(TSRMLS_C);
+  if (NULL == entry) {
+    goto end;
+  }
+
+  tlib_php_request_eval(
+      "namespace Composer;"
+      "class InstalledVersions {"
+      "  public static $nr_test_calls = 0;"
+      "  public static function getAllRawData() {"
+      "    self::$nr_test_calls++;"
+      "    if (self::$nr_test_calls === 1) {"
+      "      return array(array('versions' => array("
+      "        'vendor/package' => array('pretty_version' => 'v1.2.3'),"
+      "      )));"
+      "    }"
+      "    throw new \\Exception('simulated Composer API failure');"
+      "  }"
+      "  public static function getRootPackage() {"
+      "    return array('name' => 'root/package');"
+      "  }"
+      "}" TSRMLS_CC);
+
+  filename = autoload_filename();
+
+  /* Call 1: fresh entry -> COLLECTED, real good data. */
+  nr_composer_handle_autoload(filename);
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("call 1 collects successfully",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  {
+    nr_php_package_t* package
+        = nr_php_packages_get_package(entry->packages, "vendor/package");
+    tlib_pass_if_not_null("call 1 has vendor/package", package);
+    tlib_pass_if_str_equal("call 1's package version is captured", "1.2.3",
+                          NULL == package ? NULL : package->package_version);
+    tlib_pass_if_size_t_equal("call 1 has exactly one package", 1,
+                              nr_php_packages_count(entry->packages));
+  }
+  packages_after_call1 = entry->packages;
+
+  /* Call 2: fails with INVALID_RESULT -- the bug-fix assertion: entry must
+   * be completely unchanged from call 1, including the packages pointer
+   * itself (never destroyed-and-replaced on a failed rescan). */
+  nr_composer_handle_autoload(filename);
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal(
+      "call 2's failure does not change status away from COLLECTED",
+      (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED, (int)entry->status);
+  tlib_pass_if_true("call 2's failure leaves the same packages pointer",
+                    entry->packages == packages_after_call1,
+                    "entry->packages == packages_after_call1");
+  tlib_pass_if_uint64_t_equal(
+      "call 2's failure does not bump epoch past call 1's", 1, entry->epoch);
+  {
+    nr_php_package_t* package
+        = (NULL == entry->packages)
+              ? NULL
+              : nr_php_packages_get_package(entry->packages, "vendor/package");
+    tlib_pass_if_not_null(
+        "the package from call 1 is still present after call 2's failure",
+        package);
+    tlib_pass_if_str_equal(
+        "the package's version is unchanged after call 2's failure", "1.2.3",
+        NULL == package ? NULL : package->package_version);
+    tlib_pass_if_size_t_equal("call 2's failure leaves exactly one package",
+                              1, nr_php_packages_count(entry->packages));
+  }
+
+  nr_free(filename);
+
+end:
+  tlib_php_request_end();
+}
+
+/*
+ * Scenario 5: call 1 fails (INIT_FAILURE, no class defined yet), call 2
+ * succeeds (the stub is eval'd for the first time between calls -- no
+ * redeclare conflict, since call 1 never defined anything).
+ *
+ * This calls nr_composer_handle_autoload() directly, bypassing
+ * agent/php_execute.c's per-thread gate, which would normally block a
+ * second call once status is no longer UNSET -- this tests what the
+ * write logic does if a second call happens anyway, not whether the
+ * gate would allow one.
+ */
+static void test_scenario_5_failure_then_success(TSRMLS_D) {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+
+  reset_entry_between_scenarios();
+  tlib_php_request_start();
+
+  entry = require_live_entry(TSRMLS_C);
+  if (NULL == entry) {
+    goto end;
+  }
+
+  filename = autoload_filename();
+
+  /* Call 1: no Composer\InstalledVersions defined yet -> INIT_FAILURE. */
+  nr_composer_handle_autoload(filename);
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("call 1 fails with INIT_FAILURE",
+                        (int)NR_COMPOSER_API_STATUS_INIT_FAILURE,
+                        (int)entry->status);
+  tlib_pass_if_null("call 1's failure leaves packages NULL", entry->packages);
+  tlib_pass_if_uint64_t_equal("call 1's failure leaves epoch at 0", 0,
+                             entry->epoch);
+
+  /* Now define the stub for the first time -- nothing was ever declared by
+   * call 1, so this is not a redeclare. */
+  tlib_php_request_eval(
+      "namespace Composer;"
+      "class InstalledVersions {"
+      "  public static function getAllRawData() {"
+      "    return array(array('versions' => array("
+      "      'vendor/package' => array('pretty_version' => 'v1.2.3'),"
+      "    )));"
+      "  }"
+      "  public static function getRootPackage() {"
+      "    return array('name' => 'root/package');"
+      "  }"
+      "}" TSRMLS_CC);
+
+  /* Call 2: succeeds now that the class exists. */
+  nr_composer_handle_autoload(filename);
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("call 2 recovers to COLLECTED",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  tlib_pass_if_uint64_t_equal("call 2 bumps epoch to 1", 1, entry->epoch);
+  {
+    nr_php_package_t* package
+        = nr_php_packages_get_package(entry->packages, "vendor/package");
+    tlib_pass_if_not_null("call 2 has vendor/package", package);
+    tlib_pass_if_str_equal("call 2's package version is captured", "1.2.3",
+                          NULL == package ? NULL : package->package_version);
+    tlib_pass_if_size_t_equal("call 2 has exactly one package", 1,
+                              nr_php_packages_count(entry->packages));
+  }
+
+  nr_free(filename);
+
+end:
+  tlib_php_request_end();
+}
+
+/*
+ * Scenario 6: repeated failure, same failure code both times. Uses a
+ * malformed stub -- a Composer\InstalledVersions class missing the required
+ * methods, defined once -- so is_initialized() permanently fails against it
+ * (the class exists, so nr_php_find_class succeeds, but
+ * nr_php_find_class_method fails every time, deterministically, with no
+ * state needed).
+ *
+ * This calls nr_composer_handle_autoload() directly, bypassing
+ * agent/php_execute.c's per-thread gate, which would normally block a
+ * second call once status is no longer UNSET -- this tests what the
+ * write logic does if a second call happens anyway, not whether the
+ * gate would allow one.
+ */
+static void test_scenario_6_repeated_failure(TSRMLS_D) {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+
+  reset_entry_between_scenarios();
+  tlib_php_request_start();
+
+  entry = require_live_entry(TSRMLS_C);
+  if (NULL == entry) {
+    goto end;
+  }
+
+  tlib_php_request_eval(
+      "namespace Composer;"
+      "class InstalledVersions {}" TSRMLS_CC);
+
+  filename = autoload_filename();
+
+  /* Call 1: class exists but is missing both required methods ->
+   * INIT_FAILURE. */
+  nr_composer_handle_autoload(filename);
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("call 1 fails with INIT_FAILURE",
+                        (int)NR_COMPOSER_API_STATUS_INIT_FAILURE,
+                        (int)entry->status);
+  tlib_pass_if_null("call 1's failure leaves packages NULL", entry->packages);
+
+  /* Call 2: nothing changed -- same deterministic failure again. */
+  nr_composer_handle_autoload(filename);
+  entry = NRPRG(txn)->composer_info.entry;
+  tlib_pass_if_int_equal("call 2 fails with INIT_FAILURE again",
+                        (int)NR_COMPOSER_API_STATUS_INIT_FAILURE,
+                        (int)entry->status);
+  tlib_pass_if_null("call 2's failure still leaves packages NULL",
+                    entry->packages);
+  tlib_pass_if_uint64_t_equal("repeated failure never bumps epoch", 0,
+                             entry->epoch);
+
+  nr_free(filename);
+
+end:
+  tlib_php_request_end();
+}
+
+void test_main(void* p NRUNUSED) {
+  tlib_php_engine_create("");
+  create_vendor_dir();
+
+  test_scenario_1_fresh_entry_success(TSRMLS_C);
+  test_scenario_2_fresh_entry_init_failure(TSRMLS_C);
+  test_scenario_3_collected_then_success(TSRMLS_C);
+  test_scenario_4_collected_then_invalid_result(TSRMLS_C);
+  test_scenario_5_failure_then_success(TSRMLS_C);
+  test_scenario_6_repeated_failure(TSRMLS_C);
+
+  remove_vendor_dir();
+  tlib_php_engine_destroy();
+}

--- a/agent/tests/test_lib_composer.c
+++ b/agent/tests/test_lib_composer.c
@@ -34,7 +34,7 @@ static void reset_entry_between_scenarios(void) {
   nrapp_t* app;
 
   nr_memset(&info, 0, sizeof(info));
-  nr_php_txn_populate_app_info_identity(&info, NULL, NULL TSRMLS_CC);
+  nr_php_txn_populate_app_info_identity(&info, NULL, NULL);
 
   app = nr_app_find_locked(nr_agent_applist, &info);
   if (NULL != app) {
@@ -50,7 +50,7 @@ static void reset_entry_between_scenarios(void) {
  * fresh composer entry, asserting whichever precondition failed.
  * Returns the entry, or NULL if any assertion failed.
  */
-static nr_composer_thread_entry_t* require_live_entry(TSRMLS_D) {
+static nr_composer_thread_entry_t* require_live_entry() {
   nr_composer_thread_entry_t* entry;
 
   tlib_pass_if_not_null("request start produced a live txn", NRPRG(txn));
@@ -176,13 +176,13 @@ static char* autoload_filename(void) {
  */
 
 /* Scenario 1: a fresh (never-scanned) entry, one successful scan. */
-static void test_scenario_1_fresh_entry_success(TSRMLS_D) {
+static void test_scenario_1_fresh_entry_success() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
   tlib_php_request_start();
 
-  entry = require_live_entry(TSRMLS_C);
+  entry = require_live_entry();
   if (NULL == entry) {
     goto end;
   }
@@ -205,7 +205,7 @@ static void test_scenario_1_fresh_entry_success(TSRMLS_D) {
       "  public static function getRootPackage() {"
       "    return array('name' => 'root/package');"
       "  }"
-      "}" TSRMLS_CC);
+      "}");
 
   filename = autoload_filename();
   nr_composer_handle_autoload(filename);
@@ -244,14 +244,14 @@ end:
  * the failure code (closing the once-per-thread gate for a
  * never-yet-successful entry).
  */
-static void test_scenario_2_fresh_entry_init_failure(TSRMLS_D) {
+static void test_scenario_2_fresh_entry_init_failure() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
   reset_entry_between_scenarios();
   tlib_php_request_start();
 
-  entry = require_live_entry(TSRMLS_C);
+  entry = require_live_entry();
   if (NULL == entry) {
     goto end;
   }
@@ -278,14 +278,14 @@ end:
  * the latest scan, same as today's unconditional-overwrite behavior on the
  * success path.
  */
-static void test_scenario_3_collected_then_success(TSRMLS_D) {
+static void test_scenario_3_collected_then_success() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
   reset_entry_between_scenarios();
   tlib_php_request_start();
 
-  entry = require_live_entry(TSRMLS_C);
+  entry = require_live_entry();
   if (NULL == entry) {
     goto end;
   }
@@ -308,7 +308,7 @@ static void test_scenario_3_collected_then_success(TSRMLS_D) {
       "  public static function getRootPackage() {"
       "    return array('name' => 'root/package');"
       "  }"
-      "}" TSRMLS_CC);
+      "}");
 
   filename = autoload_filename();
 
@@ -372,7 +372,7 @@ end:
  * catch (Throwable) turns into a non-array return (NULL), i.e.
  * INVALID_RESULT.
  */
-static void test_scenario_4_collected_then_invalid_result(TSRMLS_D) {
+static void test_scenario_4_collected_then_invalid_result() {
   char* filename;
   nr_composer_thread_entry_t* entry;
   nr_php_packages_t* packages_after_call1;
@@ -380,7 +380,7 @@ static void test_scenario_4_collected_then_invalid_result(TSRMLS_D) {
   reset_entry_between_scenarios();
   tlib_php_request_start();
 
-  entry = require_live_entry(TSRMLS_C);
+  entry = require_live_entry();
   if (NULL == entry) {
     goto end;
   }
@@ -401,7 +401,7 @@ static void test_scenario_4_collected_then_invalid_result(TSRMLS_D) {
       "  public static function getRootPackage() {"
       "    return array('name' => 'root/package');"
       "  }"
-      "}" TSRMLS_CC);
+      "}");
 
   filename = autoload_filename();
 
@@ -467,14 +467,14 @@ end:
  * write logic does if a second call happens anyway, not whether the
  * gate would allow one.
  */
-static void test_scenario_5_failure_then_success(TSRMLS_D) {
+static void test_scenario_5_failure_then_success() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
   reset_entry_between_scenarios();
   tlib_php_request_start();
 
-  entry = require_live_entry(TSRMLS_C);
+  entry = require_live_entry();
   if (NULL == entry) {
     goto end;
   }
@@ -504,7 +504,7 @@ static void test_scenario_5_failure_then_success(TSRMLS_D) {
       "  public static function getRootPackage() {"
       "    return array('name' => 'root/package');"
       "  }"
-      "}" TSRMLS_CC);
+      "}");
 
   /* Call 2: succeeds now that the class exists. */
   nr_composer_handle_autoload(filename);
@@ -543,21 +543,21 @@ end:
  * write logic does if a second call happens anyway, not whether the
  * gate would allow one.
  */
-static void test_scenario_6_repeated_failure(TSRMLS_D) {
+static void test_scenario_6_repeated_failure() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
   reset_entry_between_scenarios();
   tlib_php_request_start();
 
-  entry = require_live_entry(TSRMLS_C);
+  entry = require_live_entry();
   if (NULL == entry) {
     goto end;
   }
 
   tlib_php_request_eval(
       "namespace Composer;"
-      "class InstalledVersions {}" TSRMLS_CC);
+      "class InstalledVersions {}");
 
   filename = autoload_filename();
 
@@ -587,16 +587,379 @@ end:
   tlib_php_request_end();
 }
 
+/*
+ * The 4 scenarios below cover a different route into the same entry:
+ * newrelic_ignore_transaction() and newrelic_set_appname()'s default
+ * (no $xmit) discard, both of which drive nr_php_txn_end()'s ignoretxn
+ * branch and thus nr_txn_discard_composer_packages(). Each API is tested
+ * against both halves of that function's behavior: destroying a scan that
+ * never got pulled/sent, and leaving an already-sent scan alone.
+ *
+ * #   API                   original entry before   packages after   status after
+ * 7   ignore_transaction    new, unsent             destroyed        UNSET
+ * 8   set_appname           new, unsent             destroyed        UNSET
+ * 9   ignore_transaction    already sent            unchanged        COLLECTED
+ * 10  set_appname           already sent            unchanged        COLLECTED
+ *
+ * (Rows 8 and 10 also create a second, new entry via set_appname's app
+ * switch -- separately verified in each scenario to start fresh: UNSET, no
+ * packages, epoch 0. This table describes only the original entry's fate,
+ * not the new one's.)
+ *
+ * All four scenarios keep dereferencing their saved `entry` pointer after
+ * calling tlib_php_request_end() (which destroys the current txn) or after
+ * newrelic_set_appname() swaps NRPRG(txn) to a new one. That's safe because
+ * the entry lives on the app's composer_map, keyed by (app, tid) -- not on
+ * the txn object -- so it outlives whichever txn happened to be looking at
+ * it when the scan ran.
+ */
+
+static const char* const one_package_stub
+    = "namespace Composer;"
+      "class InstalledVersions {"
+      "  public static function getAllRawData() {"
+      "    return array(array('versions' => array("
+      "      'vendor/package' => array('pretty_version' => 'v1.2.3'),"
+      "    )));"
+      "  }"
+      "  public static function getRootPackage() {"
+      "    return array('name' => 'root/package');"
+      "  }"
+      "}";
+
+/*
+ * Scenario 7: a scan happens, then newrelic_ignore_transaction() is called
+ * before the request ends. Ignoring sets status.ignore before
+ * nr_php_txn_end's ignoretxn snapshot is taken, so the normal pull/send path
+ * is skipped entirely -- the scan is genuinely unsent when RSHUTDOWN runs
+ * the discard.
+ */
+static void test_ignore_transaction_discards_unsent_scan() {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+
+  reset_entry_between_scenarios();
+  tlib_php_request_start();
+
+  entry = require_live_entry();
+  if (NULL == entry) {
+    tlib_php_request_end();
+    return;
+  }
+
+  /* Precondition: scan, then confirm it produced new, unsent data. */
+  tlib_php_request_eval(one_package_stub);
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+
+  tlib_pass_if_int_equal("scan collects successfully before ignoring",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  tlib_pass_if_not_null("scan installs packages before ignoring",
+                        entry->packages);
+  tlib_pass_if_uint64_t_equal("scan bumps epoch to 1 before ignoring", 1,
+                             entry->epoch);
+  tlib_pass_if_uint64_t_equal(
+      "scan's data is still unsent before ignoring (epoch != "
+      "last_sent_epoch)",
+      0, entry->last_sent_epoch);
+
+  /* Action under test: ignore the transaction, then confirm the discard. */
+  tlib_php_request_eval("newrelic_ignore_transaction();");
+  tlib_php_request_end();
+
+  tlib_pass_if_int_equal(
+      "ignore_transaction resets status to UNSET when scan was unsent",
+      (int)NR_COMPOSER_API_STATUS_UNSET, (int)entry->status);
+  tlib_pass_if_null(
+      "ignore_transaction destroys packages when scan was unsent",
+      entry->packages);
+  tlib_pass_if_uint64_t_equal(
+      "ignore_transaction still advances last_sent_epoch to match epoch", 1,
+      entry->last_sent_epoch);
+}
+
+/*
+ * Scenario 8: same as 7, but via newrelic_set_appname()'s default discard.
+ * That call fires nr_php_txn_end synchronously, before nr_php_txn_begin
+ * swaps NRPRG(txn) to the new app -- so the discard is already visible on
+ * the saved entry pointer by the time the eval call returns.
+ */
+static void test_set_appname_discards_unsent_scan() {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+
+  reset_entry_between_scenarios();
+  tlib_php_request_start();
+
+  entry = require_live_entry();
+  if (NULL == entry) {
+    tlib_php_request_end();
+    return;
+  }
+
+  /* Precondition: scan, then confirm it produced new, unsent data. */
+  tlib_php_request_eval(one_package_stub);
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+
+  tlib_pass_if_int_equal("scan collects successfully before switching apps",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  tlib_pass_if_not_null("scan installs packages before switching apps",
+                        entry->packages);
+  tlib_pass_if_uint64_t_equal("scan bumps epoch to 1 before switching apps",
+                             1, entry->epoch);
+  tlib_pass_if_uint64_t_equal(
+      "scan's data is still unsent before switching apps (epoch != "
+      "last_sent_epoch)",
+      0, entry->last_sent_epoch);
+
+  /* Action under test: switch apps, then confirm the discard. */
+  tlib_php_request_eval(
+      "newrelic_set_appname('SoakScratchAppUnsent');");
+
+  /*
+   * Confirms the switch landed on a genuinely different, genuinely fresh
+   * entry -- not just a different pointer that happens to carry stale
+   * state through some other path. This is a sanity check on the switch
+   * itself, not on the discard behavior under test below.
+   */
+  tlib_pass_if_true(
+      "set_appname moves NRPRG(txn) to a different composer entry",
+      NRPRG(txn)->composer_info.entry != entry,
+      "NRPRG(txn)->composer_info.entry != entry");
+  tlib_pass_if_int_equal("new app's entry starts fresh (UNSET)",
+                        (int)NR_COMPOSER_API_STATUS_UNSET,
+                        (int)NRPRG(txn)->composer_info.entry->status);
+  tlib_pass_if_null("new app's entry starts fresh (no packages)",
+                    NRPRG(txn)->composer_info.entry->packages);
+  tlib_pass_if_uint64_t_equal("new app's entry starts fresh (epoch 0)", 0,
+                             NRPRG(txn)->composer_info.entry->epoch);
+
+  tlib_pass_if_int_equal(
+      "set_appname resets the old app's status to UNSET when scan was "
+      "unsent",
+      (int)NR_COMPOSER_API_STATUS_UNSET, (int)entry->status);
+  tlib_pass_if_null(
+      "set_appname destroys the old app's packages when scan was unsent",
+      entry->packages);
+  tlib_pass_if_uint64_t_equal(
+      "set_appname still advances the old app's last_sent_epoch to match "
+      "epoch",
+      1, entry->last_sent_epoch);
+
+  tlib_php_request_end();
+}
+
+/*
+ * Scenario 9: a scan happens and is allowed to complete a normal (non-
+ * ignored) request, so the ordinary pull/mark-sent path in nr_php_txn_end
+ * catches it up (last_sent_epoch == epoch). A second request on the same
+ * thread then calls newrelic_ignore_transaction() with nothing new to
+ * discard -- the already-sent data must be left completely alone.
+ */
+static void test_ignore_transaction_preserves_already_sent_scan() {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+  nr_php_packages_t* packages_after_first_send;
+
+  reset_entry_between_scenarios();
+
+  /* Request 1: plain scan, plain (non-ignored) end -- pull + mark-sent run
+   * normally. */
+  tlib_php_request_start();
+  entry = require_live_entry();
+  if (NULL == entry) {
+    tlib_php_request_end();
+    return;
+  }
+
+  tlib_php_request_eval(one_package_stub);
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+  tlib_php_request_end();
+
+  tlib_pass_if_uint64_t_equal("first request's scan bumps epoch to 1", 1,
+                             entry->epoch);
+  tlib_pass_if_uint64_t_equal(
+      "first request's normal end marks it fully sent", 1,
+      entry->last_sent_epoch);
+  packages_after_first_send = entry->packages;
+  tlib_pass_if_not_null("packages survive the first request's normal end",
+                        packages_after_first_send);
+
+  /* Request 2: same thread, same (default) app -- nothing new has scanned,
+   * so ignoring this request must be a no-op on the entry. */
+  tlib_php_request_start();
+  tlib_pass_if_true("second request reuses the same composer entry",
+                    NRPRG(txn)->composer_info.entry == entry,
+                    "NRPRG(txn)->composer_info.entry == entry");
+
+  tlib_php_request_eval("newrelic_ignore_transaction();");
+  tlib_php_request_end();
+
+  tlib_pass_if_true(
+      "already-sent packages pointer is untouched by a later discard",
+      entry->packages == packages_after_first_send,
+      "entry->packages == packages_after_first_send");
+  {
+    nr_php_package_t* package
+        = nr_php_packages_get_package(entry->packages, "vendor/package");
+    tlib_pass_if_not_null("already-sent package is still present", package);
+    tlib_pass_if_str_equal(
+        "already-sent package version is unchanged", "1.2.3",
+        NULL == package ? NULL : package->package_version);
+    tlib_pass_if_size_t_equal("already-sent packages count is unchanged", 1,
+                              nr_php_packages_count(entry->packages));
+  }
+  tlib_pass_if_int_equal("already-sent status stays COLLECTED",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  tlib_pass_if_uint64_t_equal("already-sent epoch is unchanged", 1,
+                             entry->epoch);
+  tlib_pass_if_uint64_t_equal("already-sent last_sent_epoch is unchanged", 1,
+                             entry->last_sent_epoch);
+}
+
+/*
+ * Scenario 10: same setup as 9, but the second request calls
+ * newrelic_set_appname() instead of newrelic_ignore_transaction(). Nothing
+ * new has scanned since the first request's normal send, so switching apps
+ * must leave the original app's already-sent entry alone.
+ */
+static void test_set_appname_preserves_already_sent_scan() {
+  char* filename;
+  nr_composer_thread_entry_t* entry;
+  nr_php_packages_t* packages_after_first_send;
+
+  reset_entry_between_scenarios();
+
+  /* Request 1: plain scan, plain (non-ignored) end. */
+  tlib_php_request_start();
+  entry = require_live_entry();
+  if (NULL == entry) {
+    tlib_php_request_end();
+    return;
+  }
+
+  tlib_php_request_eval(one_package_stub);
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+  tlib_php_request_end();
+
+  tlib_pass_if_uint64_t_equal("first request's scan bumps epoch to 1", 1,
+                             entry->epoch);
+  tlib_pass_if_uint64_t_equal(
+      "first request's normal end marks it fully sent", 1,
+      entry->last_sent_epoch);
+  packages_after_first_send = entry->packages;
+
+  /* Request 2: same thread, same (default) app at start -- switch away via
+   * set_appname with nothing new pending. */
+  tlib_php_request_start();
+  tlib_pass_if_true(
+      "second request reuses the same composer entry before switching",
+      NRPRG(txn)->composer_info.entry == entry,
+      "NRPRG(txn)->composer_info.entry == entry");
+
+  tlib_php_request_eval(
+      "newrelic_set_appname('SoakScratchAppSent');");
+
+  /*
+   * Confirms the switch landed on a genuinely different, genuinely fresh
+   * entry -- not just a different pointer that happens to carry stale
+   * state through some other path. This is a sanity check on the switch
+   * itself, not on the preserve behavior under test below.
+   */
+  tlib_pass_if_true(
+      "set_appname moves NRPRG(txn) to a different composer entry",
+      NRPRG(txn)->composer_info.entry != entry,
+      "NRPRG(txn)->composer_info.entry != entry");
+  tlib_pass_if_int_equal("new app's entry starts fresh (UNSET)",
+                        (int)NR_COMPOSER_API_STATUS_UNSET,
+                        (int)NRPRG(txn)->composer_info.entry->status);
+  tlib_pass_if_null("new app's entry starts fresh (no packages)",
+                    NRPRG(txn)->composer_info.entry->packages);
+  tlib_pass_if_uint64_t_equal("new app's entry starts fresh (epoch 0)", 0,
+                             NRPRG(txn)->composer_info.entry->epoch);
+
+  /*
+   * Scan the new app too, using a distinct package name -- not just to
+   * confirm the bare act of switching leaves the original entry alone
+   * (already covered), but to positively confirm that real activity on
+   * the new app afterward doesn't bleed back into it either. A distinct
+   * package name means any accidental cross-app bleed-through would be
+   * unmistakable in the assertions below, not just a stale-looking match.
+   */
+  tlib_php_request_eval(
+      "namespace Composer;"
+      "class InstalledVersions {"
+      "  public static function getAllRawData() {"
+      "    return array(array('versions' => array("
+      "      'vendor/new-app-package' => array('pretty_version' => "
+      "'v9.9.9'),"
+      "    )));"
+      "  }"
+      "  public static function getRootPackage() {"
+      "    return array('name' => 'root/package');"
+      "  }"
+      "}");
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+
+  tlib_pass_if_int_equal("new app's own scan succeeds independently",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)NRPRG(txn)->composer_info.entry->status);
+  tlib_pass_if_null(
+      "new app's scan doesn't leak into the original entry's packages",
+      nr_php_packages_get_package(entry->packages, "vendor/new-app-package"));
+
+  tlib_pass_if_true(
+      "already-sent packages pointer is untouched by set_appname's discard",
+      entry->packages == packages_after_first_send,
+      "entry->packages == packages_after_first_send");
+  {
+    nr_php_package_t* package
+        = nr_php_packages_get_package(entry->packages, "vendor/package");
+    tlib_pass_if_not_null("already-sent package is still present", package);
+    tlib_pass_if_str_equal(
+        "already-sent package version is unchanged", "1.2.3",
+        NULL == package ? NULL : package->package_version);
+    tlib_pass_if_size_t_equal("already-sent packages count is unchanged", 1,
+                              nr_php_packages_count(entry->packages));
+  }
+  tlib_pass_if_int_equal("already-sent status stays COLLECTED",
+                        (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                        (int)entry->status);
+  tlib_pass_if_uint64_t_equal("already-sent epoch is unchanged", 1,
+                             entry->epoch);
+  tlib_pass_if_uint64_t_equal("already-sent last_sent_epoch is unchanged", 1,
+                             entry->last_sent_epoch);
+
+  tlib_php_request_end();
+}
+
 void test_main(void* p NRUNUSED) {
   tlib_php_engine_create("");
   create_vendor_dir();
 
-  test_scenario_1_fresh_entry_success(TSRMLS_C);
-  test_scenario_2_fresh_entry_init_failure(TSRMLS_C);
-  test_scenario_3_collected_then_success(TSRMLS_C);
-  test_scenario_4_collected_then_invalid_result(TSRMLS_C);
-  test_scenario_5_failure_then_success(TSRMLS_C);
-  test_scenario_6_repeated_failure(TSRMLS_C);
+  test_scenario_1_fresh_entry_success();
+  test_scenario_2_fresh_entry_init_failure();
+  test_scenario_3_collected_then_success();
+  test_scenario_4_collected_then_invalid_result();
+  test_scenario_5_failure_then_success();
+  test_scenario_6_repeated_failure();
+
+  test_ignore_transaction_discards_unsent_scan();
+  test_set_appname_discards_unsent_scan();
+  test_ignore_transaction_preserves_already_sent_scan();
+  test_set_appname_preserves_already_sent_scan();
 
   remove_vendor_dir();
   tlib_php_engine_destroy();

--- a/agent/tests/test_lib_composer.c
+++ b/agent/tests/test_lib_composer.c
@@ -22,6 +22,25 @@ tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};
 static char* vendor_path = NULL;
 
 /*
+ * Finds and locks the nrapp_t matching the given appname's identity, or
+ * NULL if none is registered yet -- the same find-only identity
+ * resolution nr_composer_find_app_no_txn() itself uses. NULL falls back
+ * to NRINI(appnames), matching every production caller that doesn't pass
+ * an explicit override. Caller must unlock app->app_lock if non-NULL.
+ */
+static nrapp_t* find_app_by_name(const char* appname) {
+  nr_app_info_t info;
+  nrapp_t* app;
+
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, appname, NULL);
+  app = nr_app_find_locked(nr_agent_applist, &info);
+  nr_app_info_destroy_fields(&info);
+
+  return app;
+}
+
+/*
  * Every scenario in this file uses the same default ("PHP Application")
  * app, since none of them override newrelic.appname/license -- so the same
  * (app, tid) composer_map entry persists across scenarios unless reset.
@@ -30,19 +49,12 @@ static char* vendor_path = NULL;
  * creation.
  */
 static void reset_entry_between_scenarios(void) {
-  nr_app_info_t info;
-  nrapp_t* app;
+  nrapp_t* app = find_app_by_name(NULL);
 
-  nr_memset(&info, 0, sizeof(info));
-  nr_php_txn_populate_app_info_identity(&info, NULL, NULL);
-
-  app = nr_app_find_locked(nr_agent_applist, &info);
   if (NULL != app) {
     nr_app_tid_maps_evict(app, (uint64_t)nr_gettid());
     nrt_mutex_unlock(&app->app_lock);
   }
-
-  nr_app_info_destroy_fields(&info);
 }
 
 /*
@@ -69,6 +81,27 @@ static nr_composer_thread_entry_t* require_live_entry() {
                         (int)NR_COMPOSER_API_STATUS_UNSET, (int)entry->status);
   tlib_pass_if_null("fresh entry starts with no packages", entry->packages);
   tlib_pass_if_uint64_t_equal("fresh entry starts at epoch 0", 0, entry->epoch);
+
+  return entry;
+}
+
+/*
+ * Common opening for every scenario below: reset the default app's
+ * per-tid entry, start a fresh request, and confirm it produced a live,
+ * genuinely fresh composer entry. Returns the entry, or NULL if any
+ * precondition failed -- the request has already been ended in that
+ * case, so the caller should return immediately with no further cleanup.
+ */
+static nr_composer_thread_entry_t* start_fresh_request(void) {
+  nr_composer_thread_entry_t* entry;
+
+  reset_entry_between_scenarios();
+  tlib_php_request_start();
+
+  entry = require_live_entry();
+  if (NULL == entry) {
+    tlib_php_request_end();
+  }
 
   return entry;
 }
@@ -147,17 +180,11 @@ static char* autoload_filename(void) {
  */
 
 /*
- * None of these scenarios call nr_composer_handle_autoload() with no live
- * txn (the FrankenPHP worker-bootstrap case, where the app hasn't yet been
- * acknowledged by the daemon) -- every scenario here runs through
- * tlib_php_request_start()'s live NRPRG(txn). That's adequate today only
- * because, once the (app, thread) entry is resolved, the function's write
- * logic never reads NRPRG(txn) again -- the with-txn and no-txn resolution
- * paths both hand it the same kind of entry pointer, and everything
- * downstream operates on that pointer alone, not on the txn. If the write
- * logic ever starts referencing NRPRG(txn) directly, this file's coverage
- * would no longer stand in for the no-txn case, and a real no-txn scenario
- * would need to be added.
+ * Scenarios 1-10 below all run through tlib_php_request_start()'s live
+ * NRPRG(txn), so they only exercise nr_composer_handle_autoload()'s
+ * with-txn entry resolution. The no-txn resolution path (no live
+ * NRPRG(txn), e.g. a FrankenPHP worker-bootstrap autoload event before
+ * any transaction exists) is covered separately, further down.
  */
 
 /*
@@ -180,11 +207,9 @@ static void test_scenario_1_fresh_entry_success() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
-  tlib_php_request_start();
-
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    goto end;
+    return;
   }
 
   /*
@@ -231,7 +256,6 @@ static void test_scenario_1_fresh_entry_success() {
                               nr_php_packages_count(entry->packages));
   }
 
-end:
   tlib_php_request_end();
 }
 
@@ -248,12 +272,9 @@ static void test_scenario_2_fresh_entry_init_failure() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
-  reset_entry_between_scenarios();
-  tlib_php_request_start();
-
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    goto end;
+    return;
   }
 
   filename = autoload_filename();
@@ -268,7 +289,6 @@ static void test_scenario_2_fresh_entry_init_failure() {
   tlib_pass_if_uint64_t_equal("failed scan never bumps epoch", 0,
                              entry->epoch);
 
-end:
   tlib_php_request_end();
 }
 
@@ -282,12 +302,9 @@ static void test_scenario_3_collected_then_success() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
-  reset_entry_between_scenarios();
-  tlib_php_request_start();
-
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    goto end;
+    return;
   }
 
   tlib_php_request_eval(
@@ -355,7 +372,6 @@ static void test_scenario_3_collected_then_success() {
 
   nr_free(filename);
 
-end:
   tlib_php_request_end();
 }
 
@@ -377,12 +393,9 @@ static void test_scenario_4_collected_then_invalid_result() {
   nr_composer_thread_entry_t* entry;
   nr_php_packages_t* packages_after_call1;
 
-  reset_entry_between_scenarios();
-  tlib_php_request_start();
-
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    goto end;
+    return;
   }
 
   tlib_php_request_eval(
@@ -452,7 +465,6 @@ static void test_scenario_4_collected_then_invalid_result() {
 
   nr_free(filename);
 
-end:
   tlib_php_request_end();
 }
 
@@ -471,12 +483,9 @@ static void test_scenario_5_failure_then_success() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
-  reset_entry_between_scenarios();
-  tlib_php_request_start();
-
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    goto end;
+    return;
   }
 
   filename = autoload_filename();
@@ -525,7 +534,6 @@ static void test_scenario_5_failure_then_success() {
 
   nr_free(filename);
 
-end:
   tlib_php_request_end();
 }
 
@@ -547,12 +555,9 @@ static void test_scenario_6_repeated_failure() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
-  reset_entry_between_scenarios();
-  tlib_php_request_start();
-
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    goto end;
+    return;
   }
 
   tlib_php_request_eval(
@@ -583,7 +588,6 @@ static void test_scenario_6_repeated_failure() {
 
   nr_free(filename);
 
-end:
   tlib_php_request_end();
 }
 
@@ -638,12 +642,8 @@ static void test_ignore_transaction_discards_unsent_scan() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
-  reset_entry_between_scenarios();
-  tlib_php_request_start();
-
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    tlib_php_request_end();
     return;
   }
 
@@ -690,12 +690,8 @@ static void test_set_appname_discards_unsent_scan() {
   char* filename;
   nr_composer_thread_entry_t* entry;
 
-  reset_entry_between_scenarios();
-  tlib_php_request_start();
-
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    tlib_php_request_end();
     return;
   }
 
@@ -766,14 +762,10 @@ static void test_ignore_transaction_preserves_already_sent_scan() {
   nr_composer_thread_entry_t* entry;
   nr_php_packages_t* packages_after_first_send;
 
-  reset_entry_between_scenarios();
-
   /* Request 1: plain scan, plain (non-ignored) end -- pull + mark-sent run
    * normally. */
-  tlib_php_request_start();
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    tlib_php_request_end();
     return;
   }
 
@@ -836,13 +828,9 @@ static void test_set_appname_preserves_already_sent_scan() {
   nr_composer_thread_entry_t* entry;
   nr_php_packages_t* packages_after_first_send;
 
-  reset_entry_between_scenarios();
-
   /* Request 1: plain scan, plain (non-ignored) end. */
-  tlib_php_request_start();
-  entry = require_live_entry();
+  entry = start_fresh_request();
   if (NULL == entry) {
-    tlib_php_request_end();
     return;
   }
 
@@ -945,6 +933,132 @@ static void test_set_appname_preserves_already_sent_scan() {
   tlib_php_request_end();
 }
 
+/*
+ * Scenarios 11 and 12 both drive nr_composer_handle_autoload()'s no-txn
+ * branch by directly controlling the one condition it actually checks
+ * (NULL != NRPRG(txn)), rather than reverse-engineering a real RINIT
+ * failure to produce it. The latter was tried first and worked, but
+ * depended on internal call-ordering inside nr_php_txn_begin()/
+ * nr_agent_find_or_add_app() (e.g. which validation check runs before
+ * which) that isn't a documented contract -- a future reordering there
+ * could silently invalidate the setup without touching anything this
+ * file is actually meant to cover. Temporarily nulling NRPRG(txn) around
+ * the call under test has no such dependency: the request itself is
+ * completely normal (real txn, real already-connected default app);
+ * only the one pointer the function under test reads is hidden from it,
+ * for exactly the duration of that call, then restored before the
+ * request ends so RSHUTDOWN tears down the real txn correctly.
+ */
+
+/*
+ * Scenario 11: the no-txn lookup finds an app, exercising
+ * nr_composer_find_app_no_txn() and the immediate lock/unlock around
+ * nr_app_get_or_create_thread_composer_entry() in
+ * nr_composer_handle_autoload()'s no-txn branch. The default app is
+ * already registered by this same request's own (untouched) RINIT, so
+ * nr_composer_find_app_no_txn()'s identity resolution (NULL appnames ->
+ * NRINI(appnames)) finds it the same way any already-known app would be
+ * found in production -- connection state plays no part in that lookup.
+ */
+static void test_no_txn_scan_finds_app() {
+  char* filename;
+  nrtxn_t* saved_txn;
+  nr_composer_thread_entry_t* entry;
+
+  entry = start_fresh_request();
+  if (NULL == entry) {
+    return;
+  }
+
+  saved_txn = NRPRG(txn);
+  NRPRG(txn) = NULL;
+
+  tlib_php_request_eval(one_package_stub);
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+
+  NRPRG(txn) = saved_txn;
+  tlib_php_request_end();
+
+  /* entry lives on the app's composer_map, keyed by (app, tid) -- not on
+   * the txn object -- so it's still the exact same entry the no-txn call
+   * above just wrote to, whether reached via NRPRG(txn)->composer_info.entry
+   * (before it was nulled) or via nr_composer_find_app_no_txn() (during
+   * the call itself). */
+  tlib_pass_if_int_equal(
+      "no-txn scan collects successfully via nr_composer_find_app_no_txn",
+      (int)NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED, (int)entry->status);
+  tlib_pass_if_not_null("no-txn scan installs packages", entry->packages);
+  tlib_pass_if_uint64_t_equal("no-txn scan bumps epoch to 1", 1, entry->epoch);
+  {
+    nr_php_package_t* package
+        = nr_php_packages_get_package(entry->packages, "vendor/package");
+    tlib_pass_if_not_null("the no-txn-scanned package is present", package);
+    tlib_pass_if_str_equal(
+        "the no-txn-scanned package's version is captured", "1.2.3",
+        NULL == package ? NULL : package->package_version);
+  }
+}
+
+/*
+ * Scenario 12: the no-txn lookup finds nothing -- nr_composer_find_app_no_txn()
+ * returns NULL, so nr_composer_handle_autoload() must hit its NULL-entry
+ * no-op (logs at debug, frees vendor_path, returns) rather than crash or
+ * fabricate an entry from nothing.
+ *
+ * NRINI(appnames) is temporarily overridden to a never-before-used name
+ * for the duration of the call under test -- nr_composer_find_app_no_txn()
+ * falls back to NRINI(appnames) when given no explicit override, same as
+ * production. Since that identity has never been registered by any
+ * create_new_app() call, nr_app_find_locked() finds nothing -- the same
+ * outcome as a real request whose nr_php_txn_begin() bails before ever
+ * reaching app creation (e.g. a per-request newrelic.enabled=0, or no
+ * daemon connection yet) on a thread where no other request has resolved
+ * this identity either.
+ */
+static char* const no_txn_scratch_appname = "NoTxnScratchApp";
+
+static void test_no_txn_scan_finds_no_app() {
+  char* filename;
+  char* original_appnames;
+  nrtxn_t* saved_txn;
+  nr_composer_thread_entry_t* entry;
+
+  entry = start_fresh_request();
+  if (NULL == entry) {
+    return;
+  }
+
+  original_appnames = NRINI(appnames);
+  NRINI(appnames) = no_txn_scratch_appname;
+
+  saved_txn = NRPRG(txn);
+  NRPRG(txn) = NULL;
+
+  tlib_php_request_eval(one_package_stub);
+  filename = autoload_filename();
+  nr_composer_handle_autoload(filename);
+  nr_free(filename);
+
+  NRPRG(txn) = saved_txn;
+  NRINI(appnames) = original_appnames;
+  tlib_php_request_end();
+
+  /* No crash getting here, plus the default app's own entry (captured
+   * above, before the no-txn call) being completely untouched, is this
+   * scenario's whole point -- the no-txn lookup above resolved a
+   * different, nonexistent identity and never found anything to write
+   * into. */
+  tlib_pass_if_int_equal(
+      "the default app's entry is untouched by the failed lookup",
+      (int)NR_COMPOSER_API_STATUS_UNSET, (int)entry->status);
+  tlib_pass_if_null("the default app's entry still has no packages",
+                    entry->packages);
+  tlib_pass_if_uint64_t_equal("the default app's entry is still at epoch 0",
+                             0, entry->epoch);
+}
+
 void test_main(void* p NRUNUSED) {
   tlib_php_engine_create("");
   create_vendor_dir();
@@ -960,6 +1074,9 @@ void test_main(void* p NRUNUSED) {
   test_set_appname_discards_unsent_scan();
   test_ignore_transaction_preserves_already_sent_scan();
   test_set_appname_preserves_already_sent_scan();
+
+  test_no_txn_scan_finds_app();
+  test_no_txn_scan_finds_no_app();
 
   remove_vendor_dir();
   tlib_php_engine_destroy();

--- a/agent/tests/test_php_txn.c
+++ b/agent/tests/test_php_txn.c
@@ -6,6 +6,7 @@
 #include "tlib_php.h"
 
 #include "php_agent.h"
+#include "php_globals.h"
 #include "php_txn_private.h"
 
 #define LIBRARY_NAME "vendor_name/package_name"
@@ -16,6 +17,10 @@
 #define COMPOSER_MAJOR_VERSION "2"
 #define PACKAGE_METRIC_PREFIX "Supportability/PHP/package/"
 #define PACKAGE_METRIC PACKAGE_METRIC_PREFIX LIBRARY_NAME
+/* nr_php_use_license() requires exactly NR_LICENSE_SIZE (40) characters or
+ * it returns NULL regardless of input -- this is a valid-length stand-in,
+ * not a real license. */
+#define TEST_LICENSE "0123456789012345678901234567890123456789"
 
 tlib_parallel_info_t parallel_info = {.suggested_nthreads = 1, .state_size = 0};
 
@@ -299,9 +304,81 @@ static void test_nr_php_txn_create_packages_major_metrics() {
 }
 
 
+static void test_nr_php_txn_populate_app_info_identity() {
+  nr_app_info_t info;
+
+  tlib_php_request_start();
+
+  /* Test : NULL info doesn't crash. */
+  nr_php_txn_populate_app_info_identity(NULL, "myapp", TEST_LICENSE);
+
+  /* Test : explicit non-empty appnames/license pass through unchanged. */
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, "myapp", TEST_LICENSE);
+  tlib_pass_if_str_equal("explicit appname used", "myapp", info.appname);
+  tlib_pass_if_str_equal("explicit license used", TEST_LICENSE, info.license);
+  nr_app_info_destroy_fields(&info);
+
+  /* Test : NULL/empty appnames falls back to NRINI(appnames). */
+  NRINI(appnames) = "inidefault";
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, NULL, TEST_LICENSE);
+  tlib_pass_if_str_equal("appname falls back to INI", "inidefault",
+                        info.appname);
+  nr_app_info_destroy_fields(&info);
+
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, "", TEST_LICENSE);
+  tlib_pass_if_str_equal("empty appname falls back to INI", "inidefault",
+                        info.appname);
+  nr_app_info_destroy_fields(&info);
+
+  /* Test : unresolvable license leaves info.license NULL, but the other
+   * required fields are still all populated -- the regression guard for
+   * the historical bug this whole extraction is named after. */
+  NRINI(license) = NULL;
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, "myapp", NULL);
+  tlib_pass_if_null("unresolvable license is NULL", info.license);
+  tlib_pass_if_not_null("environment still populated", info.environment);
+  tlib_pass_if_not_null("lang still populated", info.lang);
+  tlib_pass_if_not_null("version still populated", info.version);
+  tlib_pass_if_not_null("redirect_collector still populated",
+                       info.redirect_collector);
+  nr_app_info_destroy_fields(&info);
+
+  /* Test : high_security is copied through. */
+  NR_PHP_PROCESS_GLOBALS(high_security) = 1;
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, "myapp", TEST_LICENSE);
+  tlib_pass_if_true("high_security copied through", info.high_security,
+                    "expected high_security to be set");
+  NR_PHP_PROCESS_GLOBALS(high_security) = 0;
+  nr_app_info_destroy_fields(&info);
+
+  /* Test : trace_observer_host is DT-gated. */
+  NRINI(distributed_tracing_enabled) = 1;
+  NRINI(trace_observer_host) = "observer.example.com";
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, "myapp", TEST_LICENSE);
+  tlib_pass_if_str_equal("trace_observer_host copied when DT enabled",
+                        "observer.example.com", info.trace_observer_host);
+  nr_app_info_destroy_fields(&info);
+
+  NRINI(distributed_tracing_enabled) = 0;
+  nr_memset(&info, 0, sizeof(info));
+  nr_php_txn_populate_app_info_identity(&info, "myapp", TEST_LICENSE);
+  tlib_pass_if_str_equal("trace_observer_host empty when DT disabled", "",
+                        info.trace_observer_host);
+  nr_app_info_destroy_fields(&info);
+
+  tlib_php_request_end();
+}
+
 void test_main(void* p NRUNUSED) {
   tlib_php_engine_create("");
   test_nr_php_txn_php_package_create_major_metric();
   test_nr_php_txn_create_packages_major_metrics();
+  test_nr_php_txn_populate_app_info_identity();
   tlib_php_engine_destroy();
 }

--- a/agent/tests/test_php_txn.c
+++ b/agent/tests/test_php_txn.c
@@ -88,6 +88,7 @@ static void test_nr_php_txn_create_packages_major_metrics() {
   txn->unscoped_metrics = nrm_table_create(10);
   txn->php_packages = nr_php_packages_create();
   txn->php_package_major_version_metrics_suggestions = nr_php_packages_create();
+  txn->composer_info.entry = NULL;
 
   tlib_php_request_start();
 
@@ -250,6 +251,44 @@ static void test_nr_php_txn_create_packages_major_metrics() {
       nrm_find(txn->unscoped_metrics,
                PACKAGE_METRIC "/" LIBRARY_MAJOR_VERSION "/detected"));
 
+  /* reset everything */
+  nrm_table_destroy(&txn->unscoped_metrics);
+  txn->unscoped_metrics = nrm_table_create(10);
+  nr_php_packages_destroy(&txn->php_packages);
+  txn->php_packages = nr_php_packages_create();
+  nr_php_packages_destroy(&txn->php_package_major_version_metrics_suggestions);
+  txn->php_package_major_version_metrics_suggestions = nr_php_packages_create();
+
+  /* 10. package missing from txn->php_packages but present in this
+   * thread's own composer scan cache (txn->composer_info.entry->packages):
+   * the metric should fall back to the cache's version instead of the
+   * suggestion's
+   */
+  {
+    nr_composer_thread_entry_t composer_entry = {0};
+
+    composer_entry.packages = nr_php_packages_create();
+    nr_php_packages_add_package(composer_entry.packages,
+                                nr_php_package_create_with_source(
+                                    LIBRARY_NAME, COMPOSER_PACKAGE_VERSION,
+                                    NR_PHP_PACKAGE_SOURCE_COMPOSER));
+    txn->composer_info.entry = &composer_entry;
+
+    nr_txn_suggest_package_supportability_metric(txn, LIBRARY_NAME,
+                                                 LIBRARY_VERSION);
+    nr_php_txn_create_packages_major_metrics(txn);
+    tlib_pass_if_int_equal(
+        "package only in composer scan cache, metric created", 1,
+        nrm_table_size(txn->unscoped_metrics));
+    tlib_pass_if_not_null(
+        "composer scan cache's version is used for 'detected' metric when "
+        "txn->php_packages does not have the package",
+        nrm_find(txn->unscoped_metrics,
+                 PACKAGE_METRIC "/" COMPOSER_MAJOR_VERSION "/detected"));
+
+    txn->composer_info.entry = NULL;
+    nr_php_packages_destroy(&composer_entry.packages);
+  }
 
   /* cleanup */
   nr_php_packages_destroy(&txn->php_packages);

--- a/agent/tests/test_php_txn.c
+++ b/agent/tests/test_php_txn.c
@@ -261,8 +261,8 @@ static void test_nr_php_txn_create_packages_major_metrics() {
 
   /* 10. package missing from txn->php_packages but present in this
    * thread's own composer scan cache (txn->composer_info.entry->packages):
-   * the metric should fall back to the cache's version instead of the
-   * suggestion's
+   * the cache is never consulted for this, so the metric falls back to the
+   * suggestion's own version instead of the cache's
    */
   {
     nr_composer_thread_entry_t composer_entry = {0};
@@ -281,10 +281,10 @@ static void test_nr_php_txn_create_packages_major_metrics() {
         "package only in composer scan cache, metric created", 1,
         nrm_table_size(txn->unscoped_metrics));
     tlib_pass_if_not_null(
-        "composer scan cache's version is used for 'detected' metric when "
-        "txn->php_packages does not have the package",
+        "composer scan cache is not consulted, so the suggestion's own "
+        "version is used for 'detected' metric",
         nrm_find(txn->unscoped_metrics,
-                 PACKAGE_METRIC "/" COMPOSER_MAJOR_VERSION "/detected"));
+                 PACKAGE_METRIC "/" LIBRARY_MAJOR_VERSION "/detected"));
 
     txn->composer_info.entry = NULL;
     nr_php_packages_destroy(&composer_entry.packages);

--- a/axiom/Makefile
+++ b/axiom/Makefile
@@ -90,6 +90,7 @@ OBJS := \
 	nr_app_harvest.o \
 	nr_app_harvest_map.o \
 	nr_app_rnd_map.o \
+	nr_app_composer_map.o \
 	nr_attributes.o \
 	nr_banner.o \
 	nr_configstrings.o \

--- a/axiom/nr_app.c
+++ b/axiom/nr_app.c
@@ -303,8 +303,8 @@ static nrapp_t* create_new_app(const nr_app_info_t* info) {
       = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_harvest_stats_dtor);
   app->rnd_map
       = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
-  app->composer_map = nr_hashmap_create(
-      (nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+  app->composer_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_entry_dtor);
 
   nrt_mutex_init(&app->app_lock, 0);
   nrt_mutex_lock(&app->app_lock);
@@ -361,6 +361,46 @@ static int nr_app_info_valid(const nr_app_info_t* info) {
   return 1;
 }
 
+/* internal, assumes applist->applist_lock already held by caller */
+static nrapp_t* nr_app_find_matching_locked(nrapplist_t* applist,
+                                            const nr_app_info_t* info) {
+  int i;
+  int num_apps;
+
+  if (NULL == applist) {
+    return NULL;
+  }
+
+  num_apps = applist->num_apps;
+
+  for (i = 0; i < num_apps; i++) {
+    nrapp_t* test_app = applist->apps[i];
+
+    if (NULL != test_app) {
+      nrt_mutex_lock(&test_app->app_lock);
+      if (NR_SUCCESS == nr_app_match(test_app, info)) {
+        return test_app; /* returned locked */
+      }
+      nrt_mutex_unlock(&test_app->app_lock);
+    }
+  }
+  return NULL;
+}
+
+nrapp_t* nr_app_find_locked(nrapplist_t* applist, const nr_app_info_t* info) {
+  nrapp_t* app;
+
+  if (0 == nr_app_info_valid(info) || NULL == applist) {
+    return NULL;
+  }
+
+  nrt_mutex_lock(&applist->applist_lock);
+  app = nr_app_find_matching_locked(applist, info);
+  nrt_mutex_unlock(&applist->applist_lock);
+
+  return app; /* app->app_lock still held if non-NULL; caller must unlock */
+}
+
 nrapp_t* nr_app_find_or_add_app(nrapplist_t* applist,
                                 const nr_app_info_t* info) {
   nrapp_t* app = 0;
@@ -374,30 +414,12 @@ nrapp_t* nr_app_find_or_add_app(nrapplist_t* applist,
 
   nrt_mutex_lock(&applist->applist_lock);
   {
-    int i;
     int num_apps = applist->num_apps;
 
     /*
      * Search for the application.
      */
-    app = 0;
-    for (i = 0; i < num_apps; i++) {
-      nrapp_t* test_app = applist->apps[i];
-
-      if (0 != test_app) {
-        nrt_mutex_lock(&test_app->app_lock);
-        {
-          if (NR_SUCCESS == nr_app_match(test_app, info)) {
-            /*
-             * The app is returned locked.
-             */
-            app = test_app;
-            break;
-          }
-        }
-        nrt_mutex_unlock(&test_app->app_lock);
-      }
-    }
+    app = nr_app_find_matching_locked(applist, info);
 
     if (app) {
       /*

--- a/axiom/nr_app.c
+++ b/axiom/nr_app.c
@@ -336,6 +336,24 @@ static void nr_app_log_high_security_mismatch(const char* appname) {
   }
 }
 
+static void nr_app_log_high_security_mismatch_on_find(const char* appname) {
+  static int last_warn = 0;
+  time_t now = time(0);
+
+  if ((now - last_warn) > NR_APP_LOG_HIGH_SECURITY_MISMATCH_BACKOFF_SECONDS) {
+    last_warn = now;
+    nrl_error(
+        NRL_DAEMON,
+        "found app=" NRP_FMT
+        " but it has a different high security "
+        "setting than an existing app with the same name.  "
+        "Please ensure that all of your PHP ini files have the same "
+        "newrelic.high_security value then restart your web servers and the "
+        "newrelic-daemon.",
+        NRP_APPNAME(appname ? appname : "<unknown>"));
+  }
+}
+
 static int nr_app_info_valid(const nr_app_info_t* info) {
   if (NULL == info) {
     return 0;
@@ -397,6 +415,15 @@ nrapp_t* nr_app_find_locked(nrapplist_t* applist, const nr_app_info_t* info) {
   nrt_mutex_lock(&applist->applist_lock);
   app = nr_app_find_matching_locked(applist, info);
   nrt_mutex_unlock(&applist->applist_lock);
+
+  if (NULL != app && info->high_security != app->info.high_security) {
+    /* Mirrors the check in nr_app_find_or_add_app(): a license+appname
+     * match with a different high_security setting means this is a
+     * different app, not this one. */
+    nr_app_log_high_security_mismatch_on_find(info->appname);
+    nrt_mutex_unlock(&app->app_lock);
+    app = NULL;
+  }
 
   return app; /* app->app_lock still held if non-NULL; caller must unlock */
 }

--- a/axiom/nr_app.c
+++ b/axiom/nr_app.c
@@ -96,6 +96,24 @@ void nr_app_info_destroy_fields(nr_app_info_t* info) {
   nr_free(info->docker_id);
 }
 
+void nr_app_tid_maps_evict(nrapp_t* app, uint64_t tid) {
+  if (NULL == app) {
+    return;
+  }
+  nr_hashmap_index_delete(app->harvest_map, tid);
+  nr_hashmap_index_delete(app->rnd_map, tid);
+  nr_hashmap_index_delete(app->composer_map, tid);
+}
+
+void nr_app_tid_maps_destroy(nrapp_t* app) {
+  if (NULL == app) {
+    return;
+  }
+  nr_hashmap_destroy(&app->harvest_map);
+  nr_hashmap_destroy(&app->rnd_map);
+  nr_hashmap_destroy(&app->composer_map);
+}
+
 /*
  * Purpose : Destroy an application freeing all of its associated memory.
  *
@@ -126,8 +144,7 @@ void nr_app_destroy(nrapp_t** app_ptr) {
   nr_segment_terms_destroy(&app->segment_terms);
   nro_delete(app->connect_reply);
   nro_delete(app->security_policies);
-  nr_hashmap_destroy(&app->harvest_map);
-  nr_hashmap_destroy(&app->rnd_map);
+  nr_app_tid_maps_destroy(app);
 
   nrt_mutex_unlock(&app->app_lock);
   nrt_mutex_destroy(&app->app_lock);

--- a/axiom/nr_app.c
+++ b/axiom/nr_app.c
@@ -286,6 +286,8 @@ static nrapp_t* create_new_app(const nr_app_info_t* info) {
       = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_harvest_stats_dtor);
   app->rnd_map
       = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
+  app->composer_map = nr_hashmap_create(
+      (nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
 
   nrt_mutex_init(&app->app_lock, 0);
   nrt_mutex_lock(&app->app_lock);

--- a/axiom/nr_app.h
+++ b/axiom/nr_app.h
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 
 #include "nr_app_harvest.h"
+#include "nr_php_packages.h"
 #include "nr_rules.h"
 #include "nr_segment_terms.h"
 #include "util_hashmap.h"
@@ -234,6 +235,22 @@ extern nrapp_t* nr_agent_find_or_add_app(nrapplist_t* applist,
                                          nrtime_t timeout);
 
 /*
+ * Purpose : Search for an existing application matching the given app
+ *           info, without creating one if no match is found.
+ *
+ * Params  : 1. The application list unlocked.
+ *           2. The application information.
+ *
+ * Returns : A pointer to the locked matching application, or NULL if no
+ *           match was found or the parameters were invalid.
+ *
+ * Locking : Returns the application locked, if one is returned; the caller
+ *           must unlock it.
+ */
+extern nrapp_t* nr_app_find_locked(nrapplist_t* applist,
+                                   const nr_app_info_t* info);
+
+/*
  * Purpose : Create and return a sanitized/obfuscated version of the license
  *           for use in the phpinfo and log files.
  *
@@ -377,8 +394,8 @@ extern nr_random_t* nr_app_get_or_create_thread_rnd(nrapp_t* app,
 /*
  * Composer package-detection status for a single (app, thread) attempt.
  * Lives here (not nr_txn.h) because nr_txn.h includes nr_app.h, and this
- * type is now returned by nr_app_get_or_create_thread_composer_status()
- * below.
+ * type is now embedded in nr_composer_thread_entry_t, returned by
+ * nr_app_get_or_create_thread_composer_entry() below.
  */
 typedef enum {
   NR_COMPOSER_API_STATUS_UNSET = 0,
@@ -390,25 +407,49 @@ typedef enum {
 } nr_composer_api_status_t;
 
 /*
- * Purpose : Destructor for nr_composer_api_status_t values stored in
- *           composer_map. For use as nr_hashmap_create dtor argument.
- *
- * Params  : 1. The status pointer to free.
+ * Per-(app, thread) Composer detection state, stored in composer_map.
+ * status/packages/epoch/last_sent_epoch are only safe to mutate under
+ * app->app_lock.
  */
-extern void nr_app_composer_status_dtor(nr_composer_api_status_t* status);
+typedef struct {
+  nr_composer_api_status_t status; /* unchanged semantics: gates whether a
+                                       scan is attempted at all */
+  nr_php_packages_t* packages;     /* latest known snapshot; NULL until
+                                       first successful scan; never
+                                       destroyed as part of send/consume,
+                                       only on rescan-overwrite or eviction */
+  uint64_t epoch;                  /* bumped every time `packages` is
+                                       overwritten by a scan */
+  uint64_t last_sent_epoch;        /* epoch as of the last txn that reached
+                                       the transmit call with this epoch
+                                       still current (i.e. no newer scan had
+                                       overwritten `packages` since that txn
+                                       pulled); bumped unconditionally at
+                                       that point regardless of transmit
+                                       success/failure -- NOT gated on
+                                       confirmed delivery */
+} nr_composer_thread_entry_t;
 
 /*
- * Purpose : Return the Composer detection status for the calling thread,
- *           creating an entry initialized to NR_COMPOSER_API_STATUS_UNSET
- *           if this thread has not been seen before. Must be called with
- *           app->app_lock held.
+ * Purpose : Destructor for nr_composer_thread_entry_t values stored in
+ *           composer_map. For use as nr_hashmap_create dtor argument.
+ *
+ * Params  : 1. The entry pointer to free.
+ */
+extern void nr_app_composer_entry_dtor(nr_composer_thread_entry_t* entry);
+
+/*
+ * Purpose : Return the Composer detection entry for the calling thread,
+ *           creating one initialized to NR_COMPOSER_API_STATUS_UNSET (with
+ *           no packages, epoch 0, last_sent_epoch 0) if this thread has not
+ *           been seen before. Must be called with app->app_lock held.
  *
  * Params  : 1. The application.
  *           2. The thread key: (uint64_t)nr_gettid().
  *
- * Returns : Pointer to the per-thread status, or NULL on allocation failure.
+ * Returns : Pointer to the per-thread entry, or NULL on allocation failure.
  */
-extern nr_composer_api_status_t* nr_app_get_or_create_thread_composer_status(
+extern nr_composer_thread_entry_t* nr_app_get_or_create_thread_composer_entry(
     nrapp_t* app,
     uint64_t key);
 

--- a/axiom/nr_app.h
+++ b/axiom/nr_app.h
@@ -355,4 +355,19 @@ extern void nr_app_rnd_dtor(nr_random_t* rnd);
 extern nr_random_t* nr_app_get_or_create_thread_rnd(nrapp_t* app,
                                                      uint64_t key);
 
+/*
+ * Composer package-detection status for a single (app, thread) attempt.
+ * Lives here (not nr_txn.h) because nr_txn.h includes nr_app.h, and this
+ * type is now returned by nr_app_get_or_create_thread_composer_status()
+ * below.
+ */
+typedef enum {
+  NR_COMPOSER_API_STATUS_UNSET = 0,
+  NR_COMPOSER_API_STATUS_INVALID_USE = 1,
+  NR_COMPOSER_API_STATUS_INIT_FAILURE = 2,
+  NR_COMPOSER_API_STATUS_CALL_FAILURE = 3,
+  NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED = 4,
+  NR_COMPOSER_API_STATUS_INVALID_RESULT = 5,
+} nr_composer_api_status_t;
+
 #endif /* NR_APP_HDR */

--- a/axiom/nr_app.h
+++ b/axiom/nr_app.h
@@ -409,10 +409,18 @@ typedef enum {
 /*
  * Per-(app, thread) Composer detection state, stored in composer_map.
  * status/packages/epoch/last_sent_epoch are only safe to mutate under
- * app->app_lock. One lock-free exception: a txn's own read/mark-sent of
- * its own entry's epoch/packages/last_sent_epoch via
- * nr_txn_pull_composer_packages()/nr_txn_mark_composer_packages_sent() —
- * see nr_txn.h for why that same-owning-thread path needs no lock.
+ * app->app_lock. Two lock-free exceptions, both resting on the same
+ * same-owning-thread-only invariant (an entry is keyed by
+ * (uint64_t)nr_gettid(), so no thread other than the one that owns it ever
+ * touches it):
+ *   1. A txn's own read/mark-sent of its own entry's epoch/packages/
+ *      last_sent_epoch via nr_txn_pull_composer_packages()/
+ *      nr_txn_mark_composer_packages_sent() — see nr_txn.h for why that
+ *      path needs no lock.
+ *   2. The Composer-scan write in nr_composer_handle_autoload()
+ *      (agent/lib_composer.c), which mutates status/packages/epoch once it
+ *      has resolved the entry (with or without a txn) — see the comment at
+ *      that write site for why that path needs no lock either.
  */
 typedef struct {
   nr_composer_api_status_t status; /* unchanged semantics: gates whether a

--- a/axiom/nr_app.h
+++ b/axiom/nr_app.h
@@ -124,12 +124,31 @@ typedef struct _nrapp_t {
   nr_app_harvest_config_t adaptive_sampling_config; /* Adaptive sampling config
                                                        from daemon; updated on
                                                        every appinfo reply */
-  nr_hashmap_t* harvest_map;                        /* Per-thread harvest stats,
-                                                       keyed by
-                                                       (uint64_t)nr_gettid() */
-  nr_hashmap_t* rnd_map;                            /* Per-thread RNG state,
-                                                       keyed by
-                                                       (uint64_t)nr_gettid() */
+
+  /*
+   * The following fields are per-thread state, keyed by (uint64_t)nr_gettid().
+   * Each holds one entry per thread that has touched this app.
+   *
+   * Concurrency contract:
+   *  - app_lock MUST be held around get-or-create (map insert) for all three —
+   *    the hashmap's internal structure is not thread-safe against concurrent
+   *    inserts of *different* keys by *different* threads.
+   *  - Reading/writing an already-fetched entry's VALUE is lock-free IFF no
+   *    code path ever mutates a different thread's entry:
+   *      - rnd_map: lock-free-safe. No cross-thread mutator exists.
+   *      - composer_map: lock-free-safe as of this writing. If a
+   *        reconnect-triggered reset is ever added for this field, this
+   *        breaks — re-audit every access site under app_lock at that point.
+   *      - harvest_map: NOT lock-free-safe. nr_app_update_harvest_config()
+   *        resets every thread's entry on connect/reconnect via
+   *        nr_hashmap_apply(), a cross-thread mutation. Do not add lock-free
+   *        value access for this field without accounting for that reset.
+   *  - Moral: don't copy the lock-free pattern from one field to another
+   *    without checking whether THAT field has a bulk cross-thread mutator.
+   */
+  nr_hashmap_t* harvest_map;
+  nr_hashmap_t* rnd_map;
+  nr_hashmap_t* composer_map;
 
   /* The limits are set based on the event harvest configuration provided in
    * the connect reply. They do not reflect any agent side configuration.
@@ -369,5 +388,37 @@ typedef enum {
   NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED = 4,
   NR_COMPOSER_API_STATUS_INVALID_RESULT = 5,
 } nr_composer_api_status_t;
+
+/*
+ * Purpose : Destructor for nr_composer_api_status_t values stored in
+ *           composer_map. For use as nr_hashmap_create dtor argument.
+ *
+ * Params  : 1. The status pointer to free.
+ */
+extern void nr_app_composer_status_dtor(nr_composer_api_status_t* status);
+
+/*
+ * Purpose : Return the Composer detection status for the calling thread,
+ *           creating an entry initialized to NR_COMPOSER_API_STATUS_UNSET
+ *           if this thread has not been seen before. Must be called with
+ *           app->app_lock held.
+ *
+ * Params  : 1. The application.
+ *           2. The thread key: (uint64_t)nr_gettid().
+ *
+ * Returns : Pointer to the per-thread status, or NULL on allocation failure.
+ */
+extern nr_composer_api_status_t* nr_app_get_or_create_thread_composer_status(
+    nrapp_t* app,
+    uint64_t key);
+
+/*
+ * Purpose : Remove one thread's entry from harvest_map, rnd_map, and
+ *           composer_map. Call when a thread exits, under app->app_lock.
+ *
+ * Params  : 1. The application.
+ *           2. The thread key: (uint64_t)nr_gettid().
+ */
+extern void nr_app_tid_maps_evict(nrapp_t* app, uint64_t tid);
 
 #endif /* NR_APP_HDR */

--- a/axiom/nr_app.h
+++ b/axiom/nr_app.h
@@ -409,7 +409,10 @@ typedef enum {
 /*
  * Per-(app, thread) Composer detection state, stored in composer_map.
  * status/packages/epoch/last_sent_epoch are only safe to mutate under
- * app->app_lock.
+ * app->app_lock. One lock-free exception: a txn's own read/mark-sent of
+ * its own entry's epoch/packages/last_sent_epoch via
+ * nr_txn_pull_composer_packages()/nr_txn_mark_composer_packages_sent() —
+ * see nr_txn.h for why that same-owning-thread path needs no lock.
  */
 typedef struct {
   nr_composer_api_status_t status; /* unchanged semantics: gates whether a

--- a/axiom/nr_app.h
+++ b/axiom/nr_app.h
@@ -409,7 +409,7 @@ typedef enum {
 /*
  * Per-(app, thread) Composer detection state, stored in composer_map.
  * status/packages/epoch/last_sent_epoch are only safe to mutate under
- * app->app_lock. Two lock-free exceptions, both resting on the same
+ * app->app_lock. Three lock-free exceptions, all resting on the same
  * same-owning-thread-only invariant (an entry is keyed by
  * (uint64_t)nr_gettid(), so no thread other than the one that owns it ever
  * touches it):
@@ -421,6 +421,9 @@ typedef enum {
  *      (agent/lib_composer.c), which mutates status/packages/epoch once it
  *      has resolved the entry (with or without a txn) — see the comment at
  *      that write site for why that path needs no lock either.
+ *   3. A discarded txn's advance of its own entry's last_sent_epoch via
+ *      nr_txn_discard_composer_packages() — see nr_txn.h for why that path
+ *      needs no lock either; same rationale as exception 1.
  */
 typedef struct {
   nr_composer_api_status_t status; /* unchanged semantics: gates whether a

--- a/axiom/nr_app_composer_map.c
+++ b/axiom/nr_app_composer_map.c
@@ -6,36 +6,41 @@
 #include "nr_axiom.h"
 
 #include "nr_app.h"
+#include "nr_php_packages.h"
 #include "util_hashmap.h"
 #include "util_memory.h"
 
-void nr_app_composer_status_dtor(nr_composer_api_status_t* status) {
-  nr_free(status);
+void nr_app_composer_entry_dtor(nr_composer_thread_entry_t* entry) {
+  if (NULL == entry) {
+    return;
+  }
+  nr_php_packages_destroy(&entry->packages);
+  nr_free(entry);
 }
 
-nr_composer_api_status_t* nr_app_get_or_create_thread_composer_status(
+nr_composer_thread_entry_t* nr_app_get_or_create_thread_composer_entry(
     nrapp_t* app,
     uint64_t key) {
-  nr_composer_api_status_t* status;
+  nr_composer_thread_entry_t* entry;
 
   if (NULL == app || NULL == app->composer_map) {
     return NULL;
   }
 
-  status
-      = (nr_composer_api_status_t*)nr_hashmap_index_get(app->composer_map, key);
-  if (status) {
-    return status;
+  entry = (nr_composer_thread_entry_t*)nr_hashmap_index_get(app->composer_map,
+                                                            key);
+  if (entry) {
+    return entry;
   }
 
-  status
-      = (nr_composer_api_status_t*)nr_malloc(sizeof(nr_composer_api_status_t));
-  *status = NR_COMPOSER_API_STATUS_UNSET;
+  entry = (nr_composer_thread_entry_t*)nr_zalloc(
+      sizeof(nr_composer_thread_entry_t));
+  entry->status = NR_COMPOSER_API_STATUS_UNSET;
 
-  if (NR_SUCCESS != nr_hashmap_index_set(app->composer_map, key, status)) {
-    nr_free(status);
+  if (NR_SUCCESS != nr_hashmap_index_set(app->composer_map, key, entry)) {
+    nr_free(entry);
     return NULL;
   }
 
-  return status;
+  return entry;
 }

--- a/axiom/nr_app_composer_map.c
+++ b/axiom/nr_app_composer_map.c
@@ -22,14 +22,14 @@ nr_composer_api_status_t* nr_app_get_or_create_thread_composer_status(
     return NULL;
   }
 
-  status = (nr_composer_api_status_t*)nr_hashmap_index_get(
-      app->composer_map, key);
+  status
+      = (nr_composer_api_status_t*)nr_hashmap_index_get(app->composer_map, key);
   if (status) {
     return status;
   }
 
-  status = (nr_composer_api_status_t*)nr_malloc(
-      sizeof(nr_composer_api_status_t));
+  status
+      = (nr_composer_api_status_t*)nr_malloc(sizeof(nr_composer_api_status_t));
   *status = NR_COMPOSER_API_STATUS_UNSET;
 
   if (NR_SUCCESS != nr_hashmap_index_set(app->composer_map, key, status)) {

--- a/axiom/nr_app_composer_map.c
+++ b/axiom/nr_app_composer_map.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nr_axiom.h"
+
+#include "nr_app.h"
+#include "util_hashmap.h"
+#include "util_memory.h"
+
+void nr_app_composer_status_dtor(nr_composer_api_status_t* status) {
+  nr_free(status);
+}
+
+nr_composer_api_status_t* nr_app_get_or_create_thread_composer_status(
+    nrapp_t* app,
+    uint64_t key) {
+  nr_composer_api_status_t* status;
+
+  if (NULL == app || NULL == app->composer_map) {
+    return NULL;
+  }
+
+  status = (nr_composer_api_status_t*)nr_hashmap_index_get(
+      app->composer_map, key);
+  if (status) {
+    return status;
+  }
+
+  status = (nr_composer_api_status_t*)nr_malloc(
+      sizeof(nr_composer_api_status_t));
+  *status = NR_COMPOSER_API_STATUS_UNSET;
+
+  if (NR_SUCCESS != nr_hashmap_index_set(app->composer_map, key, status)) {
+    nr_free(status);
+    return NULL;
+  }
+
+  return status;
+}

--- a/axiom/nr_app_private.h
+++ b/axiom/nr_app_private.h
@@ -57,9 +57,9 @@
 extern void nr_app_destroy(nrapp_t** app_ptr);
 
 /*
- * Purpose: White box testing. Do not use except for unit tests — production
- *          code only reaches this via nr_app_destroy (same translation
- *          unit, axiom/nr_app.c).
+ * Purpose: Destroy harvest_map, rnd_map, and composer_map. White box
+ *          testing only — production code only reaches this via
+ *          nr_app_destroy (same translation unit, axiom/nr_app.c).
  */
 extern void nr_app_tid_maps_destroy(nrapp_t* app);
 

--- a/axiom/nr_app_private.h
+++ b/axiom/nr_app_private.h
@@ -56,6 +56,13 @@
  */
 extern void nr_app_destroy(nrapp_t** app_ptr);
 
+/*
+ * Purpose: White box testing. Do not use except for unit tests — production
+ *          code only reaches this via nr_app_destroy (same translation
+ *          unit, axiom/nr_app.c).
+ */
+extern void nr_app_tid_maps_destroy(nrapp_t* app);
+
 extern int nr_agent_should_do_app_daemon_query(const nrapp_t* app, time_t now);
 
 extern nrapp_t* nr_app_find_or_add_app(nrapplist_t* applist,

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3623,6 +3623,27 @@ void nr_txn_pull_composer_packages(nrtxn_t* txn) {
   nr_php_packages_iterate(entry->packages,
                           nr_txn_pull_composer_package_callback, txn);
   txn->composer_info.composer_pull_epoch = entry->epoch;
+
+  /*
+   * The scan that produced this data may have run with no live txn
+   * (FrankenPHP worker-mode bootstrap), in which case its own inline
+   * "detected" metric attempts (agent/lib_composer.c,
+   * agent/php_execute.c) silently no-opped. Fire whichever is still
+   * false on *this* txn -- already-true means this same scan invocation
+   * already fired it earlier in this same request. The epoch gate above
+   * already ensures only one txn per scan reaches this point, so this is
+   * exactly-once-per-scan with no new state. Deliberately read-only on
+   * these flags -- nothing downstream reads them after this point in the
+   * request, so there's nothing to update.
+   */
+  if (false == txn->composer_info.composer_detected) {
+    nrm_force_add(txn->unscoped_metrics,
+                  "Supportability/library/Composer/detected", 0);
+  }
+  if (false == txn->composer_info.autoload_detected) {
+    nrm_force_add(txn->unscoped_metrics,
+                  "Supportability/library/Autoloader/detected", 0);
+  }
 }
 
 /*

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3556,10 +3556,15 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
   }
 
   if (NR_PHP_PACKAGE_SOURCE_LEGACY == source
+      && NULL != txn->composer_info.status
       && NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED
-             == txn->composer_info.api_status) {
+             == *txn->composer_info.status) {
     // don't add packages from legacy source if packages have been detected
-    // using composer runtime api
+    // using composer runtime api. txn->composer_info.status is the same
+    // cached pointer nr_execute_handle_autoload and
+    // nr_composer_handle_autoload will use once later commits in this series
+    // wire them up — see nr_app.h for the locking contract and nr_txn_begin
+    // (this file) for where the fetch will be added.
     return NULL;
   }
 

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3572,9 +3572,8 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
     // don't add packages from legacy source if packages have been detected
     // using composer runtime api. txn->composer_info.status is the same
     // cached pointer nr_execute_handle_autoload and
-    // nr_composer_handle_autoload will use once later commits in this series
-    // wire them up — see nr_app.h for the locking contract and nr_txn_begin
-    // (this file) for where the fetch will be added.
+    // nr_composer_handle_autoload use — see nr_app.h for the locking
+    // contract and nr_txn_begin (this file) for where the fetch happens.
     return NULL;
   }
 

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -457,7 +457,6 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nr_slab_t* segment_slab;
   nr_app_harvest_stats_t* thread_harvest;
   nr_random_t* thread_rnd;
-  nr_composer_api_status_t* thread_composer_status;
   int tid;
 
   if (NULL == app) {
@@ -495,9 +494,8 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
    */
   thread_rnd = nr_app_get_or_create_thread_rnd(app, (uint64_t)tid);
   nt->rnd = thread_rnd;
-  thread_composer_status
-      = nr_app_get_or_create_thread_composer_status(app, (uint64_t)tid);
-  nt->composer_info.status = thread_composer_status;
+  nt->composer_info.entry
+      = nr_app_get_or_create_thread_composer_entry(app, (uint64_t)tid);
   nt->segment_slab = segment_slab;
 
   /*
@@ -3566,12 +3564,12 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
   }
 
   if (NR_PHP_PACKAGE_SOURCE_LEGACY == source
-      && NULL != txn->composer_info.status
+      && NULL != txn->composer_info.entry
       && NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED
-             == *txn->composer_info.status) {
+             == txn->composer_info.entry->status) {
     // don't add packages from legacy source if packages have been detected
-    // using composer runtime api. txn->composer_info.status is the same
-    // cached pointer nr_execute_handle_autoload and
+    // using composer runtime api. txn->composer_info.entry->status is the
+    // same cached entry->status nr_execute_handle_autoload and
     // nr_composer_handle_autoload use — see nr_app.h for the locking
     // contract and nr_txn_begin (this file) for where the fetch happens.
     return NULL;

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3647,6 +3647,23 @@ void nr_txn_mark_composer_packages_sent(nrtxn_t* txn) {
    * pull */
 }
 
+/*
+ * Assumed to run only on the entry's owning thread, for the same reason as
+ * nr_txn_pull_composer_packages()/nr_txn_mark_composer_packages_sent()
+ * above -- no locking is taken here. See the doc comment in nr_txn.h for
+ * the rationale.
+ */
+void nr_txn_discard_composer_packages(nrtxn_t* txn) {
+  nr_composer_thread_entry_t* entry;
+
+  if (NULL == txn || NULL == txn->composer_info.entry) {
+    return;
+  }
+
+  entry = txn->composer_info.entry;
+  entry->last_sent_epoch = entry->epoch;
+}
+
 nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
                                          char* package_name,
                                          char* package_version) {

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -457,6 +457,7 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nr_slab_t* segment_slab;
   nr_app_harvest_stats_t* thread_harvest;
   nr_random_t* thread_rnd;
+  nr_composer_api_status_t* thread_composer_status;
   int tid;
 
   if (NULL == app) {
@@ -486,8 +487,17 @@ nrtxn_t* nr_txn_begin(nrapp_t* app,
   nt->status.path_type = NR_PATH_TYPE_UNKNOWN;
   nt->agent_run_id = nr_strdup(app->agent_run_id);
   tid = nr_gettid();
+  /*
+   * Both fetched once per request, under the app_lock this function's
+   * caller already holds (agent/php_txn.c) — not a new acquisition. Cached
+   * here for lock-free reuse for the rest of the transaction. See
+   * nr_app.h for the full per-thread-map locking contract.
+   */
   thread_rnd = nr_app_get_or_create_thread_rnd(app, (uint64_t)tid);
   nt->rnd = thread_rnd;
+  thread_composer_status
+      = nr_app_get_or_create_thread_composer_status(app, (uint64_t)tid);
+  nt->composer_info.status = thread_composer_status;
   nt->segment_slab = segment_slab;
 
   /*

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3661,6 +3661,10 @@ void nr_txn_discard_composer_packages(nrtxn_t* txn) {
   }
 
   entry = txn->composer_info.entry;
+  if (entry->epoch != entry->last_sent_epoch) {
+    nr_php_packages_destroy(&entry->packages);
+    entry->status = NR_COMPOSER_API_STATUS_UNSET;
+  }
   entry->last_sent_epoch = entry->epoch;
 }
 

--- a/axiom/nr_txn.c
+++ b/axiom/nr_txn.c
@@ -3579,6 +3579,74 @@ nr_php_package_t* nr_txn_add_php_package_from_source(
   return nr_php_packages_add_package(txn->php_packages, p);
 }
 
+/*
+ * Callback for nr_php_packages_iterate(), used by
+ * nr_txn_pull_composer_packages() below to copy each package from the
+ * per-thread composer entry into the transaction's own php_packages.
+ */
+static void nr_txn_pull_composer_package_callback(void* value,
+                                                  const char* name NRUNUSED,
+                                                  size_t name_len NRUNUSED,
+                                                  void* user_data) {
+  nr_php_package_t* p = (nr_php_package_t*)value;
+  nrtxn_t* txn = (nrtxn_t*)user_data;
+
+  if (NULL == p) {
+    return;
+  }
+
+  nr_txn_add_php_package_from_source(txn, p->package_name, p->package_version,
+                                     NR_PHP_PACKAGE_SOURCE_COMPOSER);
+}
+
+/*
+ * Assumed to run only on the entry's owning thread, as part of that
+ * thread's own request lifecycle -- no locking is taken here. See the doc
+ * comment in nr_txn.h for the rationale.
+ */
+void nr_txn_pull_composer_packages(nrtxn_t* txn) {
+  nr_composer_thread_entry_t* entry;
+
+  if (NULL == txn || NULL == txn->composer_info.entry) {
+    return;
+  }
+
+  entry = txn->composer_info.entry;
+  if (entry->epoch == entry->last_sent_epoch) {
+    /* nothing new since the last successful send */
+    return;
+  }
+
+  /* iterate-and-re-add, never a raw pointer swap — protects any
+   * independent legacy/suggestion entries already in txn->php_packages
+   * from this same request */
+  nr_php_packages_iterate(entry->packages,
+                          nr_txn_pull_composer_package_callback, txn);
+  txn->composer_info.composer_pull_epoch = entry->epoch;
+}
+
+/*
+ * Assumed to run only on the entry's owning thread, for the same reason as
+ * nr_txn_pull_composer_packages() above -- no locking is taken here. See
+ * the doc comment in nr_txn.h for the rationale.
+ */
+void nr_txn_mark_composer_packages_sent(nrtxn_t* txn) {
+  nr_composer_thread_entry_t* entry;
+
+  if (NULL == txn || NULL == txn->composer_info.entry) {
+    return;
+  }
+
+  entry = txn->composer_info.entry;
+  if (txn->composer_info.composer_pull_epoch == entry->epoch) {
+    entry->last_sent_epoch = entry->epoch;
+  }
+  /* else: a newer scan overwrote entry->packages after this txn pulled but
+   * before it reached transmit — leave last_sent_epoch alone; the newer
+   * epoch is correctly still unsent and will be picked up by a future
+   * pull */
+}
+
 nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
                                          char* package_name,
                                          char* package_version) {

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -215,19 +215,18 @@ typedef enum _nr_cpu_usage_t {
   NR_CPU_USAGE_COUNT = 2
 } nr_cpu_usage_t;
 
-typedef enum {
-  NR_COMPOSER_API_STATUS_UNSET = 0,
-  NR_COMPOSER_API_STATUS_INVALID_USE = 1,
-  NR_COMPOSER_API_STATUS_INIT_FAILURE = 2,
-  NR_COMPOSER_API_STATUS_CALL_FAILURE = 3,
-  NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED = 4,
-  NR_COMPOSER_API_STATUS_INVALID_RESULT = 5,
-} nr_composer_api_status_t;
-
 typedef struct _nr_composer_info_t {
   bool autoload_detected;
   bool composer_detected;
-  nr_composer_api_status_t api_status;
+  /*
+   * Borrowed pointer into this thread's entry in the owning nrapp_t's
+   * composer_map — not a copy. Fetched once in nr_txn_begin, alongside
+   * the rnd fetch; see nr_app.h for the locking contract and nr_txn.c for
+   * where the fetch happens. NULL means either the fetch failed (rare
+   * allocation failure) or app was NULL at txn begin — treat as "unknown"
+   * at every read site, not as UNSET.
+   */
+  nr_composer_api_status_t* status;
 } nr_composer_info_t;
 
 /*

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -1278,10 +1278,19 @@ extern void nr_txn_mark_composer_packages_sent(nrtxn_t* txn);
  * Purpose : Unconditionally advance this txn's per-thread composer entry's
  *           last_sent_epoch to match entry->epoch, without going through
  *           the normal pull/mark-sent path above (which nr_php_txn_end
- *           skips entirely whenever a transaction ends up ignored). Used
- *           so that a discarded transaction's pending Composer scan isn't
- *           inherited and re-reported by the next transaction on this
- *           thread.
+ *           skips entirely when a transaction is already known to be
+ *           ignored before nr_txn_end runs). Used so that a discarded
+ *           transaction's pending Composer scan isn't inherited and
+ *           re-reported by the next transaction on this thread.
+ *
+ *           That invariant is scoped to callers on this route only. A
+ *           transaction that is only marked ignored during nr_txn_end --
+ *           by an ignore-type url or transaction_name rule -- has already
+ *           pulled, never reaches this function, and deliberately leaves
+ *           the entry alone so the next transaction on the thread re-pulls
+ *           and reports the scan. Both routes report a given scan at most
+ *           once; they differ in whether it is swallowed or deferred. See
+ *           nr_php_txn_end for why that difference is intentional.
  *
  *           If entry->epoch != entry->last_sent_epoch going in (i.e. there
  *           was a genuinely unsent scan to swallow), also destroys

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -1275,6 +1275,39 @@ extern void nr_txn_pull_composer_packages(nrtxn_t* txn);
 extern void nr_txn_mark_composer_packages_sent(nrtxn_t* txn);
 
 /*
+ * Purpose : Unconditionally advance this txn's per-thread composer entry's
+ *           last_sent_epoch to match entry->epoch, without going through
+ *           the normal pull/mark-sent path above (which nr_php_txn_end
+ *           skips entirely whenever a transaction ends up ignored). Used
+ *           so that a discarded transaction's pending Composer scan isn't
+ *           inherited and re-reported by the next transaction on this
+ *           thread.
+ *
+ *           Unlike nr_txn_mark_composer_packages_sent(), this does not
+ *           gate on composer_pull_epoch == entry->epoch, because the pull
+ *           never ran on this path -- composer_pull_epoch is still 0 (or
+ *           stale). The write happens regardless.
+ *
+ *           Assumed to run only on the entry's owning thread, for the same
+ *           reason as nr_txn_pull_composer_packages/
+ *           nr_txn_mark_composer_packages_sent above -- no locking is
+ *           taken here.
+ *
+ *           Known limitation: if a Composer scan and this discard land in
+ *           the same transaction, that scan's data is lost -- permanently
+ *           in a persistent-worker context (no future autoload event will
+ *           re-scan), harmlessly in traditional per-request contexts
+ *           (which get another chance next request). This matches how a
+ *           discarded transaction's data is already treated everywhere
+ *           else, with no special-casing for Composer.
+ *
+ * Params  : 1. The transaction.
+ *
+ * Returns : Nothing.
+ */
+extern void nr_txn_discard_composer_packages(nrtxn_t* txn);
+
+/*
  * Purpose : Add php package suggestion to transaction. This function
  * can be used when Vulnerability Management is not enabled.  It will
  * add the package to the transaction's

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -220,13 +220,14 @@ typedef struct _nr_composer_info_t {
   bool composer_detected;
   /*
    * Borrowed pointer into this thread's entry in the owning nrapp_t's
-   * composer_map — not a copy. Fetched once in nr_txn_begin, alongside
-   * the rnd fetch; see nr_app.h for the locking contract and nr_txn.c for
-   * where the fetch happens. NULL means either the fetch failed (rare
+   * composer_map — not a copy. Fetched once in nr_txn_begin; see nr_app.h
+   * for the locking contract. NULL means either the fetch failed (rare
    * allocation failure) or app was NULL at txn begin — treat as "unknown"
    * at every read site, not as UNSET.
    */
-  nr_composer_api_status_t* status;
+  nr_composer_thread_entry_t* entry;
+  uint64_t composer_pull_epoch; /* epoch value this txn pulled at its pull
+                                    point, if any; 0 if never pulled */
 } nr_composer_info_t;
 
 /*

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -1283,6 +1283,19 @@ extern void nr_txn_mark_composer_packages_sent(nrtxn_t* txn);
  *           inherited and re-reported by the next transaction on this
  *           thread.
  *
+ *           If entry->epoch != entry->last_sent_epoch going in (i.e. there
+ *           was a genuinely unsent scan to swallow), also destroys
+ *           entry->packages and resets entry->status to
+ *           NR_COMPOSER_API_STATUS_UNSET, so the entry reads back exactly
+ *           as if the scan had never happened -- this is what lets the
+ *           legacy-detection suppression guard in
+ *           nr_txn_add_php_package_from_source() correctly re-arm for the
+ *           next transaction on this thread, instead of staying
+ *           permanently suppressed by a stale COLLECTED status. If the
+ *           entry was already fully sent (epoch == last_sent_epoch), this
+ *           is a no-op beyond the epoch write -- an unrelated discard on an
+ *           already-sent thread must not destroy legitimate history.
+ *
  *           Unlike nr_txn_mark_composer_packages_sent(), this does not
  *           gate on composer_pull_epoch == entry->epoch, because the pull
  *           never ran on this path -- composer_pull_epoch is still 0 (or

--- a/axiom/nr_txn.h
+++ b/axiom/nr_txn.h
@@ -1239,6 +1239,42 @@ extern nr_php_package_t* nr_txn_add_php_package(nrtxn_t* txn,
                                                 char* package_version);
 
 /*
+ * Purpose : Pull any Composer packages newly scanned into this txn's
+ *           per-thread composer entry (txn->composer_info.entry) into the
+ *           transaction's own php_packages, if the entry's epoch has moved
+ *           on since this txn last pulled.
+ *
+ *           Assumed to run only on the entry's owning thread, as part of
+ *           that thread's own request lifecycle -- no locking is taken
+ *           here, matching the fact that only that thread ever touches its
+ *           own entry (see nr_app.h for the app_lock contract, which
+ *           governs the composer_map structure and a separate cross-thread
+ *           read path, not this same-thread pull).
+ *
+ * Params  : 1. The transaction.
+ *
+ * Returns : Nothing.
+ */
+extern void nr_txn_pull_composer_packages(nrtxn_t* txn);
+
+/*
+ * Purpose : Mark this txn's pulled Composer packages as sent by advancing
+ *           the per-thread entry's last_sent_epoch to match the epoch this
+ *           txn pulled, provided no newer scan has overwritten the entry
+ *           since then (otherwise left alone, so a future pull picks up
+ *           the newer epoch).
+ *
+ *           Assumed to run only on the entry's owning thread, for the same
+ *           reason as nr_txn_pull_composer_packages above -- no locking is
+ *           taken here.
+ *
+ * Params  : 1. The transaction.
+ *
+ * Returns : Nothing.
+ */
+extern void nr_txn_mark_composer_packages_sent(nrtxn_t* txn);
+
+/*
  * Purpose : Add php package suggestion to transaction. This function
  * can be used when Vulnerability Management is not enabled.  It will
  * add the package to the transaction's

--- a/axiom/tests/test_app.c
+++ b/axiom/tests/test_app.c
@@ -335,6 +335,60 @@ static void test_find_or_add_app(void) {
   nr_applist_destroy(&applist);
 }
 
+static void test_app_find_locked(void) {
+  nrapplist_t* applist = nr_applist_create();
+  nrapp_t* app = NULL;
+  nr_app_info_t info;
+  nr_app_info_t search_info;
+
+  nr_memset(&info, 0, sizeof(info));
+  info.license = nr_strdup("0123456789012345678901234567890123456789");
+  info.appname = nr_strdup("Test App");
+  info.trace_observer_host = nr_strdup("");
+  /* nr_app_info_valid() requires these to be non-NULL as well. */
+  info.environment = nro_create_from_json("[]");
+  info.lang = nr_strdup("php");
+  info.version = nr_strdup("1.0");
+  info.redirect_collector = nr_strdup("collector.newrelic.com");
+
+  /* Bad parameters */
+  tlib_pass_if_null("NULL applist", nr_app_find_locked(NULL, &info));
+  tlib_pass_if_null("NULL info", nr_app_find_locked(applist, NULL));
+
+  /* No match yet: does not create */
+  tlib_pass_if_null("no match, empty applist",
+                    nr_app_find_locked(applist, &info));
+  tlib_pass_if_int_equal("no creation side effect", 0, applist->num_apps);
+
+  /* Create the app via the existing creating path, then find it */
+  app = nr_app_find_or_add_app(applist, &info);
+  tlib_pass_if_not_null("app created", app);
+  if (app) {
+    nrt_mutex_unlock(&app->app_lock);
+  }
+
+  nr_memset(&search_info, 0, sizeof(search_info));
+  search_info.license = nr_strdup(info.license);
+  search_info.appname = nr_strdup(info.appname);
+  search_info.trace_observer_host = nr_strdup("");
+  search_info.environment = nro_create_from_json("[]");
+  search_info.lang = nr_strdup("php");
+  search_info.version = nr_strdup("1.0");
+  search_info.redirect_collector = nr_strdup("collector.newrelic.com");
+
+  app = nr_app_find_locked(applist, &search_info);
+  tlib_pass_if_not_null("match found", app);
+  if (app) {
+    nrt_mutex_unlock(&app->app_lock);
+  }
+  tlib_pass_if_int_equal("still just one app, no duplicate creation", 1,
+                         applist->num_apps);
+
+  nr_app_info_destroy_fields(&info);
+  nr_app_info_destroy_fields(&search_info);
+  nr_applist_destroy(&applist);
+}
+
 static void test_find_or_add_app_high_security_mismatch(void) {
   nrapp_t* app;
   nr_app_info_t info;
@@ -1280,79 +1334,75 @@ static void test_get_or_create_thread_rnd(void) {
   nr_hashmap_destroy(&app.rnd_map);
 }
 
-static void test_get_or_create_thread_composer_status(void) {
+static void test_get_or_create_thread_composer_entry(void) {
   nrapp_t app = {0};
-  nr_composer_api_status_t* s1;
-  nr_composer_api_status_t* s2;
+  nr_composer_thread_entry_t* e1;
+  nr_composer_thread_entry_t* e2;
+  nr_composer_thread_entry_t* e_same_key;
 
-  /* NULL app returns NULL. */
   tlib_pass_if_null("NULL app",
-                    nr_app_get_or_create_thread_composer_status(NULL, 1));
+                    nr_app_get_or_create_thread_composer_entry(NULL, 1));
 
-  /* NULL composer_map returns NULL. */
-  tlib_pass_if_null(
-      "NULL composer_map",
-      nr_app_get_or_create_thread_composer_status(&app, 1));
+  app.composer_map = NULL;
+  tlib_pass_if_null("NULL composer_map",
+                    nr_app_get_or_create_thread_composer_entry(&app, 1));
 
   app.composer_map
-      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_entry_dtor);
 
-  /* First call for key 1 creates an entry initialized to UNSET. */
-  s1 = nr_app_get_or_create_thread_composer_status(&app, 1);
-  tlib_pass_if_not_null("first call returns non-NULL", s1);
-  tlib_pass_if_true("initialized to UNSET",
-                    NR_COMPOSER_API_STATUS_UNSET == *s1, "*s1=%d", *s1);
+  e1 = nr_app_get_or_create_thread_composer_entry(&app, 1);
+  tlib_pass_if_not_null("entry created", e1);
+  tlib_pass_if_int_equal("starts UNSET", NR_COMPOSER_API_STATUS_UNSET,
+                         e1->status);
+  tlib_pass_if_null("starts with no packages", e1->packages);
+  tlib_pass_if_uint64_t_equal("starts at epoch 0", 0, e1->epoch);
+  tlib_pass_if_uint64_t_equal("starts at last_sent_epoch 0", 0,
+                              e1->last_sent_epoch);
 
-  /* Mutate the value in place to simulate a completed scan. */
-  *s1 = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+  e1->status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+  e1->epoch = 7;
+  e_same_key = nr_app_get_or_create_thread_composer_entry(&app, 1);
+  tlib_pass_if_true("same pointer for same key", e1 == e_same_key,
+                    "e1=%p e_same_key=%p", (void*)e1, (void*)e_same_key);
+  tlib_pass_if_int_equal("mutation preserved",
+                         NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED,
+                         e_same_key->status);
+  tlib_pass_if_uint64_t_equal("epoch preserved", 7, e_same_key->epoch);
 
-  /* Second call for key 1 returns the same pointer, value preserved. */
-  s2 = nr_app_get_or_create_thread_composer_status(&app, 1);
-  tlib_pass_if_true("same pointer on second call", s1 == s2,
-                    "s1=%p s2=%p", (void*)s1, (void*)s2);
-  tlib_pass_if_true("value preserved on second call",
-                    NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED == *s2,
-                    "*s2=%d", *s2);
-
-  /* Different key returns a different, independently-UNSET pointer. */
-  s2 = nr_app_get_or_create_thread_composer_status(&app, 2);
-  tlib_pass_if_not_null("key 2 non-NULL", s2);
-  tlib_pass_if_true("different pointer for different key", s1 != s2,
-                    "s1=%p s2=%p", (void*)s1, (void*)s2);
-  tlib_pass_if_true("key 2 independently UNSET",
-                    NR_COMPOSER_API_STATUS_UNSET == *s2, "*s2=%d", *s2);
+  e2 = nr_app_get_or_create_thread_composer_entry(&app, 2);
+  tlib_pass_if_not_null("different key, different entry", e2);
+  tlib_pass_if_true("different pointer for different key", e1 != e2,
+                    "e1=%p e2=%p", (void*)e1, (void*)e2);
+  tlib_pass_if_int_equal("independent, still UNSET",
+                         NR_COMPOSER_API_STATUS_UNSET, e2->status);
 
   nr_hashmap_destroy(&app.composer_map);
 }
 
 static void test_app_tid_maps_evict(void) {
   nrapp_t app = {0};
+  nr_composer_thread_entry_t* entry;
 
   nrt_mutex_init(&app.app_lock, 0);
   app.harvest_map
       = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_harvest_stats_dtor);
   app.rnd_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
   app.composer_map
-      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_entry_dtor);
 
-  nr_app_get_or_create_thread_harvest(&app, 1);
   nr_app_get_or_create_thread_rnd(&app, 1);
-  nr_app_get_or_create_thread_composer_status(&app, 1);
+  entry = nr_app_get_or_create_thread_composer_entry(&app, 1);
+  entry->packages = nr_php_packages_create();
+  nr_app_get_or_create_thread_harvest(&app, 1);
 
-  tlib_pass_if_not_null("harvest entry present before evict",
-                        nr_hashmap_index_get(app.harvest_map, 1));
+  nr_app_tid_maps_evict(NULL, 1); /* must not crash */
 
   nr_app_tid_maps_evict(&app, 1);
-
-  tlib_pass_if_null("harvest entry evicted",
-                    nr_hashmap_index_get(app.harvest_map, 1));
-  tlib_pass_if_null("rnd entry evicted",
-                    nr_hashmap_index_get(app.rnd_map, 1));
-  tlib_pass_if_null("composer entry evicted",
+  tlib_pass_if_null("rnd evicted", nr_hashmap_index_get(app.rnd_map, 1));
+  tlib_pass_if_null("composer entry evicted (and its packages destroyed)",
                     nr_hashmap_index_get(app.composer_map, 1));
-
-  /* NULL app does not crash. */
-  nr_app_tid_maps_evict(NULL, 1);
+  tlib_pass_if_null("harvest evicted",
+                    nr_hashmap_index_get(app.harvest_map, 1));
 
   nr_hashmap_destroy(&app.harvest_map);
   nr_hashmap_destroy(&app.rnd_map);
@@ -1367,79 +1417,65 @@ static void test_app_tid_maps_destroy(void) {
       = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_harvest_stats_dtor);
   app.rnd_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
   app.composer_map
-      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_entry_dtor);
+
+  nr_app_tid_maps_destroy(NULL); /* must not crash */
 
   nr_app_tid_maps_destroy(&app);
-
-  tlib_pass_if_null("harvest_map destroyed", app.harvest_map);
-  tlib_pass_if_null("rnd_map destroyed", app.rnd_map);
-  tlib_pass_if_null("composer_map destroyed", app.composer_map);
-
-  /* NULL app does not crash. */
-  nr_app_tid_maps_destroy(NULL);
+  tlib_pass_if_null("harvest_map nulled", app.harvest_map);
+  tlib_pass_if_null("rnd_map nulled", app.rnd_map);
+  tlib_pass_if_null("composer_map nulled", app.composer_map);
 }
 
-static void test_composer_status_cross_app_isolation(void) {
+static void test_composer_entry_cross_app_isolation(void) {
   nrapp_t app_a = {0};
   nrapp_t app_b = {0};
-  nr_composer_api_status_t* status_a;
-  nr_composer_api_status_t* status_b;
+  nr_composer_thread_entry_t* entry_a;
+  nr_composer_thread_entry_t* entry_b;
 
+  /*
+   * Simulates FrankenPHP worker mode: one OS process, per-app thread pools,
+   * so the SAME tid can legitimately show up under two different nrapp_t
+   * instances. This is the bug the per-(app,thread) map closes relative to
+   * the old process-global design: writes to one app's entry must never
+   * leak into another app's entry for the identical tid.
+   */
   app_a.composer_map
-      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_entry_dtor);
   app_b.composer_map
-      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_entry_dtor);
 
-  /* Both apps' thread (same tid, different app — the FrankenPHP worker-mode
-   * scenario: one process, per-app thread pools) start UNSET. */
-  status_a = nr_app_get_or_create_thread_composer_status(&app_a, 42);
-  status_b = nr_app_get_or_create_thread_composer_status(&app_b, 42);
-  tlib_pass_if_true("app_a starts UNSET",
-                    NR_COMPOSER_API_STATUS_UNSET == *status_a, "*status_a=%d",
-                    *status_a);
-  tlib_pass_if_true("app_b starts UNSET",
-                    NR_COMPOSER_API_STATUS_UNSET == *status_b, "*status_b=%d",
-                    *status_b);
+  entry_a = nr_app_get_or_create_thread_composer_entry(&app_a, 42);
+  entry_b = nr_app_get_or_create_thread_composer_entry(&app_b, 42);
 
-  /* app_a's thread completes detection (success). */
-  *status_a = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+  entry_a->status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+  entry_a->epoch = 1;
 
-  /* app_b's thread must be unaffected — this is the bug this fix closes.
-   * Under the old process-global design, app_a's write would have latched
-   * a single shared flag and app_b would see it as already-set. */
-  tlib_pass_if_true("app_b unaffected by app_a's completion",
-                    NR_COMPOSER_API_STATUS_UNSET == *status_b, "*status_b=%d",
-                    *status_b);
-
-  /* app_b's thread now independently completes with a different outcome. */
-  *status_b = NR_COMPOSER_API_STATUS_INIT_FAILURE;
-  tlib_pass_if_true("app_a unaffected by app_b's completion",
-                    NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED == *status_a,
-                    "*status_a=%d", *status_a);
+  tlib_pass_if_int_equal("app_b's entry for same tid unaffected",
+                         NR_COMPOSER_API_STATUS_UNSET, entry_b->status);
+  tlib_pass_if_uint64_t_equal("app_b's epoch unaffected", 0, entry_b->epoch);
 
   nr_hashmap_destroy(&app_a.composer_map);
   nr_hashmap_destroy(&app_b.composer_map);
 }
 
-static void test_composer_status_same_app_multi_thread_isolation(void) {
+static void test_composer_entry_same_app_multi_thread_isolation(void) {
   nrapp_t app = {0};
-  nr_composer_api_status_t* status_thread1;
-  nr_composer_api_status_t* status_thread2;
+  nr_composer_thread_entry_t* entry_1;
+  nr_composer_thread_entry_t* entry_2;
 
   app.composer_map
-      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_entry_dtor);
 
-  /* Two threads of the SAME app, both starting UNSET. */
-  status_thread1 = nr_app_get_or_create_thread_composer_status(&app, 1);
-  status_thread2 = nr_app_get_or_create_thread_composer_status(&app, 2);
+  entry_1 = nr_app_get_or_create_thread_composer_entry(&app, 1);
+  entry_2 = nr_app_get_or_create_thread_composer_entry(&app, 2);
 
-  /* Thread 1 completes successfully. */
-  *status_thread1 = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+  entry_1->status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+  entry_1->epoch = 3;
 
-  /* Thread 2's entry is untouched — free to attempt on its own. */
-  tlib_pass_if_true("thread 2 still UNSET after thread 1 completes",
-                    NR_COMPOSER_API_STATUS_UNSET == *status_thread2,
-                    "*status_thread2=%d", *status_thread2);
+  tlib_pass_if_int_equal("thread 2 unaffected by thread 1's completion",
+                         NR_COMPOSER_API_STATUS_UNSET, entry_2->status);
+  tlib_pass_if_uint64_t_equal("thread 2 epoch unaffected", 0, entry_2->epoch);
 
   nr_hashmap_destroy(&app.composer_map);
 }
@@ -1452,6 +1488,7 @@ void test_main(void* p NRUNUSED) {
 
   test_app_match();
   test_find_or_add_app();
+  test_app_find_locked();
   test_find_or_add_app_high_security_mismatch();
   test_agent_should_do_app_daemon_query();
   test_agent_find_or_add_app();
@@ -1469,9 +1506,9 @@ void test_main(void* p NRUNUSED) {
   test_get_or_create_thread_harvest();
   test_sync_harvest_config();
   test_get_or_create_thread_rnd();
-  test_get_or_create_thread_composer_status();
+  test_get_or_create_thread_composer_entry();
   test_app_tid_maps_evict();
   test_app_tid_maps_destroy();
-  test_composer_status_cross_app_isolation();
-  test_composer_status_same_app_multi_thread_isolation();
+  test_composer_entry_cross_app_isolation();
+  test_composer_entry_same_app_multi_thread_isolation();
 }

--- a/axiom/tests/test_app.c
+++ b/axiom/tests/test_app.c
@@ -1280,6 +1280,51 @@ static void test_get_or_create_thread_rnd(void) {
   nr_hashmap_destroy(&app.rnd_map);
 }
 
+static void test_get_or_create_thread_composer_status(void) {
+  nrapp_t app = {0};
+  nr_composer_api_status_t* s1;
+  nr_composer_api_status_t* s2;
+
+  /* NULL app returns NULL. */
+  tlib_pass_if_null("NULL app",
+                    nr_app_get_or_create_thread_composer_status(NULL, 1));
+
+  /* NULL composer_map returns NULL. */
+  tlib_pass_if_null(
+      "NULL composer_map",
+      nr_app_get_or_create_thread_composer_status(&app, 1));
+
+  app.composer_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+
+  /* First call for key 1 creates an entry initialized to UNSET. */
+  s1 = nr_app_get_or_create_thread_composer_status(&app, 1);
+  tlib_pass_if_not_null("first call returns non-NULL", s1);
+  tlib_pass_if_true("initialized to UNSET",
+                    NR_COMPOSER_API_STATUS_UNSET == *s1, "*s1=%d", *s1);
+
+  /* Mutate the value in place to simulate a completed scan. */
+  *s1 = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+
+  /* Second call for key 1 returns the same pointer, value preserved. */
+  s2 = nr_app_get_or_create_thread_composer_status(&app, 1);
+  tlib_pass_if_true("same pointer on second call", s1 == s2,
+                    "s1=%p s2=%p", (void*)s1, (void*)s2);
+  tlib_pass_if_true("value preserved on second call",
+                    NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED == *s2,
+                    "*s2=%d", *s2);
+
+  /* Different key returns a different, independently-UNSET pointer. */
+  s2 = nr_app_get_or_create_thread_composer_status(&app, 2);
+  tlib_pass_if_not_null("key 2 non-NULL", s2);
+  tlib_pass_if_true("different pointer for different key", s1 != s2,
+                    "s1=%p s2=%p", (void*)s1, (void*)s2);
+  tlib_pass_if_true("key 2 independently UNSET",
+                    NR_COMPOSER_API_STATUS_UNSET == *s2, "*s2=%d", *s2);
+
+  nr_hashmap_destroy(&app.composer_map);
+}
+
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = 4, .state_size = sizeof(test_app_state_t)};
 
@@ -1305,4 +1350,5 @@ void test_main(void* p NRUNUSED) {
   test_get_or_create_thread_harvest();
   test_sync_harvest_config();
   test_get_or_create_thread_rnd();
+  test_get_or_create_thread_composer_status();
 }

--- a/axiom/tests/test_app.c
+++ b/axiom/tests/test_app.c
@@ -1379,6 +1379,71 @@ static void test_app_tid_maps_destroy(void) {
   nr_app_tid_maps_destroy(NULL);
 }
 
+static void test_composer_status_cross_app_isolation(void) {
+  nrapp_t app_a = {0};
+  nrapp_t app_b = {0};
+  nr_composer_api_status_t* status_a;
+  nr_composer_api_status_t* status_b;
+
+  app_a.composer_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+  app_b.composer_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+
+  /* Both apps' thread (same tid, different app — the FrankenPHP worker-mode
+   * scenario: one process, per-app thread pools) start UNSET. */
+  status_a = nr_app_get_or_create_thread_composer_status(&app_a, 42);
+  status_b = nr_app_get_or_create_thread_composer_status(&app_b, 42);
+  tlib_pass_if_true("app_a starts UNSET",
+                    NR_COMPOSER_API_STATUS_UNSET == *status_a, "*status_a=%d",
+                    *status_a);
+  tlib_pass_if_true("app_b starts UNSET",
+                    NR_COMPOSER_API_STATUS_UNSET == *status_b, "*status_b=%d",
+                    *status_b);
+
+  /* app_a's thread completes detection (success). */
+  *status_a = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+
+  /* app_b's thread must be unaffected — this is the bug this fix closes.
+   * Under the old process-global design, app_a's write would have latched
+   * a single shared flag and app_b would see it as already-set. */
+  tlib_pass_if_true(
+      "app_b unaffected by app_a's completion",
+      NR_COMPOSER_API_STATUS_UNSET == *status_b, "*status_b=%d", *status_b);
+
+  /* app_b's thread now independently completes with a different outcome. */
+  *status_b = NR_COMPOSER_API_STATUS_INIT_FAILURE;
+  tlib_pass_if_true("app_a unaffected by app_b's completion",
+                    NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED == *status_a,
+                    "*status_a=%d", *status_a);
+
+  nr_hashmap_destroy(&app_a.composer_map);
+  nr_hashmap_destroy(&app_b.composer_map);
+}
+
+static void test_composer_status_same_app_multi_thread_isolation(void) {
+  nrapp_t app = {0};
+  nr_composer_api_status_t* status_thread1;
+  nr_composer_api_status_t* status_thread2;
+
+  app.composer_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+
+  /* Two threads of the SAME app, both starting UNSET. */
+  status_thread1 = nr_app_get_or_create_thread_composer_status(&app, 1);
+  status_thread2 = nr_app_get_or_create_thread_composer_status(&app, 2);
+
+  /* Thread 1 completes successfully. */
+  *status_thread1 = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+
+  /* Thread 2's entry is untouched — free to attempt on its own. */
+  tlib_pass_if_true("thread 2 still UNSET after thread 1 completes",
+                    NR_COMPOSER_API_STATUS_UNSET == *status_thread2,
+                    "*status_thread2=%d", *status_thread2);
+
+  nr_hashmap_destroy(&app.composer_map);
+}
+
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = 4, .state_size = sizeof(test_app_state_t)};
 
@@ -1407,4 +1472,6 @@ void test_main(void* p NRUNUSED) {
   test_get_or_create_thread_composer_status();
   test_app_tid_maps_evict();
   test_app_tid_maps_destroy();
+  test_composer_status_cross_app_isolation();
+  test_composer_status_same_app_multi_thread_isolation();
 }

--- a/axiom/tests/test_app.c
+++ b/axiom/tests/test_app.c
@@ -469,6 +469,54 @@ static void test_find_or_add_app_high_security_mismatch(void) {
   nr_app_info_destroy_fields(&info);
 }
 
+static void test_find_locked_high_security_mismatch(void) {
+  nrapp_t* app;
+  nr_app_info_t info;
+  nrapplist_t* applist = nr_applist_create();
+
+  nr_memset(&info, 0, sizeof(info));
+  info.license = nr_strdup("1234500000000000000000000000000000006789");
+  info.version = nr_strdup("my_version");
+  info.lang = nr_strdup("my_language");
+  info.appname = nr_strdup("test-app");
+  info.environment = nro_create_from_json("[\"my_environment\"]");
+  info.trace_observer_host = nr_strdup("");
+  info.redirect_collector = nr_strdup("collector.newrelic.com");
+  info.high_security = 0;
+
+  /*
+   * Add the app without high security.
+   */
+  app = nr_app_find_or_add_app(applist, &info);
+  tlib_pass_if_not_null("app added", app);
+  if (app) {
+    nrt_mutex_unlock(&app->app_lock);
+  }
+
+  /*
+   * Finding the same app with high security on fails -- before the fix,
+   * nr_app_find_locked() never checked high_security at all and would
+   * have returned the mismatched app.
+   */
+  info.high_security = 1;
+  app = nr_app_find_locked(applist, &info);
+  tlib_pass_if_null("mismatched high security not found", app);
+
+  /*
+   * Finding the same app with matching high security still succeeds --
+   * confirms the check doesn't false-positive.
+   */
+  info.high_security = 0;
+  app = nr_app_find_locked(applist, &info);
+  tlib_pass_if_not_null("matching high security found", app);
+  if (app) {
+    nrt_mutex_unlock(&app->app_lock);
+  }
+
+  nr_applist_destroy(&applist);
+  nr_app_info_destroy_fields(&info);
+}
+
 /*
  * This global variable allows us to control the app state
  * set by the local nr_cmd_appinfo_tx mock function.
@@ -1490,6 +1538,7 @@ void test_main(void* p NRUNUSED) {
   test_find_or_add_app();
   test_app_find_locked();
   test_find_or_add_app_high_security_mismatch();
+  test_find_locked_high_security_mismatch();
   test_agent_should_do_app_daemon_query();
   test_agent_find_or_add_app();
   test_verify_id();

--- a/axiom/tests/test_app.c
+++ b/axiom/tests/test_app.c
@@ -1407,9 +1407,9 @@ static void test_composer_status_cross_app_isolation(void) {
   /* app_b's thread must be unaffected — this is the bug this fix closes.
    * Under the old process-global design, app_a's write would have latched
    * a single shared flag and app_b would see it as already-set. */
-  tlib_pass_if_true(
-      "app_b unaffected by app_a's completion",
-      NR_COMPOSER_API_STATUS_UNSET == *status_b, "*status_b=%d", *status_b);
+  tlib_pass_if_true("app_b unaffected by app_a's completion",
+                    NR_COMPOSER_API_STATUS_UNSET == *status_b, "*status_b=%d",
+                    *status_b);
 
   /* app_b's thread now independently completes with a different outcome. */
   *status_b = NR_COMPOSER_API_STATUS_INIT_FAILURE;

--- a/axiom/tests/test_app.c
+++ b/axiom/tests/test_app.c
@@ -1325,6 +1325,60 @@ static void test_get_or_create_thread_composer_status(void) {
   nr_hashmap_destroy(&app.composer_map);
 }
 
+static void test_app_tid_maps_evict(void) {
+  nrapp_t app = {0};
+
+  nrt_mutex_init(&app.app_lock, 0);
+  app.harvest_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_harvest_stats_dtor);
+  app.rnd_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
+  app.composer_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+
+  nr_app_get_or_create_thread_harvest(&app, 1);
+  nr_app_get_or_create_thread_rnd(&app, 1);
+  nr_app_get_or_create_thread_composer_status(&app, 1);
+
+  tlib_pass_if_not_null("harvest entry present before evict",
+                        nr_hashmap_index_get(app.harvest_map, 1));
+
+  nr_app_tid_maps_evict(&app, 1);
+
+  tlib_pass_if_null("harvest entry evicted",
+                    nr_hashmap_index_get(app.harvest_map, 1));
+  tlib_pass_if_null("rnd entry evicted",
+                    nr_hashmap_index_get(app.rnd_map, 1));
+  tlib_pass_if_null("composer entry evicted",
+                    nr_hashmap_index_get(app.composer_map, 1));
+
+  /* NULL app does not crash. */
+  nr_app_tid_maps_evict(NULL, 1);
+
+  nr_hashmap_destroy(&app.harvest_map);
+  nr_hashmap_destroy(&app.rnd_map);
+  nr_hashmap_destroy(&app.composer_map);
+  nrt_mutex_destroy(&app.app_lock);
+}
+
+static void test_app_tid_maps_destroy(void) {
+  nrapp_t app = {0};
+
+  app.harvest_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_harvest_stats_dtor);
+  app.rnd_map = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_rnd_dtor);
+  app.composer_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+
+  nr_app_tid_maps_destroy(&app);
+
+  tlib_pass_if_null("harvest_map destroyed", app.harvest_map);
+  tlib_pass_if_null("rnd_map destroyed", app.rnd_map);
+  tlib_pass_if_null("composer_map destroyed", app.composer_map);
+
+  /* NULL app does not crash. */
+  nr_app_tid_maps_destroy(NULL);
+}
+
 tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = 4, .state_size = sizeof(test_app_state_t)};
 
@@ -1351,4 +1405,6 @@ void test_main(void* p NRUNUSED) {
   test_sync_harvest_config();
   test_get_or_create_thread_rnd();
   test_get_or_create_thread_composer_status();
+  test_app_tid_maps_evict();
+  test_app_tid_maps_destroy();
 }

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -9156,9 +9156,18 @@ static void test_txn_discard_composer_packages(void) {
   /* Discard after a scan: pull never ran (composer_pull_epoch still 0),
    * entry has a newer epoch than last_sent_epoch -- unlike
    * nr_txn_mark_composer_packages_sent, this must still advance
-   * last_sent_epoch unconditionally, with no epoch-match gate. */
+   * last_sent_epoch unconditionally, with no epoch-match gate. Since there
+   * was genuinely unsent data (epoch != last_sent_epoch going in), the
+   * entry's packages/status must also be reset back to as if the scan
+   * never happened. */
   entry.epoch = 5;
   entry.last_sent_epoch = 2;
+  entry.packages = nr_php_packages_create();
+  nr_php_packages_add_package(
+      entry.packages, nr_php_package_create_with_source(
+                          "doctrine/orm", "2.5.0",
+                          NR_PHP_PACKAGE_SOURCE_COMPOSER));
+  entry.status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
   txn = build_txn_with_composer_entry(&entry);
   /* composer_pull_epoch intentionally left at 0 -- pull never happened */
 
@@ -9166,19 +9175,40 @@ static void test_txn_discard_composer_packages(void) {
   tlib_pass_if_uint64_t_equal(
       "discard advances last_sent_epoch even though pull never ran", 5,
       entry.last_sent_epoch);
+  tlib_pass_if_null("discard of unsent data destroys entry->packages",
+                    entry.packages);
+  tlib_pass_if_true(
+      "discard of unsent data resets entry->status to UNSET",
+      NR_COMPOSER_API_STATUS_UNSET == entry.status, "status=%d",
+      (int)entry.status);
 
   nr_txn_destroy(&txn);
 
-  /* Already caught up: no-op but harmless */
+  /* Already caught up: no-op beyond the (already-matching) epoch write --
+   * an unrelated discard on an already-sent thread must not destroy
+   * legitimate packages/status history. */
   entry.epoch = 5;
   entry.last_sent_epoch = 5;
+  entry.packages = nr_php_packages_create();
+  nr_php_packages_add_package(
+      entry.packages, nr_php_package_create_with_source(
+                          "doctrine/orm", "2.5.0",
+                          NR_PHP_PACKAGE_SOURCE_COMPOSER));
+  entry.status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
   txn = build_txn_with_composer_entry(&entry);
 
   nr_txn_discard_composer_packages(txn);
   tlib_pass_if_uint64_t_equal("already caught up, stays caught up", 5,
                               entry.last_sent_epoch);
+  tlib_pass_if_not_null(
+      "already caught up: entry->packages left untouched", entry.packages);
+  tlib_pass_if_true(
+      "already caught up: entry->status left untouched",
+      NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED == entry.status, "status=%d",
+      (int)entry.status);
 
   nr_txn_destroy(&txn);
+  nr_php_packages_destroy(&entry.packages);
 }
 
 static void test_nr_txn_suggest_package_supportability_metric(void) {

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -9101,6 +9101,58 @@ static void test_txn_pull_composer_packages(void) {
   tlib_pass_if_not_null("composer package still pulled alongside it", p);
 
   nr_txn_destroy(&txn);
+
+  /* Same-txn scan already fired: composer_detected/autoload_detected are
+   * already true on this txn (as scan-time code would leave them), so the
+   * "detected" metric fallback below must not fire a second time even
+   * though real pull work is pending. */
+  entry.epoch = 4;
+  entry.last_sent_epoch = 3;
+  txn = build_txn_with_composer_entry(&entry);
+  txn->composer_info.composer_detected = true;
+  txn->composer_info.autoload_detected = true;
+  txn->unscoped_metrics = nrm_table_create(2);
+
+  nr_txn_pull_composer_packages(txn);
+  tlib_pass_if_int_equal(
+      "already-detected: no fallback metric added",
+      0, nrm_table_size(txn->unscoped_metrics));
+
+  nr_txn_destroy(&txn);
+
+  /* Bootstrap loss: composer_detected/autoload_detected are false (the
+   * scan ran with no live txn, so scan-time code never set them), and
+   * real pull work is pending -- the fallback must fire both metrics
+   * exactly once on this txn. */
+  entry.epoch = 5;
+  entry.last_sent_epoch = 4;
+  txn = build_txn_with_composer_entry(&entry);
+  txn->unscoped_metrics = nrm_table_create(2);
+
+  nr_txn_pull_composer_packages(txn);
+  test_txn_metric_is("fallback: Composer/detected fires once",
+                     txn->unscoped_metrics, MET_FORCED,
+                     "Supportability/library/Composer/detected", 1, 0, 0, 0,
+                     0, 0);
+  test_txn_metric_is("fallback: Autoloader/detected fires once",
+                     txn->unscoped_metrics, MET_FORCED,
+                     "Supportability/library/Autoloader/detected", 1, 0, 0, 0,
+                     0, 0);
+
+  nr_txn_destroy(&txn);
+
+  /* No real work: epoch == last_sent_epoch, so the early return happens
+   * before the fallback is ever reached, regardless of the flags' state. */
+  entry.epoch = 5;
+  entry.last_sent_epoch = 5;
+  txn = build_txn_with_composer_entry(&entry);
+  txn->unscoped_metrics = nrm_table_create(2);
+
+  nr_txn_pull_composer_packages(txn);
+  tlib_pass_if_int_equal("no real work: fallback not reached", 0,
+                        nrm_table_size(txn->unscoped_metrics));
+
+  nr_txn_destroy(&txn);
   nr_php_packages_destroy(&entry.packages);
 }
 

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -9023,6 +9023,124 @@ static void test_nr_txn_add_php_package_from_source(void) {
   }
 }
 
+static nrtxn_t* build_txn_with_composer_entry(
+    nr_composer_thread_entry_t* entry) {
+  nrtxn_t* txn = (nrtxn_t*)nr_zalloc(sizeof(nrtxn_t));
+  txn->php_packages = nr_php_packages_create();
+  txn->composer_info.entry = entry;
+  return txn;
+}
+
+static void test_txn_pull_composer_packages(void) {
+  nr_composer_thread_entry_t entry = {0};
+  nrtxn_t* txn;
+  nr_php_package_t* p;
+
+  /*
+   * NULL parameters: ensure it does not crash
+   */
+  nr_txn_pull_composer_packages(NULL);
+  txn = build_txn_with_composer_entry(NULL);
+  nr_txn_pull_composer_packages(txn);
+  nr_txn_destroy(&txn);
+
+  /* Nothing new: epoch == last_sent_epoch, nothing pulled */
+  entry.epoch = 1;
+  entry.last_sent_epoch = 1;
+  entry.packages = nr_php_packages_create();
+  txn = build_txn_with_composer_entry(&entry);
+
+  nr_txn_pull_composer_packages(txn);
+  tlib_pass_if_uint64_t_equal("no-op: pull epoch stays 0", 0,
+                              txn->composer_info.composer_pull_epoch);
+  tlib_pass_if_null("no-op: nothing merged",
+                    nr_php_packages_get_package(txn->php_packages, "foo/bar"));
+
+  nr_txn_destroy(&txn);
+
+  /* Something new: epoch != last_sent_epoch, gets pulled */
+  entry.epoch = 2;
+  entry.last_sent_epoch = 1;
+  nr_php_packages_add_package(
+      entry.packages, nr_php_package_create_with_source(
+                          "foo/bar", "1.2.3", NR_PHP_PACKAGE_SOURCE_COMPOSER));
+  txn = build_txn_with_composer_entry(&entry);
+
+  nr_txn_pull_composer_packages(txn);
+  tlib_pass_if_uint64_t_equal("pull epoch now matches entry epoch", 2,
+                              txn->composer_info.composer_pull_epoch);
+  p = nr_php_packages_get_package(txn->php_packages, "foo/bar");
+  tlib_pass_if_not_null("package merged into txn", p);
+  if (p) {
+    tlib_pass_if_str_equal("version correct", "1.2.3", p->package_version);
+    tlib_pass_if_true("pulled package sourced as composer",
+                      NR_PHP_PACKAGE_SOURCE_COMPOSER == p->source_priority,
+                      "source_priority=%d", (int)p->source_priority);
+  }
+
+  nr_txn_destroy(&txn);
+
+  /* Pre-existing (e.g. legacy) package already in txn->php_packages must
+   * survive the pull: nr_txn_pull_composer_packages() iterates and re-adds
+   * composer packages one at a time, it never swaps the whole map, so an
+   * unrelated entry from this same request should be untouched. */
+  entry.epoch = 3;
+  entry.last_sent_epoch = 2;
+  txn = build_txn_with_composer_entry(&entry);
+  nr_txn_add_php_package_from_source(txn, "baz/qux", "9.9.9",
+                                     NR_PHP_PACKAGE_SOURCE_LEGACY);
+
+  nr_txn_pull_composer_packages(txn);
+  p = nr_php_packages_get_package(txn->php_packages, "baz/qux");
+  tlib_pass_if_not_null("pre-existing legacy package not clobbered by pull", p);
+  if (p) {
+    tlib_pass_if_str_equal("pre-existing package version untouched", "9.9.9",
+                           p->package_version);
+  }
+  p = nr_php_packages_get_package(txn->php_packages, "foo/bar");
+  tlib_pass_if_not_null("composer package still pulled alongside it", p);
+
+  nr_txn_destroy(&txn);
+  nr_php_packages_destroy(&entry.packages);
+}
+
+static void test_txn_mark_composer_packages_sent(void) {
+  nr_composer_thread_entry_t entry = {0};
+  nrtxn_t* txn;
+
+  /*
+   * NULL parameters: ensure it does not crash
+   */
+  nr_txn_mark_composer_packages_sent(NULL);
+  txn = build_txn_with_composer_entry(NULL);
+  nr_txn_mark_composer_packages_sent(txn);
+  nr_txn_destroy(&txn);
+
+  /* Matching case: this txn's pulled epoch is still current -> marks sent */
+  entry.epoch = 3;
+  entry.last_sent_epoch = 1;
+  txn = build_txn_with_composer_entry(&entry);
+  txn->composer_info.composer_pull_epoch = 3;
+
+  nr_txn_mark_composer_packages_sent(txn);
+  tlib_pass_if_uint64_t_equal("last_sent_epoch caught up", 3,
+                              entry.last_sent_epoch);
+  nr_txn_destroy(&txn);
+
+  /* Race case: a newer scan overwrote entry after this txn pulled ->
+   * leave last_sent_epoch alone */
+  entry.epoch = 4;
+  entry.last_sent_epoch = 1;
+  txn = build_txn_with_composer_entry(&entry);
+  txn->composer_info.composer_pull_epoch
+      = 3; /* stale relative to entry.epoch */
+
+  nr_txn_mark_composer_packages_sent(txn);
+  tlib_pass_if_uint64_t_equal("last_sent_epoch NOT advanced on race", 1,
+                              entry.last_sent_epoch);
+  nr_txn_destroy(&txn);
+}
+
 static void test_nr_txn_suggest_package_supportability_metric(void) {
   char* json;
   char* package_name1 = "Laravel";
@@ -9179,5 +9297,7 @@ void test_main(void* p NRUNUSED) {
   test_txn_log_configuration();
   test_nr_txn_add_php_package();
   test_nr_txn_add_php_package_from_source();
+  test_txn_pull_composer_packages();
+  test_txn_mark_composer_packages_sent();
   test_nr_txn_suggest_package_supportability_metric();
 }

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -8899,15 +8899,21 @@ static void test_nr_txn_add_php_package(void) {
       "same package name, different version, add returns same pointer", p1, p2);
   nr_txn_destroy(&txn);
 
-  txn = new_txn(0);
-  // simulate composer api was successfully used
-  txn->composer_info.api_status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
-  p1 = nr_txn_add_php_package(txn, package_name1, package_version1);
-  tlib_pass_if_null(
-      "legacy package information not added to transaction after composer api "
-      "was called successfully",
-      p1);
-  nr_txn_destroy(&txn);
+  {
+    nr_composer_api_status_t composer_status
+        = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+    txn = new_txn(0);
+    // simulate composer api was successfully used. new_txn()'s test app has
+    // composer_map == NULL, so txn->composer_info.status is NULL after
+    // begin — point it at a local variable instead of relying on the map.
+    txn->composer_info.status = &composer_status;
+    p1 = nr_txn_add_php_package(txn, package_name1, package_version1);
+    tlib_pass_if_null(
+        "legacy package information not added to transaction after composer api "
+        "was called successfully",
+        p1);
+    nr_txn_destroy(&txn);
+  }
 }
 
 static void test_nr_txn_add_php_package_from_source(void) {
@@ -8974,28 +8980,34 @@ static void test_nr_txn_add_php_package_from_source(void) {
 
   nr_txn_destroy(&txn);
 
-  txn = new_txn(0);
-  // simulate composer api was successfully used
-  txn->composer_info.api_status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
-  p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
-                                          NR_PHP_PACKAGE_SOURCE_LEGACY);
-  tlib_pass_if_null(
-      "legacy package information not added to transaction after composer api "
-      "was called successfully",
-      p1);
-  p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
-                                          NR_PHP_PACKAGE_SOURCE_SUGGESTION);
-  tlib_pass_if_not_null(
-      "suggestion package information added to transaction even after composer "
-      "api was called successfully",
-      p1);
-  p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
-                                          NR_PHP_PACKAGE_SOURCE_COMPOSER);
-  tlib_pass_if_not_null(
-      "composer package information added to transaction even after composer "
-      "api was called successfully",
-      p1);
-  nr_txn_destroy(&txn);
+  {
+    nr_composer_api_status_t composer_status
+        = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+    txn = new_txn(0);
+    // simulate composer api was successfully used. new_txn()'s test app has
+    // composer_map == NULL, so txn->composer_info.status is NULL after
+    // begin — point it at a local variable instead of relying on the map.
+    txn->composer_info.status = &composer_status;
+    p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                            NR_PHP_PACKAGE_SOURCE_LEGACY);
+    tlib_pass_if_null(
+        "legacy package information not added to transaction after composer api "
+        "was called successfully",
+        p1);
+    p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                            NR_PHP_PACKAGE_SOURCE_SUGGESTION);
+    tlib_pass_if_not_null(
+        "suggestion package information added to transaction even after composer "
+        "api was called successfully",
+        p1);
+    p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
+                                            NR_PHP_PACKAGE_SOURCE_COMPOSER);
+    tlib_pass_if_not_null(
+        "composer package information added to transaction even after composer "
+        "api was called successfully",
+        p1);
+    nr_txn_destroy(&txn);
+  }
 }
 
 static void test_nr_txn_suggest_package_supportability_metric(void) {

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -1716,7 +1716,7 @@ static void test_begin(void) {
     nr_hashmap_index_set(app->rnd_map, (uint64_t)self, rnd);
   }
   app->composer_map
-      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_entry_dtor);
   app->info.high_security = 0;
   app->connect_reply = nro_new_hash();
   app->security_policies = nro_new_hash();
@@ -1767,14 +1767,16 @@ static void test_begin(void) {
 
   rv = nr_txn_begin(app, opts, attribute_config, NULL);
   test_created_txn("options provided", rv, &correct);
-  tlib_pass_if_not_null("composer_info.status populated by nr_txn_begin",
-                        rv->composer_info.status);
+  tlib_pass_if_not_null("composer_info.entry populated by nr_txn_begin",
+                        rv->composer_info.entry);
   tlib_pass_if_true(
-      "composer_info.status points at this thread's composer_map entry",
-      rv->composer_info.status
-          == nr_app_get_or_create_thread_composer_status(app,
-                                                         (uint64_t)nr_gettid()),
-      "status=%p", (void*)rv->composer_info.status);
+      "composer_info.entry points at this thread's composer_map entry",
+      rv->composer_info.entry
+          == nr_app_get_or_create_thread_composer_entry(app,
+                                                        (uint64_t)nr_gettid()),
+      "entry=%p", (void*)rv->composer_info.entry);
+  tlib_pass_if_uint64_t_equal("composer_pull_epoch starts at 0", 0,
+                              rv->composer_info.composer_pull_epoch);
   json = nr_attributes_debug_json(rv->attributes);
   tlib_pass_if_str_equal("display host attribute created", json,
                          "{\"user\":[],\"agent\":["
@@ -8911,13 +8913,13 @@ static void test_nr_txn_add_php_package(void) {
   nr_txn_destroy(&txn);
 
   {
-    nr_composer_api_status_t composer_status
-        = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+    nr_composer_thread_entry_t composer_entry = {0};
+    composer_entry.status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
     txn = new_txn(0);
     // simulate composer api was successfully used. new_txn()'s test app has
-    // composer_map == NULL, so txn->composer_info.status is NULL after
+    // composer_map == NULL, so txn->composer_info.entry is NULL after
     // begin — point it at a local variable instead of relying on the map.
-    txn->composer_info.status = &composer_status;
+    txn->composer_info.entry = &composer_entry;
     p1 = nr_txn_add_php_package(txn, package_name1, package_version1);
     tlib_pass_if_null(
         "legacy package information not added to transaction after composer api "
@@ -8992,13 +8994,13 @@ static void test_nr_txn_add_php_package_from_source(void) {
   nr_txn_destroy(&txn);
 
   {
-    nr_composer_api_status_t composer_status
-        = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
+    nr_composer_thread_entry_t composer_entry = {0};
+    composer_entry.status = NR_COMPOSER_API_STATUS_PACKAGES_COLLECTED;
     txn = new_txn(0);
     // simulate composer api was successfully used. new_txn()'s test app has
-    // composer_map == NULL, so txn->composer_info.status is NULL after
+    // composer_map == NULL, so txn->composer_info.entry is NULL after
     // begin — point it at a local variable instead of relying on the map.
-    txn->composer_info.status = &composer_status;
+    txn->composer_info.entry = &composer_entry;
     p1 = nr_txn_add_php_package_from_source(txn, package_name1, package_version1,
                                             NR_PHP_PACKAGE_SOURCE_LEGACY);
     tlib_pass_if_null(

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -9141,6 +9141,46 @@ static void test_txn_mark_composer_packages_sent(void) {
   nr_txn_destroy(&txn);
 }
 
+static void test_txn_discard_composer_packages(void) {
+  nr_composer_thread_entry_t entry = {0};
+  nrtxn_t* txn;
+
+  /*
+   * NULL parameters: ensure it does not crash
+   */
+  nr_txn_discard_composer_packages(NULL);
+  txn = build_txn_with_composer_entry(NULL);
+  nr_txn_discard_composer_packages(txn);
+  nr_txn_destroy(&txn);
+
+  /* Discard after a scan: pull never ran (composer_pull_epoch still 0),
+   * entry has a newer epoch than last_sent_epoch -- unlike
+   * nr_txn_mark_composer_packages_sent, this must still advance
+   * last_sent_epoch unconditionally, with no epoch-match gate. */
+  entry.epoch = 5;
+  entry.last_sent_epoch = 2;
+  txn = build_txn_with_composer_entry(&entry);
+  /* composer_pull_epoch intentionally left at 0 -- pull never happened */
+
+  nr_txn_discard_composer_packages(txn);
+  tlib_pass_if_uint64_t_equal(
+      "discard advances last_sent_epoch even though pull never ran", 5,
+      entry.last_sent_epoch);
+
+  nr_txn_destroy(&txn);
+
+  /* Already caught up: no-op but harmless */
+  entry.epoch = 5;
+  entry.last_sent_epoch = 5;
+  txn = build_txn_with_composer_entry(&entry);
+
+  nr_txn_discard_composer_packages(txn);
+  tlib_pass_if_uint64_t_equal("already caught up, stays caught up", 5,
+                              entry.last_sent_epoch);
+
+  nr_txn_destroy(&txn);
+}
+
 static void test_nr_txn_suggest_package_supportability_metric(void) {
   char* json;
   char* package_name1 = "Laravel";
@@ -9299,5 +9339,6 @@ void test_main(void* p NRUNUSED) {
   test_nr_txn_add_php_package_from_source();
   test_txn_pull_composer_packages();
   test_txn_mark_composer_packages_sent();
+  test_txn_discard_composer_packages();
   test_nr_txn_suggest_package_supportability_metric();
 }

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -1715,6 +1715,8 @@ static void test_begin(void) {
     nr_random_seed(rnd, 345345);
     nr_hashmap_index_set(app->rnd_map, (uint64_t)self, rnd);
   }
+  app->composer_map
+      = nr_hashmap_create((nr_hashmap_dtor_func_t)nr_app_composer_status_dtor);
   app->info.high_security = 0;
   app->connect_reply = nro_new_hash();
   app->security_policies = nro_new_hash();
@@ -1765,6 +1767,14 @@ static void test_begin(void) {
 
   rv = nr_txn_begin(app, opts, attribute_config, NULL);
   test_created_txn("options provided", rv, &correct);
+  tlib_pass_if_not_null("composer_info.status populated by nr_txn_begin",
+                        rv->composer_info.status);
+  tlib_pass_if_true(
+      "composer_info.status points at this thread's composer_map entry",
+      rv->composer_info.status
+          == nr_app_get_or_create_thread_composer_status(app,
+                                                         (uint64_t)nr_gettid()),
+      "status=%p", (void*)rv->composer_info.status);
   json = nr_attributes_debug_json(rv->attributes);
   tlib_pass_if_str_equal("display host attribute created", json,
                          "{\"user\":[],\"agent\":["
@@ -1934,6 +1944,7 @@ static void test_begin(void) {
   nro_delete(app->security_policies);
   nr_hashmap_destroy(&app->harvest_map);
   nr_hashmap_destroy(&app->rnd_map);
+  nr_hashmap_destroy(&app->composer_map);
   nr_attribute_config_destroy(&attribute_config);
 }
 


### PR DESCRIPTION
## Summary

Composer's autoload-based package scan was gated by a single status
flag shared by every thread on an app. Under FrankenPHP's ZTS model,
where many threads run the same app in one long-lived process, only
the first thread to hit that autoload event actually ran the scan and
set the flag — every other thread then saw the flag already set and
skipped scanning entirely, so those threads never captured or reported
any Composer package data.

The fix moves that flag to a per-(app, thread) entry, so each thread
independently runs the scan once for itself instead of once per app.
Keying the entry by app as well as thread was also necessary for
multi-app deployments: FrankenPHP can run multiple apps on the same
shared thread pool, and a flag keyed by thread alone would have let one
app's scan incorrectly suppress scanning for a second app that later
runs on that same thread.

Testing under FrankenPHP's worker mode surfaced a follow-on problem:
a thread's one-time scan can happen during worker bootstrap, before a
transaction exists and before the app has finished registering with
the daemon — so there's nowhere to attach the scanned data at the time
it's collected. To handle that, the per-thread entry now also caches
the scan result independently of any transaction, and each transaction
pulls whatever is cached on its thread when it runs, rather than
requiring a transaction to be live at scan time.

Additional correctness fixes that came out of testing this cache:

- A transaction that ends up discarded (ignored) no longer causes the
  next transaction on that thread to inherit and resend its data.
- Removed a fallback that could re-report already-sent package data on
  every later transaction.
- Restored the `Composer/detected` and `Autoloader/detected` metrics
  for the case where the scan runs with no live transaction (e.g.
  during worker bootstrap) — they were previously lost in that window
  even though the package data itself was recovered by the cache.
