### PR TITLE
fix(agent): opcache preload handling improvements

### DIFF
--- a/agent/php_execute.c
+++ b/agent/php_execute.c
@@ -1628,14 +1628,112 @@ void nr_php_execute_internal(zend_execute_data* execute_data,
   nr_segment_end(&segment);
 }
 
-void nr_php_user_instrumentation_from_opcache(TSRMLS_D) {
-  zval* status = NULL;
-  zval* scripts = NULL;
+static nr_status_t nr_php_user_instrumentation_from_opcache_scripts(
+    const zval* status) {
   zend_ulong key_num = 0;
   nr_php_string_hash_key_t* key_str = NULL;
   zval* val = NULL;
   const char* filename;
   size_t filename_len;
+  zval* scripts = nr_php_zend_hash_find(Z_ARRVAL_P(status), "scripts");
+
+  if (NULL == scripts) {
+    nrl_warning(NRL_INSTRUMENT,
+                "User instrumentation from opcache: missing 'scripts' key in "
+                "status information");
+    return NR_FAILURE;
+  }
+
+  if (IS_ARRAY != Z_TYPE_P(scripts)) {
+    nrl_warning(NRL_INSTRUMENT,
+                "User instrumentation from opcache: 'scripts' value in status "
+                "information is not an array");
+    return NR_FAILURE;
+  }
+
+  nrl_debug(NRL_INSTRUMENT, "User instrumentation from opcache: started");
+
+  ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(scripts), key_num, key_str, val) {
+    (void)key_num;
+    (void)val;
+
+    filename = ZEND_STRING_VALUE(key_str);
+    filename_len = ZEND_STRING_LEN(key_str);
+
+    if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_loaded_files)) {
+      nrl_debug(NRL_AGENT, "loaded file=" NRP_FMT, NRP_FILENAME(filename));
+    }
+
+    nr_php_user_instrumentation_from_file(filename, filename_len TSRMLS_CC);
+  }
+  ZEND_HASH_FOREACH_END();
+
+  nrl_debug(NRL_INSTRUMENT, "User instrumentation from opcache: done");
+  return NR_SUCCESS;
+}
+
+static void nr_php_user_instrumentation_from_opcache_preload_statistics(
+    const zval* status) {
+  zval* val = NULL;
+  zval* scripts = NULL;
+  zval* preload_statistics = NULL;
+
+  preload_statistics
+      = nr_php_zend_hash_find(Z_ARRVAL_P(status), "preload_statistics");
+  if (NULL == preload_statistics) {
+    nrl_warning(NRL_INSTRUMENT,
+                "User instrumentation from opcache: missing "
+                "'preload_statistics' key in "
+                "status information");
+    return;
+  }
+  if (IS_ARRAY != Z_TYPE_P(preload_statistics)) {
+    nrl_warning(NRL_INSTRUMENT,
+                "User instrumentation from opcache: 'preload_statistics' value "
+                "in status information is not an array");
+    return;
+  }
+
+  scripts = nr_php_zend_hash_find(Z_ARRVAL_P(preload_statistics), "scripts");
+
+  if (NULL == scripts) {
+    nrl_warning(NRL_INSTRUMENT,
+                "User instrumentation from opcache: missing 'scripts' key in "
+                "'preload_statistics' status information");
+    return;
+  }
+
+  if (IS_ARRAY != Z_TYPE_P(scripts)) {
+    nrl_warning(NRL_INSTRUMENT,
+                "User instrumentation from opcache: 'scripts' value in "
+                "'preload_statistics' status information is not an array");
+    return;
+  }
+
+  nrl_debug(NRL_INSTRUMENT,
+            "User instrumentation from opcache preload_statistics: started");
+
+  ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(scripts), val) {
+    if (!nr_php_is_zval_valid_string(val)) {
+      nrl_warning(NRL_INSTRUMENT,
+                  "User instrumentation from opcache: invalid script name in "
+                  "'scripts' array");
+      continue;
+    }
+    if (nrunlikely(NR_PHP_PROCESS_GLOBALS(special_flags).show_loaded_files)) {
+      nrl_debug(NRL_AGENT, "loaded file=" NRP_FMT,
+                NRP_FILENAME(Z_STRVAL_P(val)));
+    }
+    nr_php_user_instrumentation_from_file(Z_STRVAL_P(val), Z_STRLEN_P(val));
+  }
+  ZEND_HASH_FOREACH_END();
+
+  nrl_debug(NRL_INSTRUMENT,
+            "User instrumentation from opcache preload_statistics: done");
+}
+
+void nr_php_user_instrumentation_from_opcache(TSRMLS_D) {
+  zval* status = NULL;
 
   status = nr_php_call(NULL, "opcache_get_status");
 
@@ -1657,36 +1755,11 @@ void nr_php_user_instrumentation_from_opcache(TSRMLS_D) {
     goto end;
   }
 
-  scripts = nr_php_zend_hash_find(Z_ARRVAL_P(status), "scripts");
-
-  if (NULL == scripts) {
-    nrl_warning(NRL_INSTRUMENT,
-                "User instrumentation from opcache: missing 'scripts' key in "
-                "status information");
-    goto end;
+  // Scan 'scripts' key in opcache status array first:
+  if (NR_FAILURE == nr_php_user_instrumentation_from_opcache_scripts(status)) {
+    // If that fails, scan 'scripts' key in 'preload_statistics' array:
+    nr_php_user_instrumentation_from_opcache_preload_statistics(status);
   }
-
-  if (IS_ARRAY != Z_TYPE_P(scripts)) {
-    nrl_warning(NRL_INSTRUMENT,
-                "User instrumentation from opcache: 'scripts' value in status "
-                "information is not an array");
-    goto end;
-  }
-
-  nrl_debug(NRL_INSTRUMENT, "User instrumentation from opcache: started");
-
-  ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(scripts), key_num, key_str, val) {
-    (void)key_num;
-    (void)val;
-
-    filename = ZEND_STRING_VALUE(key_str);
-    filename_len = ZEND_STRING_LEN(key_str);
-
-    nr_php_user_instrumentation_from_file(filename, filename_len TSRMLS_CC);
-  }
-  ZEND_HASH_FOREACH_END();
-
-  nrl_debug(NRL_INSTRUMENT, "User instrumentation from opcache: done");
 
 end:
   nr_php_zval_free(&status);

--- a/tests/integration/opcache/preload/config/ignored_preload.php
+++ b/tests/integration/opcache/preload/config/ignored_preload.php
@@ -1,0 +1,4 @@
+<?php
+
+newrelic_end_transaction(true);
+require __DIR__ . '/../vendor/mongodb/mongodb/src/Client.php';

--- a/tests/integration/opcache/preload/config/recorded_preload.php
+++ b/tests/integration/opcache/preload/config/recorded_preload.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/../vendor/mongodb/mongodb/src/Client.php';

--- a/tests/integration/opcache/preload/test_library_detection_survives_ignored_preload.php
+++ b/tests/integration/opcache/preload/test_library_detection_survives_ignored_preload.php
@@ -1,0 +1,141 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+GH #1280 regression test: https://github.com/newrelic/newrelic-php-agent/issues/1280
+
+Under opcache.preload, a library signature file executes exactly once, at
+server startup, before any transaction exists - and, because the class it
+declares is now preloaded, is never require()'d again for the life of the
+pool. Library detection can't rely on that one require() at file-execution
+time, so the agent re-derives it every transaction from opcache_get_status()
+information, matching each script's path against the known signature files
+without re-executing the file.
+
+This test uses a fake MongoDB\Operation\Aggregate class (matching the libraries[]
+path suffix mongodb/src/client.php) purely as a vehicle for that preloaded-path
+match - no real mongodb extension or package is required. Because the MongoDB
+mock doesn't provide a real database name or connection/instance info, this
+test disables database name and instance reporting.
+
+Furthermore, a preload file used in this test executes when the agent is not recording,
+therefore preload file execution is not captured as a separate analytic event and
+additional root span with the name OtherTransaction/php/<unknown> is not created.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+if (!extension_loaded('Zend OPcache')) {
+  die("skip: OPcache extension required\n");
+}
+*/
+
+/*INI
+opcache.enable=1
+opcache.enable_cli=1
+opcache.preload=config/ignored_preload.php
+opcache.preload_user=www-data
+;comment=disabling database name and instance reporting:
+;comment=mongodb mock used for this test doesn't mock these features
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/library/MongoDB/detected, 1
+Datastore/operation/MongoDB/aggregate, 1
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 2
+  },
+  [
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "category": "datastore",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "Datastore\/operation\/MongoDB\/aggregate",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "MongoDB"
+      },
+      {},
+      {
+        "peer.address": "unknown:unknown"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 50,
+    "events_seen": 1
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "databaseDuration": "??",
+        "databaseCallCount": 1,
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": false
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS null */
+
+// Trigger MongoDB's auto-instrumentation, which executes as expected
+// even though the mongodb signature file was not explicitly require()'d
+$op = new \MongoDB\Operation\Aggregate();
+$op->execute();

--- a/tests/integration/opcache/preload/test_library_detection_survives_recorded_preload.php
+++ b/tests/integration/opcache/preload/test_library_detection_survives_recorded_preload.php
@@ -1,0 +1,175 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*DESCRIPTION
+GH #1280 regression test: https://github.com/newrelic/newrelic-php-agent/issues/1280
+
+Under opcache.preload, a library signature file executes exactly once, at
+server startup, before any transaction exists - and, because the class it
+declares is now preloaded, is never require()'d again for the life of the
+pool. Library detection can't rely on that one require() at file-execution
+time, so the agent re-derives it every transaction from opcache_get_status()
+information, matching each script's path against the known signature files
+without re-executing the file.
+
+This test uses a fake MongoDB\Operation\Aggregate class (matching the libraries[]
+path suffix mongodb/src/client.php) purely as a vehicle for that preloaded-path
+match - no real mongodb extension or package is required. Because the MongoDB
+mock doesn't provide a real database name or connection/instance info, this
+test disables database name and instance reporting.
+
+Furthermore, a preload file used in this test executes when the agent is recording,
+therefore preload file execution is recorded as a separate analytic event and
+additional root span with the name OtherTransaction/php/<unknown>.
+*/
+
+/*SKIPIF
+<?php
+if (version_compare(PHP_VERSION, "8.0", "<")) {
+  die("skip: PHP < 8.0 not supported\n");
+}
+if (!extension_loaded('Zend OPcache')) {
+  die("skip: OPcache extension required\n");
+}
+*/
+
+/*INI
+opcache.enable=1
+opcache.enable_cli=1
+opcache.preload=config/recorded_preload.php
+opcache.preload_user=www-data
+;comment=disabling database name and instance reporting:
+;comment=mongodb mock used for this test doesn't mock these features
+newrelic.datastore_tracer.database_name_reporting.enabled = 0
+newrelic.datastore_tracer.instance_reporting.enabled = 0
+*/
+
+/*EXPECT_METRICS_EXIST
+Supportability/library/MongoDB/detected, 1
+Datastore/operation/MongoDB/aggregate, 1
+*/
+
+/*EXPECT_SPAN_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 10000,
+    "events_seen": 3
+  },
+  [
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php\/<unknown>",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "transaction.name": "OtherTransaction\/php\/<unknown>"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "category": "generic",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "nr.entryPoint": true,
+        "transaction.name": "OtherTransaction\/php__FILE__"
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "category": "datastore",
+        "type": "Span",
+        "guid": "??",
+        "traceId": "??",
+        "transactionId": "??",
+        "name": "Datastore\/operation\/MongoDB\/aggregate",
+        "timestamp": "??",
+        "duration": "??",
+        "priority": "??",
+        "sampled": true,
+        "parentId": "??",
+        "span.kind": "client",
+        "component": "MongoDB"
+      },
+      {},
+      {
+        "peer.address": "unknown:unknown"
+      }
+    ]
+  ]
+]
+*/
+
+/*EXPECT_ANALYTICS_EVENTS
+[
+  "?? agent run id",
+  {
+    "reservoir_size": 50,
+    "events_seen": 2
+  },
+  [
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php\/<unknown>",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error":false
+      },
+      {},
+      {}
+    ],
+    [
+      {
+        "type": "Transaction",
+        "name": "OtherTransaction\/php__FILE__",
+        "timestamp": "??",
+        "duration": "??",
+        "totalTime": "??",
+        "databaseDuration": "??",
+        "databaseCallCount": 1,
+        "guid": "??",
+        "sampled": true,
+        "priority": "??",
+        "traceId": "??",
+        "error": false
+      },
+      {},
+      {}
+    ]
+  ]
+]
+*/
+
+/*EXPECT_TRACED_ERRORS null */
+
+// Trigger MongoDB's auto-instrumentation, which executes as expected
+// even though the mongodb signature file was not explicitly require()'d
+$op = new \MongoDB\Operation\Aggregate();
+$op->execute();

--- a/tests/integration/opcache/preload/vendor/mongodb/mongodb/src/Client.php
+++ b/tests/integration/opcache/preload/vendor/mongodb/mongodb/src/Client.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * A minimal stand-in for the real mongodb/mongodb package's Aggregate
+ * operation class. nr_mongodb_operation_before/after (agent/lib_mongodb.c)
+ * unconditionally start and finalize a datastore segment regardless of
+ * whether this object is a real MongoDB client, and read its
+ * collectionName/databaseName properties and its first constructor
+ * argument defensively - so execute() needs no real properties or
+ * arguments to produce a Datastore/operation/MongoDB/aggregate segment.
+ */
+namespace MongoDB\Operation;
+
+class Aggregate {
+    public function execute() {
+        return null;
+    }
+}
+


### PR DESCRIPTION
1. [Add regression tests for library detection under opcache.preload](https://github.com/newrelic/newrelic-php-agent/commit/1f232fea54d997890dab64912087667fc21769bc)
These tests pin that behavior down with a fake MongoDB\Operation\Aggregate class exercised via opcache.preload, covering both the recording and non-recording paths through the preload file

2. [Prototype using 'preload_statistics.scripts' for library detection](https://github.com/newrelic/newrelic-php-agent/commit/e0971d5981b5a5286b4fcde1f1f1857dfd8a9d44) 
On the first transaction after preload, opcache_get_status() sometimes
reports an empty/missing top-level 'scripts' key even though 'scripts'
array in 'preload_statistics' key already lists the preloaded files.
Walk top-level 'scripts' array first, and if it fails, fallback to
walking 'scripts' array in 'preload_statistics' key to give the agent
the highest chances of auto-instrumenting frameworks and libraries even
if their signature files have been preloaded.