### PR TITLE
fix(daemon): handle Trace Observer graceful stream close

### DIFF
--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
@@ -127,7 +127,7 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 	// shutdown). A caller that reconnects while a prior stream is still
 	// live could still leave a push arriving after this drain -
 	// TestConcurrentRecvOnReassignedStream forces exactly that
-	// interleaving to prove Fix 4's stream-binding is what makes this
+	// interleaving to prove stream-binding is what makes this
 	// safe in practice.
 	for {
 		select {

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
@@ -117,9 +117,18 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 	// Drain any status left over from a previous stream generation.
 	// s.responseError is never recreated across statusRestart/
 	// statusImmediateRestart reconnects (only clone(), on statusReconnect,
-	// gets a fresh one), so anything still buffered here can only be a
-	// leftover from a goroutine that has already terminated - the new
-	// generation's goroutine doesn't exist yet.
+	// gets a fresh one), and the new generation's goroutine doesn't exist
+	// yet, so anything still buffered here can only be a leftover push.
+	// That leftover is guaranteed to come from an already-terminated
+	// goroutine only because of a caller-side precondition, not anything
+	// intrinsic to connect(): the only caller, doStreaming() in
+	// trace_observer.go, calls connect() only after the previous stream
+	// has already terminated (a send error, a responseError push, or
+	// shutdown). A caller that reconnects while a prior stream is still
+	// live could still leave a push arriving after this drain -
+	// TestConcurrentRecvOnReassignedStream forces exactly that
+	// interleaving to prove Fix 4's stream-binding is what makes this
+	// safe in practice.
 	for {
 		select {
 		case <-s.responseError:
@@ -143,6 +152,9 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 	s.stream = stream
 
 	log.Debugf("connected to grpc endpoint %s", s.Host)
+	// stream is taken as a parameter (not a closure over the local above)
+	// so the binding is structural: nothing inside this goroutine can
+	// accidentally read s.stream, which is reassigned on every reconnect.
 	go func(stream v1.IngestService_RecordSpanBatchClient) {
 		for {
 			in, err := stream.Recv()

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
@@ -156,14 +156,8 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 				return
 			default:
 				log.Errorf("unexpected error from grpc endpoint:  %v", err)
-				status := newSpanBatchStatusFromGrpcErr(err)
-				if status.code == statusShutdown || status.code == statusReconnect {
-					s.responseError <- status
-					return
-				} else {
-					status.code = statusOk
-					s.responseError <- status
-				}
+				s.responseError <- newSpanBatchStatusFromGrpcErr(err)
+				return
 			}
 		}
 	}()

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
@@ -156,8 +156,24 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 	return nil, spanBatchSenderStatus{code: statusOk}
 }
 
+// sendEofStatusGracePeriod bounds how long send() waits for the receive
+// goroutine's classification after an EOF from SendMsg. Not tuned to any
+// measured EOF-detection latency - chosen defensively, well above what a
+// healthy local transport should ever take, so the common case resolves in
+// well under a millisecond and this only matters in already-degraded
+// conditions.
+const sendEofStatusGracePeriod = 1 * time.Second
+
 func (s *grpcSpanBatchSender) send(batch encodedSpanBatch) (error, spanBatchSenderStatus) {
 	if err := s.stream.SendMsg(batch); err != nil {
+		if err == io.EOF {
+			select {
+			case status := <-s.responseError:
+				return err, status
+			case <-time.After(sendEofStatusGracePeriod):
+				log.Errorf("timed out waiting for grpc stream status after EOF from SendMsg")
+			}
+		}
 		return err, newSpanBatchStatusFromGrpcErr(err)
 	}
 	return nil, spanBatchSenderStatus{code: statusOk}

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
@@ -114,6 +114,21 @@ func (s *grpcSpanBatchSender) clone() (spanBatchSender, error) {
 }
 
 func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
+	// Drain any status left over from a previous stream generation.
+	// s.responseError is never recreated across statusRestart/
+	// statusImmediateRestart reconnects (only clone(), on statusReconnect,
+	// gets a fresh one), so anything still buffered here can only be a
+	// leftover from a goroutine that has already terminated - the new
+	// generation's goroutine doesn't exist yet.
+	for {
+		select {
+		case <-s.responseError:
+			continue
+		default:
+		}
+		break
+	}
+
 	md := newMetadata(s.RunId, s.License, s.RequestHeadersMap)
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
@@ -143,9 +143,9 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 	s.stream = stream
 
 	log.Debugf("connected to grpc endpoint %s", s.Host)
-	go func() {
+	go func(stream v1.IngestService_RecordSpanBatchClient) {
 		for {
-			in, err := s.stream.Recv()
+			in, err := stream.Recv()
 
 			switch err {
 			case nil:
@@ -160,7 +160,7 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 				return
 			}
 		}
-	}()
+	}(stream)
 
 	return nil, spanBatchSenderStatus{code: statusOk}
 }

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender.go
@@ -137,6 +137,7 @@ func (s *grpcSpanBatchSender) connect() (error, spanBatchSenderStatus) {
 				log.Debugf("grpc endpoint messages seen: %d", in.MessagesSeen)
 			case io.EOF:
 				log.Debugf("received EOF from grpc endpoint")
+				s.responseError <- spanBatchSenderStatus{code: statusImmediateRestart}
 				return
 			default:
 				log.Errorf("unexpected error from grpc endpoint:  %v", err)

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
@@ -348,6 +348,15 @@ func TestInvalidSpan(t *testing.T) {
 	if status.metric != "Supportability/InfiniteTracing/Span/gRPC/INTERNAL" {
 		t.Fatalf("expected the INTERNAL supportability metric, got %q", status.metric)
 	}
+
+	// The receive goroutine must push exactly once and return - not loop
+	// back into Recv() and refill the channel. Fix 5's drain at the top of
+	// connect() depends on every exit path behaving this way.
+	select {
+	case extra := <-responseError:
+		t.Fatalf("receive goroutine kept pushing after a genuine error: %v", extra)
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 func TestErrToCodeString(t *testing.T) {
@@ -605,5 +614,54 @@ func TestConcurrentRecvOnReassignedStream(t *testing.T) {
 
 	if atomic.LoadInt32(&violated) != 0 {
 		t.Fatalf("concurrent Recv() calls observed on a reassigned stream")
+	}
+}
+
+// eofOnSendStream stubs just enough of
+// v1.IngestService_RecordSpanBatchClient to make SendMsg return io.EOF.
+// Every other method is left to panic if ever called - send()'s fallback
+// path under test never reaches them, and no receive goroutine is started
+// against this stream (it's assigned directly to s.stream, bypassing
+// connect()), so there is nothing to push onto s.responseError.
+type eofOnSendStream struct {
+	v1.IngestService_RecordSpanBatchClient
+}
+
+func (e *eofOnSendStream) SendMsg(m any) error {
+	return io.EOF
+}
+
+// TestSendEofGracePeriodTimeout exercises send()'s fallback branch: when
+// SendMsg returns io.EOF and nothing arrives on s.responseError within
+// sendEofStatusGracePeriod, send() must fall through to classifying the
+// bare io.EOF itself rather than hang or return early.
+func TestSendEofGracePeriodTimeout(t *testing.T) {
+	sender, err := newGrpcSpanBatchSender(&Config{
+		Host:   "localhost",
+		Port:   10999,
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("error initializing sender: %v", err)
+	}
+	defer sender.conn.Close()
+
+	sender.stream = &eofOnSendStream{}
+
+	start := time.Now()
+	sendErr, status := sender.send(encodedSpanBatch([]byte{1, 2, 3}))
+	elapsed := time.Since(start)
+
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("send() returned after %v, expected it to wait out the ~%v grace period", elapsed, sendEofStatusGracePeriod)
+	}
+	if sendErr != io.EOF {
+		t.Fatalf("expected send() to return io.EOF, got %v", sendErr)
+	}
+	if status.code != statusRestart {
+		t.Fatalf("expected statusRestart, got %v", status.code)
+	}
+	if status.metric != "Supportability/InfiniteTracing/Span/gRPC/UNKNOWN" {
+		t.Fatalf("expected the UNKNOWN supportability metric, got %q", status.metric)
 	}
 }

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
@@ -428,3 +428,41 @@ func TestSendAfterServerOkCloseGetsCorrectStatus(t *testing.T) {
 		t.Fatalf("expected statusImmediateRestart after OK close, got %v", status.code)
 	}
 }
+
+func TestConnectDrainsStaleResponseError(t *testing.T) {
+	srv := newTestObsServer(t)
+	defer srv.Close()
+
+	sender, err := newGrpcSpanBatchSender(&Config{
+		Host:   srv.host,
+		Port:   srv.port,
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("error initializing sender: %v", err)
+	}
+	defer sender.conn.Close()
+
+	if err, _ := sender.connect(); err != nil {
+		t.Fatalf("unexpected error during first connect: %v", err)
+	}
+
+	// Simulate a stale push left over from a previous generation: something
+	// the old generation's receive goroutine pushed after send()'s grace
+	// period had already timed out and moved on without consuming it.
+	sender.responseError <- spanBatchSenderStatus{code: statusRestart, metric: "stale"}
+
+	if err, _ := sender.connect(); err != nil {
+		t.Fatalf("unexpected error during second connect: %v", err)
+	}
+
+	// The server never closes or errors (closeAfterOneMessage is unset), so
+	// the new generation's own goroutine has no reason to push anything by
+	// the time connect() returns - this check is deterministic, not a race
+	// against the new goroutine.
+	select {
+	case status := <-sender.responseError:
+		t.Fatalf("expected the stale status to have been drained, got %v", status)
+	default:
+	}
+}

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
@@ -533,8 +533,7 @@ func TestConnectDrainsStaleResponseError(t *testing.T) {
 }
 
 // guardedRecordSpanBatchClient wraps a real stream and flags it if Recv()
-// is ever called by more than one goroutine at a time - the exact
-// is ever called by more than one goroutine at a time to validate 
+// is ever called by more than one goroutine at a time to validate
 // stream generation does not share streams between goroutines.
 type guardedRecordSpanBatchClient struct {
 	v1.IngestService_RecordSpanBatchClient

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
@@ -377,3 +377,54 @@ func TestServerClosesWithOK(t *testing.T) {
 		t.Fatalf("timed out waiting for responseError after OK close")
 	}
 }
+
+func TestSendAfterServerOkCloseGetsCorrectStatus(t *testing.T) {
+	srv := newTestObsServer(t)
+	srv.closeAfterOneMessage = true
+	defer srv.Close()
+
+	sender, err := newGrpcSpanBatchSender(&Config{
+		Host:   srv.host,
+		Port:   srv.port,
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("error initializing sender: %v", err)
+	}
+	defer sender.conn.Close()
+
+	err, _ = sender.connect()
+	if err != nil {
+		t.Fatalf("unexpected error during connect: %v", err)
+	}
+
+	s := &v1.Span{TraceId: "trace_id"}
+	b := &v1.SpanBatch{Spans: []*v1.Span{s}}
+	bs, _ := proto.Marshal(b)
+
+	// First send triggers the server's graceful OK close after one message.
+	if err, _ := sender.send(encodedSpanBatch(bs)); err != nil {
+		t.Fatalf("unexpected error during first send: %v", err)
+	}
+
+	// The transport doesn't guarantee exactly when a subsequent SendMsg
+	// discovers the closed stream, so poll rather than assume the first
+	// retry hits it.
+	deadline := time.Now().Add(2 * time.Second)
+	var sendErr error
+	var status spanBatchSenderStatus
+	for time.Now().Before(deadline) {
+		sendErr, status = sender.send(encodedSpanBatch(bs))
+		if sendErr != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if sendErr == nil {
+		t.Fatalf("expected send to eventually observe the closed stream")
+	}
+	if status.code != statusImmediateRestart {
+		t.Fatalf("expected statusImmediateRestart after OK close, got %v", status.code)
+	}
+}

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -26,6 +27,7 @@ type testGrpcServer struct {
 	port                 uint16
 	spansReceivedChan    chan *v1.SpanBatch
 	metadataReceivedChan chan metadata.MD
+	closeAfterOneMessage bool
 }
 
 func (s *testGrpcServer) RecordSpanBatch(stream v1.IngestService_RecordSpanBatchServer) error {
@@ -41,6 +43,9 @@ func (s *testGrpcServer) RecordSpanBatch(stream v1.IngestService_RecordSpanBatch
 			return err
 		}
 		s.spansReceivedChan <- batch
+		if s.closeAfterOneMessage {
+			return nil
+		}
 	}
 }
 
@@ -326,5 +331,49 @@ func TestErrToCodeString(t *testing.T) {
 					actual, test.expect)
 			}
 		})
+	}
+}
+
+func TestServerClosesWithOK(t *testing.T) {
+	srv := newTestObsServer(t)
+	srv.closeAfterOneMessage = true
+	defer srv.Close()
+
+	sender, err := newGrpcSpanBatchSender(&Config{
+		Host:   srv.host,
+		Port:   srv.port,
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("error initializing sender: %v", err)
+	}
+	defer sender.conn.Close()
+
+	responseError := sender.response()
+
+	err, _ = sender.connect()
+	if err != nil {
+		t.Fatalf("unexpected error during connect: %v", err)
+	}
+
+	s := &v1.Span{TraceId: "trace_id"}
+	b := &v1.SpanBatch{Spans: []*v1.Span{s}}
+	bs, _ := proto.Marshal(b)
+
+	err, _ = sender.send(encodedSpanBatch(bs))
+	if err != nil {
+		t.Fatalf("unexpected error during sending: %v", err)
+	}
+
+	select {
+	case status := <-responseError:
+		if status.code != statusImmediateRestart {
+			t.Fatalf("expected statusImmediateRestart on responseError, got %v", status.code)
+		}
+		if status.metric != "" {
+			t.Fatalf("expected no supportability metric for a graceful close, got %q", status.metric)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for responseError after OK close")
 	}
 }

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
@@ -350,7 +350,7 @@ func TestInvalidSpan(t *testing.T) {
 	}
 
 	// The receive goroutine must push exactly once and return - not loop
-	// back into Recv() and refill the channel. Fix 5's drain at the top of
+	// back into Recv() and refill the channel. The drain at the top of
 	// connect() depends on every exit path behaving this way.
 	select {
 	case extra := <-responseError:
@@ -534,7 +534,8 @@ func TestConnectDrainsStaleResponseError(t *testing.T) {
 
 // guardedRecordSpanBatchClient wraps a real stream and flags it if Recv()
 // is ever called by more than one goroutine at a time - the exact
-// violation defect 4 makes possible once a stream generation is shared.
+// is ever called by more than one goroutine at a time to validate 
+// stream generation does not share streams between goroutines.
 type guardedRecordSpanBatchClient struct {
 	v1.IngestService_RecordSpanBatchClient
 	recvInFlight int32

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
@@ -289,8 +289,11 @@ func TestInvalidSpan(t *testing.T) {
 
 	status := <-responseError
 
-	if status.code != statusOk {
-		t.Fatalf("expected statusOk on responseError")
+	if status.code != statusRestart {
+		t.Fatalf("expected statusRestart on responseError, got %v", status.code)
+	}
+	if status.metric != "Supportability/InfiniteTracing/Span/gRPC/INTERNAL" {
+		t.Fatalf("expected the INTERNAL supportability metric, got %q", status.metric)
 	}
 }
 

--- a/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/grpc_sender_test.go
@@ -6,9 +6,11 @@
 package infinite_tracing
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,12 +30,19 @@ type testGrpcServer struct {
 	spansReceivedChan    chan *v1.SpanBatch
 	metadataReceivedChan chan metadata.MD
 	closeAfterOneMessage bool
+	ackThenWait          bool
+	ackStreamCalls       int32
+	firstAckSent         chan struct{}
+	proceedWithSecondAck chan struct{}
 }
 
 func (s *testGrpcServer) RecordSpanBatch(stream v1.IngestService_RecordSpanBatchServer) error {
 	md, ok := metadata.FromIncomingContext(stream.Context())
 	if ok {
 		s.metadataReceivedChan <- md
+	}
+	if s.ackThenWait {
+		return s.recordSpanBatchAckThenWait(stream)
 	}
 	for {
 		batch, err := stream.Recv()
@@ -47,6 +56,24 @@ func (s *testGrpcServer) RecordSpanBatch(stream v1.IngestService_RecordSpanBatch
 			return nil
 		}
 	}
+}
+
+// recordSpanBatchAckThenWait handles the FIRST RecordSpanBatch call by
+// sending one ack, signalling the test, then waiting to be told to send a
+// second ack. Every later call (a second connect() on the same sender)
+// just idles until the client disconnects, so it never interferes.
+func (s *testGrpcServer) recordSpanBatchAckThenWait(stream v1.IngestService_RecordSpanBatchServer) error {
+	if atomic.AddInt32(&s.ackStreamCalls, 1) == 1 {
+		if err := stream.Send(&v1.RecordStatus{MessagesSeen: 1}); err != nil {
+			return err
+		}
+		close(s.firstAckSent)
+		<-s.proceedWithSecondAck
+		stream.Send(&v1.RecordStatus{MessagesSeen: 2})
+		return nil
+	}
+	<-stream.Context().Done()
+	return nil
 }
 
 func (s *testGrpcServer) RecordSpan(stream v1.IngestService_RecordSpanServer) error {
@@ -118,6 +145,32 @@ func newInvalidObsServer(t *testing.T) *testGrpcServer {
 		spansReceivedChan:    make(chan *v1.SpanBatch, 10),
 		metadataReceivedChan: make(chan metadata.MD, 10),
 	}
+}
+
+func newAckThenWaitObsServer(t *testing.T) *testGrpcServer {
+	lis, port, err := getPortListener()
+	if err != nil {
+		t.Fatalf("Cannot start grpc test server: %v", err)
+	}
+
+	grpcServer := grpc.NewServer()
+
+	s := &testGrpcServer{
+		host:                 "localhost",
+		port:                 port,
+		server:               grpcServer,
+		spansReceivedChan:    make(chan *v1.SpanBatch, 10),
+		metadataReceivedChan: make(chan metadata.MD, 10),
+		ackThenWait:          true,
+		firstAckSent:         make(chan struct{}),
+		proceedWithSecondAck: make(chan struct{}),
+	}
+
+	v1.RegisterIngestServiceServer(s.server, s)
+
+	go grpcServer.Serve(*lis)
+
+	return s
 }
 
 func TestInvalidHost(t *testing.T) {
@@ -467,5 +520,90 @@ func TestConnectDrainsStaleResponseError(t *testing.T) {
 	case status := <-sender.responseError:
 		t.Fatalf("expected the stale status to have been drained, got %v", status)
 	default:
+	}
+}
+
+// guardedRecordSpanBatchClient wraps a real stream and flags it if Recv()
+// is ever called by more than one goroutine at a time - the exact
+// violation defect 4 makes possible once a stream generation is shared.
+type guardedRecordSpanBatchClient struct {
+	v1.IngestService_RecordSpanBatchClient
+	recvInFlight int32
+	violated     *int32
+}
+
+func (g *guardedRecordSpanBatchClient) Recv() (*v1.RecordStatus, error) {
+	if !atomic.CompareAndSwapInt32(&g.recvInFlight, 0, 1) {
+		atomic.StoreInt32(g.violated, 1)
+	}
+	defer atomic.StoreInt32(&g.recvInFlight, 0)
+	return g.IngestService_RecordSpanBatchClient.Recv()
+}
+
+// guardedIngestServiceClient wraps every stream RecordSpanBatch returns in
+// a guardedRecordSpanBatchClient, sharing one violated flag across all of
+// them.
+type guardedIngestServiceClient struct {
+	v1.IngestServiceClient
+	violated *int32
+}
+
+func (g *guardedIngestServiceClient) RecordSpanBatch(ctx context.Context, opts ...grpc.CallOption) (v1.IngestService_RecordSpanBatchClient, error) {
+	stream, err := g.IngestServiceClient.RecordSpanBatch(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &guardedRecordSpanBatchClient{IngestService_RecordSpanBatchClient: stream, violated: g.violated}, nil
+}
+
+func TestConcurrentRecvOnReassignedStream(t *testing.T) {
+	srv := newAckThenWaitObsServer(t)
+	defer srv.Close()
+
+	sender, err := newGrpcSpanBatchSender(&Config{
+		Host:   srv.host,
+		Port:   srv.port,
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("error initializing sender: %v", err)
+	}
+	defer sender.conn.Close()
+
+	var violated int32
+	sender.client = &guardedIngestServiceClient{IngestServiceClient: sender.client, violated: &violated}
+
+	// Generation 1: the receive goroutine takes case nil on the first ack
+	// and loops back into Recv(), where it blocks waiting for the second.
+	if err, _ := sender.connect(); err != nil {
+		t.Fatalf("unexpected error during first connect: %v", err)
+	}
+
+	select {
+	case <-srv.firstAckSent:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for the first ack to be sent")
+	}
+
+	// Give the receive goroutine a moment to process the ack and re-enter
+	// Recv() before the field it reads gets reassigned under it.
+	time.Sleep(50 * time.Millisecond)
+
+	// Generation 2: reconnect on the SAME sender - simulating a
+	// send-failure-triggered reconnect racing the still-looping
+	// generation-1 goroutine.
+	if err, _ := sender.connect(); err != nil {
+		t.Fatalf("unexpected error during second connect: %v", err)
+	}
+
+	// Release the second ack on stream 1. If defect 4 is present, the
+	// generation-1 goroutine reads the reassigned s.stream field and calls
+	// Recv() on stream 2, concurrently with generation 2's own goroutine.
+	close(srv.proceedWithSecondAck)
+
+	time.Sleep(200 * time.Millisecond)
+
+	if atomic.LoadInt32(&violated) != 0 {
+		t.Fatalf("concurrent Recv() calls observed on a reassigned stream")
 	}
 }

--- a/daemon/internal/newrelic/infinite_tracing/trace_observer.go
+++ b/daemon/internal/newrelic/infinite_tracing/trace_observer.go
@@ -7,6 +7,7 @@ package infinite_tracing
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -54,6 +55,30 @@ const (
 	// immediately.
 	statusImmediateRestart
 )
+
+// String is needed because spanBatchSenderStatus.code is unexported: fmt won't call
+// spanBatchSenderCode's own String() through a reflected unexported field.
+func (s spanBatchSenderStatus) String() string {
+	return fmt.Sprintf("{%v %s}", s.code, s.metric)
+}
+
+// String prints the code's name alongside its number.
+func (c spanBatchSenderCode) String() string {
+	name := "unknown"
+	switch c {
+	case statusOk:
+		name = "statusOk"
+	case statusShutdown:
+		name = "statusShutdown"
+	case statusRestart:
+		name = "statusRestart"
+	case statusReconnect:
+		name = "statusReconnect"
+	case statusImmediateRestart:
+		name = "statusImmediateRestart"
+	}
+	return fmt.Sprintf("%d - %s", int(c), name)
+}
 
 // The sender is split out via an interface. This is not strictly necessary,
 // but makes it easier to test things.

--- a/daemon/internal/newrelic/infinite_tracing/trace_observer_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/trace_observer_test.go
@@ -7,6 +7,7 @@ package infinite_tracing
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -467,5 +468,63 @@ func TestOkCloseReconnectsWithoutBackoff(t *testing.T) {
 	case <-srv.spansReceivedChan:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("second batch didn't arrive within 2s - looks like it hit the 15s backoff")
+	}
+}
+
+func TestSpanBatchSenderCodeString(t *testing.T) {
+	testcases := []struct {
+		code   spanBatchSenderCode
+		expect string
+	}{
+		{code: statusOk, expect: "0 - statusOk"},
+		{code: statusShutdown, expect: "1 - statusShutdown"},
+		{code: statusRestart, expect: "2 - statusRestart"},
+		{code: statusReconnect, expect: "3 - statusReconnect"},
+		{code: statusImmediateRestart, expect: "4 - statusImmediateRestart"},
+		// one past the last defined code, to catch an unhandled value if a
+		// new status is ever added without updating String()
+		{code: spanBatchSenderCode(5), expect: "5 - unknown"},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.expect, func(t *testing.T) {
+			actual := test.code.String()
+			if actual != test.expect {
+				t.Errorf("wrong string returned: actual=%s expected=%s", actual, test.expect)
+			}
+		})
+	}
+}
+
+func TestSpanBatchSenderStatusString(t *testing.T) {
+	testcases := []struct {
+		name   string
+		status spanBatchSenderStatus
+		expect string
+	}{
+		{
+			name:   "no metric",
+			status: spanBatchSenderStatus{code: statusImmediateRestart},
+			expect: "{4 - statusImmediateRestart }",
+		},
+		{
+			name:   "with metric",
+			status: spanBatchSenderStatus{code: statusRestart, metric: "Supportability/InfiniteTracing/Span/gRPC/UNKNOWN"},
+			expect: "{2 - statusRestart Supportability/InfiniteTracing/Span/gRPC/UNKNOWN}",
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			// Exercise the exact call sites that motivated this: %v on the
+			// status struct directly, not just calling String() by hand -
+			// this is what caught that fmt won't invoke a Stringer through
+			// an unexported field without a String() method on the struct
+			// itself.
+			actual := fmt.Sprintf("%v", test.status)
+			if actual != test.expect {
+				t.Errorf("wrong string returned: actual=%s expected=%s", actual, test.expect)
+			}
+		})
 	}
 }

--- a/daemon/internal/newrelic/infinite_tracing/trace_observer_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/trace_observer_test.go
@@ -10,6 +10,10 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	v1 "github.com/newrelic/newrelic-php-agent/daemon/internal/newrelic/infinite_tracing/com_newrelic_trace_v1"
 )
 
 type mockSpanBatchSender struct {
@@ -399,5 +403,64 @@ func TestReconnect(t *testing.T) {
 
 	if sender.cloneAttempts != 2 {
 		t.Errorf("expected 2 clone attempts, got %v", sender.cloneAttempts)
+	}
+}
+
+func TestOkCloseReconnectsWithoutBackoff(t *testing.T) {
+	srv := newTestObsServer(t)
+	srv.closeAfterOneMessage = true
+	defer srv.Close()
+
+	sender, err := newGrpcSpanBatchSender(&Config{
+		Host:   srv.host,
+		Port:   srv.port,
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("error initializing sender: %v", err)
+	}
+
+	to, worker := newTraceObserverWithWorker(&Config{
+		QueueSize: 100,
+	})
+	defer to.Shutdown(10 * time.Millisecond)
+	go func() {
+		to.sender = sender
+		worker()
+	}()
+
+	batch1, _ := proto.Marshal(&v1.SpanBatch{Spans: []*v1.Span{{TraceId: "first"}}})
+	to.QueueBatch(1, batch1)
+
+	select {
+	case <-srv.spansReceivedChan:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("didn't receive first span batch")
+	}
+
+	// srv.spansReceivedChan fires the instant the server's handler receives
+	// the first message - before that handler returns and the OK close
+	// trailer actually reaches the client over the socket. Without this
+	// pause, queuing batch2 races the close notification: if it loses,
+	// SendMsg can succeed locally on the already-server-closed stream
+	// (the message is silently dropped, no error at all - the same
+	// transport quirk TestSendAfterServerOkCloseGetsCorrectStatus polls
+	// around), and the batch is gone before send() ever gets a chance to
+	// classify anything. This isn't a fixed EOF-detection latency either -
+	// it's comfortably longer than a loopback close round-trip should ever
+	// take, so the pause resolves before it's noticed in the common case.
+	time.Sleep(50 * time.Millisecond)
+
+	// The server closes the stream with OK after that first message. A
+	// second batch should still land quickly - well under the 15s
+	// recordSpanBackoff - if the OK close is handled as an immediate
+	// reconnect instead of a generic error.
+	batch2, _ := proto.Marshal(&v1.SpanBatch{Spans: []*v1.Span{{TraceId: "second"}}})
+	to.QueueBatch(1, batch2)
+
+	select {
+	case <-srv.spansReceivedChan:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("second batch didn't arrive within 2s - looks like it hit the 15s backoff")
 	}
 }

--- a/daemon/internal/newrelic/infinite_tracing/trace_observer_test.go
+++ b/daemon/internal/newrelic/infinite_tracing/trace_observer_test.go
@@ -419,11 +419,16 @@ func TestOkCloseReconnectsWithoutBackoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error initializing sender: %v", err)
 	}
+	defer sender.conn.Close()
 
 	to, worker := newTraceObserverWithWorker(&Config{
 		QueueSize: 100,
 	})
-	defer to.Shutdown(10 * time.Millisecond)
+	defer func() {
+		if err := to.Shutdown(10 * time.Millisecond); err != nil {
+			t.Logf("Shutdown returned an error (likely just the tight 10ms timeout): %v", err)
+		}
+	}()
 	go func() {
 		to.sender = sender
 		worker()


### PR DESCRIPTION
## Summary

The Trace Observer closes every Infinite Tracing gRPC stream with an `OK` status roughly every 30s as a load-balancing measure. The daemon mishandled this in four ways, all in `grpc_sender.go`'s `connect()`/`send()`:

- **Receive path swallowed the close.** A bare `io.EOF` from `Recv()` (how grpc-go signals a clean `OK` close) was treated as "nothing to report" and discarded silently.
- **Send path misclassified the resulting failure.** The dead stream was only discovered on the next `send()`, where `SendMsg` also returns bare `io.EOF` — misclassified as a generic error, triggering the spec's 15s error backoff for a routine, expected close, and dropping the batch in flight.
- **The `default:` branch rewrote genuine errors to `statusOk`** without returning, so a truly dead stream spun the goroutine and could leak stale statuses into the next stream generation.
- **The receive goroutine read the reassignable `s.stream` field instead of the stream it was spawned for**, letting a goroutine from a stale generation call `Recv()` concurrently with a newer generation's own goroutine — forbidden by grpc-go, and a plain data race.

Net effect: ~33% of wall-clock time not streaming, and one span batch destroyed on every ~45s cycle for as long as spans were being produced.

Fixes, one commit each:
1. Signal `statusImmediateRestart` on a graceful `io.EOF` instead of returning silently.
2. Defer to the receive goroutine's classification on a send-side `EOF`, closing the race where a queued batch could still hit the dead stream first.
3. Drain any `responseError` entry left over from a previous generation before establishing a new stream — closes a narrow leak in fix 2's own channel-reuse design.
4. Stop rewriting genuine receive errors to `statusOk`.
5. Bind the receive goroutine to the stream it was created for — closes the stale-field race and the data race in the same change.

Plus a final review pass (test-gap and invariant hardening) and a small logging improvement that fell out of manual log inspection while verifying the fix.

**Out of scope**: batch retention/retransmission on reconnect, `Span/Sent` over-counting, gzip compression, `ConnectParams.Backoff` being shadowed on a genuinely dropped TCP connection (a different code path than this fix), the `handleSupportability` goroutine leak, and wiring `go test -race` into CI.

## Test plan

- [x] New/updated unit tests in `grpc_sender_test.go` and `trace_observer_test.go`: `TestServerClosesWithOK`, `TestSendAfterServerOkCloseGetsCorrectStatus`, `TestConnectDrainsStaleResponseError`, `TestConcurrentRecvOnReassignedStream`, `TestSendEofGracePeriodTimeout`, `TestOkCloseReconnectsWithoutBackoff`, updated `TestInvalidSpan`, plus `TestSpanBatchSenderCodeString`/`TestSpanBatchSenderStatusString` for the logging change.
- [x] `go test ./...`, `go vet ./...`, `gofmt -l` clean on the `daemon` module.
- [x] `go test -race` clean on `internal/newrelic/infinite_tracing` across repeated runs (not wired into CI — see out-of-scope above).
- [x] End-to-end before/after verification: two runs each of the pre-fix build (version-matched to the customer's reported `12.9.0.38`) and this branch, against a real Trace Observer test harness. Every pre-fix cycle (26/26 across both runs) loses a batch, stalls 15s, and misreports `Supportability/InfiniteTracing/Span/gRPC/UNKNOWN`; every post-fix cycle (40/40 across both runs) reconnects in under 1.2ms with zero loss and zero misclassification.
