### PR TITLE
fix(agent): Change exclusive_time/total_time calculations for suspend cases

### DIFF
--- a/agent/lib_guzzle_common.c
+++ b/agent/lib_guzzle_common.c
@@ -112,7 +112,7 @@ nr_segment_t* nr_guzzle_obj_add(const zval* obj,
   segment = nr_segment_start(NRPRG(txn),
                              nr_txn_get_current_segment_txn_context(NRPRG(txn)),
                              async_context);
-
+  segment->consider_for_blocking = true;
   nr_free(async_context);
   NRTXN(current_async_context) = old_context;
 

--- a/agent/lib_guzzle_common.c
+++ b/agent/lib_guzzle_common.c
@@ -112,7 +112,9 @@ nr_segment_t* nr_guzzle_obj_add(const zval* obj,
   segment = nr_segment_start(NRPRG(txn),
                              nr_txn_get_current_segment_txn_context(NRPRG(txn)),
                              async_context);
-  segment->consider_for_blocking = true;
+  if (NULL != segment) {
+    segment->consider_for_blocking = true;
+  }
   nr_free(async_context);
   NRTXN(current_async_context) = old_context;
 

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -559,6 +559,7 @@ NR_PHP_WRAPPER(nr_predis_connection_readResponse) {
    * the actively executing fiber.
    */
   segment = nr_segment_start(NRPRG(txn), auto_segment, async_context);
+  segment->consider_for_blocking = true;
   nr_segment_set_timing(segment, *start, duration);
   nr_segment_datastore_end(&segment, &params);
 

--- a/agent/lib_predis.c
+++ b/agent/lib_predis.c
@@ -559,7 +559,9 @@ NR_PHP_WRAPPER(nr_predis_connection_readResponse) {
    * the actively executing fiber.
    */
   segment = nr_segment_start(NRPRG(txn), auto_segment, async_context);
-  segment->consider_for_blocking = true;
+  if (NULL != segment) {
+    segment->consider_for_blocking = true;
+  }
   nr_segment_set_timing(segment, *start, duration);
   nr_segment_datastore_end(&segment, &params);
 

--- a/agent/php_curl.c
+++ b/agent/php_curl.c
@@ -671,6 +671,7 @@ void nr_php_curl_exec_pre(zval* curlres,
   if (nr_php_curl_should_instrument_proto(uri)
       && (0 == nr_guzzle_in_call_stack(TSRMLS_C))) {
     segment = nr_segment_start(NRPRG(txn), parent, async_context);
+    segment->consider_for_blocking = true;
     nr_php_curl_md_set_segment(curlres, segment TSRMLS_CC);
   }
 
@@ -760,7 +761,7 @@ void nr_php_curl_multi_exec_pre(zval* curlres TSRMLS_DC) {
     segment = nr_segment_start(
         NRPRG(txn), nr_txn_get_current_segment_txn_context(NRPRG(txn)),
         nr_php_curl_multi_md_get_async_context(curlres TSRMLS_CC));
-
+    segment->consider_for_blocking = true;
     nr_segment_set_name(segment, "curl_multi_exec");
     nr_php_curl_multi_md_set_segment(curlres, segment TSRMLS_CC);
 

--- a/agent/php_curl.c
+++ b/agent/php_curl.c
@@ -671,7 +671,9 @@ void nr_php_curl_exec_pre(zval* curlres,
   if (nr_php_curl_should_instrument_proto(uri)
       && (0 == nr_guzzle_in_call_stack(TSRMLS_C))) {
     segment = nr_segment_start(NRPRG(txn), parent, async_context);
-    segment->consider_for_blocking = true;
+    if (NULL != segment) {
+      segment->consider_for_blocking = true;
+    }
     nr_php_curl_md_set_segment(curlres, segment TSRMLS_CC);
   }
 
@@ -761,7 +763,9 @@ void nr_php_curl_multi_exec_pre(zval* curlres TSRMLS_DC) {
     segment = nr_segment_start(
         NRPRG(txn), nr_txn_get_current_segment_txn_context(NRPRG(txn)),
         nr_php_curl_multi_md_get_async_context(curlres TSRMLS_CC));
-    segment->consider_for_blocking = true;
+    if (NULL != segment) {
+      segment->consider_for_blocking = true;
+    }
     nr_segment_set_name(segment, "curl_multi_exec");
     nr_php_curl_multi_md_set_segment(curlres, segment TSRMLS_CC);
 

--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1254,7 +1254,10 @@ static inline void nr_php_execute_segment_end(
     stacked->stop_time = nr_txn_now_rel(NRPRG(txn));
   }
 
-  duration = nr_time_duration(stacked->start_time, stacked->stop_time);
+  duration = nr_time_duration(
+      stacked->start_time,
+      nr_segment_amend_stop_with_suspend_time(
+          stacked->start_time, stacked->stop_time, stacked->suspend_time));
   if (create_metric || (duration >= NR_PHP_PROCESS_GLOBALS(expensive_min))
       || nr_vector_size(stacked->metrics) || stacked->id || stacked->attributes
       || stacked->error) {

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -350,6 +350,7 @@ static inline void nr_fiber_handle_fiber_suspend(zend_fiber_context* zfc) {
  */
 static inline void nr_fiber_handle_exclusive_time() {
   nr_segment_t* fiber_segment = NULL;
+  nr_segment_t* suspend_segment = NULL;
   nrtime_t current_time = 0;
 
   if (NULL == NRPRG(txn)) {
@@ -377,8 +378,8 @@ static inline void nr_fiber_handle_exclusive_time() {
     //                             fiber_segment->stop_time, current_time);
 
     /* Create a segment that is then discarded so time won't show as uninstrumented. */
-    suspend_segment = nr_segment_start(NRPRG(txn), NRPRG_SHARED(fiber_segment),
-                             NRPRG_SHARED(current_php_context));
+    suspend_segment = nr_segment_start(NRPRG(txn), fiber_segment,
+                                       NRPRG_SHARED(current_php_context));
     if (nrunlikely(NULL == suspend_segment)) {
      nrl_verbosedebug(NRL_AGENT, "Error starting segment.");
       return;

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -387,8 +387,8 @@ static inline void nr_fiber_handle_exclusive_time() {
     suspend_segment->start_time = fiber_segment->stop_time;
     suspend_segment->stop_time = current_time;
     /* create a metric so it won't show as uninstrumented*/
-    nr_segment_add_metric(suspend_segment, "Custom/FiberSuspend", true);
-    nr_segment_set_name(suspend_segment, "Custom/FiberSuspend");
+    nr_segment_add_metric(suspend_segment, "FiberSuspend", true);
+//    nr_segment_set_name(suspend_segment, "Custom/FiberSuspend");
     nr_segment_discard(&suspend_segment);
 
     /* reset the stop_time now that the fiber is resumed. */

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -367,14 +367,28 @@ static inline void nr_fiber_handle_exclusive_time() {
   }
 
   if (nrlikely(0 != fiber_segment->stop_time)) {
-    nr_exclusive_time_ensure(&fiber_segment->exclusive_time,
-                             NR_PHP_DEFAULT_SUSPEND_TIMES,
-                             fiber_segment->start_time, current_time);
+    //nr_exclusive_time_ensure(&fiber_segment->exclusive_time,
+    //                         NR_PHP_DEFAULT_SUSPEND_TIMES,
+    //                         fiber_segment->start_time, current_time);
     /* Add the suspension which existed from the previous stop time to the
      * current time. */
 
-    nr_exclusive_time_add_child(fiber_segment->exclusive_time,
-                                fiber_segment->stop_time, current_time);
+    //nr_exclusive_time_add_child(fiber_segment->exclusive_time,
+    //                             fiber_segment->stop_time, current_time);
+
+    /* Create a segment that is then discarded so time won't show as uninstrumented. */
+    suspend_segment = nr_segment_start(NRPRG(txn), NRPRG_SHARED(fiber_segment),
+                             NRPRG_SHARED(current_php_context));
+    if (nrunlikely(NULL == suspend_segment)) {
+     nrl_verbosedebug(NRL_AGENT, "Error starting segment.");
+      return;
+    }
+    suspend_segment->start_time = fiber_segment->stop_time;
+    suspend_segment->stop_time = current_time;
+    /* create a metric so it won't show as uninstrumented*/
+    nr_segment_add_metric(suspend_segment, "FiberSuspend", true);
+    nr_segment_discard(&suspend_segment);
+
     /* reset the stop_time now that the fiber is resumed. */
     fiber_segment->stop_time = 0;
   } else {

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -387,7 +387,8 @@ static inline void nr_fiber_handle_exclusive_time() {
     suspend_segment->start_time = fiber_segment->stop_time;
     suspend_segment->stop_time = current_time;
     /* create a metric so it won't show as uninstrumented*/
-    nr_segment_add_metric(suspend_segment, "FiberSuspend", true);
+    nr_segment_add_metric(suspend_segment, "Custom/FiberSuspend", true);
+    nr_segment_set_name(suspend_segment, "Custom/FiberSuspend");
     nr_segment_discard(&suspend_segment);
 
     /* reset the stop_time now that the fiber is resumed. */

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -265,7 +265,8 @@ static inline void nr_fiber_set_contexts(zend_fiber_context* zfc) {
    * must remain the owners of current_async_context within a single context.
    * This is the one callsite where the field is written outside that contract,
    * and it is safe here because the stacks themselves are already correct —
-   * only the "which context is PHP currently running in" pointer needs updating.
+   * only the "which context is PHP currently running in" pointer needs
+   * updating.
    */
 
   if (zfc->kind != zend_ce_fiber) {
@@ -299,35 +300,62 @@ static inline void nr_fiber_set_contexts(zend_fiber_context* zfc) {
  *                so we don't have to calculate the context twice
  *
  * Ensure we don't count fiber suspend time in the segment's exclusive time
- * duration. In addition to a fiber being able to suspend itself via
+ * or duration. In addition to a fiber being able to suspend itself via
  * Fiber::suspend(), since ONLY ONE fiber can run at a time, any fiber that
- * calls another will automatically be suspended.
+ * calls another will automatically be marked ZEND_FIBER_STATUS_SUSPENDED.
  *
- * Note: We need to handle both types of suspension.
+ * We deliberately only mark suspend_time for the self-suspend case
+ * (fiber->caller == NULL). An earlier version handled both cases and got
+ * exact timings to subtract from the exclusive time, but the reclaimed suspend
+ * time then showed up as an
+ * uninstrumented gap on the response time breakdown graph, since PHP is
+ * displayed there as a remainder and any unattributed gap makes PHP look
+ * like it was missing.
+ * The spec says as an alternative to subtracting from exclusive time, an agent
+ * MAY choose to subtract blocking, non-actionable times directly from the
+ * duration.
+ * Those subtractions are done when the metric is generated.
  *
- * If in the future, we ever need to differentiate, it is possible to
- * differentiate. To detect that the fiber suspended itself using
- * Fiber::suspend(), check:
- *
+ * To detect self-suspend via Fiber::suspend(), check:
  * 1) the "from" fiber context status is ZEND_FIBER_STATUS_RUNNING
  * 2) the fiber in the "from" fiber context, has a fiber->caller value of
  * NULL
- *
+
  */
 static inline void nr_fiber_handle_fiber_suspend(zend_fiber_context* zfc) {
   nr_segment_t* fiber_segment = NULL;
+  zend_fiber* zfc_fiber = NULL;
 
   if (NULL == NRPRG(txn)) {
     /* nothing to do if the txn is NULL */
     return;
   }
+  if (zfc->kind != zend_ce_fiber) {
+    /* Context is the Main PHP Process and can't suspend itself and
+     * `main` is not a real zend_fiber,
+     * so calling zend_fiber_from_context()/reading ->caller on it is reading
+     * off a non-Fiber context.
+     */
+    return;
+  }
 
   if (ZEND_FIBER_STATUS_RUNNING == zfc->status) {
-    fiber_segment = nr_txn_get_current_segment(
-        NRPRG(txn), NRPRG_SHARED(current_php_context));
+    zfc_fiber = zend_fiber_from_context(zfc);
 
-    if (NULL != fiber_segment && 0 == fiber_segment->stop_time) {
-      fiber_segment->stop_time = nr_txn_now_rel(NRPRG(txn));
+    if (nrunlikely(NULL == zfc_fiber)) {
+      nrl_verbosedebug(
+          NRL_INSTRUMENT,
+          "PHP Issue: The Fiber associated with %p is unexpectedly NULL.", zfc);
+      return;
+    }
+    if (NULL == zfc_fiber->caller) {
+      /* This fiber has suspended itself.*/
+      fiber_segment = nr_txn_get_current_segment(
+          NRPRG(txn), NRPRG_SHARED(current_php_context));
+
+      if (NULL != fiber_segment && 0 == fiber_segment->stop_time) {
+        fiber_segment->stop_time = nr_txn_now_rel(NRPRG(txn));
+      }
     }
   }
 }
@@ -347,11 +375,18 @@ static inline void nr_fiber_handle_fiber_suspend(zend_fiber_context* zfc) {
  *                so we don't have to calculate the context twice
  * During a fiber switch, update the exclusive time of a the "to" fiber context
  *
+ * The "to" segment's stop_time is nonzero only if
+ * nr_fiber_handle_fiber_suspend() marked it as self-suspended on a prior
+ * switch; that's the only case suspend_time accumulates here. If stop_time
+ * is 0 (see the else branch below), this resume was not preceded by a
+ * tracked self-suspend - e.g. it called/resumed a nested fiber instead -
+ * and is intentionally left uncorrected (see nr_fiber_handle_fiber_suspend
+ * above for why).
  */
-static inline void nr_fiber_handle_exclusive_time() {
+static inline void nr_fiber_handle_suspend_time() {
   nr_segment_t* fiber_segment = NULL;
-  nr_segment_t* suspend_segment = NULL;
   nrtime_t current_time = 0;
+  nrtime_t current_suspend_time = 0;
 
   if (NULL == NRPRG(txn)) {
     /* nothing to do if the txn is NULL */
@@ -367,46 +402,29 @@ static inline void nr_fiber_handle_exclusive_time() {
     return; /* Valid case - ex: will happen if there was a txn stop. */
   }
 
+  /*
+    * Check if the stop time was set.
+    * if stop_time is 0, this segment was never marked self-suspended.
+    */
   if (nrlikely(0 != fiber_segment->stop_time)) {
-    //nr_exclusive_time_ensure(&fiber_segment->exclusive_time,
-    //                         NR_PHP_DEFAULT_SUSPEND_TIMES,
-    //                         fiber_segment->start_time, current_time);
     /* Add the suspension which existed from the previous stop time to the
      * current time. */
-
-    //nr_exclusive_time_add_child(fiber_segment->exclusive_time,
-    //                             fiber_segment->stop_time, current_time);
-
-    /* Create a segment that is then discarded so time won't show as uninstrumented. */
-    suspend_segment = nr_segment_start(NRPRG(txn), fiber_segment,
-                                       NRPRG_SHARED(current_php_context));
-    if (nrunlikely(NULL == suspend_segment)) {
-     nrl_verbosedebug(NRL_AGENT, "Error starting segment.");
-      return;
+    current_suspend_time = current_time - fiber_segment->stop_time;
+    if (nrlikely(current_suspend_time > 0)) {
+      fiber_segment->suspend_time += current_suspend_time;
+    } else {
+      /* This case should not happen.*/
+      nrl_verbosedebug(NRL_AGENT, "Cannot have stop_time greater than current time.");
     }
-    suspend_segment->start_time = fiber_segment->stop_time;
-    suspend_segment->stop_time = current_time;
-    /* create a metric so it won't show as uninstrumented*/
-    nr_segment_add_metric(suspend_segment, "FiberSuspend", true);
-//    nr_segment_set_name(suspend_segment, "Custom/FiberSuspend");
-    nr_segment_discard(&suspend_segment);
 
     /* reset the stop_time now that the fiber is resumed. */
     fiber_segment->stop_time = 0;
-  } else {
-    /*
-     * Shouldn't get to this case, but doublechecking so as not to overwrite a
-     * time that something else wrote.
-     */
-    nrl_verbosedebug(
-        NRL_AGENT, "Current segment time was already set for fiber context %s",
-        NRPRG_SHARED(current_php_context));
   }
 }
 
 /*
  * Purpose: Determine the parent for a new, given fiber context and set the
- fiber_parent_segment global accordingly.
+ * fiber_parent_segment global accordingly.
  *
  * Params:  zend_fiber_context* zfc
  *
@@ -481,7 +499,7 @@ static void nr_fiber_switch_observe(zend_fiber_context* from,
   if (ZEND_FIBER_STATUS_INIT == to->status) {
     nr_fiber_set_fiber_parent_segment(from);
   } else if (ZEND_FIBER_STATUS_SUSPENDED == to->status) {
-    nr_fiber_handle_exclusive_time();
+    nr_fiber_handle_suspend_time();
   }
 
   if (NR_FAILURE

--- a/agent/php_observer.c
+++ b/agent/php_observer.c
@@ -408,9 +408,16 @@ static inline void nr_fiber_handle_suspend_time() {
     */
   if (nrlikely(0 != fiber_segment->stop_time)) {
     /* Add the suspension which existed from the previous stop time to the
-     * current time. */
-    current_suspend_time = current_time - fiber_segment->stop_time;
-    if (nrlikely(current_suspend_time > 0)) {
+     * current time.
+     *
+     * Check the operands before subtracting, not the subtraction's result:
+     * nrtime_t is unsigned, so if current_time were ever less than
+     * fiber_segment->stop_time, current_time - fiber_segment->stop_time
+     * would underflow into a huge wrapped value rather than something
+     * negative/zero, and a post-hoc "> 0" check on that result can't
+     * reliably detect it (a wrapped value is still > 0 too). */
+    if (nrlikely(current_time > fiber_segment->stop_time)) {
+      current_suspend_time = current_time - fiber_segment->stop_time;
       fiber_segment->suspend_time += current_suspend_time;
     } else {
       /* This case should not happen.*/

--- a/axiom/nr_exclusive_time.c
+++ b/axiom/nr_exclusive_time.c
@@ -7,6 +7,7 @@
 #include "nr_exclusive_time_private.h"
 
 #include "nr_axiom.h"
+#include "nr_segment.h"
 #include "util_logging.h"
 #include "util_memory.h"
 #include "util_sort.h"
@@ -15,7 +16,8 @@
 bool nr_exclusive_time_ensure(nr_exclusive_time_t** et_ptr,
                               size_t child_segments,
                               nrtime_t start_time,
-                              nrtime_t stop_time) {
+                              nrtime_t stop_time,
+                              nrtime_t suspend_time) {
   nr_exclusive_time_t* et;
   size_t unused;
 
@@ -28,7 +30,7 @@ bool nr_exclusive_time_ensure(nr_exclusive_time_t** et_ptr,
    * new one.
    */
   if (NULL == *et_ptr) {
-    (*et_ptr) = nr_exclusive_time_create(child_segments, start_time, stop_time);
+    (*et_ptr) = nr_exclusive_time_create(child_segments, start_time, stop_time, suspend_time);
     return (NULL != *et_ptr);
   }
 
@@ -39,6 +41,8 @@ bool nr_exclusive_time_ensure(nr_exclusive_time_t** et_ptr,
    */
   et->start_time = start_time;
   et->stop_time = stop_time;
+  et->suspend_time = suspend_time;
+
 
   /*
    * Ensure the given number of children can be added to the exclusive
@@ -66,15 +70,18 @@ bool nr_exclusive_time_ensure(nr_exclusive_time_t** et_ptr,
 
 nr_exclusive_time_t* nr_exclusive_time_create(size_t child_segments,
                                               nrtime_t start_time,
-                                              nrtime_t stop_time) {
+                                              nrtime_t stop_time,
+                                              nrtime_t suspend_time) {
   nr_exclusive_time_t* et;
 
   et = nr_malloc(sizeof(nr_exclusive_time_t)
                  + sizeof(nr_exclusive_time_transition_t) * child_segments * 2);
   et->start_time = start_time;
   et->stop_time = stop_time;
+  et->suspend_time = suspend_time;
   et->transitions.capacity = child_segments * 2;
   et->transitions.used = 0;
+
 
   return et;
 }
@@ -91,12 +98,15 @@ bool nr_exclusive_time_destroy(nr_exclusive_time_t** et_ptr) {
 
 bool nr_exclusive_time_add_child(nr_exclusive_time_t* parent_et,
                                  nrtime_t start_time,
-                                 nrtime_t stop_time) {
+                                 nrtime_t stop_time,
+                                 nrtime_t suspend_time) {
   if (nrunlikely(NULL == parent_et
                  || (parent_et->transitions.used + 2)
                         > parent_et->transitions.capacity)) {
     return false;
   }
+
+  stop_time = nr_segment_amend_stop_with_suspend_time(start_time, stop_time, suspend_time);
 
   if (start_time > stop_time) {
     nrl_verbosedebug(NRL_TXN,
@@ -168,6 +178,8 @@ nrtime_t nr_exclusive_time_calculate(nr_exclusive_time_t* et) {
   nrtime_t exclusive_time;
   size_t i;
   nrtime_t last_start = 0;
+  nrtime_t amended_stop_time = 0;
+  nrtime_t amended_duration = 0;
 
   if (nrunlikely(NULL == et)) {
     return 0;
@@ -177,8 +189,11 @@ nrtime_t nr_exclusive_time_calculate(nr_exclusive_time_t* et) {
     return 0;
   }
 
+  amended_stop_time = nr_segment_amend_stop_with_suspend_time(et->start_time, et->stop_time, et->suspend_time);
+  amended_duration = nr_time_duration(et->start_time, amended_stop_time);
+
   if (0 == et->transitions.used) {
-    return nr_time_duration(et->start_time, et->stop_time);
+    return amended_duration;
   }
 
   /*
@@ -196,7 +211,7 @@ nrtime_t nr_exclusive_time_calculate(nr_exclusive_time_t* et) {
    * was doing stuff. So we'll start by setting the exclusive time to be the
    * full duration of the segment.
    */
-  exclusive_time = nr_time_duration(et->start_time, et->stop_time);
+  exclusive_time = amended_duration;
 
   for (i = 0; i < et->transitions.used; i++) {
     const nrtime_t time = et->transitions.transitions[i].time;

--- a/axiom/nr_exclusive_time.h
+++ b/axiom/nr_exclusive_time.h
@@ -23,12 +23,17 @@ typedef struct _nr_exclusive_time_t nr_exclusive_time_t;
  * Params  : 1. The number of child segments within the parent segment.
  *           2. The start time of the parent segment.
  *           3. The stop time of the parent segment.
+ *           4. The suspend time of the parent segment (0 if it never
+ *              self-suspended); subtracted from stop_time before duration
+ *              is computed. See nr_segment.h's suspend_time field comment.
  *
  * Returns : A pointer to the exclusive time structure, or NULL on error.
  */
 extern nr_exclusive_time_t* nr_exclusive_time_create(size_t child_segments,
                                                      nrtime_t start_time,
-                                                     nrtime_t stop_time);
+                                                     nrtime_t stop_time,
+                                                     nrtime_t suspend_time
+                                                    );
 
 /*
  * Purpose : Destroy an exclusive time structure.
@@ -48,12 +53,16 @@ extern bool nr_exclusive_time_destroy(nr_exclusive_time_t** et_ptr);
  * Params  : 1. A pointer to the exclusive time structure.
  *           2. The start time of the child segment.
  *           3. The stop time of the child segment.
+ *           4. The suspend time of the child segment; stop_time is amended
+ *              by this before the period is removed, so a self-suspended
+ *              child only removes the time it was actually active.
  *
  * Returns : True on success; false otherwise.
  */
 extern bool nr_exclusive_time_add_child(nr_exclusive_time_t* parent_et,
                                         nrtime_t start_time,
-                                        nrtime_t stop_time);
+                                        nrtime_t stop_time,
+                                        nrtime_t suspend_time);
 
 /*
  * Purpose : Calculate how much exclusive time the parent segment actually had.
@@ -61,7 +70,11 @@ extern bool nr_exclusive_time_add_child(nr_exclusive_time_t* parent_et,
  * Params  : 1. A pointer to the exclusive time structure.
  *
  * Returns : The amount of exclusive time. On error, 0 is returned, but note
- *           that 0 may also be a valid value.
+ *           that 0 may also be a valid value. Also returns 0 if a child's
+ *           duration exceeds the parent's remaining exclusive-time budget -
+ *           logged as "this should be impossible" - which only happens if
+ *           a suspend_time fed into this structure was wrong (see
+ *           nr_segment.h's suspend_time field comment).
  */
 extern nrtime_t nr_exclusive_time_calculate(nr_exclusive_time_t* et);
 
@@ -72,8 +85,7 @@ extern nrtime_t nr_exclusive_time_calculate(nr_exclusive_time_t* et);
  *           This function does the following:
  *            - If the first parameter is NULL, a new exclusive time structure
  *              with the given parameters is allocated.
- *            - If the first parameter is given, start and stop times are set
- *              the start and stop times given as parameters.
+ *            - If the first parameter is given, start, stop and suspend times are set
  *            - If the first paramester is given and the exclusive time
  *              structure is not large enough to accomodate adding the given
  *              number of children, then it is resized.
@@ -84,6 +96,7 @@ extern nrtime_t nr_exclusive_time_calculate(nr_exclusive_time_t* et);
  *              time structure.
  *           3. The start time of the parent segment.
  *           4. The stop time of the parent segment.
+ *           5. The suspend time of the parent segment.
  *
  * Returns : true if the exclusive time structure fits the given parameters or
  *           could be resized/changed to fit them.
@@ -91,6 +104,7 @@ extern nrtime_t nr_exclusive_time_calculate(nr_exclusive_time_t* et);
 extern bool nr_exclusive_time_ensure(nr_exclusive_time_t** et_ptr,
                                      size_t child_segments,
                                      nrtime_t start_time,
-                                     nrtime_t stop_time);
+                                     nrtime_t stop_time,
+                                     nrtime_t suspend_time);
 
 #endif /* NR_EXCLUSIVE_TIME_HDR */

--- a/axiom/nr_exclusive_time_private.h
+++ b/axiom/nr_exclusive_time_private.h
@@ -24,6 +24,7 @@ typedef struct _nr_exclusive_time_transition_t {
 struct _nr_exclusive_time_t {
   nrtime_t start_time;
   nrtime_t stop_time;
+  nrtime_t suspend_time;
   struct {
     size_t capacity;
     size_t used;

--- a/axiom/nr_segment.c
+++ b/axiom/nr_segment.c
@@ -11,7 +11,6 @@
 #include "nr_segment.h"
 #include "nr_segment_traces.h"
 #include "nr_txn.h"
-#include "util_logging.h"
 #include "util_memory.h"
 #include "util_slab.h"
 #include "util_string_pool.h"
@@ -65,8 +64,10 @@ static void nr_segment_discard_merge_metrics(nr_segment_t* segment) {
   }
 
   metric_count = nr_vector_size(segment->metrics);
-  duration = nr_time_duration(segment->start_time, segment->stop_time);
-
+  duration = nr_time_duration(
+      segment->start_time,
+      nr_segment_amend_stop_with_suspend_time(
+          segment->start_time, segment->stop_time, segment->suspend_time));
   /*
    * In case a segment limit is set, calculating total time for metrics
    * of discarded segments is skipped.
@@ -108,14 +109,21 @@ static void nr_segment_discard_merge_metrics(nr_segment_t* segment) {
    */
   if (num_children) {
     nr_exclusive_time_ensure(&segment->exclusive_time, num_children,
-                             segment->start_time, segment->stop_time);
+                             segment->start_time, segment->stop_time,
+                             segment->suspend_time);
 
     for (size_t i = 0; i < num_children; i++) {
       nr_segment_t* child = nr_segment_children_get(&segment->children, i);
 
-      if (child && child->async_context == segment->async_context) {
+      /* Subtract child unless it's on a different async_context (fiber)
+       * AND explicitly opted out via consider_for_blocking=true (see
+       * nr_segment.h). Default false means fiber children are still
+       * subtracted like ordinary blocking children. */
+      if (child
+          && (child->async_context == segment->async_context
+              || (!child->consider_for_blocking))) {
         nr_exclusive_time_add_child(segment->exclusive_time, child->start_time,
-                                    child->stop_time);
+                                    child->stop_time, child->suspend_time);
       }
     }
   }
@@ -140,13 +148,14 @@ static void nr_segment_discard_merge_metrics(nr_segment_t* segment) {
    * added to the exclusive time data structure of the parent. The
    * exclusive time on the parent is initialized if necessary.
    */
-  if (segment->parent->async_context == segment->async_context) {
-    nr_exclusive_time_ensure(&parent->exclusive_time,
-                             nr_segment_children_size(&parent->children),
-                             parent->start_time, parent->stop_time);
+  if (segment->parent->async_context == segment->async_context
+      || (!segment->consider_for_blocking)) {
+    nr_exclusive_time_ensure(
+        &parent->exclusive_time, nr_segment_children_size(&parent->children),
+        parent->start_time, parent->stop_time, parent->suspend_time);
 
     nr_exclusive_time_add_child(parent->exclusive_time, segment->start_time,
-                                segment->stop_time);
+                                segment->stop_time, segment->suspend_time);
   }
 
   /*
@@ -228,6 +237,11 @@ bool nr_segment_init(nr_segment_t* segment,
   if (parent) {
     segment->parent = parent;
     nr_segment_children_add(&parent->children, segment);
+    /* consider_for_blocking is left at its default (false) here. It's set
+     * explicitly, per-call, only at the few instrumentation sites that need
+     * it (curl_multi, Guzzle, Predis - see nr_segment.h's
+     * consider_for_blocking comment), not generically on every
+     * explicit-parent segment. */
     /*
      * Special case: if the new async context stack does not exist and the async
      * context is not NULL, then this indicates that the new segment is the root
@@ -1058,10 +1072,21 @@ nr_minmax_heap_t* nr_segment_heap_create(ssize_t bound,
   return nr_minmax_heap_create(bound, comparator, NULL, NULL, NULL);
 }
 
+/*
+ * Post-order callback: computes this segment's exclusive time (suspend-time
+ * amended) and its metrics' duration/exclusive fields, and adds this
+ * segment's exclusive time into metadata->total_time, which becomes
+ * WebTransactionTotalTime. That sum is a plain accumulation across every
+ * segment in the tree - it relies on each segment's own suspend_time being
+ * correct (see nr_segment.h) to avoid double-counting; it does not merge
+ * overlapping spans across different branches on its own.
+ */
 static void nr_segment_stoh_post_iterator_callback(
     nr_segment_t* segment,
     nr_segment_tree_to_heap_metadata_t* metadata) {
-  nrtime_t exclusive_time;
+  nrtime_t exclusive_time = 0;
+  nrtime_t duration = 0;
+  nrtime_t amended_stop_time = 0;
   size_t i;
   size_t metric_count;
 
@@ -1070,7 +1095,11 @@ static void nr_segment_stoh_post_iterator_callback(
   }
 
   // Calculate the exclusive time.
+
   exclusive_time = nr_exclusive_time_calculate(segment->exclusive_time);
+  amended_stop_time = nr_segment_amend_stop_with_suspend_time(
+      segment->start_time, segment->stop_time, segment->suspend_time);
+  duration = nr_time_duration(segment->start_time, amended_stop_time);
 
   // Update the transaction total time.
   metadata->total_time += exclusive_time;
@@ -1083,9 +1112,7 @@ static void nr_segment_stoh_post_iterator_callback(
 
     nrm_add_ex(sm->scoped ? segment->txn->scoped_metrics
                           : segment->txn->unscoped_metrics,
-               sm->name,
-               nr_time_duration(segment->start_time, segment->stop_time),
-               exclusive_time);
+               sm->name, duration, exclusive_time);
   }
 
   /*
@@ -1121,15 +1148,18 @@ static nr_segment_iter_return_t nr_segment_stoh_iterator_callback(
   }
 
   /* Set up the exclusive time so that children can adjust it as necessary. */
-  nr_exclusive_time_ensure(&segment->exclusive_time,
-                           nr_segment_children_size(&segment->children),
-                           segment->start_time, segment->stop_time);
+
+  nr_exclusive_time_ensure(
+      &segment->exclusive_time, nr_segment_children_size(&segment->children),
+      segment->start_time, segment->stop_time, segment->suspend_time);
 
   /* Adjust the parent's exclusive time. */
   if (segment->parent
-      && segment->parent->async_context == segment->async_context) {
+      && (segment->parent->async_context == segment->async_context
+          || (!segment->consider_for_blocking))) {
     nr_exclusive_time_add_child(segment->parent->exclusive_time,
-                                segment->start_time, segment->stop_time);
+                                segment->start_time, segment->stop_time,
+                                segment->suspend_time);
   }
 
   /*
@@ -1141,9 +1171,10 @@ static nr_segment_iter_return_t nr_segment_stoh_iterator_callback(
    * need to add the segment to the main context exclusive time structure so the
    * blocking time can be calculated once the first pass is complete.
    */
-  if (segment->async_context && metadata->main_context) {
+  if (segment->async_context && segment->consider_for_blocking
+      && metadata->main_context) {
     nr_exclusive_time_add_child(metadata->main_context, segment->start_time,
-                                segment->stop_time);
+                                segment->stop_time, segment->suspend_time);
   }
 
   trace_heap = metadata->trace_heap;

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -509,30 +509,37 @@ extern bool nr_segment_set_timing(nr_segment_t* segment,
  *          suspend_time too large for the segment's real span still trips
  *          the "impossible" clamp in nr_exclusive_time_calculate().
  *
+ *          If stop_time is already before start_time, that's an invalid
+ *          span on its own terms, independent of suspend_time - it's
+ *          returned untouched so callers' own start_time-vs-stop_time
+ *          checks still catch it and log the right diagnostic.
+ *
  * Caller is responsible for ensuring segment is not NULL
  */
 static inline nrtime_t nr_segment_amend_stop_with_suspend_time(nrtime_t start_time,nrtime_t stop_time, nrtime_t suspend_time) {
-
-  nrtime_t amended_stop_time = 0;
-
+  if (nrunlikely(stop_time < start_time)) {
+    return stop_time;
+  }
 
   /*
-  * Spec says the agent MAY choose to subtract blocking, non-actionable time from the total time.
-  * This is done here by adjusting the stop time that is used to calculate total time
-  */
-  amended_stop_time = stop_time - suspend_time;
-
-  /* Only clamp when suspend_time is what caused the underflow, i.e. the
-   * raw (pre-amendment) span was valid. If stop_time was already before
-   * start_time, that's an invalid span on its own terms - leave it alone
-   * so callers' own start_time-vs-stop_time checks still catch it. */
-  if (nrunlikely(stop_time >= start_time && 0 != amended_stop_time
-                 && amended_stop_time < start_time)) {
+   * Spec says the agent MAY choose to subtract blocking, non-actionable time
+   * from the total time. This is done here by adjusting the stop time that
+   * is used to calculate total time.
+   *
+   * Clamp against the segment's own duration (stop_time - start_time),
+   * which we already know is safe to compute, rather than subtracting
+   * suspend_time from stop_time first and inspecting the result: nrtime_t
+   * is unsigned, so if suspend_time > stop_time that subtraction
+   * underflows into a huge wrapped value instead of a small/negative one,
+   * and a post-hoc check against start_time can't reliably detect that.
+   * Checking against the duration up front avoids the underflow entirely.
+   */
+  if (nrunlikely(suspend_time > stop_time - start_time)) {
     nrl_verbosedebug(NRL_API, "nr_segment_stop_time: segment suspend time is larger than duration");
     return start_time;
-  } else {
-    return amended_stop_time;
   }
+
+  return stop_time - suspend_time;
 }
 
 

--- a/axiom/nr_segment.h
+++ b/axiom/nr_segment.h
@@ -25,6 +25,7 @@ typedef struct _nrtxn_t nrtxn_t;
 #include "nr_segment_children.h"
 #include "nr_span_event.h"
 #include "nr_txn.h"
+#include "util_logging.h"
 #include "util_metrics.h"
 #include "util_minmax_heap.h"
 #include "util_object.h"
@@ -214,6 +215,10 @@ typedef struct _nr_segment_t {
                           the transaction. */
   nrtime_t stop_time;  /* Stop time for node, relative to the start of the
                           transaction. */
+  nrtime_t suspend_time;  /* blocking, non-actionable time */
+  bool consider_for_blocking; /* Is not automatically considered blocking,
+                                  but can be considered for it when using 
+                                  discount_main_context_blocking. */
 
   int name;             /* Node name (pooled string index) */
   int async_context;    /* Execution context (pooled string index) */
@@ -491,6 +496,45 @@ extern bool nr_segment_set_parent(nr_segment_t* segment, nr_segment_t* parent);
 extern bool nr_segment_set_timing(nr_segment_t* segment,
                                   nrtime_t start,
                                   nrtime_t duration);
+
+/*
+ * Purpose: Shrink stop_time by suspend_time, excluding suspended time from
+ *          duration/exclusive-time math.
+ *
+ * Params:  1. start_time, 2. stop_time (raw), 3. suspend_time.
+ *
+ * Returns: Amended stop time, for local duration/exclusive-time use only -
+ *          does not write back to the segment. Clamped to start_time so a
+ *          bad suspend_time can't produce a negative duration; a
+ *          suspend_time too large for the segment's real span still trips
+ *          the "impossible" clamp in nr_exclusive_time_calculate().
+ *
+ * Caller is responsible for ensuring segment is not NULL
+ */
+static inline nrtime_t nr_segment_amend_stop_with_suspend_time(nrtime_t start_time,nrtime_t stop_time, nrtime_t suspend_time) {
+
+  nrtime_t amended_stop_time = 0;
+
+
+  /*
+  * Spec says the agent MAY choose to subtract blocking, non-actionable time from the total time.
+  * This is done here by adjusting the stop time that is used to calculate total time
+  */
+  amended_stop_time = stop_time - suspend_time;
+
+  /* Only clamp when suspend_time is what caused the underflow, i.e. the
+   * raw (pre-amendment) span was valid. If stop_time was already before
+   * start_time, that's an invalid span on its own terms - leave it alone
+   * so callers' own start_time-vs-stop_time checks still catch it. */
+  if (nrunlikely(stop_time >= start_time && 0 != amended_stop_time
+                 && amended_stop_time < start_time)) {
+    nrl_verbosedebug(NRL_API, "nr_segment_stop_time: segment suspend time is larger than duration");
+    return start_time;
+  } else {
+    return amended_stop_time;
+  }
+}
+
 
 /*
  * Purpose  : Add a user attribute to a segment.

--- a/axiom/nr_segment_tree.c
+++ b/axiom/nr_segment_tree.c
@@ -59,7 +59,7 @@ nrtxnfinal_t nr_segment_tree_finalise(nrtxn_t* txn,
    */
   if (txn->options.discount_main_context_blocking) {
     first_pass_metadata.main_context
-        = nr_exclusive_time_create(txn->segment_count, 0, duration);
+        = nr_exclusive_time_create(txn->segment_count, 0, duration,0);
   }
 
   /*

--- a/axiom/tests/test_exclusive_time.c
+++ b/axiom/tests/test_exclusive_time.c
@@ -26,7 +26,7 @@ static void test_create_destroy(void) {
   /*
    * Test : Normal operation.
    */
-  et = nr_exclusive_time_create(10, 1, 2);
+  et = nr_exclusive_time_create(10, 1, 2, 0);
   tlib_pass_if_not_null("create should succeed", et);
   tlib_pass_if_time_equal("create should set the start time", 1,
                           et->start_time);
@@ -44,7 +44,7 @@ static void test_create_destroy(void) {
   /*
    * Test : No children.
    */
-  et = nr_exclusive_time_create(0, 1, 2);
+  et = nr_exclusive_time_create(0, 1, 2, 0);
   tlib_pass_if_not_null("create should succeed", et);
   tlib_pass_if_time_equal("create should set the start time", 1,
                           et->start_time);
@@ -67,7 +67,7 @@ static void test_ensure(void) {
    * Create a new exclusive time with capacity 3.
    */
   tlib_pass_if_bool_equal("ensure should succeed", true,
-                          nr_exclusive_time_ensure(&et, 3, 1, 2));
+                          nr_exclusive_time_ensure(&et, 3, 1, 2, 0));
   tlib_pass_if_not_null("ensure should succeed", et);
   tlib_pass_if_time_equal("ensure should set the start time", 1,
                           et->start_time);
@@ -82,9 +82,9 @@ static void test_ensure(void) {
    * Add 2 children.
    */
   tlib_pass_if_bool_equal("add first child", true,
-                          nr_exclusive_time_add_child(et, 1, 2));
+                          nr_exclusive_time_add_child(et, 1, 2, 0));
   tlib_pass_if_bool_equal("add second child", true,
-                          nr_exclusive_time_add_child(et, 1, 2));
+                          nr_exclusive_time_add_child(et, 1, 2, 0));
   tlib_pass_if_size_t_equal("ensure should ensure an empty transitions array",
                             4, et->transitions.used);
 
@@ -93,7 +93,7 @@ static void test_ensure(void) {
    * should enlarge the capacity to 5.
    */
   tlib_pass_if_bool_equal("ensure should succeed", true,
-                          nr_exclusive_time_ensure(&et, 3, 1, 9));
+                          nr_exclusive_time_ensure(&et, 3, 1, 9, 0));
   tlib_pass_if_not_null("ensure should succeed", et);
   tlib_pass_if_time_equal("ensure should set the start time", 1,
                           et->start_time);
@@ -115,36 +115,36 @@ static void test_add_child(void) {
   /*
    * Test : Bad parameters.
    */
-  et = nr_exclusive_time_create(3, 1, 4);
+  et = nr_exclusive_time_create(3, 1, 4, 0);
 
   tlib_pass_if_bool_equal("a child cannot be added to a NULL exclusive time",
-                          false, nr_exclusive_time_add_child(NULL, 1, 2));
+                          false, nr_exclusive_time_add_child(NULL, 1, 2, 0));
   tlib_pass_if_bool_equal(
       "a child cannot be added with a start time after its stop time", false,
-      nr_exclusive_time_add_child(et, 2, 1));
+      nr_exclusive_time_add_child(et, 2, 1, 0));
 
   nr_exclusive_time_destroy(&et);
 
   /*
    * Test : No children.
    */
-  et = nr_exclusive_time_create(0, 1, 4);
+  et = nr_exclusive_time_create(0, 1, 4, 0);
 
   tlib_pass_if_bool_equal(
       "a child cannot be added if there were no children defined", false,
-      nr_exclusive_time_add_child(et, 1, 2));
+      nr_exclusive_time_add_child(et, 1, 2, 0));
 
   nr_exclusive_time_destroy(&et);
 
   /*
    * Test : Normal operation.
    */
-  et = nr_exclusive_time_create(5, 1, 4);
+  et = nr_exclusive_time_create(5, 1, 4, 0);
 
   tlib_pass_if_bool_equal(
       "adding a child completely within the bounds of the parent should "
       "succeed",
-      true, nr_exclusive_time_add_child(et, 2, 3));
+      true, nr_exclusive_time_add_child(et, 2, 3, 0));
   tlib_pass_if_size_t_equal("adding a normal child should add two transitions",
                             2, et->transitions.used);
 
@@ -164,7 +164,7 @@ static void test_add_child(void) {
 
   tlib_pass_if_bool_equal(
       "adding a child with the exact bounds of the parent should succeed", true,
-      nr_exclusive_time_add_child(et, 1, 4));
+      nr_exclusive_time_add_child(et, 1, 4, 0));
   tlib_pass_if_size_t_equal("adding a normal child should add two transitions",
                             4, et->transitions.used);
 
@@ -184,7 +184,7 @@ static void test_add_child(void) {
 
   tlib_pass_if_bool_equal(
       "adding a child with the same start and stop time should succeed", true,
-      nr_exclusive_time_add_child(et, 1, 1));
+      nr_exclusive_time_add_child(et, 1, 1, 0));
   tlib_pass_if_size_t_equal("adding a normal child should add two transitions",
                             6, et->transitions.used);
 
@@ -203,12 +203,12 @@ static void test_add_child(void) {
                           trans->time);
 
   tlib_pass_if_bool_equal("adding a child before the parent should succeed",
-                          true, nr_exclusive_time_add_child(et, 0, 0));
+                          true, nr_exclusive_time_add_child(et, 0, 0, 0));
   tlib_pass_if_size_t_equal("adding a child before the parent should succeed",
                             8, et->transitions.used);
 
   tlib_pass_if_bool_equal("adding a child after the parent should succeed",
-                          true, nr_exclusive_time_add_child(et, 5, 5));
+                          true, nr_exclusive_time_add_child(et, 5, 5, 0));
   tlib_pass_if_size_t_equal("adding a child after the parent should succeed",
                             10, et->transitions.used);
 
@@ -227,7 +227,7 @@ static void test_calculate(void) {
   /*
    * Test : Exclusive time with start time after stop time.
    */
-  et = nr_exclusive_time_create(10, 50, 10);
+  et = nr_exclusive_time_create(10, 50, 10, 0);
 
   tlib_pass_if_time_equal(
       "start time after stop time should return an exclusive time of 0", 0,
@@ -238,7 +238,7 @@ static void test_calculate(void) {
   /*
    * Test : Empty exclusive time.
    */
-  et = nr_exclusive_time_create(10, 10, 50);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
 
   tlib_pass_if_time_equal(
       "a segment with no children should have its entire duration attributed "
@@ -256,9 +256,9 @@ static void test_calculate(void) {
    *                     Child----->
    *                                    Child----->
    */
-  et = nr_exclusive_time_create(10, 10, 50);
-  nr_exclusive_time_add_child(et, 20, 30);
-  nr_exclusive_time_add_child(et, 35, 45);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
+  nr_exclusive_time_add_child(et, 20, 30, 0);
+  nr_exclusive_time_add_child(et, 35, 45, 0);
 
   tlib_pass_if_time_equal("synchronous children", 20,
                           nr_exclusive_time_calculate(et));
@@ -274,9 +274,9 @@ static void test_calculate(void) {
    *                     Child----->
    *                               Child----->
    */
-  et = nr_exclusive_time_create(10, 10, 50);
-  nr_exclusive_time_add_child(et, 20, 30);
-  nr_exclusive_time_add_child(et, 30, 40);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
+  nr_exclusive_time_add_child(et, 20, 30, 0);
+  nr_exclusive_time_add_child(et, 30, 40, 0);
 
   tlib_pass_if_time_equal("synchronous children with separation anxiety", 20,
                           nr_exclusive_time_calculate(et));
@@ -291,9 +291,9 @@ static void test_calculate(void) {
    *                     C
    *                               C
    */
-  et = nr_exclusive_time_create(10, 10, 50);
-  nr_exclusive_time_add_child(et, 20, 20);
-  nr_exclusive_time_add_child(et, 30, 30);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
+  nr_exclusive_time_add_child(et, 20, 20, 0);
+  nr_exclusive_time_add_child(et, 30, 30, 0);
 
   tlib_pass_if_time_equal("wee bairns", 40, nr_exclusive_time_calculate(et));
 
@@ -308,9 +308,9 @@ static void test_calculate(void) {
    *                     Child----->
    *                          Child----->
    */
-  et = nr_exclusive_time_create(10, 10, 50);
-  nr_exclusive_time_add_child(et, 20, 30);
-  nr_exclusive_time_add_child(et, 25, 35);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
+  nr_exclusive_time_add_child(et, 20, 30, 0);
+  nr_exclusive_time_add_child(et, 25, 35, 0);
 
   tlib_pass_if_time_equal("asynchronous children", 25,
                           nr_exclusive_time_calculate(et));
@@ -327,9 +327,9 @@ static void test_calculate(void) {
    *      Child----->
    *           Child----->
    */
-  et = nr_exclusive_time_create(10, 10, 50);
-  nr_exclusive_time_add_child(et, 5, 15);
-  nr_exclusive_time_add_child(et, 10, 20);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
+  nr_exclusive_time_add_child(et, 5, 15, 0);
+  nr_exclusive_time_add_child(et, 10, 20, 0);
 
   tlib_pass_if_time_equal("asynchronous children who have partially left home",
                           30, nr_exclusive_time_calculate(et));
@@ -346,9 +346,9 @@ static void test_calculate(void) {
    *                                              Child----->
    *           Child----->
    */
-  et = nr_exclusive_time_create(10, 10, 50);
-  nr_exclusive_time_add_child(et, 45, 55);
-  nr_exclusive_time_add_child(et, 10, 20);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
+  nr_exclusive_time_add_child(et, 45, 55, 0);
+  nr_exclusive_time_add_child(et, 10, 20, 0);
 
   tlib_pass_if_time_equal("asynchronous children who have partially left home",
                           25, nr_exclusive_time_calculate(et));
@@ -362,8 +362,8 @@ static void test_calculate(void) {
    *           Parent---------------------------------->
    *      Child--------------------------------------------->
    */
-  et = nr_exclusive_time_create(10, 10, 50);
-  nr_exclusive_time_add_child(et, 5, 55);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
+  nr_exclusive_time_add_child(et, 5, 55, 0);
 
   tlib_pass_if_time_equal("time travelling, long lived children", 0,
                           nr_exclusive_time_calculate(et));
@@ -378,7 +378,7 @@ static void test_calculate(void) {
    * Child>
    *                                                        Child----->
    */
-  et = nr_exclusive_time_create(10, 10, 50);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
 
   et->transitions.transitions[et->transitions.used++]
       = (nr_exclusive_time_transition_t){
@@ -412,7 +412,7 @@ static void test_calculate(void) {
   /*
    * Test : One CHILD_START only, which should be effectively ignored.
    */
-  et = nr_exclusive_time_create(10, 10, 50);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
 
   et->transitions.transitions[et->transitions.used++]
       = (nr_exclusive_time_transition_t){
@@ -428,7 +428,7 @@ static void test_calculate(void) {
   /*
    * Test : One CHILD_STOP only, which should be effectively ignored.
    */
-  et = nr_exclusive_time_create(10, 10, 50);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
 
   et->transitions.transitions[et->transitions.used++]
       = (nr_exclusive_time_transition_t){
@@ -449,7 +449,7 @@ static void test_calculate(void) {
    *        not a valid value within the enum. If we get weird behaviour when
    *        we port this to some weird mainframe, it's probably that.
    */
-  et = nr_exclusive_time_create(10, 10, 50);
+  et = nr_exclusive_time_create(10, 10, 50, 0);
 
   et->transitions.transitions[et->transitions.used++]
       = (nr_exclusive_time_transition_t){
@@ -459,6 +459,55 @@ static void test_calculate(void) {
 
   tlib_pass_if_time_equal("not a child at all; maybe a dog", 40,
                           nr_exclusive_time_calculate(et));
+
+  nr_exclusive_time_destroy(&et);
+
+  /*
+   * Test : suspend_time is excluded from a childless segment's exclusive
+   *        time, same as its duration.
+   *
+   * time ->   10                                        50
+   *           Parent----------------------------------->
+   *                                              ^suspended for 15
+   */
+  et = nr_exclusive_time_create(10, 10, 50, 15);
+
+  tlib_pass_if_time_equal(
+      "suspend_time should be excluded from a childless segment's "
+      "exclusive time",
+      25, nr_exclusive_time_calculate(et));
+
+  nr_exclusive_time_destroy(&et);
+
+  /*
+   * Test : suspend_time shrinks the base duration before children are
+   *        subtracted, but otherwise exclusive time is calculated as
+   *        normal.
+   */
+  et = nr_exclusive_time_create(10, 10, 50, 10);
+  nr_exclusive_time_add_child(et, 20, 30, 0);
+
+  tlib_pass_if_time_equal(
+      "suspend_time on the parent should reduce the base duration used for "
+      "exclusive time, before the child is subtracted",
+      20, nr_exclusive_time_calculate(et));
+
+  nr_exclusive_time_destroy(&et);
+
+  /*
+   * Test : a child larger than the parent's suspend-reduced exclusive time
+   *        budget clamps to 0 exclusive time (the "this should be
+   *        impossible" guard) rather than underflowing. This is what
+   *        happens if a segment's suspend_time is wrong for its actual
+   *        span - e.g. a fiber incorrectly marked as self-suspended.
+   */
+  et = nr_exclusive_time_create(10, 10, 50, 30);
+  nr_exclusive_time_add_child(et, 10, 50, 0);
+
+  tlib_pass_if_time_equal(
+      "a child larger than the suspend-reduced exclusive time budget "
+      "should clamp to 0",
+      0, nr_exclusive_time_calculate(et));
 
   nr_exclusive_time_destroy(&et);
 }

--- a/axiom/tests/test_segment.c
+++ b/axiom/tests/test_segment.c
@@ -2024,6 +2024,90 @@ static void test_segment_tree_to_heap(void) {
   nr_free(maxi);
 }
 
+static void test_segment_tree_to_heap_consider_for_blocking(void) {
+  nr_segment_tree_to_heap_metadata_t heaps
+      = {.trace_heap = NULL, .span_heap = NULL};
+  nr_segment_t* root;
+  nr_segment_t* child;
+
+  /*
+   * Test : A child on a different async_context than its parent, with
+   * consider_for_blocking left at its default (false), should still be
+   * subtracted from the parent's exclusive time - i.e. treated like an
+   * ordinary same-context (blocking) child.
+   */
+  root = nr_zalloc(sizeof(nr_segment_t));
+  child = nr_zalloc(sizeof(nr_segment_t));
+
+  root->start_time = 0;
+  root->stop_time = 100;
+  root->async_context = 0;
+
+  child->start_time = 10;
+  child->stop_time = 50;
+  child->async_context = 99;
+
+  nr_segment_children_init(&root->children);
+  nr_segment_add_child(root, child);
+
+  heaps.trace_heap
+      = nr_segment_heap_create(2, nr_segment_wrapped_duration_comparator);
+  heaps.span_heap
+      = nr_segment_heap_create(2, nr_segment_wrapped_duration_comparator);
+  nr_segment_tree_to_heap(root, &heaps);
+
+  tlib_pass_if_time_equal(
+      "a cross-async_context child with consider_for_blocking=false "
+      "(default) should still be subtracted from its parent's exclusive "
+      "time",
+      60, nr_exclusive_time_calculate(root->exclusive_time));
+
+  nr_minmax_heap_destroy(&heaps.trace_heap);
+  nr_minmax_heap_destroy(&heaps.span_heap);
+  nr_segment_destroy_tree(root);
+  nr_free(root);
+  nr_free(child);
+
+  /*
+   * Test : The same cross-async_context child, but with
+   * consider_for_blocking explicitly set true, should NOT be subtracted
+   * from the parent's exclusive time - this is what curl_multi, Guzzle,
+   * and Predis rely on for segments representing genuinely concurrent
+   * work.
+   */
+  root = nr_zalloc(sizeof(nr_segment_t));
+  child = nr_zalloc(sizeof(nr_segment_t));
+
+  root->start_time = 0;
+  root->stop_time = 100;
+  root->async_context = 0;
+
+  child->start_time = 10;
+  child->stop_time = 50;
+  child->async_context = 99;
+  child->consider_for_blocking = true;
+
+  nr_segment_children_init(&root->children);
+  nr_segment_add_child(root, child);
+
+  heaps.trace_heap
+      = nr_segment_heap_create(2, nr_segment_wrapped_duration_comparator);
+  heaps.span_heap
+      = nr_segment_heap_create(2, nr_segment_wrapped_duration_comparator);
+  nr_segment_tree_to_heap(root, &heaps);
+
+  tlib_pass_if_time_equal(
+      "a cross-async_context child with consider_for_blocking=true should "
+      "NOT be subtracted from its parent's exclusive time",
+      100, nr_exclusive_time_calculate(root->exclusive_time));
+
+  nr_minmax_heap_destroy(&heaps.trace_heap);
+  nr_minmax_heap_destroy(&heaps.span_heap);
+  nr_segment_destroy_tree(root);
+  nr_free(root);
+  nr_free(child);
+}
+
 static void test_segment_set(void) {
   nr_set_t* set;
 
@@ -3279,6 +3363,7 @@ void test_main(void* p NRUNUSED) {
   test_segment_discard_keep_metrics_while_running();
   test_segment_discard_keep_metrics_no_exclusive();
   test_segment_tree_to_heap();
+  test_segment_tree_to_heap_consider_for_blocking();
   test_segment_set();
   test_segment_heap_to_set();
   test_segment_set_parent_cycle();

--- a/axiom/tests/test_segment.c
+++ b/axiom/tests/test_segment.c
@@ -2108,6 +2108,56 @@ static void test_segment_tree_to_heap_consider_for_blocking(void) {
   nr_free(child);
 }
 
+static void test_segment_amend_stop_with_suspend_time(void) {
+  /*
+   * Test : No suspend time is a no-op.
+   */
+  tlib_pass_if_time_equal("no suspend time is a no-op", 50,
+                          nr_segment_amend_stop_with_suspend_time(10, 50, 0));
+
+  /*
+   * Test : suspend_time within the segment's own span is simply subtracted.
+   */
+  tlib_pass_if_time_equal("suspend_time within the segment's span", 35,
+                          nr_segment_amend_stop_with_suspend_time(10, 50, 15));
+
+  /*
+   * Test : suspend_time exactly equal to the duration clamps to start_time.
+   */
+  tlib_pass_if_time_equal(
+      "suspend_time equal to duration clamps to start_time", 10,
+      nr_segment_amend_stop_with_suspend_time(10, 50, 40));
+
+  /*
+   * Test : suspend_time moderately larger than the duration, but still
+   *        less than stop_time, clamps to start_time. This case already
+   *        worked before this fix.
+   */
+  tlib_pass_if_time_equal(
+      "suspend_time moderately larger than duration clamps", 10,
+      nr_segment_amend_stop_with_suspend_time(10, 50, 45));
+
+  /*
+   * Test : suspend_time larger than stop_time itself. Regression test:
+   *        stop_time - suspend_time underflows nrtime_t (unsigned), which
+   *        used to produce a huge wrapped value that evaded the old
+   *        post-subtraction clamp check instead of clamping to
+   *        start_time.
+   */
+  tlib_pass_if_time_equal(
+      "suspend_time larger than stop_time clamps, no underflow", 10,
+      nr_segment_amend_stop_with_suspend_time(10, 50, 60));
+
+  /*
+   * Test : An already-invalid raw span (stop_time before start_time) is
+   *        left untouched by suspend_time, so callers' own
+   *        start_time-vs-stop_time checks still catch it.
+   */
+  tlib_pass_if_time_equal(
+      "an already-invalid raw span is left untouched by suspend_time", 5,
+      nr_segment_amend_stop_with_suspend_time(10, 5, 3));
+}
+
 static void test_segment_set(void) {
   nr_set_t* set;
 
@@ -3364,6 +3414,7 @@ void test_main(void* p NRUNUSED) {
   test_segment_discard_keep_metrics_no_exclusive();
   test_segment_tree_to_heap();
   test_segment_tree_to_heap_consider_for_blocking();
+  test_segment_amend_stop_with_suspend_time();
   test_segment_set();
   test_segment_heap_to_set();
   test_segment_set_parent_cycle();

--- a/axiom/tests/test_segment_private.c
+++ b/axiom/tests/test_segment_private.c
@@ -457,7 +457,7 @@ static void test_destroy_fields(void) {
   s.metrics = nr_vector_create(8, NULL, NULL);
   s.attributes = nr_attributes_create(NULL);
   s.type = NR_SEGMENT_CUSTOM;
-  s.exclusive_time = nr_exclusive_time_create(0, 1, 2);
+  s.exclusive_time = nr_exclusive_time_create(0, 1, 2, 0);
 
   nr_segment_destroy_fields(&s);
 }

--- a/axiom/tests/test_segment_tree.c
+++ b/axiom/tests/test_segment_tree.c
@@ -466,15 +466,19 @@ static void test_finalise_total_time(void) {
   a = nr_segment_start(&txn, root, "1");
   nr_segment_set_name(a, "a");
   nr_segment_set_timing(a, 10 * NR_TIME_DIVISOR_MS, 30 * NR_TIME_DIVISOR_MS);
+  a->consider_for_blocking = true;
   b = nr_segment_start(&txn, a, "1");
   nr_segment_set_name(b, "b");
   nr_segment_set_timing(b, 20 * NR_TIME_DIVISOR_MS, 20 * NR_TIME_DIVISOR_MS);
+  b->consider_for_blocking = true;
   c = nr_segment_start(&txn, root, "2");
   nr_segment_set_name(c, "c");
   nr_segment_set_timing(c, 10 * NR_TIME_DIVISOR_MS, 30 * NR_TIME_DIVISOR_MS);
+  c->consider_for_blocking = true;
   d = nr_segment_start(&txn, c, "2");
   nr_segment_set_name(d, "d");
   nr_segment_set_timing(d, 30 * NR_TIME_DIVISOR_MS, 20 * NR_TIME_DIVISOR_MS);
+  d->consider_for_blocking = true;
 
   nr_segment_end(&a);
   nr_segment_end(&b);
@@ -593,15 +597,19 @@ static void test_finalise_total_time_discounted_async(void) {
   a = nr_segment_start(&txn, root, "1");
   nr_segment_set_name(a, "a");
   nr_segment_set_timing(a, 10 * NR_TIME_DIVISOR_MS, 30 * NR_TIME_DIVISOR_MS);
+  a->consider_for_blocking = true;
   b = nr_segment_start(&txn, a, "1");
   nr_segment_set_name(b, "b");
   nr_segment_set_timing(b, 20 * NR_TIME_DIVISOR_MS, 20 * NR_TIME_DIVISOR_MS);
+  b->consider_for_blocking = true;
   c = nr_segment_start(&txn, root, "2");
   nr_segment_set_name(c, "c");
   nr_segment_set_timing(c, 10 * NR_TIME_DIVISOR_MS, 30 * NR_TIME_DIVISOR_MS);
+  c->consider_for_blocking = true;
   d = nr_segment_start(&txn, c, "2");
   nr_segment_set_name(d, "d");
   nr_segment_set_timing(d, 30 * NR_TIME_DIVISOR_MS, 20 * NR_TIME_DIVISOR_MS);
+  d->consider_for_blocking = true;
 
   nr_segment_end(&a);
   nr_segment_end(&b);

--- a/axiom/tests/test_txn.c
+++ b/axiom/tests/test_txn.c
@@ -875,7 +875,7 @@ static void test_create_duration_metrics(void) {
   txn->segment_root = nr_segment_start(txn, NULL, NULL);
   txn->segment_root->start_time = 0;
   txn->segment_root->stop_time = duration;
-  txn->segment_root->exclusive_time = nr_exclusive_time_create(16, 0, duration);
+  txn->segment_root->exclusive_time = nr_exclusive_time_create(16, 0, duration, 0);
 
   /*
    * Test : Bad Params.  Should not blow up.
@@ -886,7 +886,7 @@ static void test_create_duration_metrics(void) {
   /*
    * Test : Web Transaction
    */
-  nr_exclusive_time_add_child(txn->segment_root->exclusive_time, 0, 111);
+  nr_exclusive_time_add_child(txn->segment_root->exclusive_time, 0, 111, 0);
   txn->unscoped_metrics = nrm_table_create(2);
   txn->name = "WebTransaction/Action/not_words";
   nr_txn_create_duration_metrics(txn, duration, total_time);
@@ -910,7 +910,7 @@ static void test_create_duration_metrics(void) {
   /*
    * Test : Web Transaction No Exclusive
    */
-  nr_exclusive_time_add_child(txn->segment_root->exclusive_time, 0, 1000);
+  nr_exclusive_time_add_child(txn->segment_root->exclusive_time, 0, 1000, 0);
   txn->unscoped_metrics = nrm_table_create(2);
   nr_txn_create_duration_metrics(txn, duration, total_time);
   test_txn_metric_is("web txn no exclusive", txn->unscoped_metrics, MET_FORCED,
@@ -955,8 +955,8 @@ static void test_create_duration_metrics(void) {
    * Background Task
    */
   nr_exclusive_time_destroy(&txn->segment_root->exclusive_time);
-  txn->segment_root->exclusive_time = nr_exclusive_time_create(16, 0, duration);
-  nr_exclusive_time_add_child(txn->segment_root->exclusive_time, 0, 111);
+  txn->segment_root->exclusive_time = nr_exclusive_time_create(16, 0, duration, 0);
+  nr_exclusive_time_add_child(txn->segment_root->exclusive_time, 0, 111, 0);
   txn->status.background = 1;
   txn->name = "WebTransaction/Action/not_words";
   txn->unscoped_metrics = nrm_table_create(2);
@@ -976,7 +976,7 @@ static void test_create_duration_metrics(void) {
   /*
    * Background Task No Exclusive
    */
-  nr_exclusive_time_add_child(txn->segment_root->exclusive_time, 0, 1111);
+  nr_exclusive_time_add_child(txn->segment_root->exclusive_time, 0, 1111, 0);
   txn->status.background = 1;
   txn->unscoped_metrics = nrm_table_create(2);
   nr_txn_create_duration_metrics(txn, duration, total_time);
@@ -6193,7 +6193,7 @@ static void test_txn_accept_distributed_trace_payload_metrics(void) {
 
   txn.segment_slab = nr_slab_create(sizeof(nr_segment_t), 0);
   txn.segment_root = nr_segment_start(&txn, NULL, NULL);
-  txn.segment_root->exclusive_time = nr_exclusive_time_create(16, 0, 999);
+  txn.segment_root->exclusive_time = nr_exclusive_time_create(16, 0, 999, 0);
 
   txn.unscoped_metrics = nrm_table_create(2);
   txn.distributed_trace = nr_distributed_trace_create();

--- a/tests/integration/span_events/fibers/test_fiber_nested_exclusive_basic.php
+++ b/tests/integration/span_events/fibers/test_fiber_nested_exclusive_basic.php
@@ -5,8 +5,17 @@
  */
 
 /*DESCRIPTION
-Test should show proper exclusive time in metrics generated for fibers when all 
+Test should show proper exclusive time in metrics generated for fibers when all
 fibers are properly resumed after suspension.
+
+total - exclusive for a segment is exactly the amount subtracted for its
+children; suspend_time shifts total and exclusive by the same amount, so it
+cancels out of their difference. fiber two has no nested custom-traced
+children, so its total and exclusive are always equal (diff 0), regardless
+of how much of it was spent suspended. fiber one's diff instead reflects the
+one real, uninterrupted block of active work its child (fiber two) did
+while fiber one was busy with its own work - here fiber two's single
+un-suspended time_nanosleep(0.1s).
 */
 
 /*SKIPIF
@@ -77,10 +86,12 @@ $metrics = $txn->getScopedMetrics();
 tap_assert(isset($metrics["Custom/two"]), 'metric for fiber two exists');
 tap_assert(isset($metrics["Custom/one"]), 'metric for fiber one exists');
 
-// The diff should be approx equal to the time spent suspended(0.3) + the time it's child spent sleeping (0.1)
+// fiber one's own explicit Fiber::suspend() (0.3s) cancels out of the diff;
+// what's left is exactly fiber two's own amended total - the one
+// uninterrupted 0.1s time_nanosleep it did between its two suspends.
 $round_one = round($metrics["Custom/one"]->total - $metrics["Custom/one"]->exclusive, 1);
-tap_assert($round_one === 0.3 + 0.1, 'fiber one: total - exclusive diff is as expected');
+tap_assert($round_one === 0.1, 'fiber one: total - exclusive diff is as expected');
 
-// The diff should be approx equal to the time spent suspended(0.1 + 0.1)
+// fiber two has no nested custom-traced children, so total == exclusive.
 $round_two = round($metrics["Custom/two"]->total - $metrics["Custom/two"]->exclusive, 1);
-tap_assert($round_two === 0.1 + 0.1, 'fiber two: total - exclusive diff is as expected');
+tap_assert($round_two === 0.0, 'fiber two: total - exclusive diff is as expected');

--- a/tests/integration/span_events/fibers/test_fiber_nested_exclusive_exception.php
+++ b/tests/integration/span_events/fibers/test_fiber_nested_exclusive_exception.php
@@ -5,8 +5,16 @@
  */
 
 /*DESCRIPTION
-Test should show proper exclusive time in metrics generated for fibers even when a 
+Test should show proper exclusive time in metrics generated for fibers even when a
 fiber throws an exception.
+
+total - exclusive for a segment is exactly the amount subtracted for its
+children; suspend_time shifts total and exclusive by the same amount, so it
+cancels out of their difference. fiber two has no nested custom-traced
+children, so its total and exclusive are always equal (diff 0). fiber one's
+diff instead reflects the one real, uninterrupted block of active work its
+child (fiber two) did before throwing - here fiber two's single
+un-suspended time_nanosleep(0.1s).
 */
 
 /*SKIPIF
@@ -85,12 +93,13 @@ $metrics = $txn->getScopedMetrics();
 tap_assert(isset($metrics["Custom/two"]), 'metric for fiber two exists');
 tap_assert(isset($metrics["Custom/one"]), 'metric for fiber one exists');
 
-// The diff should be approx equal to the time it's child spent sleeping (0.1); 
-// the time spent suspended (0.3) is not counted since the child threw an error that 
-// wasn't caught before the fiber one's suspend call so it didn't get called
+// The diff should be approx equal to the time its child spent sleeping (0.1);
+// fiber one's own Fiber::suspend() is never reached (the uncaught exception
+// unwinds one() before it gets there), and suspend_time cancels out of the
+// diff regardless, so this is purely fiber two's own amended total.
 $round_one = round($metrics["Custom/one"]->total - $metrics["Custom/one"]->exclusive, 1);
 tap_assert($round_one === 0.1, 'fiber one: total - exclusive diff is as expected');
 
-// The diff should be approx equal to the time spent suspended(0.1 + 0.1)
+// fiber two has no nested custom-traced children, so total == exclusive.
 $round_two = round($metrics["Custom/two"]->total - $metrics["Custom/two"]->exclusive, 1);
-tap_assert($round_two === 0.1 + 0.1, 'fiber two: total - exclusive diff is as expected');
+tap_assert($round_two === 0.0, 'fiber two: total - exclusive diff is as expected');

--- a/tests/integration/span_events/fibers/test_fiber_nested_exclusive_fiberthrow.php
+++ b/tests/integration/span_events/fibers/test_fiber_nested_exclusive_fiberthrow.php
@@ -7,6 +7,14 @@
 /*DESCRIPTION
 Test should show proper exclusive time in metrics generated for fibers even when
 Fiber::throw is used to resume a fiber.
+
+total - exclusive for a segment is exactly the amount subtracted for its
+children; suspend_time shifts total and exclusive by the same amount, so it
+cancels out of their difference. fiber two has no nested custom-traced
+children, so its total and exclusive are always equal (diff 0). fiber one's
+diff instead reflects the one real, uninterrupted block of active work its
+child (fiber two) did before the injected exception unwound it - here fiber
+two's single un-suspended time_nanosleep(0.1s).
 */
 
 /*SKIPIF
@@ -84,12 +92,13 @@ $metrics = $txn->getScopedMetrics();
 tap_assert(isset($metrics["Custom/two"]), 'metric for fiber two exists');
 tap_assert(isset($metrics["Custom/one"]), 'metric for fiber one exists');
 
-// The diff should be approx equal to the time it's child spent sleeping (0.1); 
-// the time spent suspended (0.3) is not counted since the child threw an error 
-// that wasn't caught before the fiber one's suspend call so it didn't get called
+// The diff should be approx equal to the time its child spent sleeping (0.1);
+// fiber one's own Fiber::suspend() is never reached (the injected exception
+// unwinds one() before it gets there), and suspend_time cancels out of the
+// diff regardless, so this is purely fiber two's own amended total.
 $round_one = round($metrics["Custom/one"]->total - $metrics["Custom/one"]->exclusive, 1);
 tap_assert($round_one === 0.1, 'fiber one: total - exclusive diff is as expected');
 
-// The diff should be approx equal to the time spent suspended(0.1 + 0.1)
+// fiber two has no nested custom-traced children, so total == exclusive.
 $round_two = round($metrics["Custom/two"]->total - $metrics["Custom/two"]->exclusive, 1);
-tap_assert($round_two === 0.1 + 0.1, 'fiber two: total - exclusive diff is as expected');
+tap_assert($round_two === 0.0, 'fiber two: total - exclusive diff is as expected');

--- a/tests/integration/span_events/fibers/test_fiber_nested_exclusive_noresume.php
+++ b/tests/integration/span_events/fibers/test_fiber_nested_exclusive_noresume.php
@@ -7,6 +7,18 @@
 /*DESCRIPTION
 Test should show proper exclusive time in metrics generated for fibers
 even when a fiber isn't resumed.
+
+total - exclusive for a segment is exactly the amount subtracted for its
+children; suspend_time shifts total and exclusive by the same amount, so it
+cancels out of their difference. fiber two has no nested custom-traced
+children, so its total and exclusive are always equal (diff 0) - this holds
+even though fiber two is never resumed after its second suspend and its
+segment is force-closed at its last known suspend point rather than ended
+normally. fiber one's diff instead reflects the one real, uninterrupted
+block of active work its child (fiber two) did between its two suspends -
+here fiber two's single completed time_nanosleep(0.1s); the sleep fiber two
+never reaches (0.2s) after its second, never-resumed suspend contributes
+nothing.
 */
 
 /*SKIPIF
@@ -84,14 +96,14 @@ $metrics = $txn->getScopedMetrics();
 tap_assert(isset($metrics["Custom/two"]), 'metric for fiber two exists');
 tap_assert(isset($metrics["Custom/one"]), 'metric for fiber one exists');
 
-// The diff should be approx equal to the time it's child spent sleeping (0.1) before the second suspend
-// plus the time spent suspended (0.3) 
-// Since two's second sleep time never got called (non-resume) it doesn't get added.
+// The diff should be approx equal to the time its child (fiber two) spent
+// sleeping between its two suspends (0.1); fiber one's own Fiber::suspend()
+// (0.3s) cancels out of the diff regardless.
 $round_one = round($metrics["Custom/one"]->total - $metrics["Custom/one"]->exclusive, 1);
-tap_assert($round_one === 0.4, 'fiber one: total - exclusive diff is as expected');
+tap_assert($round_one === 0.1, 'fiber one: total - exclusive diff is as expected');
 
-// The diff should be approx equal to the time spent suspended for the first suspend(0.1)
-// plus the time `one` slept after the first `two` resume (0.2) 
-// plus the time `one` spent suspended (0.3)
+// fiber two has no nested custom-traced children, so total == exclusive,
+// even though it's never resumed after its second suspend and its segment
+// is force-closed rather than ended normally.
 $round_two = round($metrics["Custom/two"]->total - $metrics["Custom/two"]->exclusive, 1);
-tap_assert($round_two === 0.6, 'fiber two: total - exclusive diff is as expected');
+tap_assert($round_two === 0.0, 'fiber two: total - exclusive diff is as expected');


### PR DESCRIPTION
The spec says to subtract all non-execution time from exclusive time.  However, it also says an agent MAY choose to subtract non-actionable, blocking time from the total_time on a case by case basis.
## Summary of Changes
- suspend_time: excludes true self-suspend time from a segment's own
  duration/exclusive time. Not applied for nested-fiber resumes (avoids
  uninstrumented gap in PHP breakdown graph).
- consider_for_blocking: keeps cross-context children subtracted from
  parent by default; curl_multi/Guzzle/Predis opt out.
## Testing
- axiom unit tests updated/added for suspend_time and
  consider_for_blocking.
- Fiber integration test (test_fiber_nested_exclusive_*.php)
  expectations corrected.