### PR TITLE
feat(agent): Guzzle 8 support

### DIFF
--- a/agent/fw_hooks.h
+++ b/agent/fw_hooks.h
@@ -35,6 +35,7 @@ extern void nr_aws_sdk_php_enable();
 extern void nr_doctrine2_enable(TSRMLS_D);
 extern void nr_guzzle4_enable(TSRMLS_D);
 extern void nr_guzzle6_enable(TSRMLS_D);
+extern void nr_guzzle8_enable(TSRMLS_D);
 extern void nr_laminas_http_enable(TSRMLS_D);
 extern void nr_mongodb_enable(TSRMLS_D);
 extern void nr_php_amqplib_enable();

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -438,75 +438,12 @@ end:
 NR_PHP_WRAPPER_END
 
 void nr_guzzle6_enable(TSRMLS_D) {
-  int retval;
-
   if (0 == NRINI(guzzle_enabled)) {
     return;
   }
 
-  /*
-   * Here's something new: we're going to evaluate PHP code to build our
-   * middleware in PHP, rather than doing it in C. This is mostly because it's
-   * fairly difficult to return a higher-order function from C; while possible,
-   * the code to do so is horrible enough that this actually feels cleaner.
-   *
-   * We'll do it when the library is detected because that should only happen
-   * once, but we'll also be careful to put guards around the function
-   * declaration just in case.
-   *
-   * On the bright side, zend_eval_string() effectively treats the string given
-   * as a standalone file, so we can use a normal namespace declaration to
-   * avoid possible clashes.
-   */
-  retval = zend_eval_string(
-      "namespace newrelic\\Guzzle6;"
-
-      "use Psr\\Http\\Message\\RequestInterface;"
-      "use GuzzleHttp\\Promise\\PromiseInterface;"
-
-      "if (!function_exists('newrelic\\Guzzle6\\middleware')) {"
-      "  function middleware(callable $handler) {"
-      "    return function (RequestInterface $request, array $options) use "
-      "($handler) {"
-
-      /*
-       * Start by adding the outbound CAT/DT/Synthetics headers to the request.
-       */
-      "      foreach (newrelic_get_request_metadata('Guzzle 6') as $k => $v) {"
-      "        $request = $request->withHeader($k, $v);"
-      "      }"
-
-      /*
-       * Set up the RequestHandler object and attach it to the promise so that
-       * we create an external node and deal with the CAT headers coming back
-       * from the far end.
-       */
-      "      $rh = new RequestHandler($request);"
-      "      $promise = $handler($request, $options);"
-      "      if (PromiseInterface::REJECTED == $promise->getState()) {"
-      /*
-                Special case for sync request. When sync requests is rejected,
-                onRejected callback is not called via `PromiseInterface::then`
-                and needs to be called manually.
-       */
-      "        $rh->onRejected($promise);"
-      "      } else {"
-      "        $promise->then([$rh, 'onFulfilled'], [$rh, 'onRejected']);"
-      "      }"
-      "      return $promise;"
-      "    };"
-      "  }"
-      "}",
-      NULL, "newrelic/Guzzle6" TSRMLS_CC);
-
-  if (SUCCESS == retval) {
-    nr_php_wrap_user_function(NR_PSTR("GuzzleHttp\\Client::__construct"),
+  nr_php_wrap_user_function(NR_PSTR("GuzzleHttp\\Client::__construct"),
                               nr_guzzle_client_construct TSRMLS_CC);
-  } else {
-    nrl_warning(NRL_FRAMEWORK,
-                "%s: error evaluating PHP code; not installing handler",
-                __func__);
-  }
 }
 
 void nr_guzzle6_minit(TSRMLS_D) {

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -438,12 +438,95 @@ end:
 NR_PHP_WRAPPER_END
 
 void nr_guzzle6_enable(TSRMLS_D) {
+  zend_function* middleware_func = NULL;
   if (0 == NRINI(guzzle_enabled)) {
     return;
   }
+  middleware_func = nr_php_find_function("newrelic\\Guzzle6\\middleware");
+  if (NULL != middleware_func) {
+    return;
+  }
 
-  nr_php_wrap_user_function(NR_PSTR("GuzzleHttp\\Client::__construct"),
+  /*
+   * Here's something new: we're going to evaluate PHP code to build our
+   * middleware in PHP, rather than doing it in C. This is mostly because it's
+   * fairly difficult to return a higher-order function from C; while possible,
+   * the code to do so is horrible enough that this actually feels cleaner.
+   *
+   * We'll do it when the library is detected because that should only happen
+   * once, but we'll also be careful to put guards around the function
+   * declaration just in case.
+   *
+   * On the bright side, zend_eval_string() effectively treats the string given
+   * as a standalone file, so we can use a normal namespace declaration to
+   * avoid possible clashes.
+   */
+  retval = zend_eval_string(
+      "namespace newrelic\\Guzzle6;"
+
+      "use Psr\\Http\\Message\\RequestInterface;"
+      "use GuzzleHttp\\Promise\\PromiseInterface;"
+
+      "if (!function_exists('newrelic\\Guzzle6\\middleware')) {"
+      "  function middleware(callable $handler) {"
+      "    return function (RequestInterface $request, array $options) use "
+      "($handler) {"
+
+      /*
+       * Start by adding the outbound CAT/DT/Synthetics headers to the request.
+       */
+      "      foreach (newrelic_get_request_metadata('Guzzle 6') as $k => $v) {"
+      "        $request = $request->withHeader($k, $v);"
+      "      }"
+
+      /*
+       * Set up the RequestHandler object and attach it to the promise so that
+       * we create an external node and deal with the CAT headers coming back
+       * from the far end.
+       */
+      "      $rh = new RequestHandler($request);"
+      "      $promise = $handler($request, $options);"
+      "      if (PromiseInterface::REJECTED == $promise->getState()) {"
+      /*
+                Special case for sync request. When sync requests is rejected,
+                onRejected callback is not called via `PromiseInterface::then`
+                and needs to be called manually.
+       */
+      "        $rh->onRejected($promise);"
+      "      } else {"
+      "        $promise->then([$rh, 'onFulfilled'], [$rh, 'onRejected']);"
+      "      }"
+      "      return $promise;"
+      "    };"
+      "  }"
+      "}",
+      NULL, "newrelic/Guzzle6" TSRMLS_CC);
+
+  if (SUCCESS == retval) {
+    nr_php_wrap_user_function(NR_PSTR("GuzzleHttp\\Client::__construct"),
                               nr_guzzle_client_construct TSRMLS_CC);
+  } else {
+    nrl_warning(NRL_FRAMEWORK,
+                "%s: error evaluating PHP code; not installing handler",
+                __func__);
+  }
+}
+
+void nr_guzzle8_enable(TSRMLS_D) {
+  /*
+   * The Guzzle 8 magic file is detected on all lower versions of Guzzle.
+   * The PHP version check prevents all Guzzle 5 from running the code,
+   * as Guzzle 8 and 5 are mutually exclusive in supported PHP versions.
+   * The middleware_func check ensures that for Guzzle 6-7 we only install
+   * the middleware a single time.
+   */
+#if ZEND_MODULE_API_NO >= ZEND_7_4_X_API_NO /* PHP 7.4+ */
+  zend_function* middleware_func = NULL;
+  middleware_func = nr_php_find_function("newrelic\\Guzzle6\\middleware");
+  if (NULL == middleware_func) {
+    nr_guzzle6_enable();
+  }
+#endif /* PHP 7.4+ */
 }
 
 void nr_guzzle6_minit(TSRMLS_D) {

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -438,7 +438,7 @@ end:
 NR_PHP_WRAPPER_END
 
 void nr_guzzle6_enable(TSRMLS_D) {
-  zend_result retval;
+  int retval;
   zend_function* middleware_func = NULL;
   if (0 == NRINI(guzzle_enabled)) {
     return;

--- a/agent/lib_guzzle6.c
+++ b/agent/lib_guzzle6.c
@@ -438,6 +438,7 @@ end:
 NR_PHP_WRAPPER_END
 
 void nr_guzzle6_enable(TSRMLS_D) {
+  zend_result retval;
   zend_function* middleware_func = NULL;
   if (0 == NRINI(guzzle_enabled)) {
     return;

--- a/agent/lib_guzzle_common.c
+++ b/agent/lib_guzzle_common.c
@@ -246,7 +246,6 @@ char* nr_guzzle_response_get_header(const char* header,
 
 NR_PHP_WRAPPER_START(nr_guzzle_client_construct) {
   int is_guzzle_45 = 0;
-  int retval;
 
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
 

--- a/agent/lib_guzzle_common.c
+++ b/agent/lib_guzzle_common.c
@@ -246,6 +246,8 @@ char* nr_guzzle_response_get_header(const char* header,
 
 NR_PHP_WRAPPER_START(nr_guzzle_client_construct) {
   int is_guzzle_45 = 0;
+  int retval;
+
   zval* this_var = nr_php_scope_get(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
 
   (void)wraprec;
@@ -257,7 +259,68 @@ NR_PHP_WRAPPER_START(nr_guzzle_client_construct) {
   if (is_guzzle_45) {
     NR_PHP_WRAPPER_DELEGATE(nr_guzzle4_client_construct);
   } else {
-    NR_PHP_WRAPPER_DELEGATE(nr_guzzle6_client_construct);
+    /*
+     * Here's something new: we're going to evaluate PHP code to build our
+     * middleware in PHP, rather than doing it in C. This is mostly because it's
+     * fairly difficult to return a higher-order function from C; while possible,
+     * the code to do so is horrible enough that this actually feels cleaner.
+     *
+     * We'll do it when the library is detected because that should only happen
+     * once, but we'll also be careful to put guards around the function
+     * declaration just in case.
+     *
+     * On the bright side, zend_eval_string() effectively treats the string given
+     * as a standalone file, so we can use a normal namespace declaration to
+     * avoid possible clashes.
+     */
+    retval = zend_eval_string(
+        "namespace newrelic\\Guzzle6;"
+
+        "use Psr\\Http\\Message\\RequestInterface;"
+        "use GuzzleHttp\\Promise\\PromiseInterface;"
+
+        "if (!function_exists('newrelic\\Guzzle6\\middleware')) {"
+        "  function middleware(callable $handler) {"
+        "    return function (RequestInterface $request, array $options) use "
+        "($handler) {"
+
+        /*
+         * Start by adding the outbound CAT/DT/Synthetics headers to the request.
+         */
+        "      foreach (newrelic_get_request_metadata('Guzzle 6') as $k => $v) {"
+        "        $request = $request->withHeader($k, $v);"
+        "      }"
+
+        /*
+         * Set up the RequestHandler object and attach it to the promise so that
+         * we create an external node and deal with the CAT headers coming back
+         * from the far end.
+         */
+        "      $rh = new RequestHandler($request);"
+        "      $promise = $handler($request, $options);"
+        "      if (PromiseInterface::REJECTED == $promise->getState()) {"
+        /*
+                  Special case for sync request. When sync requests is rejected,
+                  onRejected callback is not called via `PromiseInterface::then`
+                  and needs to be called manually.
+         */
+        "        $rh->onRejected($promise);"
+        "      } else {"
+        "        $promise->then([$rh, 'onFulfilled'], [$rh, 'onRejected']);"
+        "      }"
+        "      return $promise;"
+        "    };"
+        "  }"
+        "}",
+        NULL, "newrelic/Guzzle6" TSRMLS_CC);
+
+    if (SUCCESS == retval) {
+      NR_PHP_WRAPPER_DELEGATE(nr_guzzle6_client_construct);
+    } else {
+      nrl_warning(NRL_FRAMEWORK,
+                  "%s: error evaluating PHP code; not installing handler",
+                  __func__);
+    }
   }
 }
 NR_PHP_WRAPPER_END

--- a/agent/lib_guzzle_common.c
+++ b/agent/lib_guzzle_common.c
@@ -259,68 +259,7 @@ NR_PHP_WRAPPER_START(nr_guzzle_client_construct) {
   if (is_guzzle_45) {
     NR_PHP_WRAPPER_DELEGATE(nr_guzzle4_client_construct);
   } else {
-    /*
-     * Here's something new: we're going to evaluate PHP code to build our
-     * middleware in PHP, rather than doing it in C. This is mostly because it's
-     * fairly difficult to return a higher-order function from C; while possible,
-     * the code to do so is horrible enough that this actually feels cleaner.
-     *
-     * We'll do it when the library is detected because that should only happen
-     * once, but we'll also be careful to put guards around the function
-     * declaration just in case.
-     *
-     * On the bright side, zend_eval_string() effectively treats the string given
-     * as a standalone file, so we can use a normal namespace declaration to
-     * avoid possible clashes.
-     */
-    retval = zend_eval_string(
-        "namespace newrelic\\Guzzle6;"
-
-        "use Psr\\Http\\Message\\RequestInterface;"
-        "use GuzzleHttp\\Promise\\PromiseInterface;"
-
-        "if (!function_exists('newrelic\\Guzzle6\\middleware')) {"
-        "  function middleware(callable $handler) {"
-        "    return function (RequestInterface $request, array $options) use "
-        "($handler) {"
-
-        /*
-         * Start by adding the outbound CAT/DT/Synthetics headers to the request.
-         */
-        "      foreach (newrelic_get_request_metadata('Guzzle 6') as $k => $v) {"
-        "        $request = $request->withHeader($k, $v);"
-        "      }"
-
-        /*
-         * Set up the RequestHandler object and attach it to the promise so that
-         * we create an external node and deal with the CAT headers coming back
-         * from the far end.
-         */
-        "      $rh = new RequestHandler($request);"
-        "      $promise = $handler($request, $options);"
-        "      if (PromiseInterface::REJECTED == $promise->getState()) {"
-        /*
-                  Special case for sync request. When sync requests is rejected,
-                  onRejected callback is not called via `PromiseInterface::then`
-                  and needs to be called manually.
-         */
-        "        $rh->onRejected($promise);"
-        "      } else {"
-        "        $promise->then([$rh, 'onFulfilled'], [$rh, 'onRejected']);"
-        "      }"
-        "      return $promise;"
-        "    };"
-        "  }"
-        "}",
-        NULL, "newrelic/Guzzle6" TSRMLS_CC);
-
-    if (SUCCESS == retval) {
-      NR_PHP_WRAPPER_DELEGATE(nr_guzzle6_client_construct);
-    } else {
-      nrl_warning(NRL_FRAMEWORK,
-                  "%s: error evaluating PHP code; not installing handler",
-                  __func__);
-    }
+    NR_PHP_WRAPPER_DELEGATE(nr_guzzle6_client_construct);
   }
 }
 NR_PHP_WRAPPER_END

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -434,9 +434,15 @@ static nr_library_table_t libraries[] = {
     /* Doctrine 2.18 reworked the directory structure */
     {"Doctrine 2", NR_PSTR("doctrine/orm/src/query.php"), nr_doctrine2_enable},
 
+    /*
+     * When Guzzle 5 support is removed, Guzzle 6+ magic files should be consolidated
+     * into just using client.php
+     */
     {"Guzzle 4-5", NR_PSTR("hasemitterinterface.php"), nr_guzzle4_enable},
-    {"Guzzle 6", NR_PSTR("guzzle/src/client.php"),
+    {"Guzzle 6", NR_PSTR("guzzle/src/functions_include.php"),
      nr_guzzle6_enable},
+    {"Guzzle 8", NR_PSTR("guzzle/src/client.php"),
+     nr_guzzle8_enable},
 
     {"MongoDB", NR_PSTR("mongodb/src/client.php"), nr_mongodb_enable},
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -441,7 +441,7 @@ static nr_library_table_t libraries[] = {
     {"Guzzle 4-5", NR_PSTR("hasemitterinterface.php"), nr_guzzle4_enable},
     {"Guzzle 6", NR_PSTR("guzzle/src/functions_include.php"),
      nr_guzzle6_enable},
-    {"Guzzle 8", NR_PSTR("guzzle/src/client.php"),
+    {"Guzzle", NR_PSTR("guzzle/src/client.php"),
      nr_guzzle8_enable},
 
     {"MongoDB", NR_PSTR("mongodb/src/client.php"), nr_mongodb_enable},

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -435,7 +435,7 @@ static nr_library_table_t libraries[] = {
     {"Doctrine 2", NR_PSTR("doctrine/orm/src/query.php"), nr_doctrine2_enable},
 
     {"Guzzle 4-5", NR_PSTR("hasemitterinterface.php"), nr_guzzle4_enable},
-    {"Guzzle 6", NR_PSTR("guzzle/src/functions_include.php"),
+    {"Guzzle 6", NR_PSTR("guzzle/src/client.php"),
      nr_guzzle6_enable},
 
     {"MongoDB", NR_PSTR("mongodb/src/client.php"), nr_mongodb_enable},

--- a/tests/integration/external/guzzle5/test_cat.php
+++ b/tests/integration/external/guzzle5/test_cat.php
@@ -52,7 +52,7 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_cat.php
+++ b/tests/integration/external/guzzle5/test_cat.php
@@ -52,7 +52,7 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_cat.php
+++ b/tests/integration/external/guzzle5/test_cat.php
@@ -52,6 +52,7 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt.php
+++ b/tests/integration/external/guzzle5/test_dt.php
@@ -41,7 +41,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt.php
+++ b/tests/integration/external/guzzle5/test_dt.php
@@ -41,6 +41,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt.php
+++ b/tests/integration/external/guzzle5/test_dt.php
@@ -41,7 +41,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
@@ -42,7 +42,7 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
@@ -42,7 +42,7 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle5/test_dt_newrelic_header_disabled.php
@@ -42,6 +42,7 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics.php
@@ -72,7 +72,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics.php
@@ -72,7 +72,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics.php
@@ -72,6 +72,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
@@ -75,7 +75,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
@@ -75,6 +75,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle5/test_dt_synthetics_logging_off.php
@@ -75,7 +75,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"WebTransactionTotalTime/Uri__FILE__"},                [1, "??", "??", "??", "??", "??"]],
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle5/test_no_cat_no_dt.php
@@ -43,7 +43,7 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle5/test_no_cat_no_dt.php
@@ -43,7 +43,7 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle5/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle5/test_no_cat_no_dt.php
@@ -43,6 +43,7 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime"},                          [1, "??", "??", "??", "??", "??"]],
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 4-5/detected"},         [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Metrics/PHP/enabled"},         [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_cat.php
+++ b/tests/integration/external/guzzle6/test_cat.php
@@ -53,6 +53,7 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_cat.php
+++ b/tests/integration/external/guzzle6/test_cat.php
@@ -53,7 +53,7 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_dt.php
+++ b/tests/integration/external/guzzle6/test_dt.php
@@ -44,7 +44,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle6/test_dt.php
+++ b/tests/integration/external/guzzle6/test_dt.php
@@ -44,6 +44,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
@@ -45,7 +45,7 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle6/test_dt_newrelic_header_disabled.php
@@ -45,6 +45,7 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics.php
@@ -67,7 +67,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics.php
@@ -67,6 +67,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics_logging_off.php
@@ -70,7 +70,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle6/test_dt_synthetics_logging_off.php
+++ b/tests/integration/external/guzzle6/test_dt_synthetics_logging_off.php
@@ -70,6 +70,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                                     [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle6/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle6/test_no_cat_no_dt.php
@@ -44,6 +44,7 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle6/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle6/test_no_cat_no_dt.php
@@ -44,7 +44,7 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime/php__FILE__"},              [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/6/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"},      [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_cat.php
+++ b/tests/integration/external/guzzle7/test_cat.php
@@ -53,6 +53,7 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_cat.php
+++ b/tests/integration/external/guzzle7/test_cat.php
@@ -53,7 +53,7 @@ X-NewRelic-App-Data=??
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_dt.php
+++ b/tests/integration/external/guzzle7/test_dt.php
@@ -44,7 +44,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle7/test_dt.php
+++ b/tests/integration/external/guzzle7/test_dt.php
@@ -44,6 +44,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
@@ -45,6 +45,7 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
+++ b/tests/integration/external/guzzle7/test_dt_newrelic_header_disabled.php
@@ -45,7 +45,7 @@ traceparent=found tracestate=found X-NewRelic-ID=missing X-NewRelic-Transaction=
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"},           [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"},           [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"},           [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle7/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle7/test_dt_synthetics.php
@@ -67,6 +67,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle7/test_dt_synthetics.php
+++ b/tests/integration/external/guzzle7/test_dt_synthetics.php
@@ -67,7 +67,7 @@ traceparent=found tracestate=found newrelic=found X-NewRelic-ID=missing X-NewRel
     [{"name":"HttpDispatcher"},                           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Unsupported/curl_setopt/CURLOPT_HEADERFUNCTION/closure"}, [3, 0, 0, 0, 0, 0]],

--- a/tests/integration/external/guzzle7/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle7/test_no_cat_no_dt.php
@@ -44,7 +44,7 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
-    [{"name":"Supportability/library/Guzzle 8/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"}, [1, "??", "??", "??", "??", "??"]],

--- a/tests/integration/external/guzzle7/test_no_cat_no_dt.php
+++ b/tests/integration/external/guzzle7/test_no_cat_no_dt.php
@@ -44,6 +44,7 @@ X-NewRelic-ID=missing X-NewRelic-Transaction=missing Customer-Header=found traci
     [{"name":"OtherTransactionTotalTime/php__FILE__"},    [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/PHP/package/guzzlehttp/guzzle/7/detected"}, [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Guzzle 6/detected"}, [1, 0, 0, 0, 0, 0]],
+    [{"name":"Supportability/library/Guzzle 8/detected"}, [1, 0, 0, 0, 0, 0]],
     [{"name":"Supportability/library/Autoloader/detected"},         [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/library/Composer/detected"},           [1, "??", "??", "??", "??", "??"]],
     [{"name":"Supportability/Logging/Forwarding/PHP/enabled"}, [1, "??", "??", "??", "??", "??"]],


### PR DESCRIPTION
Changes the magic file for Guzzle 6+ to be one available in Guzzle 8. This file is also present in Guzzle 5, so the middleware installation has been moved to prevent 5 from installing it.