### PR TITLE
fix(agent): register fcall_begin/fcall_end handlers when not recording

### DIFF
--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -109,6 +109,7 @@ TEST_BINARIES = \
         tests/test_php_error \
 	tests/test_php_execute \
 	tests/test_php_minit \
+	tests/test_php_observer \
 	tests/test_php_stack \
 	tests/test_php_stacked_segment \
 	tests/test_php_txn \
@@ -285,6 +286,8 @@ TEST_LDFLAGS := $(shell $(PHP_CONFIG) --ldflags) $(EXPORT_DYNAMIC)
 TEST_LDFLAGS += $(USER_LDFLAGS)
 CROSS_AGENT_DIR := $(CURDIR)/../axiom/tests/cross_agent_tests
 EXTRA_CFLAGS += -DCROSS_AGENT_TESTS_DIR="\"$(CROSS_AGENT_DIR)\""
+PHP_SCRIPTS_DIR := $(CURDIR)/tests/php_scripts
+EXTRA_CFLAGS += -DPHP_SCRIPTS_DIR="\"$(PHP_SCRIPTS_DIR)\""
 
 #
 # Implicit rule to build test object files with the appropriate flags.

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -14,6 +14,7 @@
 #include "php_curl.h"
 #include "php_error.h"
 #include "php_execute.h"
+#include "php_execute_private.h"
 #include "php_globals.h"
 #include "php_hash.h"
 #include "php_hooks.h"
@@ -95,22 +96,6 @@
 
 static void nr_php_show_exec_return(NR_EXECUTE_PROTO TSRMLS_DC);
 static int nr_php_show_exec_indentation(TSRMLS_D);
-
-/*
- * Purpose: Enable monitoring on specific functions in the framework.
- */
-typedef void (*nr_framework_enable_fn_t)(TSRMLS_D);
-
-/*
- * Purpose: Enable monitoring on specific functions for a detected library.
- */
-typedef void (*nr_library_enable_fn_t)(TSRMLS_D);
-
-/*
- * Purpose: Enable monitoring on specific functions for a detected vulnerability
- *          management package.
- */
-typedef void (*nr_vuln_mgmt_enable_fn_t)();
 
 /*
  * This code is used for function call debugging.
@@ -295,19 +280,6 @@ static void nr_show_execute_params(NR_EXECUTE_PROTO, char* pbuf TSRMLS_DC) {
 }
 
 /*
- * Framework handling, definition and callbacks.
- */
-typedef struct _nr_framework_table_t {
-  const char* framework_name;
-  const char* config_name;
-  const char* file_to_check;
-  size_t file_to_check_len;
-  nr_framework_special_fn_t special;
-  nr_framework_enable_fn_t enable;
-  nrframework_t detected;
-} nr_framework_table_t;
-
-/*
  * Note that the maximum length of framework and library names is presently 31
  * bytes due to the use of a 64 byte static buffer when constructing
  * supportability metrics.
@@ -315,7 +287,7 @@ typedef struct _nr_framework_table_t {
  * Note that all paths should be in lowercase.
  */
 // clang-format: off
-static const nr_framework_table_t all_frameworks[] = {
+const nr_framework_table_t all_frameworks[] = {
     {"CakePHP", "cakephp", NR_PSTR("cakephp/src/core/functions.php"), 0,
      nr_cakephp_enable, NR_FW_CAKEPHP},
 
@@ -370,7 +342,7 @@ static const nr_framework_table_t all_frameworks[] = {
      NR_FW_YII2},
 };
 // clang-format: on
-static const int num_all_frameworks
+const int num_all_frameworks
     = sizeof(all_frameworks) / sizeof(nr_framework_table_t);
 
 nrframework_t nr_php_framework_from_config(const char* config_name) {
@@ -413,18 +385,11 @@ nrframework_t nr_php_framework_from_config(const char* config_name) {
  * current framework is FW_UNSET, the callback will still be called.
  */
 
-typedef struct _nr_library_table_t {
-  const char* library_name;
-  const char* file_to_check;
-  size_t file_to_check_len;
-  nr_library_enable_fn_t enable;
-} nr_library_table_t;
-
 /*
  * Note that all paths should be in lowercase.
  */
 // clang-format: off
-static nr_library_table_t libraries[] = {
+const nr_library_table_t libraries[] = {
     /* AWS-SDK-PHP 3 */
     {"AWS-SDK-PHP", NR_PSTR("aws-sdk-php/src/awsclient.php"),
      nr_aws_sdk_php_enable},
@@ -463,10 +428,10 @@ static nr_library_table_t libraries[] = {
 };
 // clang-format: on
 
-static size_t num_libraries = sizeof(libraries) / sizeof(nr_library_table_t);
+const size_t num_libraries = sizeof(libraries) / sizeof(nr_library_table_t);
 
 // clang-format: off
-static nr_library_table_t logging_frameworks[] = {
+const nr_library_table_t logging_frameworks[] = {
     /* Monolog - Logging for PHP */
     {"Monolog", NR_PSTR("monolog/logger.php"), nr_monolog_enable},
     /* Consolidation/Log - Logging for PHP */
@@ -477,27 +442,21 @@ static nr_library_table_t logging_frameworks[] = {
 };
 // clang-format: on
 
-static size_t num_logging_frameworks
+const size_t num_logging_frameworks
     = sizeof(logging_frameworks) / sizeof(nr_library_table_t);
 
 /* Package handling for Vulnerability Management */
-typedef struct _nr_vuln_mgmt_table_t {
-  const char* package_name;
-  const char* file_to_check;
-  size_t file_to_check_len;
-  nr_vuln_mgmt_enable_fn_t enable;
-} nr_vuln_mgmt_table_t;
 
 /* Note that all paths should be in lowercase. */
 // clang-format: off
-static const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
+const nr_vuln_mgmt_table_t vuln_mgmt_packages[] = {
     {"Drupal", NR_PSTR("drupal/component/dependencyinjection/container.php"),
      nr_drupal_version},
     {"Wordpress", NR_PSTR("wp-includes/version.php"), nr_wordpress_version},
 };
 // clang-format: on
 
-static const size_t num_packages
+const size_t num_packages
     = sizeof(vuln_mgmt_packages) / sizeof(nr_vuln_mgmt_table_t);
 
 /*
@@ -919,9 +878,8 @@ static void nr_execute_handle_package(const char* filename,
  *
  * Params  : 1. Full name of a PHP file.
  */
-static void nr_php_user_instrumentation_from_file(const char* filename,
-                                                  const size_t filename_len
-                                                      TSRMLS_DC) {
+void nr_php_user_instrumentation_from_file(const char* filename,
+                                           const size_t filename_len) {
   /* short circuit if filename_len is 0; a single place short circuit */
   if (0 == filename_len) {
     nrl_verbosedebug(NRL_AGENT,

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -532,6 +532,8 @@ static int nr_php_show_exec_indentation(TSRMLS_D) {
   return NRPRG_CTX(php_cur_stack_depth) * NR_EXECUTE_INDENTATION_WIDTH;
 }
 
+#define NRP_RECORDING 1, (nr_php_recording() ? "+" : "-")
+
 /*
  * Note that this function doesn't handle internal functions, and will crash if
  * you give it one.
@@ -550,14 +552,14 @@ void nr_php_show_exec(const char* context, NR_EXECUTE_PROTO TSRMLS_DC) {
     nr_show_execute_params(NR_EXECUTE_ORIG_ARGS, argstr TSRMLS_CC);
     nrl_verbosedebug(
         NRL_AGENT,
-        NRP_FMT_UQ ": %.*s scope={%.*s} function={" NRP_FMT_UQ
+        NRP_FMT_UQ "%.*s: %.*s scope={%.*s} function={" NRP_FMT_UQ
                    "}"
                    " params={" NRP_FMT_UQ
                    "}"
                    " %.5s"
                    "@ " NRP_FMT_UQ ":%d",
-        NRP_SHOW_EXEC_CONTEXT(ctx), nr_php_show_exec_indentation(TSRMLS_C),
-        nr_php_indentation_spaces,
+        NRP_SHOW_EXEC_CONTEXT(ctx), NRP_RECORDING,
+        nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces,
         NRSAFELEN(nr_php_class_entry_name_length(NR_OP_ARRAY->scope)),
         nr_php_class_entry_name(NR_OP_ARRAY->scope),
         NRP_PHP(function_name ? function_name : "?"), NRP_ARGSTR(argstr),
@@ -574,13 +576,13 @@ void nr_php_show_exec(const char* context, NR_EXECUTE_PROTO TSRMLS_DC) {
     nr_show_execute_params(NR_EXECUTE_ORIG_ARGS, argstr TSRMLS_CC);
     nrl_verbosedebug(
         NRL_AGENT,
-        NRP_FMT_UQ ": %.*s function={" NRP_FMT_UQ
+        NRP_FMT_UQ "%.*s: %.*s function={" NRP_FMT_UQ
                    "}"
                    " params={" NRP_FMT_UQ
                    "}"
                    " %.5s"
                    "@ " NRP_FMT_UQ ":%d",
-        NRP_SHOW_EXEC_CONTEXT(ctx), nr_php_show_exec_indentation(TSRMLS_C),
+        NRP_SHOW_EXEC_CONTEXT(ctx), NRP_RECORDING, nr_php_show_exec_indentation(TSRMLS_C),
         nr_php_indentation_spaces, NRP_PHP(function_name), NRP_ARGSTR(argstr),
 #if ZEND_MODULE_API_NO < ZEND_7_4_X_API_NO
         nr_php_op_array_get_wraprec(NR_OP_ARRAY TSRMLS_CC) ? " *" : "",
@@ -592,8 +594,8 @@ void nr_php_show_exec(const char* context, NR_EXECUTE_PROTO TSRMLS_DC) {
     /*
      * file
      */
-    nrl_verbosedebug(NRL_AGENT, NRP_FMT_UQ ": %.*s file={" NRP_FMT "}",
-                     NRP_SHOW_EXEC_CONTEXT(ctx),
+    nrl_verbosedebug(NRL_AGENT, NRP_FMT_UQ "%.*s: %.*s file={" NRP_FMT "}",
+                     NRP_SHOW_EXEC_CONTEXT(ctx), NRP_RECORDING,
                      nr_php_show_exec_indentation(TSRMLS_C),
                      nr_php_indentation_spaces, NRP_FILENAME(filename));
   } else {
@@ -601,7 +603,7 @@ void nr_php_show_exec(const char* context, NR_EXECUTE_PROTO TSRMLS_DC) {
      * unknown
      */
     nrl_verbosedebug(
-        NRL_AGENT, NRP_FMT_UQ ": %.*s ?", NRP_SHOW_EXEC_CONTEXT(ctx),
+        NRL_AGENT, NRP_FMT_UQ "%.*s: %.*s ?", NRP_SHOW_EXEC_CONTEXT(ctx), NRP_RECORDING,
         nr_php_show_exec_indentation(TSRMLS_C), nr_php_indentation_spaces);
   }
 }
@@ -618,8 +620,8 @@ static void nr_php_show_exec_return(NR_EXECUTE_PROTO TSRMLS_DC) {
   if (NULL != return_value) {
     nr_format_zval_for_debug(return_value, argstr, 0,
                              NR_EXECUTE_DEBUG_STRBUFSZ - 1, 0 TSRMLS_CC);
-    nrl_verbosedebug(NRL_AGENT, "execute: %.*s return: " NRP_FMT,
-                     nr_php_show_exec_indentation(TSRMLS_C),
+    nrl_verbosedebug(NRL_AGENT, "execute%.*s: %.*s return: " NRP_FMT,
+                     NRP_RECORDING, nr_php_show_exec_indentation(TSRMLS_C),
                      nr_php_indentation_spaces, NRP_ARGSTR(argstr));
   }
 }
@@ -2141,15 +2143,14 @@ void nr_php_observer_fcall_begin(zend_execute_data* execute_data) {
     nr_php_max_nesting_level_reached();
   }
 
+  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_executes)) {
+    nr_php_show_exec("execute", NR_EXECUTE_ORIG_ARGS);
+  }
+
   if (nrunlikely(0 == nr_php_recording())) {
     return;
   }
 
-  int show_executes = NR_PHP_PROCESS_GLOBALS(special_flags).show_executes;
-
-  if (nrunlikely(show_executes)) {
-    nr_php_show_exec("execute", NR_EXECUTE_ORIG_ARGS);
-  }
   nr_php_instrument_func_begin(NR_EXECUTE_ORIG_ARGS);
 
   return;
@@ -2168,14 +2169,11 @@ void nr_php_observer_fcall_end(zend_execute_data* execute_data,
     return;
   }
 
+  if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_execute_returns)) {
+    nr_php_show_exec_return(NR_EXECUTE_ORIG_ARGS);
+  }
+
   if (nrlikely(1 == nr_php_recording())) {
-    int show_executes_return
-        = NR_PHP_PROCESS_GLOBALS(special_flags).show_execute_returns;
-
-    if (nrunlikely(show_executes_return)) {
-      nr_php_show_exec_return(NR_EXECUTE_ORIG_ARGS TSRMLS_CC);
-    }
-
     nr_php_instrument_func_end(NR_EXECUTE_ORIG_ARGS);
   }
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -877,6 +877,13 @@ static void nr_execute_handle_package(const char* filename,
  *           defined as a key file for this library or framework.
  *
  * Params  : 1. Full name of a PHP file.
+ *
+ * Note    : The callbacks dispatched from here run under looser conditions
+ *           than this call site alone suggests - NRPRG(txn) may be NULL, the
+ *           transaction may not be recording, and the same file may be offered
+ *           more than once per process. See "Contract for magic-file
+ *           callbacks" in php_execute_private.h before writing or changing
+ *           one.
  */
 void nr_php_user_instrumentation_from_file(const char* filename,
                                            const size_t filename_len) {

--- a/agent/php_execute_private.h
+++ b/agent/php_execute_private.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This header exposes php_execute.c internals for unit testing.
+ */
+#ifndef PHP_EXECUTE_PRIVATE_HDR
+#define PHP_EXECUTE_PRIVATE_HDR
+
+/*
+ * Purpose: Enable monitoring on specific functions in the framework.
+ */
+typedef void (*nr_framework_enable_fn_t)(TSRMLS_D);
+
+/*
+ * Purpose: Enable monitoring on specific functions for a detected library.
+ */
+typedef void (*nr_library_enable_fn_t)(TSRMLS_D);
+
+/*
+ * Purpose: Enable monitoring on specific functions for a detected vulnerability
+ *          management package.
+ */
+typedef void (*nr_vuln_mgmt_enable_fn_t)();
+
+typedef struct _nr_framework_table_t {
+  const char* framework_name;
+  const char* config_name;
+  const char* file_to_check;
+  size_t file_to_check_len;
+  nr_framework_special_fn_t special;
+  nr_framework_enable_fn_t enable;
+  nrframework_t detected;
+} nr_framework_table_t;
+
+typedef struct _nr_library_table_t {
+  const char* library_name;
+  const char* file_to_check;
+  size_t file_to_check_len;
+  nr_library_enable_fn_t enable;
+} nr_library_table_t;
+
+typedef struct _nr_vuln_mgmt_table_t {
+  const char* package_name;
+  const char* file_to_check;
+  size_t file_to_check_len;
+  nr_vuln_mgmt_enable_fn_t enable;
+} nr_vuln_mgmt_table_t;
+
+extern const nr_framework_table_t all_frameworks[];
+extern const int num_all_frameworks;
+
+extern const nr_library_table_t libraries[];
+extern const size_t num_libraries;
+
+extern const nr_library_table_t logging_frameworks[];
+extern const size_t num_logging_frameworks;
+
+extern const nr_vuln_mgmt_table_t vuln_mgmt_packages[];
+extern const size_t num_packages;
+
+/*
+ * Purpose : ONLY for testing to verify library/framework/logging-framework
+ *           detection behavior directly, without going through
+ *           nr_php_execute_file (which also executes the file's op array).
+ *
+ *           Detect library and framework usage from a PHP file. Enables a
+ *           library or framework if the passed file is defined as a key
+ *           file for this library or framework.
+ *
+ * Params  : 1. Full name of a PHP file.
+ *           2. Length of the file name.
+ */
+extern void nr_php_user_instrumentation_from_file(const char* filename,
+                                                  const size_t filename_len);
+
+#endif /* PHP_EXECUTE_PRIVATE_HDR */

--- a/agent/php_execute_private.h
+++ b/agent/php_execute_private.h
@@ -8,6 +8,137 @@
 #define PHP_EXECUTE_PRIVATE_HDR
 
 /*
+ * Contract for magic-file callbacks
+ * =================================
+ *
+ * nr_php_user_instrumentation_from_file() matches a filename against the magic
+ * files listed in the tables below and invokes the matching callback: a
+ * framework's enable() or special(), a library's or logging framework's
+ * enable(), a vulnerability-management package's enable(), or
+ * nr_composer_handle_autoload() for the fixed autoload magic file. Everything
+ * in this section applies to all of them, and transitively to every function
+ * they call.
+ *
+ * These callbacks do not all do the same kind of work - some register
+ * instrumentation, some only extract a version, some only record telemetry,
+ * some only write agent-internal state. What they have in common is the
+ * operating conditions described here, which are looser than they may appear
+ * from any single call site.
+ *
+ * When they run
+ * -------------
+ *
+ * There are two independent call sites into
+ * nr_php_user_instrumentation_from_file(), with different conditions. A
+ * callback must be correct under both:
+ *
+ *   a) nr_php_execute_file(), from nr_php_fcall_register_handlers() - the
+ *      Observer API's zend_observer_fcall_init callback (agent/php_observer.c).
+ *      Zend calls that once per op_array, the first time the op_array is ever
+ *      executed, i.e. whenever userland happens to require() the magic file.
+ *      The agent does not control that moment, and *there may be no
+ *      transaction at it*: NRPRG(txn) can legitimately be NULL.
+ *
+ *   b) nr_php_user_instrumentation_from_opcache(), from nr_php_txn_begin()
+ *      (agent/php_txn.c). When opcache.preload is in use, this walks the
+ *      opcache script list against the same tables as transactions start, so a
+ *      given magic file may be offered again on later transaction starts, over
+ *      the life of the process. Here NRPRG(txn) is always non-NULL and freshly
+ *      created.
+ *
+ * So a callback may run:
+ *
+ *   - with NRPRG(txn) == NULL (call site (a) only). This is not an error path.
+ *     It happens when the magic file is first executed before any transaction
+ *     exists for the current PHP request - e.g. during a persistent worker's
+ *     bootstrap/warm-up before its first logical request (FrankenPHP worker
+ *     mode serves many HTTP requests inside one PHP request) - or after
+ *     newrelic_end_transaction() has destroyed the request's transaction
+ *     (nr_php_txn_end() frees it and leaves NRPRG(txn) NULL);
+ *   - with a transaction that exists but is not recording
+ *     (nr_php_recording() == 0), which is what newrelic_ignore_transaction()
+ *     leaves behind: nr_txn_ignore() clears status.recording but keeps the
+ *     transaction, so NRPRG(txn) stays non-NULL;
+ *   - more than once per process for the same file (call site (b)).
+ *
+ * Classify your effects by scope
+ * ------------------------------
+ *
+ * The single question that resolves nearly every case: at what scope does this
+ * effect live? Each row below is expanded in the correspondingly-numbered note
+ * that follows.
+ */
+/* clang-format off */
+/*
+ * | #  | Scope       | Examples                                           | Needs txn? | If NRPRG(txn) is NULL   |
+ * | -- | ----------- | -------------------------------------------------- | ---------- | ----------------------- |
+ * | S1 | Process     | wraprec registration, NR_PHP_PROCESS_GLOBALS(...)  | No         | Must still happen       |
+ * | S2 | Request     | NRPRG(...), NRPRG_SHARED(...)                      | No         | Must still happen       |
+ * | S3 | Transaction | nr_fw_support_add_library_supportability_metric(), | Yes        | Attempt it; let it drop |
+ * |    |             | nr_fw_support_add_logging_supportability_metric(), |            |                         |
+ * |    |             | nr_txn_add_php_package(),                          |            |                         |
+ * |    |             | nr_txn_suggest_package_supportability_metric(),    |            |                         |
+ * |    |             | nr_txn_set_path()                                  |            |                         |
+ */
+/* clang-format on */
+/*
+ * S1. Process-scoped effects outlive the request that triggered them, and the
+ *     callback may not be invoked again at a more convenient time - so
+ *     skipping them is a permanent loss, not a deferral. Registering
+ *     instrumentation is the clearest example: nr_php_wrap_user_function() and
+ *     friends write to the process-global wraprec hashmap, need no
+ *     transaction, and are what *later* requests rely on to instrument
+ *     anything at all. This is the main reason these callbacks must work with
+ *     a NULL txn rather than bail out.
+ *
+ * S2. Request-scoped effects are valid with no transaction too, but mind that
+ *     RINIT resets some of them: NRPRG_SHARED(current_framework) goes back to
+ *     NR_FW_UNSET on every request (agent/php_rinit.c), so a framework
+ *     detected in one request is forgotten by the next, and only its
+ *     process-scoped effects persist.
+ *
+ * S3. Transaction-scoped effects are the only ones contingent on NRPRG(txn),
+ *     and the correct handling is to attempt them anyway and let them drop.
+ *     Every helper listed above no-ops on a NULL txn by design; pass
+ *     NRPRG(txn) and rely on that. A datum attributed to a transaction that
+ *     does not exist has nowhere to go, and dropping it is the right outcome -
+ *     do not stash it for "later" unless the state is genuinely process-scoped
+ *     (S1), because the transaction that would have received it is never
+ *     coming back. Any new helper taking a txn should get the same
+ *     NULL-tolerant contract at its own top.
+ *
+ * Rules
+ * -----
+ *
+ * Do not bail out early just because NRPRG(txn) is NULL. A missing transaction
+ * says nothing about whether the process- and request-scoped work above should
+ * happen, and a blanket early return sacrifices all of it to protect calls
+ * that are already NULL-safe.
+ *
+ * Do not dereference NRPRG(txn), NRTXN(...) or NRTXNGLOBAL(...) directly. The
+ * guard belongs at the call site or inside the callee, never as a blanket
+ * early return in the callback. See nr_fw_*_add_*_supportability_metric(),
+ * which guards inside the callee so no caller has to.
+ *
+ * Do not assume any class, interface, function or constant exists. Only the
+ * magic file itself is known to have executed, and nothing else about the
+ * library's load order is guaranteed. At call site (b) the filename comes from
+ * the opcache script list, so nothing has necessarily executed in this request
+ * at all - code that reaches into userland (zend_eval_string(), nr_php_call(),
+ * class or global lookups, as *_version() callbacks do) must tolerate the
+ * target being absent and degrade rather than fail.
+ *
+ * Tolerate being called more than once. Wraprec registration is already
+ * idempotent (nr_php_user_instrument_wraprec_hashmap_add() reuses an existing
+ * wraprec instead of adding a duplicate), so it needs no guard. Other work
+ * does not get that for free: version extraction, package records and path
+ * naming re-run on each invocation and must be correct and not unboundedly
+ * expensive when repeated. Where work is genuinely once-per-process, gate it
+ * on process-global state (NR_PHP_PROCESS_GLOBALS(...)), never on the presence
+ * of a transaction.
+ */
+
+/*
  * Purpose: Enable monitoring on specific functions in the framework.
  */
 typedef void (*nr_framework_enable_fn_t)(TSRMLS_D);

--- a/agent/php_mshutdown.c
+++ b/agent/php_mshutdown.c
@@ -27,6 +27,7 @@ PHP_MSHUTDOWN_FUNCTION(newrelic) {
   NR_UNUSED_TSRMLS;
 
   if (0 == NR_PHP_PROCESS_GLOBALS(enabled)) {
+    nr_php_global_destroy();
     return SUCCESS;
   }
 

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -85,7 +85,7 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
     return handlers;
   }
 
-  if (0 == nr_php_recording()) {
+  if (0 == NR_PHP_PROCESS_GLOBALS(enabled)) {
     return handlers;
   }
 

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -85,7 +85,20 @@ static zend_observer_fcall_handlers nr_php_fcall_register_handlers(
     return handlers;
   }
 
-  if (0 == NR_PHP_PROCESS_GLOBALS(enabled)) {
+  if (nrunlikely(0 == NR_PHP_PROCESS_GLOBALS(enabled))) {
+    // This should not happen - fcall_init callback is registered in MINIT,
+    // which does not execute if agent is globally disabled. Regardless of the
+    // unlikelihood, agent should not instrument anything when it is disabled.
+    return handlers;
+  }
+
+  if (0 == NRINI(enabled)) {
+    // Agent is globally enabled but disabled for this PHP request. In this
+    // case the agent should not do anything during this PHP request. This
+    // is safe because Zend caches whatever handlers returned here for the
+    // current PHP request only. New PHP request gets a fresh cache without
+    // inheriting anything from the previous request, i.e. fcall_init callback
+    // will be called again.
     return handlers;
   }
 

--- a/agent/tests/php_scripts/predis/src/Client.php
+++ b/agent/tests/php_scripts/predis/src/Client.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Minimal mock of the predis/predis package that is used to test that the agent
+// detects the package, and creates a package version metric as part of special
+// instrumentation. The mock is used by agent/tests/test_php_observer.c.
+
+namespace Predis;
+
+// Implementing an interface (rather than adding a top-level executable statement)
+// ensures this file is not marked as empty by opcache's preload_remove_empty_includes()
+// (ext/opcache/ZendAccelerator.c) and thus the file is actually executed when pulled in
+// by require(). This allows the agent's hook that detects libraries (nr_php_execute_file)
+// to be triggered.
+//
+// Note: a bare top-level statement (e.g. a stray class_exists() call) would work too,
+// but files in real-world PHP packages rarely contain one. Implementing an interface,
+// on the other hand, is completely ordinary. This mock therefore stays truer to what
+// it's standing in for.
+interface MarkerInterface {}
+
+class Client implements MarkerInterface {
+    // __construct() method is required to trigger testing conditions in test_php_observer.c,
+    // i.e. executing special instrumentation which generates package version metric.
+    public function __construct() {
+        echo "Predis\\Client::__construct called\n";
+    }
+    // VERSION constant is required to trigger testing conditions in test_php_observer.c,
+    // i.e. package version metric creation. The value is not important, just needs to be present.
+    public const VERSION = '1.1.10';
+}

--- a/agent/tests/test_php_execute.c
+++ b/agent/tests/test_php_execute.c
@@ -4,9 +4,11 @@
  */
 #include "tlib_php.h"
 
+#include "nr_commands.h"
 #include "php_agent.h"
 #include "php_call.h"
 #include "php_execute.h"
+#include "php_execute_private.h"
 #include "php_globals.h"
 #include "php_wrapper.h"
 
@@ -119,11 +121,137 @@ static void test_php_cur_stack_depth(TSRMLS_D) {
   tlib_php_request_end();
 }
 
+static nr_status_t mock_cmd_appinfo_unknown(int daemon_fd NRUNUSED,
+                                            nrapp_t* app) {
+  app->state = NR_APP_UNKNOWN;
+  return NR_SUCCESS;
+}
+
+/*
+ * The gate this PR relaxed (nr_php_fcall_register_handlers now gates on
+ * NR_PHP_PROCESS_GLOBALS(enabled) instead of nr_php_recording()) means
+ * library/framework/logging-framework detection can now run for the first
+ * time on a given op_array while NRPRG(txn) is NULL. The most direct way to
+ * reach that state is the very first request in a process: RINIT calls
+ * appinfo, and until the daemon confirms the app, NRPRG(txn) is never
+ * created at all. mock_cmd_appinfo_unknown reproduces exactly that by
+ * forcing app->state = NR_APP_UNKNOWN on every appinfo call.
+ *
+ * nr_fw_support_add_*_supportability_metric() are NULL-txn-safe, but every
+ * enable() callback in these tables is third-party code we don't control
+ * call-by-call; this test walks every table entry through the real
+ * dispatcher to catch a future enable() callback that dereferences the txn
+ * directly.
+ *
+ * nr_php_user_instrumentation_from_file (not nr_php_execute_file) is the
+ * right target here: nr_php_execute_file also re-executes the file's real
+ * op array via orig_execute, which a fabricated filename can't do safely.
+ * The dispatcher just string-matches, so passing a table's file_to_check
+ * value AS the filename trivially self-matches - no fixture files needed.
+ *
+ * The libraries/logging_frameworks/vuln_mgmt_packages tables are walked once
+ * per all_frameworks[] entry, not once overall: in a real request, a
+ * framework's file loads first and sets NRPRG_SHARED(current_framework) for
+ * the rest of that request, and libraries are detected afterward within
+ * that context. A library's enable() shouldn't depend on which framework is
+ * active, but nothing stops one from starting to, so this mirrors the real
+ * per-request sequence (each framework x the full library/logging/package
+ * set) instead of testing library detection in isolation from framework
+ * context.
+ */
+static void test_user_instrumentation_from_file_app_unknown() {
+  tlib_php_engine_create("");
+
+  // Emulate the very first request in a process: appinfo hasn't confirmed
+  // the app yet, so RINIT never creates a transaction. This is a valid
+  // state for the agent to be in.
+  nr_cmd_appinfo_hook = mock_cmd_appinfo_unknown;
+
+  for (int i = 0; i < num_all_frameworks; i++) {
+    size_t ii;
+    tlib_php_request_start();
+    tlib_pass_if_null("NRPRG(txn) was not created", NRPRG(txn));
+    tlib_pass_if_true("Transaction is not being recorded", !nr_php_recording(),
+                      "Expected transaction to be ignored");
+    nr_php_user_instrumentation_from_file(NR_PSTR("vendor/autoload.php"));
+    nr_php_user_instrumentation_from_file(all_frameworks[i].file_to_check,
+                                          all_frameworks[i].file_to_check_len);
+
+    for (ii = 0; ii < num_libraries; ii++) {
+      nr_php_user_instrumentation_from_file(libraries[ii].file_to_check,
+                                            libraries[ii].file_to_check_len);
+    }
+
+    for (ii = 0; ii < num_logging_frameworks; ii++) {
+      nr_php_user_instrumentation_from_file(
+          logging_frameworks[ii].file_to_check,
+          logging_frameworks[ii].file_to_check_len);
+    }
+
+    for (ii = 0; ii < num_packages; ii++) {
+      nr_php_user_instrumentation_from_file(
+          vuln_mgmt_packages[ii].file_to_check,
+          vuln_mgmt_packages[ii].file_to_check_len);
+    }
+
+    tlib_php_request_end();
+  }
+  tlib_php_engine_destroy();
+}
+
+/*
+ * Complementary to test_user_instrumentation_from_file_app_unknown above:
+ * here NRPRG(txn) exists, but newrelic_ignore_transaction() has marked it
+ * as not recording. This can't exercise the NULL-txn dereference risk that
+ * test covers - the fw_support NULL guards only check for NULL, and an
+ * ignored-but-alive txn sails through them - but it does confirm detection
+ * dispatch still runs correctly, without crashing or leaking, while the
+ * transaction isn't recording, which the same gate relaxation also newly
+ * allows.
+ */
+static void test_user_instrumentation_from_file_txn_ignored() {
+  tlib_php_engine_create("");
+
+  for (int i = 0; i < num_all_frameworks; i++) {
+    size_t ii;
+    tlib_php_request_start();
+    tlib_php_request_eval("newrelic_ignore_transaction();");
+    tlib_pass_if_not_null("NRPRG(txn) was created", NRPRG(txn));
+    tlib_pass_if_true("Transaction is not being recorded", !nr_php_recording(),
+                      "Expected transaction to be ignored");
+
+    nr_php_user_instrumentation_from_file(NR_PSTR("vendor/autoload.php"));
+    nr_php_user_instrumentation_from_file(all_frameworks[i].file_to_check,
+                                          all_frameworks[i].file_to_check_len);
+
+    for (ii = 0; ii < num_libraries; ii++) {
+      nr_php_user_instrumentation_from_file(libraries[ii].file_to_check,
+                                            libraries[ii].file_to_check_len);
+    }
+
+    for (ii = 0; ii < num_logging_frameworks; ii++) {
+      nr_php_user_instrumentation_from_file(
+          logging_frameworks[ii].file_to_check,
+          logging_frameworks[ii].file_to_check_len);
+    }
+
+    for (ii = 0; ii < num_packages; ii++) {
+      nr_php_user_instrumentation_from_file(
+          vuln_mgmt_packages[ii].file_to_check,
+          vuln_mgmt_packages[ii].file_to_check_len);
+    }
+
+    tlib_php_request_end();
+  }
+  tlib_php_engine_destroy();
+}
+
 void test_main(void* p NRUNUSED) {
   tlib_php_engine_create("" PTSRMLS_CC);
   test_add_segment_metric(TSRMLS_C);
   test_txn_restart_in_callstack(TSRMLS_C);
   test_php_cur_stack_depth(TSRMLS_C);
-
   tlib_php_engine_destroy(TSRMLS_C);
+  test_user_instrumentation_from_file_app_unknown();
+  test_user_instrumentation_from_file_txn_ignored();
 }

--- a/agent/tests/test_php_observer.c
+++ b/agent/tests/test_php_observer.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "tlib_php.h"
+
+tlib_parallel_info_t parallel_info
+    = {.suggested_nthreads = -1, .state_size = 0};
+
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8.0+ */
+#include "php_agent.h"
+#include "php_call.h"
+#include "php_execute.h"
+#include "php_globals.h"
+#include "php_user_instrument_wraprec_hashmap.h"
+#include "nr_php_packages.h"
+
+/*
+ * Baseline: agent is disabled at the process level:
+ *  - Observer handlers do not get installed
+ *  - Agent does not attempt to detect libraries
+ *  - Agent does not create any wraprecs
+ *  - Agent does not execute any special instrumentation
+ */
+static void test_register_handlers_globally_disabled(void) {
+  nruserfn_t* wr = NULL;
+  zend_string* scope_name = NULL;
+  zend_string* method_name = NULL;
+
+  tlib_php_engine_create("newrelic.enabled=false");
+  tlib_php_request_start();
+
+  scope_name = zend_string_init(NR_PSTR("Predis\\Client"), 0);
+  method_name = zend_string_init(NR_PSTR("__construct"), 0);
+
+  tlib_pass_if_false("Agent globally disabled", NR_PHP_PROCESS_GLOBALS(enabled),
+                     "Expected agent to be globally disabled");
+  tlib_pass_if_null("NRPRG(txn) was not created", NRPRG(txn));
+
+  // Trigger Predis detection
+  tlib_php_request_eval("require '" PHP_SCRIPTS_DIR "/predis/src/Client.php';");
+
+  // Not much to test when agent is disabled but at least check that wraprec
+  // was not created:
+  wr = nr_php_user_instrument_wraprec_hashmap_get(method_name, scope_name);
+  tlib_pass_if_null("Predis\\Client::__construct wraprec not created", wr);
+
+  zend_string_free(scope_name);
+  zend_string_free(method_name);
+
+  tlib_php_request_end();
+  tlib_php_engine_destroy();
+}
+
+/*
+ * When the agent is enabled but the current transaction is not recording,
+ * (e.g. agent not connected to daemon, or appinfo is still unknown), here
+ * emulated by explicitly setting status to not recording, Observer handlers
+ * still get installed, but not trigger special instrumentation, because
+ * they still gate instrumentation on the live nr_php_recording() state.
+ */
+static void test_register_handlers_enabled_but_not_recording(void) {
+  nruserfn_t* wr = NULL;
+  zend_string* scope_name = NULL;
+  zend_string* method_name = NULL;
+  int metric_count = 0;
+  size_t execute_count;
+  nr_php_package_t* package = NULL;
+
+  tlib_php_engine_create("");
+  tlib_php_request_start();
+
+  scope_name = zend_string_init(NR_PSTR("Predis\\Client"), 0);
+  method_name = zend_string_init(NR_PSTR("__construct"), 0);
+
+  tlib_pass_if_true("Agent globally enabled", NR_PHP_PROCESS_GLOBALS(enabled),
+                    "Expected agent to be globally enabled");
+  tlib_pass_if_not_null("NRPRG(txn) was created", NRPRG(txn));
+
+  // Emulate 'first transaction' case by forcing nr_php_recording to return 0
+  NRPRG(txn)->status.recording = 0;
+
+  metric_count = nrm_table_size(NRPRG(txn)->unscoped_metrics);
+
+  // Trigger library detection
+  tlib_php_request_eval("require '" PHP_SCRIPTS_DIR "/predis/src/Client.php';");
+
+  tlib_pass_if_int_equal("library detected metric created", metric_count + 1,
+                         nrm_table_size(NRPRG(txn)->unscoped_metrics));
+  tlib_pass_if_not_null("library detected metric created",
+                        nrm_find(NRPRG(txn)->unscoped_metrics,
+                                 "Supportability/library/Predis/detected"));
+  wr = nr_php_user_instrument_wraprec_hashmap_get(method_name, scope_name);
+  tlib_pass_if_not_null("Predis\\Client::__construct wraprec created", wr);
+
+  execute_count = NRTXNGLOBAL(execute_count);
+
+  // Call auto-instrumented function:
+  tlib_php_request_eval("new Predis\\Client();");
+
+  // Because agent is not recording, observer handlers should not be invoked.
+  // Thus nr_php_instrument_func_begin/nr_php_instrument_func_end should not
+  // execute:
+  tlib_pass_if_size_t_equal(
+      "when not recording, func_begin/func_end should not execute",
+      execute_count, NRTXNGLOBAL(execute_count));
+
+  // Because agent is not recording, instrumentation should not be invoked.
+  // **Note** : Predis instrumentation side effect is package version metric
+  // creation and that fact is used to test if instrumentation was invoked.
+  package = nr_php_packages_get_package(
+      NRPRG(txn)->php_package_major_version_metrics_suggestions,
+      "predis/predis");
+  tlib_pass_if_null("when not recording, package version metric not created",
+                    package);
+
+  zend_string_free(scope_name);
+  zend_string_free(method_name);
+
+  tlib_php_request_end();
+  tlib_php_engine_destroy();
+}
+
+/*
+ * Baseline: agent enabled, transaction recording. Observer handlers get
+ * installed, and trigger special instrumentation. Included for matrix
+ * completeness alongside the two tests above.
+ */
+static void test_register_handlers_enabled_and_recording(void) {
+  nruserfn_t* wr = NULL;
+  zend_string* scope_name = NULL;
+  zend_string* method_name = NULL;
+  int metric_count = 0;
+  size_t execute_count = 0;
+  nr_php_package_t* package = NULL;
+
+  tlib_php_engine_create("");
+  tlib_php_request_start();
+
+  scope_name = zend_string_init(NR_PSTR("Predis\\Client"), 0);
+  method_name = zend_string_init(NR_PSTR("__construct"), 0);
+
+  tlib_pass_if_true("Agent globally enabled", NR_PHP_PROCESS_GLOBALS(enabled),
+                    "Expected agent to be globally enabled");
+  tlib_pass_if_not_null("NRPRG(txn) was created", NRPRG(txn));
+  tlib_pass_if_true("Transaction is being recorded", nr_php_recording(),
+                    "Expected transaction to be recorded");
+
+  metric_count = nrm_table_size(NRPRG(txn)->unscoped_metrics);
+  /* Trigger Predis detection */
+  tlib_php_request_eval("require '" PHP_SCRIPTS_DIR "/predis/src/Client.php';");
+
+  tlib_pass_if_int_equal("library detected metric created", metric_count + 1,
+                         nrm_table_size(NRPRG(txn)->unscoped_metrics));
+  tlib_pass_if_not_null("library detected metric created",
+                        nrm_find(NRPRG(txn)->unscoped_metrics,
+                                 "Supportability/library/Predis/detected"));
+  wr = nr_php_user_instrument_wraprec_hashmap_get(method_name, scope_name);
+  tlib_pass_if_not_null("Predis\\Client::__construct wraprec created", wr);
+
+  execute_count = NRTXNGLOBAL(execute_count);
+
+  tlib_php_request_eval("new Predis\\Client();");
+
+  // Because agent is recording, nr_php_instrument_func_begin and 
+  // nr_php_instrument_func_end should execute.
+  tlib_pass_if_size_t_equal(
+      "when recording, func_begin/func_end should execute", execute_count + 1,
+      NRTXNGLOBAL(execute_count));
+
+  // Because agent is recording, wraprec instrumentation should be invoked.
+  // **Note** : Predis instrumentation side effect is package version metric
+  // creation and that fact is used to test if instrumentation was invoked.
+  package = nr_php_packages_get_package(
+      NRPRG(txn)->php_package_major_version_metrics_suggestions,
+      "predis/predis");
+  tlib_pass_if_not_null(
+      "when recording, package version metric created", package);
+
+  zend_string_free(scope_name);
+  zend_string_free(method_name);
+
+  tlib_php_request_end();
+  tlib_php_engine_destroy();
+}
+#endif
+
+void test_main(void* p NRUNUSED) {
+#if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8.0+ */
+  test_register_handlers_globally_disabled();
+  test_register_handlers_enabled_but_not_recording();
+  test_register_handlers_enabled_and_recording();
+#endif
+}

--- a/agent/tests/test_php_observer.c
+++ b/agent/tests/test_php_observer.c
@@ -8,6 +8,7 @@ tlib_parallel_info_t parallel_info
     = {.suggested_nthreads = -1, .state_size = 0};
 
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8.0+ */
+#include "nr_commands.h"
 #include "php_agent.h"
 #include "php_call.h"
 #include "php_execute.h"
@@ -52,14 +53,70 @@ static void test_register_handlers_globally_disabled(void) {
   tlib_php_engine_destroy();
 }
 
+static nr_status_t mock_cmd_appinfo_unknown(int daemon_fd NRUNUSED,
+                                            nrapp_t* app) {
+  app->state = NR_APP_UNKNOWN;
+  return NR_SUCCESS;
+}
+
 /*
  * When the agent is enabled but the current transaction is not recording,
- * (e.g. agent not connected to daemon, or appinfo is still unknown), here
- * emulated by explicitly setting status to not recording, Observer handlers
- * still get installed, but not trigger special instrumentation, because
- * they still gate instrumentation on the live nr_php_recording() state.
+ * here emulated by explicitly setting app status to unknown, Observer
+ * handlers still get installed, but not trigger special instrumentation,
+ * because they still gate instrumentation on the live nr_php_recording() state.
  */
-static void test_register_handlers_enabled_but_not_recording(void) {
+static void test_register_handlers_enabled_app_unknown(void) {
+  nruserfn_t* wr = NULL;
+  zend_string* scope_name = NULL;
+  zend_string* method_name = NULL;
+  size_t execute_count;
+
+  tlib_php_engine_create("");
+  // Emulate 'first transaction' case by forcing appinfo unknown which in turn
+  // causes nr_php_recording() to return 0 because NRPRG(txn) is NULL. This is a
+  // valid state for the agent to be in.
+  nr_cmd_appinfo_hook = mock_cmd_appinfo_unknown;
+  tlib_php_request_start();
+
+  scope_name = zend_string_init(NR_PSTR("Predis\\Client"), 0);
+  method_name = zend_string_init(NR_PSTR("__construct"), 0);
+
+  tlib_pass_if_true("Agent globally enabled", NR_PHP_PROCESS_GLOBALS(enabled),
+                    "Expected agent to be globally enabled");
+  tlib_pass_if_null("NRPRG(txn) was not created", NRPRG(txn));
+
+  // Trigger library detection
+  tlib_php_request_eval("require '" PHP_SCRIPTS_DIR "/predis/src/Client.php';");
+
+  wr = nr_php_user_instrument_wraprec_hashmap_get(method_name, scope_name);
+  tlib_pass_if_not_null("Predis\\Client::__construct wraprec created", wr);
+
+  execute_count = NRTXNGLOBAL(execute_count);
+
+  // Call auto-instrumented function:
+  tlib_php_request_eval("new Predis\\Client();");
+
+  // Because agent is not recording, observer handlers should not be invoked.
+  // Thus nr_php_instrument_func_begin/nr_php_instrument_func_end should not
+  // execute:
+  tlib_pass_if_size_t_equal(
+      "when not recording, func_begin/func_end should not execute",
+      execute_count, NRTXNGLOBAL(execute_count));
+
+  zend_string_free(scope_name);
+  zend_string_free(method_name);
+
+  tlib_php_request_end();
+  tlib_php_engine_destroy();
+}
+
+/*
+ * When the agent is enabled but the current transaction is not recording,
+ * here emulated by explicitly setting status to not recording, Observer
+ * handlers still get installed, but not trigger special instrumentation,
+ * because they still gate instrumentation on the live nr_php_recording() state.
+ */
+static void test_register_handlers_enabled_txn_ignored(void) {
   nruserfn_t* wr = NULL;
   zend_string* scope_name = NULL;
   zend_string* method_name = NULL;
@@ -75,10 +132,12 @@ static void test_register_handlers_enabled_but_not_recording(void) {
 
   tlib_pass_if_true("Agent globally enabled", NR_PHP_PROCESS_GLOBALS(enabled),
                     "Expected agent to be globally enabled");
+  // Force nr_php_recording to return 0 by ignoring transaction. This leaves
+  // NRPRG(txn) non-NULL but in a state that is not recording.
+  tlib_php_request_eval("newrelic_ignore_transaction();");
   tlib_pass_if_not_null("NRPRG(txn) was created", NRPRG(txn));
-
-  // Emulate 'first transaction' case by forcing nr_php_recording to return 0
-  NRPRG(txn)->status.recording = 0;
+  tlib_pass_if_true("Transaction is not being recorded", !nr_php_recording(),
+                    "Expected transaction to be ignored");
 
   metric_count = nrm_table_size(NRPRG(txn)->unscoped_metrics);
 
@@ -188,7 +247,8 @@ static void test_register_handlers_enabled_and_recording(void) {
 void test_main(void* p NRUNUSED) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8.0+ */
   test_register_handlers_globally_disabled();
-  test_register_handlers_enabled_but_not_recording();
+  test_register_handlers_enabled_app_unknown();
+  test_register_handlers_enabled_txn_ignored();
   test_register_handlers_enabled_and_recording();
 #endif
 }

--- a/agent/tests/test_php_observer.c
+++ b/agent/tests/test_php_observer.c
@@ -18,7 +18,7 @@ tlib_parallel_info_t parallel_info
 
 /*
  * Baseline: agent is disabled at the process level:
- *  - Observer handlers do not get installed
+ *  - Zend Observer fcall_begin/fcall_end handlers do not get installed
  *  - Agent does not attempt to detect libraries
  *  - Agent does not create any wraprecs
  *  - Agent does not execute any special instrumentation
@@ -27,6 +27,7 @@ static void test_register_handlers_globally_disabled(void) {
   nruserfn_t* wr = NULL;
   zend_string* scope_name = NULL;
   zend_string* method_name = NULL;
+  size_t execute_count = 0;
 
   tlib_php_engine_create("newrelic.enabled=false");
   tlib_php_request_start();
@@ -41,10 +42,71 @@ static void test_register_handlers_globally_disabled(void) {
   // Trigger Predis detection
   tlib_php_request_eval("require '" PHP_SCRIPTS_DIR "/predis/src/Client.php';");
 
+  execute_count = NRTXNGLOBAL(execute_count);
+
   // Not much to test when agent is disabled but at least check that wraprec
   // was not created:
   wr = nr_php_user_instrument_wraprec_hashmap_get(method_name, scope_name);
   tlib_pass_if_null("Predis\\Client::__construct wraprec not created", wr);
+
+  // Because agent is disabled per-request, observer handlers should not be
+  // invoked. Thus nr_php_instrument_func_begin/nr_php_instrument_func_end
+  // should not execute:
+  tlib_pass_if_size_t_equal(
+      "when disabled per-request, func_begin/func_end should not execute",
+      execute_count, NRTXNGLOBAL(execute_count));
+
+  zend_string_free(scope_name);
+  zend_string_free(method_name);
+
+  tlib_php_request_end();
+  tlib_php_engine_destroy();
+}
+
+/*
+ * When the agent is globally enabled but disabled for the current PHP request,
+ * here emulated by explicitly setting NRINI(enabled) to 0, the agent should
+ * behave as if it was globally disabled:
+ *  - Zend Observer fcall_begin/fcall_end handlers do not get installed
+ *  - Agent does not attempt to detect libraries
+ *  - Agent does not create any wraprecs
+ *  - Agent does not execute any special instrumentation
+ */
+static void test_register_handlers_per_request_disabled(void) {
+  nruserfn_t* wr = NULL;
+  zend_string* scope_name = NULL;
+  zend_string* method_name = NULL;
+  size_t execute_count = 0;
+
+  tlib_php_engine_create("");
+  // Emulate disabling agent per-request by explicitly setting NRINI(enabled) to 0.
+  NRINI(enabled) = 0;
+  tlib_php_request_start();
+
+  scope_name = zend_string_init(NR_PSTR("Predis\\Client"), 0);
+  method_name = zend_string_init(NR_PSTR("__construct"), 0);
+
+  tlib_pass_if_true("Agent globally enabled", NR_PHP_PROCESS_GLOBALS(enabled),
+                    "Expected agent to be globally enabled");
+  tlib_pass_if_null("NRPRG(txn) was not created", NRPRG(txn));
+
+  // Trigger library detection
+  tlib_php_request_eval("require '" PHP_SCRIPTS_DIR "/predis/src/Client.php';");
+
+  wr = nr_php_user_instrument_wraprec_hashmap_get(method_name, scope_name);
+  tlib_pass_if_null("Predis\\Client::__construct wraprec not created", wr);
+
+  execute_count = NRTXNGLOBAL(execute_count);
+
+  // Call auto-instrumented function:
+  tlib_php_request_eval("new Predis\\Client();");
+
+  // Because agent is disabled per-request, observer handlers should not be
+  // invoked. Thus nr_php_instrument_func_begin/nr_php_instrument_func_end
+  // should not execute:
+  tlib_pass_if_size_t_equal(
+      "when disabled per-request, func_begin/func_end should not execute",
+      execute_count, NRTXNGLOBAL(execute_count));
 
   zend_string_free(scope_name);
   zend_string_free(method_name);
@@ -84,6 +146,8 @@ static void test_register_handlers_enabled_app_unknown(void) {
   tlib_pass_if_true("Agent globally enabled", NR_PHP_PROCESS_GLOBALS(enabled),
                     "Expected agent to be globally enabled");
   tlib_pass_if_null("NRPRG(txn) was not created", NRPRG(txn));
+  tlib_pass_if_true("Transaction is not being recorded", !nr_php_recording(),
+                    "Expected transaction to be ignored");
 
   // Trigger library detection
   tlib_php_request_eval("require '" PHP_SCRIPTS_DIR "/predis/src/Client.php';");
@@ -247,6 +311,7 @@ static void test_register_handlers_enabled_and_recording(void) {
 void test_main(void* p NRUNUSED) {
 #if ZEND_MODULE_API_NO >= ZEND_8_0_X_API_NO /* PHP8.0+ */
   test_register_handlers_globally_disabled();
+  test_register_handlers_per_request_disabled();
   test_register_handlers_enabled_app_unknown();
   test_register_handlers_enabled_txn_ignored();
   test_register_handlers_enabled_and_recording();

--- a/tests/integration/observer/test_first_call_not_recording.php
+++ b/tests/integration/observer/test_first_call_not_recording.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+A function whose first-ever call happens while the transaction is being
+ignored must still be instrumented once a fresh, recording transaction
+starts later in the same PHP request. This is a regression test for the
+nr_php_fcall_register_handlers registration gate: the Observer API only
+invokes that gate once per op_array per PHP request, on the function's
+first call, and caches whatever handlers it returns for that op_array's
+entire life during PHP request - so gating registration on the live
+recording state meant a function first called while not recording could
+never be instrumented again.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
+/*INI
+newrelic.transaction_tracer.threshold = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+Custom/f
+*/
+
+newrelic_add_custom_tracer("f");
+
+function f() {
+    echo "f\n";
+}
+
+function main() {
+    newrelic_ignore_transaction(); // turn recording off for this New Relic transaction
+    f(); // zend_observer_fcall_init's callback is invoked for f();
+         // it is the only chance to register fcall_begin/fcall_end
+         // handlers for f() in this PHP request
+    newrelic_end_transaction(); // end New Relic transaction, which is not recording
+    newrelic_start_transaction(ini_get("newrelic.appname")); // Start New Relic transaction, recording is back on
+    f(); // fcall_begin/fcall_end handlers for f() should be invoked here and
+         // f() should be instrumented, even though its first-ever call was
+         // made while the transaction was not recording
+}
+
+main();

--- a/tests/integration/observer/test_first_include_not_recording.php
+++ b/tests/integration/observer/test_first_include_not_recording.php
@@ -1,0 +1,123 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+Regression test for the nr_php_fcall_register_handlers registration gate, as
+it applies to magic-file library detection specifically (see
+observer/test_first_call_not_recording.php for the equivalent case with a
+plain function call).
+
+The Observer API invokes the fcall_init registration callback only once per
+op_array per PHP request — on the file's first require/include — and caches
+whatever handlers that call returns for the rest of the request. Gating the
+agent's behavior in that callback on the transaction's live recording state
+was wrong: a magic file required while not recording would skip
+framework/library detection, so auto-instrumentation would never be
+installed, even after a later transaction in the same request started
+recording.
+
+This test requires (includes) the predis/predis magic file while a transaction
+is ignored, ends that transaction, then starts a fresh recording transaction
+and confirms Predis calls still produce datastore metrics. That proves
+nr_predis_enable() ran and installed wraprecs during the non-recording require,
+independent of recording status.
+
+Separately, the test forces an early connect and then restarts the
+transaction with $xmit = false (discarding it without transmitting). That is
+why the following metrics (Datastore/operation/Redis/select,
+Supportability/InstrumentedFunction/Predis\Client::__construct, package
+detection) are listed under EXPECT_METRICS_DONT_EXIST below — they fired
+against the discarded transaction, not the one actually sent.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+*/
+
+/*INI
+newrelic.datastore_tracer.database_name_reporting.enabled = 1
+newrelic.datastore_tracer.instance_reporting.enabled = 1
+newrelic.transaction_tracer.explain_enabled = true
+newrelic.transaction_tracer.explain_threshold = 0
+*/
+
+/*EXPECT
+ok - key does not exist
+ok - get key
+*/
+
+/*EXPECT_METRICS_EXIST
+Datastore/Redis/all, 5
+Datastore/operation/Redis/del, 1
+Datastore/operation/Redis/exists, 1
+Datastore/operation/Redis/get, 1
+Datastore/operation/Redis/incr, 1
+Datastore/operation/Redis/set, 1
+Datastore/instance/Redis/ENV[REDIS_HOST]/6379, 5
+Supportability/api/set_appname/after, 1
+Supportability/api/set_appname/with_license, 1
+*/
+
+/*EXPECT_METRICS_DONT_EXIST
+Supportability/InstrumentedFunction/Predis\\Client::__construct
+Datastore/operation/Redis/select
+Supportability/PHP/package/predis/predis/2/detected
+Supportability/library/Predis/detected
+*/
+
+/*EXPECT_TRACED_ERRORS null */
+
+newrelic_ignore_transaction(); // turn recording off for this New Relic transaction
+// zend_observer_fcall_init's callback is invoked for predis/src/client.php;
+// it is the only chance to execute the library detection code and create
+// predis wraprecs in nr_predis_enable(). This under normal circumstances
+// would generate Supportability/library/Predis/detected which is listed
+// under EXPECT_METRICS_DONT_EXIST because the transaction is not recording.
+require_once realpath(getenv("PREDIS_HOME") . '/../../../').'/vendor/autoload.php';
+newrelic_end_transaction(); // end New Relic transaction, which is not recording
+newrelic_start_transaction(ini_get("newrelic.appname")); // Start New Relic transaction, recording is back on
+require_once(__DIR__.'/../../include/config.php');
+require_once(__DIR__.'/../../include/helpers.php');
+require_once(__DIR__.'/../../include/tap.php');
+require_once(__DIR__.'/../../include/integration.php');
+
+global $REDIS_HOST, $REDIS_PORT;
+$client = new Predis\Client(array('host' => $REDIS_HOST, 'port' => $REDIS_PORT, 'database' => 0));
+
+// Force predis to connect - usually it will lazily connect as needed.
+// In this case the 'select' operation will still be captured because
+// the connection wont occur until the 'exists' operation is executed
+// below.
+// Following code forces predis to connect now and therefore 'select'
+// operation happens before transaction is ended below and so will not
+// appear in the operations metrics
+try {
+  $client->connect();
+} catch (Exception $e) {
+  die("skip: " . $e->getMessage() . "\n");
+}
+
+// Restart the transaction without sending current one. If you compare the expected metrics in this test to
+// test_basic.php, you'll note that the detection metrics go away (because
+// they're thrown away with the initial transaction), but we still look for the
+// Redis datastore metrics created by the $client method calls below.
+// $xmit == false (last argument) is responsible for Datastore/operation/Redis/select,
+// Supportability/InstrumentedFunction/Predis\\Client::__construct as well as
+// Supportability/PHP/package/predis/predis/2/detected to be listed under
+// EXPECT_METRICS_DONT_EXIST.
+newrelic_set_appname(ini_get("newrelic.appname"), ini_get("newrelic.license"), false);
+
+$key = uniqid(__FILE__, true);
+tap_equal(0, $client->exists($key), 'key does not exist');
+
+$client->set($key, 1);
+$client->incr($key);
+tap_equal('2', $client->get($key), 'get key');
+
+$client->del($key);

--- a/tests/integration/observer/test_first_include_not_recording.php
+++ b/tests/integration/observer/test_first_include_not_recording.php
@@ -73,19 +73,139 @@ Supportability/library/Predis/detected
 
 /*EXPECT_TRACED_ERRORS null */
 
+/*EXPECT_SPAN_EVENTS_LIKE
+[
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/operation\/Redis\/exists",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Redis"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[REDIS_HOST]",
+      "peer.address": "ENV[REDIS_HOST]:6379",
+      "db.instance": "0"
+    }
+  ],
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/operation\/Redis\/set",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Redis"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[REDIS_HOST]",
+      "peer.address": "ENV[REDIS_HOST]:6379",
+      "db.instance": "0"
+    }
+  ],
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/operation\/Redis\/incr",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Redis"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[REDIS_HOST]",
+      "peer.address": "ENV[REDIS_HOST]:6379",
+      "db.instance": "0"
+    }
+  ],
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/operation\/Redis\/get",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Redis"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[REDIS_HOST]",
+      "peer.address": "ENV[REDIS_HOST]:6379",
+      "db.instance": "0"
+    }
+  ],
+  [
+    {
+      "category": "datastore",
+      "type": "Span",
+      "guid": "??",
+      "traceId": "??",
+      "transactionId": "??",
+      "name": "Datastore\/operation\/Redis\/del",
+      "timestamp": "??",
+      "duration": "??",
+      "priority": "??",
+      "sampled": true,
+      "parentId": "??",
+      "span.kind": "client",
+      "component": "Redis"
+    },
+    {},
+    {
+      "peer.hostname": "ENV[REDIS_HOST]",
+      "peer.address": "ENV[REDIS_HOST]:6379",
+      "db.instance": "0"
+    }
+  ]
+]
+*/
+
 newrelic_ignore_transaction(); // turn recording off for this New Relic transaction
 // zend_observer_fcall_init's callback is invoked for predis/src/client.php;
 // it is the only chance to execute the library detection code and create
 // predis wraprecs in nr_predis_enable(). This under normal circumstances
 // would generate Supportability/library/Predis/detected which is listed
 // under EXPECT_METRICS_DONT_EXIST because the transaction is not recording.
-require_once realpath(getenv("PREDIS_HOME") . '/../../../').'/vendor/autoload.php';
+require_once realpath(getenv("PREDIS_HOME") . '/../../../') . '/vendor/autoload.php';
 newrelic_end_transaction(); // end New Relic transaction, which is not recording
 newrelic_start_transaction(ini_get("newrelic.appname")); // Start New Relic transaction, recording is back on
-require_once(__DIR__.'/../../include/config.php');
-require_once(__DIR__.'/../../include/helpers.php');
-require_once(__DIR__.'/../../include/tap.php');
-require_once(__DIR__.'/../../include/integration.php');
+require_once(__DIR__ . '/../../include/config.php');
+require_once(__DIR__ . '/../../include/helpers.php');
+require_once(__DIR__ . '/../../include/tap.php');
+require_once(__DIR__ . '/../../include/integration.php');
 
 global $REDIS_HOST, $REDIS_PORT;
 $client = new Predis\Client(array('host' => $REDIS_HOST, 'port' => $REDIS_PORT, 'database' => 0));


### PR DESCRIPTION
1. [Relax zend_observer_fcall_init's callback constraints](https://github.com/newrelic/newrelic-php-agent/commit/45c16002e08a7c70ccabc180a2a9207b5c1818a3) + [4b24b5ed](https://github.com/newrelic/newrelic-php-agent/commit/4b24b5edd59545a5f05a642d04d82c52f58bf678)

`nr_php_fcall_register_handlers` (`zend_observer_fcall_init` callback) only
ever runs once per op_array per PHP request - the first time a function
is called, or a file is executed via `require`/`include` - and Zend caches
whatever handlers it returns for that op_array's entire life during PHP
request. Gating registration on `nr_php_recording()` meant whichever
recording state happened to be true on a function's first-ever call, or
file's first ever include, decided whether it could ever be instrumented
again, for as long as that op_array lives - which can span many New
Relic transactions during a single PHP request (e.g. a persistent
worker). However, fcall_init's callback actions are still gated on
per-request enabled state: `NRINI(enabled)`. When the agent is globally
enabled, but disabled for a given PHP request, it should have minimal
impact on the application, i.e. the `fcall_init`'s callback shouldn't try
to detect libraries or install `fcall_begin` and `fcall_end` handlers for that
request's op_arrays.

It is safe to gate per-request despite Zend caching whatever handlers
are returned here for an op_array's entire life during a PHP request:
`zend_observer_fcall_init` runs again for that same op_array on every
new PHP request, so a disabled request just defers registration to
whichever later request re-triggers the op_array's first call while
the agent is enabled.

`nr_php_observer_fcall_begin`/`end` already re-check `nr_php_recording()`
live on every call, which is the correct place for a state that varies
per request. `NR_PHP_PROCESS_GLOBALS(enabled)` is set once at MINIT and
never changes for the life of the process, so it's safe to bake into a
decision Zend caches at op_array granularity. As of this change, the
`NR_PHP_PROCESS_GLOBALS(enabled)` gate in `nr_php_fcall_register_handlers`
is moot - `nr_php_fcall_register_handlers` is never called when agent
is globally disabled because `nr_php_fcall_register_handlers` is not
even registered as `zend_observer_fcall_init` callback. However, it is
left in `nr_php_fcall_register_handlers` as a protection if that assumption
ever changes.

2. [Log show_executes/_returns even when not recording](https://github.com/newrelic/newrelic-php-agent/commit/24fb4af9a7b9736363929b167b8505dadb8f47ef) 

`nr_php_observer_fcall_begin` and `nr_php_observer_fcall_end` each gated
their show_executes/show_execute_returns debug log calls behind the
same `nr_php_recording()` check that gates real instrumentation, so a
function's first call during a non-recording window produced no
diagnostic trace at all - misleading anyone using show_executes to
verify whether Zend Observer handlers actually got installed for a
function, which is exactly the blind spot the registration-gate fix
in this branch needs to be diagnosable.

Both log calls now run independent on recording state (they're still
gated by show_executes/show_execute_returns specials) - call moved
ahead of the `nr_php_recording()` early-return in each function, while
the actual instrumentation decision (nr_php_instrument_func_begin/end)
stays exactly as before, gated on `nr_php_recording()` live per call.
`nr_php_show_exec` gains a fixed-width "+"/"-" marker on each of its
format strings so a log reader can tell whether a given execute line
happened while recording was active.

To avoid one more check on a hot path `NR_PHP_PROCESS_GLOBALS(enabled)`
guard is not added around either log block: `nr_php_observer_minit()`,
which registers `zend_observer_fcall_init` callback (which installs
nr_php_instrument_func_begin/end callbacks with Zend), is never called
when the agent is globally disabled. Since MINIT bails out first, these
functions already can't run in that state.

nr_php_show_exec_return, and the nr_php_recording()-gated
instrumentation calls in both functions, are otherwise unchanged.

3. [Regression unit tests for zend_observer_fcall_init's callback](https://github.com/newrelic/newrelic-php-agent/commit/0f2e1c36c55d8c46fc322579d3ab024e693e42fd) 

These tests pin fcall_init's callback behavior across the three states
it has to distinguish: agent disabled at the process level, agent
enabled but the current transaction not recording, and the normal
recording case.

Library detection via a real `require` of a Predis fixture is used as
the observable signal instead of a synthetic probe, so the tests
exercise the actual detection/wraprec path rather than a stand-in for
it.

4. [End-to-end test zend_observer_fcall_init's callback](https://github.com/newrelic/newrelic-php-agent/commit/78d6162e649bb8f9afa0bd61d178feee359e03e5) + 4b569ec96164a083208ec09a5e6f94c71f45a1f0

An end-to-end integration test pins fcall_init's callback behavior when
the agent is enabled but the New Relic transaction during which a
custom-instrumented function is first called, is not being recorded. In
that case, Zend Observer's fcall_begin and fcall_end handlers must still
get registered so the function is instrumented when recording New Relic
transaction within the same PHP request calls it too.

Note: PHP request != New Relic transaction.