### PR TITLE
chore(ci): dependabot version updates config tuneup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     target-branch: "dev"
     commit-message:
       prefix: "chore(daemon):"
+    groups:
+      gomod:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"    
-    directory: "/daemon"                
+  - package-ecosystem: "gomod"
+    directory: "/daemon"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"      
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"
     commit-message:
       prefix: "chore(deps):"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(deps):"      
+      prefix: "chore(daemon):"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     commit-message:
-      prefix: "chore(deps):"
+      prefix: "ci:"
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,14 @@ updates:
     directory: "/daemon"
     schedule:
       interval: "weekly"
+    target-branch: "dev"
     commit-message:
       prefix: "chore(daemon):"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    target-branch: "dev"
     commit-message:
       prefix: "ci:"
     groups:


### PR DESCRIPTION
#### Format dependabot.yml

Remove trailing whitespace and quote all scalar values.

#### Use conventional commits for dependabot PR titles

Using conventional commits makes it easier to assign, prioritize, and
evaluate dependabot PRs based on parts of the codebase they touch.

#### Target dependabot version updates at "dev" branch

To allow automated dependabot version updates go through the the same
review/merge/release process as any other updates in this repository,
dependabot version updates should be applied to "dev" (the integration)
branch, not "main" (the default) branch.
    
**Note**: Automated dependabot security updates are still targeted at
the default branch.

#### Group gomod bumps to reduce dependabot PR sprawl
