### PR TITLE
chore(ci): backport dependabot version updates config to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"    
-    directory: "/daemon"                
+  - package-ecosystem: "gomod"
+    directory: "/daemon"
     schedule:
       interval: "weekly"
+    target-branch: "dev"
     commit-message:
-      prefix: "chore(deps):"      
-  - package-ecosystem: github-actions
-    directory: /
+      prefix: "chore(daemon):"
+    groups:
+      gomod:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"
+    target-branch: "dev"
     commit-message:
-      prefix: "chore(deps):"
+      prefix: "ci:"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Format dependabot.yml. Remove trailing whitespace and quote all scalar values.

Use conventional commits for dependabot. PR titles Using conventional commits makes it easier to assign, prioritize, and evaluate dependabot PRs based on parts of the codebase they touch.

Target dependabot version updates at "dev" branch. To allow automated dependabot version updates go through the the same review/merge/release process as any other updates in this repository, dependabot version updates should be applied to "dev" (the integration) branch, not "main" (the default) branch.

Group gomod bumps to reduce dependabot PR sprawl.

(cherry picked from commit 8264663888882bcea9666b30860e5eb3476226c0)